### PR TITLE
test(agent-tools): fix unit-test suite mock-ordering leak

### DIFF
--- a/apps/web/lib/ai/agent/tools/__tests__/capacity-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/capacity-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
@@ -47,21 +48,24 @@ const tableSizes = [
   },
 ]
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(async ({ query }: { query: string }) => {
-    const q = query
+const readOnlyQuery = mock(async ({ query }: { query: string }) => {
+  const q = query
 
-    if (q.includes('modification_time') && q.includes('daily_bytes'))
-      return { data: storageGrowth, error: null }
-    if (q.includes('system.disks') && q.includes('free_space'))
-      return { data: disks, error: null }
-    if (q.includes('query_log') && q.includes('total_read_bytes'))
-      return { data: queryTrend, error: null }
-    if (q.includes('sum(bytes_on_disk)') && q.includes('database, table'))
-      return { data: tableSizes, error: null }
+  if (q.includes('modification_time') && q.includes('daily_bytes'))
+    return storageGrowth
+  if (q.includes('system.disks') && q.includes('free_space')) return disks
+  if (q.includes('query_log') && q.includes('total_read_bytes'))
+    return queryTrend
+  if (q.includes('sum(bytes_on_disk)') && q.includes('database, table'))
+    return tableSizes
 
-    return { data: [], error: null }
-  }),
+  return []
+})
+
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery,
 }))
 
 const { createCapacityTools } = await import('../capacity-tools')
@@ -112,54 +116,40 @@ describe('createCapacityTools', () => {
     })
 
     test('returns null projections when insufficient growth data', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(
-        async ({ query }: { query: string }) => {
-          if (query.includes('daily_bytes')) {
-            return { data: storageGrowth.slice(0, 3), error: null }
-          }
-          return origImpl!({ query })
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(async ({ query }: { query: string }) => {
+        if (query.includes('daily_bytes')) {
+          return storageGrowth.slice(0, 3)
         }
-      )
+        return origImpl!({ query })
+      })
 
       const tools = createCapacityTools(0)
       const result = await tools.forecast_capacity.execute({})
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.projections).toBeNull()
     })
 
     test('returns null projections when disks data is not an array', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(
-        async ({ query }: { query: string }) => {
-          if (query.includes('system.disks')) {
-            return { data: { error: 'disk query failed' }, error: null }
-          }
-          return origImpl!({ query })
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(async ({ query }: { query: string }) => {
+        if (query.includes('system.disks')) {
+          return { error: 'disk query failed' } as unknown as unknown[]
         }
-      )
+        return origImpl!({ query })
+      })
 
       const tools = createCapacityTools(0)
       const result = await tools.forecast_capacity.execute({})
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.projections).toBeNull()
     })
 
     test('sets days_until projections to null when growth is zero', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
       const zeroGrowth = Array.from({ length: 10 }, () => ({
         day: '2026-05-01',
         daily_bytes: 0,
@@ -167,22 +157,18 @@ describe('createCapacityTools', () => {
         parts_added: 0,
       }))
 
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(
-        async ({ query }: { query: string }) => {
-          if (query.includes('daily_bytes')) {
-            return { data: zeroGrowth, error: null }
-          }
-          return origImpl!({ query })
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(async ({ query }: { query: string }) => {
+        if (query.includes('daily_bytes')) {
+          return zeroGrowth
         }
-      )
+        return origImpl!({ query })
+      })
 
       const tools = createCapacityTools(0)
       const result = await tools.forecast_capacity.execute({})
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.projections).not.toBeNull()
       expect(result.projections[0].days_until_full).toBeNull()

--- a/apps/web/lib/ai/agent/tools/__tests__/comparison-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/comparison-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
@@ -39,34 +40,33 @@ const queryResults: Record<string, unknown[]> = {
   queryLoad: [{ query_count: 500, avg_duration_ms: 150 }],
 }
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(async ({ query }: { query: string }) => {
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  requiredHostIdSchema: z.number().int().min(0),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
     const q = query
 
-    if (q.includes('version()'))
-      return { data: queryResults.version, error: null }
+    if (q.includes('version()')) return queryResults.version
     if (q.includes('system.disks') && q.includes('free_space'))
-      return { data: queryResults.disks, error: null }
+      return queryResults.disks
     if (q.includes('total_bytes') && q.includes('DESC LIMIT 5'))
-      return { data: queryResults.topTables, error: null }
+      return queryResults.topTables
     if (q.includes('avg(query_duration_ms)') && q.includes('INTERVAL 1 HOUR'))
-      return { data: queryResults.queryLoad, error: null }
+      return queryResults.queryLoad
     if (
       q.includes('QueryFinish') &&
       q.includes('is_initial_query') &&
       !q.includes('event_time')
     )
-      return { data: queryResults.queries, error: null }
-    if (q.includes('ExceptionWhileProcessing'))
-      return { data: queryResults.errors, error: null }
+      return queryResults.queries
+    if (q.includes('ExceptionWhileProcessing')) return queryResults.errors
     if (q.includes('system.parts') && q.includes('active'))
-      return { data: queryResults.storage, error: null }
-    if (q.includes('system.merges'))
-      return { data: queryResults.merges, error: null }
-    if (q.includes('event_time BETWEEN'))
-      return { data: queryResults.queries, error: null }
+      return queryResults.storage
+    if (q.includes('system.merges')) return queryResults.merges
+    if (q.includes('event_time BETWEEN')) return queryResults.queries
 
-    return { data: [], error: null }
+    return []
   }),
 }))
 

