### PR TITLE
feat(mcp): add MCP info card and documentation

### DIFF
--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { McpInfoCard } from '@/components/mcp/mcp-info-card'
+
+export default function McpPage() {
+  return (
+    <div className="flex flex-col gap-4 max-w-2xl">
+      <McpInfoCard />
+    </div>
+  )
+}

--- a/components/mcp/mcp-info-card.tsx
+++ b/components/mcp/mcp-info-card.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Check, Copy, Globe, Terminal } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const MCP_TOOLS = [
+  {
+    name: 'query',
+    description: 'Execute a read-only SQL query against ClickHouse',
+  },
+  {
+    name: 'list_databases',
+    description: 'List all databases in the ClickHouse cluster',
+  },
+  {
+    name: 'list_tables',
+    description: 'List tables in a specific database with metadata',
+  },
+  {
+    name: 'describe_table',
+    description: 'Show column names, types, and comments for a table',
+  },
+  {
+    name: 'server_info',
+    description: 'Get ClickHouse server version and uptime',
+  },
+  {
+    name: 'running_queries',
+    description: 'List currently executing queries with progress',
+  },
+  {
+    name: 'slow_queries',
+    description: 'Find slowest queries from the query log',
+  },
+  {
+    name: 'table_stats',
+    description: 'Get row counts, sizes, and part info for a table',
+  },
+] as const
+
+function CopyButton({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [text])
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={cn('h-7 px-2', className)}
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-green-600" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </Button>
+  )
+}
+
+function CodeBlock({
+  children,
+  copyText,
+}: {
+  children: string
+  copyText?: string
+}) {
+  return (
+    <div className="relative group">
+      <pre className="rounded-md bg-muted p-3 text-xs overflow-x-auto">
+        <code>{children}</code>
+      </pre>
+      <div className="absolute right-1 top-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <CopyButton text={copyText ?? children} />
+      </div>
+    </div>
+  )
+}
+
+export function McpInfoCard() {
+  const [endpointUrl, setEndpointUrl] = useState('')
+
+  useEffect(() => {
+    setEndpointUrl(window.location.origin + '/api/mcp')
+  }, [])
+
+  const claudeDesktopConfig = useMemo(
+    () =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            'clickhouse-monitor': {
+              url: endpointUrl,
+            },
+          },
+        },
+        null,
+        2
+      ),
+    [endpointUrl]
+  )
+
+  const curlExample = `curl -X POST ${endpointUrl || 'http://localhost:3000/api/mcp'} \\
+  -H "Content-Type: application/json" \\
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'`
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Globe className="h-4 w-4" />
+          MCP Server
+        </CardTitle>
+        <CardDescription>
+          Connect AI assistants to your ClickHouse cluster via the Model
+          Context Protocol (MCP).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Endpoint URL */}
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Endpoint URL</label>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono">
+              {endpointUrl || '...'}
+            </code>
+            {endpointUrl && <CopyButton text={endpointUrl} />}
+          </div>
+        </div>
+
+        {/* Connection Instructions */}
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium">Setup Instructions</h4>
+
+          {/* Claude Desktop */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Claude Desktop
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Add to{' '}
+              <code className="text-[11px]">claude_desktop_config.json</code>:
+            </p>
+            <CodeBlock copyText={claudeDesktopConfig}>
+              {claudeDesktopConfig}
+            </CodeBlock>
+          </div>
+
+          {/* Cursor */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">Cursor</p>
+            <p className="text-xs text-muted-foreground">
+              Go to{' '}
+              <code className="text-[11px]">
+                Settings &gt; MCP &gt; Add Server
+              </code>{' '}
+              and enter the endpoint URL above.
+            </p>
+          </div>
+
+          {/* Generic / curl */}
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground flex items-center gap-1">
+              <Terminal className="h-3 w-3" />
+              Test with curl
+            </p>
+            <CodeBlock>{curlExample}</CodeBlock>
+          </div>
+        </div>
+
+        {/* Available Tools */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium">
+            Available Tools ({MCP_TOOLS.length})
+          </h4>
+          <div className="grid gap-2">
+            {MCP_TOOLS.map((tool) => (
+              <div
+                key={tool.name}
+                className="flex items-start gap-3 rounded-md border px-3 py-2"
+              >
+                <code className="text-xs font-semibold whitespace-nowrap mt-0.5">
+                  {tool.name}
+                </code>
+                <span className="text-xs text-muted-foreground">
+                  {tool.description}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Monitor, Moon, RotateCcw, Sun } from 'lucide-react'
+import { Globe, Monitor, Moon, RotateCcw, Sun } from 'lucide-react'
 
 import type { UserSettings } from '@/lib/types/user-settings'
 
@@ -170,6 +170,28 @@ export function SettingsForm({
             )
           })}
         </div>
+      </div>
+
+      {/* MCP Server Section */}
+      <div className="space-y-3">
+        <Label className="text-sm font-medium flex items-center gap-1.5">
+          <Globe className="h-3.5 w-3.5" />
+          MCP Server
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          Connect AI assistants to your ClickHouse cluster via the Model Context
+          Protocol.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full justify-start text-xs"
+          onClick={() => window.open('/mcp', '_blank')}
+        >
+          <Globe className="h-3 w-3 mr-2" />
+          View MCP Server Details
+        </Button>
       </div>
 
       <div className="flex justify-end pt-4">

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,77 @@
+# MCP Server
+
+The ClickHouse Monitor exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server at `/api/mcp`. This allows AI assistants like Claude, Cursor, and other MCP-compatible clients to interact with your ClickHouse cluster programmatically.
+
+## Why MCP?
+
+MCP provides a standardized way for AI tools to access your ClickHouse data. Instead of copying query results manually, an AI assistant can directly:
+
+- Explore your database schema
+- Run read-only queries
+- Investigate slow queries and performance issues
+- Check server health and running operations
+
+## Available Tools
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `query` | Execute a read-only SQL query | `sql` (string, required) |
+| `list_databases` | List all databases | none |
+| `list_tables` | List tables in a database | `database` (string, required) |
+| `describe_table` | Show columns and types | `database` (string), `table` (string) |
+| `server_info` | Server version and uptime | none |
+| `running_queries` | Currently executing queries | none |
+| `slow_queries` | Slowest queries from query log | `limit` (number, default: 10) |
+| `table_stats` | Row counts, sizes, part info | `database` (string), `table` (string) |
+
+## Setup
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "clickhouse-monitor": {
+      "url": "https://your-deployment.example.com/api/mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+1. Open **Settings > MCP > Add Server**
+2. Enter the endpoint URL: `https://your-deployment.example.com/api/mcp`
+
+### Other MCP Clients
+
+Point any MCP-compatible client to your deployment's `/api/mcp` endpoint.
+
+### Testing
+
+```bash
+curl -X POST https://your-deployment.example.com/api/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
+```
+
+## Example Usage
+
+Once connected, you can ask your AI assistant things like:
+
+- "Show me all databases and their sizes"
+- "What are the slowest queries in the last hour?"
+- "Describe the schema of the `events` table in the `analytics` database"
+- "Are there any currently running queries that look stuck?"
+- "How many rows does each table in the `default` database have?"
+
+The AI assistant will use the MCP tools to query your ClickHouse cluster and return the results.
+
+## Security Notes
+
+- **Read-only access**: All MCP tools execute read-only operations. No data modification is possible through the MCP interface.
+- **No authentication**: The MCP endpoint inherits the same authentication as your ClickHouse Monitor deployment. For local development, no additional auth is required. For production deployments, secure the endpoint using your deployment platform's access controls (e.g., Cloudflare Access, VPN, reverse proxy auth).
+- **Query limits**: Queries executed through MCP respect the same `CLICKHOUSE_MAX_EXECUTION_TIME` timeout as the dashboard.
+- **No sensitive data exposure**: The MCP server uses the same ClickHouse credentials configured for the dashboard. It does not expose credentials to MCP clients.

--- a/menu.ts
+++ b/menu.ts
@@ -482,6 +482,13 @@ export const menuItemsConfig: MenuItem[] = [
         icon: BarChartIcon,
       },
       {
+        title: 'MCP Server',
+        href: '/mcp',
+        description: 'Connect AI assistants via Model Context Protocol',
+        icon: UnplugIcon,
+        isNew: true,
+      },
+      {
         title: 'About',
         href: '/about',
         description: 'Dashboard and server version information',


### PR DESCRIPTION
## Summary
- Add `McpInfoCard` component displaying MCP endpoint URL, copy-to-clipboard, setup instructions (Claude Desktop, Cursor, curl), and 8 available tools
- Add `/mcp` page and menu entry under Operations
- Add MCP section to settings form with link to MCP page
- Add `docs/mcp-server.md` with setup guide, tool reference, and security notes

## Test plan
- [ ] Navigate to `/mcp` page and verify endpoint URL renders correctly
- [ ] Test copy-to-clipboard for endpoint URL and code blocks
- [ ] Open Settings and verify MCP Server section appears
- [ ] Click "View MCP Server Details" button in settings
- [ ] Verify build passes with `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an MCP server information surface to the app, including a dedicated page, navigation entry, settings entry point, and user-facing documentation for connecting AI assistants.

New Features:
- Introduce an MCP Server menu item under Operations that links to a new /mcp page.
- Add an MCP Server section in the settings form that explains MCP and links to detailed server information.
- Create an MCP info card component that shows the MCP endpoint URL, setup instructions for common MCP clients, and the list of available tools exposed by the server.
- Add an MCP server documentation page describing the endpoint, available tools, setup instructions, and security considerations.

Documentation:
- Document the MCP server endpoint, supported tools, setup steps for various clients, testing via curl, example use cases, and security notes.