### PR TITLE
fix(ci): remove unused outputs from reusable workflow

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -31,12 +31,6 @@ on:
         description: 'Job timeout in minutes'
         default: 60
 
-    outputs:
-      tags:
-        value: ${{ jobs.job.outputs.tags }}
-      first_tag:
-        value: ${{ jobs.job.outputs.first_tag }}
-
 env:
   CLICKHOUSE_HOST: http://localhost:8123
   CLICKHOUSE_USER: default
@@ -54,9 +48,6 @@ jobs:
     name: ${{ inputs.job-type }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      first_tag: ${{ steps.first_tag.outputs.tag }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Remove `workflow_call.outputs` and job-level `outputs` from `base.yml`
- No caller references these outputs — they're dead code

Unused outputs in reusable workflows can cause `startup_failure` with 0 jobs created.

## Test plan
- [ ] Verify "Image build and Push" workflow initializes correctly (no startup_failure)