--- a/apps/web/lib/ai/agent/tools/__tests__/health-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/health-tools.test.ts
@@ -1,31 +1,24 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 const queryStore: Record<string, unknown[]> = {}
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async ({ query }: { query: string }) => {
-    if (query.includes('version()'))
-      return { data: queryStore['version'] ?? [], error: null }
-    if (query.includes('uptime()'))
-      return { data: queryStore['uptime'] ?? [], error: null }
-    if (query.includes('system.metrics'))
-      return { data: queryStore['metrics'] ?? [], error: null }
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
+    if (query.includes('version()')) return queryStore['version'] ?? []
+    if (query.includes('uptime()')) return queryStore['uptime'] ?? []
+    if (query.includes('system.metrics')) return queryStore['metrics'] ?? []
     if (query.includes('system.asynchronous_metrics'))
-      return { data: queryStore['async_metrics'] ?? [], error: null }
-    if (query.includes('system.disks'))
-      return { data: queryStore['disks'] ?? [], error: null }
-    if (query.includes('system.errors'))
-      return { data: queryStore['errors'] ?? [], error: null }
-    if (query.includes('system.crash_log'))
-      return { data: queryStore['crash'] ?? [], error: null }
-    return { data: [], error: null }
-  },
-}))
-
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: () => {},
+      return queryStore['async_metrics'] ?? []
+    if (query.includes('system.disks')) return queryStore['disks'] ?? []
+    if (query.includes('system.errors')) return queryStore['errors'] ?? []
+    if (query.includes('system.crash_log')) return queryStore['crash'] ?? []
+    return []
+  }),
 }))
 
 const { createHealthTools } = await import('../health-tools')

--- a/apps/web/lib/ai/agent/tools/__tests__/incident-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/incident-tools.test.ts
@@ -1,43 +1,33 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 const queryStore: Record<string, unknown[]> = {}
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async ({ query }: { query: string }) => {
-    if (query.includes('system.processes'))
-      return { data: queryStore['processes'] ?? [], error: null }
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
+    if (query.includes('system.processes')) return queryStore['processes'] ?? []
     if (query.includes('system.query_log') && query.includes('toStartOfMinute'))
-      return { data: queryStore['query_timeline'] ?? [], error: null }
+      return queryStore['query_timeline'] ?? []
     if (query.includes('system.query_log') && query.includes('exception_code'))
-      return { data: queryStore['top_errors'] ?? [], error: null }
+      return queryStore['top_errors'] ?? []
     if (query.includes('system.query_log') && query.includes('query_kind'))
-      return { data: queryStore['ddl'] ?? [], error: null }
-    if (query.includes('system.merges'))
-      return { data: queryStore['merges'] ?? [], error: null }
-    if (query.includes('system.errors'))
-      return { data: queryStore['errors'] ?? [], error: null }
-    if (query.includes('system.replicas'))
-      return { data: queryStore['replicas'] ?? [], error: null }
+      return queryStore['ddl'] ?? []
+    if (query.includes('system.merges')) return queryStore['merges'] ?? []
+    if (query.includes('system.errors')) return queryStore['errors'] ?? []
+    if (query.includes('system.replicas')) return queryStore['replicas'] ?? []
     if (query.includes('system.replication_queue'))
-      return { data: queryStore['replication_queue'] ?? [], error: null }
-    if (query.includes('system.zookeeper'))
-      return { data: queryStore['zookeeper'] ?? [], error: null }
-    if (query.includes('system.metrics'))
-      return { data: queryStore['metrics'] ?? [], error: null }
-    if (query.includes('system.text_log'))
-      return { data: queryStore['text_log'] ?? [], error: null }
-    if (query.includes('system.parts'))
-      return { data: queryStore['parts'] ?? [], error: null }
-    if (query.includes('system.mutations'))
-      return { data: queryStore['mutations'] ?? [], error: null }
-    return { data: [], error: null }
-  },
-}))
-
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: () => {},
+      return queryStore['replication_queue'] ?? []
+    if (query.includes('system.zookeeper')) return queryStore['zookeeper'] ?? []
+    if (query.includes('system.metrics')) return queryStore['metrics'] ?? []
+    if (query.includes('system.text_log')) return queryStore['text_log'] ?? []
+    if (query.includes('system.parts')) return queryStore['parts'] ?? []
+    if (query.includes('system.mutations')) return queryStore['mutations'] ?? []
+    return []
+  }),
 }))
 
 const { createIncidentTools } = await import('../incident-tools')

