### PR TITLE
opt(dashboard-tsr): stub streamdown + @streamdown/mermaid from worker bundle

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -102,6 +102,11 @@ const SSR_STUB_PREFIXES = [
   // OFF and getInitialBeautifyState() returns false under SSR (no `window`), so
   // it never executes during prerender. Stub it out of the worker bundle.
   'sql-formatter',
+  // Streaming markdown renderer — only used in assistant-ui / ai-elements
+  // components behind React.lazy boundaries (agent-thread-page,
+  // global-assistant-modal-impl). Never executes during SSR/prerender.
+  'streamdown',
+  '@streamdown',
 ]
 
 // rolldown does not honour `syntheticNamedExports` from a resolveId result, so
@@ -128,6 +133,9 @@ const SSR_STUB_NAMED_EXPORTS = [
   'keymap',
   // sql-formatter
   'format',
+  // streamdown + @streamdown/mermaid
+  'Streamdown',
+  'mermaid',
 ]
 
 const SSR_STUB_VIRTUAL_ID = '\0chm-ssr-client-only-stub'


### PR DESCRIPTION
## Finding

Stub `streamdown` and `@streamdown/mermaid` — removes streaming markdown renderer from the worker bundle chunk.

## What

- Added `streamdown` and `@streamdown` to `SSR_STUB_PREFIXES` in `apps/dashboard-tsr/vite.config.ts`
- Added named exports `Streamdown` (from `streamdown`) and `mermaid` (from `@streamdown/mermaid`) to `SSR_STUB_NAMED_EXPORTS`

These packages are only imported by assistant-ui / ai-elements components (`markdown-text.tsx`, `reasoning.tsx`, `message.tsx`), all behind the same `React.lazy` boundaries as `@assistant-ui` (`agent-thread-page` or `global-assistant-modal-impl`). They never execute during SSR/prerender, so stubbing them out of the worker bundle is safe and reduces the uploaded size.

Note: `mermaid` was already stubbed as a bare specifier, but `@streamdown/mermaid` is a separate wrapper package that re-exports it — adding the `@streamdown` prefix ensures the wrapper is also stubbed.

## Verified

- Config-only change following the exact same pattern as existing `mermaid`, `sql-formatter`, `codemirror` entries
- CI will verify build + wrangler dry-run

Ref #1392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized server-side rendering build configuration to enhance compatibility with renderer packages, ensuring consistent application performance across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->