### PR TITLE
perf(dashboard-tsr): stub highlight.js in SSR bundle (~106 KB saved)

### DIFF
--- a/apps/dashboard-tsr/vite.config.ts
+++ b/apps/dashboard-tsr/vite.config.ts
@@ -102,6 +102,12 @@ const SSR_STUB_PREFIXES = [
   // OFF and getInitialBeautifyState() returns false under SSR (no `window`), so
   // it never executes during prerender. Stub it out of the worker bundle.
   'sql-formatter',
+  // highlight.js (~106K chunk). Imported in code-block.tsx (default hljs from
+  // lib/core + subpath languages). highlightCode() runs inside useMemo guarded
+  // by `if (!displaySQL) return ''` — during SSR/prerender sql metadata is
+  // undefined so the function is never invoked. The Proxy stub satisfies
+  // the import without breaking the render.
+  'highlight.js',
 ]
 
 // rolldown does not honour `syntheticNamedExports` from a resolveId result, so


### PR DESCRIPTION
## Finding

Stub `highlight.js` in the Cloudflare Worker SSR bundle to save ~106 KB.

## What

Added `'highlight.js'` to `SSR_STUB_PREFIXES` in `apps/dashboard-tsr/vite.config.ts`.

highlight.js is imported by `code-block.tsx` (default `hljs` from `highlight.js/lib/core` + subpath languages like `highlight.js/lib/languages/sql`). The `highlightCode()` function runs inside a `useMemo` guarded by `if (!displaySQL) return ''` — during SSR/prerender, SQL metadata is undefined, so `displaySQL` is always empty and `highlightCode()` is never invoked. The Proxy stub satisfies the import without breaking the render.

The prefix match covers:
- `highlight.js/lib/core` (default import)
- `highlight.js/lib/languages/*` (subpath language imports)

## Verification

- `bun vite build` succeeds (prerender completes)
- `bun wrangler deploy --minify --dry-run` succeeds — Total Upload: 10965.23 KiB / gzip: 2377.45 KiB
- Full test suite: 828 pass, 0 fail across 69 files
- Only file changed: `apps/dashboard-tsr/vite.config.ts` (+6 lines)

Co-Authored-By: duyetbot <bot@duyet.net>