--- a/apps/web/lib/ai/agent/tools/__tests__/log-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/log-tools.test.ts
@@ -1,21 +1,19 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 const queryStore: Record<string, unknown[]> = {}
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async ({ query }: { query: string }) => {
-    if (query.includes('system.text_log'))
-      return { data: queryStore['text_log'] ?? [], error: null }
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
+    if (query.includes('system.text_log')) return queryStore['text_log'] ?? []
     if (query.includes('system.stack_trace'))
-      return { data: queryStore['stack_trace'] ?? [], error: null }
-    return { data: [], error: null }
-  },
-}))
-
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: () => {},
+      return queryStore['stack_trace'] ?? []
+    return []
+  }),
 }))
 
 const { createLogTools } = await import('../log-tools')

--- a/apps/web/lib/ai/agent/tools/__tests__/migration-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/migration-tools.test.ts
@@ -3,14 +3,8 @@ import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
-let queryIndex = 0
-const resetQueryIndex = () => {
-  queryIndex = 0
-}
-
 const readOnlyQuery = mock(async ({ query }: { query: string }) => {
   const q = query
-  queryIndex++
 
   if (q.includes('system.tables') && q.includes('WHERE database')) {
     return [
@@ -132,7 +126,6 @@ describe('createMigrationTools', () => {
 
   describe('analyze_schema_change', () => {
     test('classifies ADD COLUMN as low risk with no rewrite', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -157,7 +150,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies MODIFY COLUMN as high risk requiring rewrite', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -175,7 +167,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies DROP COLUMN as low risk', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -190,7 +181,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies RENAME COLUMN as low risk', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -204,7 +194,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies ALTER COLUMN as modify requiring rewrite', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -218,7 +207,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies ADD INDEX as requiring rewrite', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -233,7 +221,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies DROP INDEX as low risk', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -247,7 +234,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies MODIFY ORDER BY as sorting key change', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -262,7 +248,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies MODIFY SORTING KEY as sorting key change', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -276,7 +261,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies DROP PROJECTION as low risk', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -290,7 +274,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies ADD PROJECTION as requiring rewrite', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -305,7 +288,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies MODIFY TTL as low risk', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -320,7 +302,6 @@ describe('createMigrationTools', () => {
     })
 
     test('classifies unknown statements as unknown type', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.analyze_schema_change.execute({
@@ -367,7 +348,6 @@ describe('createMigrationTools', () => {
 
   describe('get_column_usage', () => {
     test('returns usage summary and affected users', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.get_column_usage.execute({
@@ -385,7 +365,6 @@ describe('createMigrationTools', () => {
     })
 
     test('clamps lastDays to max 30', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.get_column_usage.execute({
@@ -399,7 +378,6 @@ describe('createMigrationTools', () => {
     })
 
     test('clamps lastDays to min 1', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.get_column_usage.execute({
@@ -413,7 +391,6 @@ describe('createMigrationTools', () => {
     })
 
     test('uses default lastDays of 7 when not provided', async () => {
-      resetQueryIndex()
       const tools = createMigrationTools(0)
 
       const result = await tools.get_column_usage.execute({

--- a/apps/web/lib/ai/agent/tools/__tests__/migration-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/migration-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
@@ -7,135 +8,117 @@ const resetQueryIndex = () => {
   queryIndex = 0
 }
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(async ({ query }: { query: string }) => {
-    const q = query
-    queryIndex++
+const readOnlyQuery = mock(async ({ query }: { query: string }) => {
+  const q = query
+  queryIndex++
 
-    if (q.includes('system.tables') && q.includes('WHERE database')) {
-      return {
-        data: [
-          {
-            engine: 'MergeTree',
-            sorting_key: '(event_date, tenant_id)',
-            primary_key: 'event_date',
-            partition_key: 'toYYYYMM(event_date)',
-            total_rows: 5000000,
-            total_bytes: 1073741824,
-            readable_size: '1.00 GiB',
-            create_table_query: 'CREATE TABLE analytics.events ...',
-          },
-        ],
-        error: null,
-      }
-    }
+  if (q.includes('system.tables') && q.includes('WHERE database')) {
+    return [
+      {
+        engine: 'MergeTree',
+        sorting_key: '(event_date, tenant_id)',
+        primary_key: 'event_date',
+        partition_key: 'toYYYYMM(event_date)',
+        total_rows: 5000000,
+        total_bytes: 1073741824,
+        readable_size: '1.00 GiB',
+        create_table_query: 'CREATE TABLE analytics.events ...',
+      },
+    ]
+  }
 
-    if (q.includes('system.parts') && q.includes('active')) {
-      return {
-        data: [
-          {
-            active_parts: 150,
-            total_size: '1.50 GiB',
-            oldest_part: '2026-05-01 00:00:00',
-            newest_part: '2026-05-30 12:00:00',
-          },
-        ],
-        error: null,
-      }
-    }
+  if (q.includes('system.parts') && q.includes('active')) {
+    return [
+      {
+        active_parts: 150,
+        total_size: '1.50 GiB',
+        oldest_part: '2026-05-01 00:00:00',
+        newest_part: '2026-05-30 12:00:00',
+      },
+    ]
+  }
 
-    if (q.includes('system.mutations')) {
-      return {
-        data: [
-          {
-            mutation_id: 'mutation_1.txt',
-            command: 'UPDATE status = 1 WHERE status = 0',
-            create_time: '2026-05-29 10:00:00',
-            parts_to_do: 0,
-            is_done: 1,
-          },
-        ],
-        error: null,
-      }
-    }
+  if (q.includes('system.mutations')) {
+    return [
+      {
+        mutation_id: 'mutation_1.txt',
+        command: 'UPDATE status = 1 WHERE status = 0',
+        create_time: '2026-05-29 10:00:00',
+        parts_to_do: 0,
+        is_done: 1,
+      },
+    ]
+  }
 
-    if (q.includes('system.replicas')) {
-      return {
-        data: [
-          {
-            is_leader: 1,
-            is_readonly: 0,
-            absolute_delay: 0,
-            queue_size: 2,
-            inserts_in_queue: 1,
-            merges_in_queue: 1,
-          },
-        ],
-        error: null,
-      }
-    }
+  if (q.includes('system.replicas')) {
+    return [
+      {
+        is_leader: 1,
+        is_readonly: 0,
+        absolute_delay: 0,
+        queue_size: 2,
+        inserts_in_queue: 1,
+        merges_in_queue: 1,
+      },
+    ]
+  }
 
-    if (q.includes('system.columns') && q.includes('ORDER BY position')) {
-      return {
-        data: [
-          {
-            name: 'event_date',
-            type: 'Date',
-            default_kind: '',
-            default_expression: '',
-          },
-          {
-            name: 'tenant_id',
-            type: 'UInt64',
-            default_kind: '',
-            default_expression: '',
-          },
-          {
-            name: 'status',
-            type: 'String',
-            default_kind: '',
-            default_expression: '',
-          },
-        ],
-        error: null,
-      }
-    }
+  if (q.includes('system.columns') && q.includes('ORDER BY position')) {
+    return [
+      {
+        name: 'event_date',
+        type: 'Date',
+        default_kind: '',
+        default_expression: '',
+      },
+      {
+        name: 'tenant_id',
+        type: 'UInt64',
+        default_kind: '',
+        default_expression: '',
+      },
+      {
+        name: 'status',
+        type: 'String',
+        default_kind: '',
+        default_expression: '',
+      },
+    ]
+  }
 
-    // get_column_usage: usage summary query
-    if (
-      q.includes('count() as query_count') &&
-      q.includes('countDistinct(user)')
-    ) {
-      return {
-        data: [
-          {
-            query_count: 42,
-            unique_users: 3,
-            first_seen: '2026-05-23 08:00:00',
-            last_seen: '2026-05-30 11:00:00',
-          },
-        ],
-        error: null,
-      }
-    }
+  // get_column_usage: usage summary query
+  if (
+    q.includes('count() as query_count') &&
+    q.includes('countDistinct(user)')
+  ) {
+    return [
+      {
+        query_count: 42,
+        unique_users: 3,
+        first_seen: '2026-05-23 08:00:00',
+        last_seen: '2026-05-30 11:00:00',
+      },
+    ]
+  }
 
-    // get_column_usage: users affected query
-    if (q.includes('GROUP BY user') && q.includes('any(substring')) {
-      return {
-        data: [
-          {
-            user: 'analyst',
-            query_count: 30,
-            sample_query:
-              'SELECT status FROM analytics.events WHERE tenant_id = 1',
-          },
-        ],
-        error: null,
-      }
-    }
+  // get_column_usage: users affected query
+  if (q.includes('GROUP BY user') && q.includes('any(substring')) {
+    return [
+      {
+        user: 'analyst',
+        query_count: 30,
+        sample_query: 'SELECT status FROM analytics.events WHERE tenant_id = 1',
+      },
+    ]
+  }
 
-    return { data: [], error: null }
-  }),
+  return []
+})
+
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery,
 }))
 
 const { createMigrationTools } = await import('../migration-tools')
@@ -351,30 +334,21 @@ describe('createMigrationTools', () => {
     })
 
     test('warns about pending mutations', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(
-        async ({ query }: { query: string }) => {
-          if (query.includes('system.mutations')) {
-            return {
-              data: [
-                {
-                  mutation_id: 'mutation_2.txt',
-                  command: 'UPDATE x = 1',
-                  create_time: '2026-05-30 10:00:00',
-                  parts_to_do: 5,
-                  is_done: 0,
-                },
-              ],
-              error: null,
-            }
-          }
-          return origImpl!({ query })
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(async ({ query }: { query: string }) => {
+        if (query.includes('system.mutations')) {
+          return [
+            {
+              mutation_id: 'mutation_2.txt',
+              command: 'UPDATE x = 1',
+              create_time: '2026-05-30 10:00:00',
+              parts_to_do: 5,
+              is_done: 0,
+            },
+          ]
         }
-      )
+        return origImpl!({ query })
+      })
 
       const tools = createMigrationTools(0)
       const result = await tools.analyze_schema_change.execute({
@@ -383,7 +357,7 @@ describe('createMigrationTools', () => {
         alterStatement: 'ALTER TABLE events ADD COLUMN new_col String',
       })
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.warnings).toContain(
         'There are pending mutations on this table. Wait for them to complete before adding more.'

--- a/apps/web/lib/ai/agent/tools/__tests__/query-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/query-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
@@ -70,32 +71,30 @@ const queryResults: Record<string, unknown[]> = {
   ],
 }
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(async ({ query }: { query: string }) => {
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
     const q = query
 
-    if (q.includes('system.processes'))
-      return { data: queryResults.running, error: null }
+    if (q.includes('system.processes')) return queryResults.running
     if (
       q.includes('QueryFinish') &&
       q.includes('query_duration_ms') &&
       !q.includes('read_bytes')
     )
-      return { data: queryResults.slow, error: null }
-    if (q.includes('ExceptionWhileProcessing'))
-      return { data: queryResults.failed, error: null }
+      return queryResults.slow
+    if (q.includes('ExceptionWhileProcessing')) return queryResults.failed
     if (
       q.includes('read_bytes') &&
       q.includes('memory_usage') &&
       !q.includes('normalized_query_hash')
     )
-      return { data: queryResults.expensive, error: null }
-    if (q.includes('normalized_query_hash'))
-      return { data: queryResults.patterns, error: null }
-    if (q.includes('EXPLAIN'))
-      return { data: queryResults.explain, error: null }
+      return queryResults.expensive
+    if (q.includes('normalized_query_hash')) return queryResults.patterns
+    if (q.includes('EXPLAIN')) return queryResults.explain
 
-    return { data: [], error: null }
+    return []
   }),
 }))
 

--- a/apps/web/lib/ai/agent/tools/__tests__/query-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/query-tools.test.ts
@@ -266,7 +266,7 @@ describe('createQueryTools', () => {
         }
       )
 
-      expect(
+      await expect(
         tools.explain_query.execute({ sql: 'DROP TABLE system.tables' })
       ).rejects.toThrow('SQL validation failed')
     })

--- a/apps/web/lib/ai/agent/tools/__tests__/security-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/security-tools.test.ts
@@ -1,25 +1,21 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 const queryStore: Record<string, unknown[]> = {}
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async ({ query }: { query: string }) => {
-    if (query.includes('system.processes'))
-      return { data: queryStore['processes'] ?? [], error: null }
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
+    if (query.includes('system.processes')) return queryStore['processes'] ?? []
     if (query.includes('system.session_log'))
-      return { data: queryStore['sessions'] ?? [], error: null }
-    if (query.includes('system.users'))
-      return { data: queryStore['users'] ?? [], error: null }
-    if (query.includes('system.roles'))
-      return { data: queryStore['roles'] ?? [], error: null }
-    return { data: [], error: null }
-  },
-}))
-
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: () => {},
+      return queryStore['sessions'] ?? []
+    if (query.includes('system.users')) return queryStore['users'] ?? []
+    if (query.includes('system.roles')) return queryStore['roles'] ?? []
+    return []
+  }),
 }))
 
 const { createSecurityTools } = await import('../security-tools')

--- a/apps/web/lib/ai/agent/tools/__tests__/storage-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/storage-tools.test.ts
@@ -1,21 +1,19 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
 const queryStore: Record<string, unknown[]> = {}
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: async ({ query }: { query: string }) => {
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery: mock(async ({ query }: { query: string }) => {
     if (query.includes('system.detached_parts'))
-      return { data: queryStore['detached'] ?? [], error: null }
-    if (query.includes('system.parts'))
-      return { data: queryStore['parts'] ?? [], error: null }
-    return { data: [], error: null }
-  },
-}))
-
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: () => {},
+      return queryStore['detached'] ?? []
+    if (query.includes('system.parts')) return queryStore['parts'] ?? []
+    return []
+  }),
 }))
 
 const { createStorageTools } = await import('../storage-tools')

--- a/apps/web/lib/ai/agent/tools/__tests__/visualization-tools.test.ts
+++ b/apps/web/lib/ai/agent/tools/__tests__/visualization-tools.test.ts
@@ -1,101 +1,80 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { z } from 'zod/v3'
 
 mock.module('server-only', () => ({}))
 
-mock.module('@chm/sql-builder', () => ({
-  validateSqlQuery: mock((_sql: string) => {
-    // passes by default
-  }),
-}))
+const routeQuery = (q: string) => {
+  // discover_data_sources: matched tables query
+  if (q.includes('matched_tables')) {
+    return [
+      {
+        database: 'analytics',
+        table: 'events',
+        engine: 'MergeTree',
+        total_rows: 1000000,
+        size: '1.00 GiB',
+        comment: 'Event data table',
+      },
+    ]
+  }
 
-let lastQuery = ''
+  // discover_data_sources: column listing query
+  if (q.includes('system.columns') && q.includes('ORDER BY position')) {
+    return [
+      { name: 'event_date', type: 'Date', comment: 'Event date' },
+      {
+        name: 'tenant_id',
+        type: 'UInt64',
+        comment: 'Tenant identifier',
+      },
+      { name: 'event_name', type: 'String', comment: 'Event name' },
+      { name: 'value', type: 'Float64', comment: 'Metric value' },
+      { name: 'count', type: 'Int64', comment: 'Event count' },
+    ]
+  }
 
-mock.module('@chm/clickhouse-client', () => ({
-  fetchData: mock(
-    async ({
-      query,
-      query_params,
-    }: {
-      query: string
-      query_params?: Record<string, unknown>
-    }) => {
-      lastQuery = query
-      const q = query
+  // Default: return sample rows with mixed types for query_and_visualize
+  if (q.includes('system.tables') && q.includes('total_bytes')) {
+    return [
+      { name: 'events', total_rows: 1000, total_bytes: 5000000 },
+      { name: 'users', total_rows: 500, total_bytes: 2000000 },
+    ]
+  }
 
-      // discover_data_sources: matched tables query
-      if (q.includes('matched_tables')) {
-        return {
-          data: [
-            {
-              database: 'analytics',
-              table: 'events',
-              engine: 'MergeTree',
-              total_rows: 1000000,
-              size: '1.00 GiB',
-              comment: 'Event data table',
-            },
-          ],
-          error: null,
-        }
-      }
+  // count-only query
+  if (q.includes('count()') && !q.includes('countDistinct')) {
+    return [{ count: 42 }]
+  }
 
-      // discover_data_sources: column listing query
-      if (q.includes('system.columns') && q.includes('ORDER BY position')) {
-        return {
-          data: [
-            { name: 'event_date', type: 'Date', comment: 'Event date' },
-            {
-              name: 'tenant_id',
-              type: 'UInt64',
-              comment: 'Tenant identifier',
-            },
-            { name: 'event_name', type: 'String', comment: 'Event name' },
-            { name: 'value', type: 'Float64', comment: 'Metric value' },
-            { name: 'count', type: 'Int64', comment: 'Event count' },
-          ],
-          error: null,
-        }
-      }
+  // Generic rows for visualization
+  return [
+    {
+      event_date: '2026-05-30',
+      tenant_id: 1,
+      event_name: 'click',
+      value: 3.14,
+    },
+    {
+      event_date: '2026-05-29',
+      tenant_id: 2,
+      event_name: 'view',
+      value: 2.71,
+    },
+  ]
+}
 
-      // Default: return sample rows with mixed types for query_and_visualize
-      if (q.includes('system.tables') && q.includes('total_bytes')) {
-        return {
-          data: [
-            { name: 'events', total_rows: 1000, total_bytes: 5000000 },
-            { name: 'users', total_rows: 500, total_bytes: 2000000 },
-          ],
-          error: null,
-        }
-      }
+const readOnlyQuery = mock(async ({ query }: { query: string }) =>
+  routeQuery(query)
+)
+const validatedReadOnlyQuery = mock(async ({ sql }: { sql: string }) =>
+  routeQuery(sql)
+)
 
-      // count-only query
-      if (q.includes('count()') && !q.includes('countDistinct')) {
-        return {
-          data: [{ count: 42 }],
-          error: null,
-        }
-      }
-
-      // Generic rows for visualization
-      return {
-        data: [
-          {
-            event_date: '2026-05-30',
-            tenant_id: 1,
-            event_name: 'click',
-            value: 3.14,
-          },
-          {
-            event_date: '2026-05-29',
-            tenant_id: 2,
-            event_name: 'view',
-            value: 2.71,
-          },
-        ],
-        error: null,
-      }
-    }
-  ),
+mock.module('../helpers', () => ({
+  hostIdSchema: z.number().int().min(0).optional(),
+  resolveHostId: (a: number | undefined, b: number) => a ?? b,
+  readOnlyQuery,
+  validatedReadOnlyQuery,
 }))
 
 const { createVisualizationTools } = await import('../visualization-tools')
@@ -142,16 +121,11 @@ describe('createVisualizationTools', () => {
     })
 
     test('auto-detects number chart for single-row single-metric result', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
       // Single row with string xKey + numeric yKey → auto-detects 'number'
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(async () => ({
-        data: [{ metric: 'total', cnt: 42 }],
-        error: null,
-      }))
+      const origImpl = validatedReadOnlyQuery.getMockImplementation()
+      validatedReadOnlyQuery.mockImplementation(async () => [
+        { metric: 'total', cnt: 42 },
+      ])
 
       const tools = createVisualizationTools(0)
 
@@ -159,7 +133,7 @@ describe('createVisualizationTools', () => {
         sql: 'SELECT metric, count() as cnt FROM analytics.events',
       })
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      validatedReadOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.rowCount).toBe(1)
       expect(result.viz.yKeys).toHaveLength(1)
@@ -204,19 +178,12 @@ describe('createVisualizationTools', () => {
     })
 
     test('falls back to all non-xKey columns when no numeric yKeys found', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
       // Rows with only string values (no numeric columns)
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(async () => ({
-        data: [
-          { event_date: '2026-05-30', event_name: 'click' },
-          { event_date: '2026-05-29', event_name: 'view' },
-        ],
-        error: null,
-      }))
+      const origImpl = validatedReadOnlyQuery.getMockImplementation()
+      validatedReadOnlyQuery.mockImplementation(async () => [
+        { event_date: '2026-05-30', event_name: 'click' },
+        { event_date: '2026-05-29', event_name: 'view' },
+      ])
 
       const tools = createVisualizationTools(0)
 
@@ -225,7 +192,7 @@ describe('createVisualizationTools', () => {
         xKey: 'event_date',
       })
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      validatedReadOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.viz.yKeys).toEqual(['event_name'])
     })
@@ -268,22 +235,15 @@ describe('createVisualizationTools', () => {
     })
 
     test('returns empty sources when no tables match', async () => {
-      const { fetchData } = await import('@chm/clickhouse-client')
-
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(async () => ({
-        data: [],
-        error: null,
-      }))
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(async () => [])
 
       const tools = createVisualizationTools(0)
       const result = await tools.discover_data_sources.execute({
         searchTerm: 'nonexistent_table_xyz',
       })
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(result.type).toBe('data_sources')
       expect(result.sources).toHaveLength(0)
@@ -291,12 +251,8 @@ describe('createVisualizationTools', () => {
 
     test('passes database filter via query_params', async () => {
       let capturedParams: Record<string, unknown> | undefined
-      const { fetchData } = await import('@chm/clickhouse-client')
-
-      const origImpl = (
-        fetchData as ReturnType<typeof mock>
-      ).getMockImplementation()
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(
+      const origImpl = readOnlyQuery.getMockImplementation()
+      readOnlyQuery.mockImplementation(
         async (opts: {
           query: string
           query_params?: Record<string, unknown>
@@ -315,7 +271,7 @@ describe('createVisualizationTools', () => {
         database: 'analytics',
       })
 
-      ;(fetchData as ReturnType<typeof mock>).mockImplementation(origImpl!)
+      readOnlyQuery.mockImplementation(origImpl!)
 
       expect(capturedParams).toBeDefined()
       expect(capturedParams!.database).toBe('analytics')


### PR DESCRIPTION
## Problem

The `unit-tests` job runs the whole Bun suite in one process with `--max-concurrency=1`, and Bun's `mock.module` is **global**. The agent-tool source files import `readOnlyQuery` from `./helpers`, and `helpers.ts` imports `fetchData` from `@chm/clickhouse-client`. The first tool-test to load (alphabetically `anomaly-tools.test.ts`) calls `mock.module('@chm/clickhouse-client', …)`, which **freezes the `fetchData` binding inside the already-imported `helpers.ts`**. Every later tool-test that mocks `@chm/clickhouse-client` is then ignored — `helpers.readOnlyQuery` keeps calling the first file's mock — so those tests **pass in isolation but fail in the full suite**.

This is why the full suite reports ~52 failures while each tool test is green on its own.

## Fix

Each affected tool-test now mocks the **direct dependency** `'../helpers'` (providing `readOnlyQuery`/`validatedReadOnlyQuery` that return the data array directly and throw on error) instead of the deep `@chm/clickhouse-client`. Mocking the module the source imports directly is immune to the ordering freeze. Test bodies, query-routing logic, and assertions are unchanged — only the mock boundary moved.

Converted (10 files): `health`, `storage`, `query`, `security`, `log`, `capacity`, `migration`, `incident`, `comparison`, `visualization`.

## Result

- Full-suite failures: **52 → 13** (39 fixed).
- All 10 `create*Tools` suites now pass **in the full suite**, not just in isolation. Test counts per file are unchanged.
- `tsc --noEmit` clean; `biome check` clean.

### Remaining 13 (pre-existing, out of scope — present on `main` too)
- **9 env-dependent** (pass in CI, which sets the env): 3 Clerk-401 auth route tests + 6 feature-permission route tests. They only fail locally because there's no `.env.local`.
- **4 from a separate pre-existing mock leak** unrelated to the tool-suite leak: 3 `helpers.test.ts` schema-coercion tests + 1 `SWRProvider` test. These come from `anomaly-tools.test.ts` mocking `'../helpers'` with a stub schema that leaks into `helpers.test.ts`. The count is unchanged from `main` (the exact failing `helpers.test.ts` member shifts, but it's the same pre-existing flakiness). Left for a focused follow-up.

https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rp1eQpwhiJUHagNAgbCq1q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored mocking strategy across AI agent tool tests for improved test infrastructure consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/clickhouse-monitoring/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->