### PR TITLE
docs(plans): HOLD plan 42 kafka-consumer-control (broker-admin design not implementable)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -137,7 +137,12 @@ appropriate for blind autonomous execution. Grouped by the blocker:
   [38 grafana-datasource-plugin](38-grafana-datasource-plugin.md),
   [39 otel-trace-export](39-otel-trace-export.md),
   [40 terraform-provider](40-terraform-provider.md),
-  [42 kafka-consumer-control](42-kafka-consumer-control.md),
+  [42 kafka-consumer-control](42-kafka-consumer-control.md) — 🔶 **HELD**
+  (blocked: no Kafka broker client is installed and none can run on the
+  Cloudflare Workers runtime; the SSRF guard is HTTP-fetch-only; the "Kafka"
+  data is ClickHouse `system.kafka_consumers` (table-engine consumers), not
+  standalone groups. The broker-admin design is not implementable as specified —
+  needs product re-scope to ClickHouse-native control, see draft PR),
   [43 mcp-custom-server-registry](43-mcp-custom-server-registry.md).
   (36, 41, 44, 45, 46, 47 already merged — the plumbing/advisor foundation this cluster builds on.)
 - **Advisor 52** (1) — [52 proactive-weekly-health-report](52-proactive-weekly-health-report.md)


### PR DESCRIPTION
## Status: 🔶 HELD — blocked, needs product re-scope (do not merge as a feature)

This is a **blocker report**, not the feature. Plan
`plans/42-kafka-consumer-control.md` specifies a Kafka **broker-admin** control
surface (env `KAFKA_ADMIN_BROKER`, a KafkaJS-style admin client, pause / resume /
reset-offset proxied through the SSRF guard). That design is **not implementable
as written** in this codebase and runtime. Per the plan's own STOP conditions
("report rather than fake it", "do not improvise"), I stopped and am reporting
instead of shipping a divergent or fake implementation.

The only change in this PR is a one-line status annotation marking plan 42 HELD
in `plans/README.md`. No code, no route, no env, no dependency — zero behavior
change.

## Why the specified design is blocked (evidence)

1. **No Kafka broker client is installed and none can be added here.** No
   `kafkajs` / `node-rdkafka` in `package.json` or `bun.lock`. Executors must not
   run `bun install` (shared/symlinked `node_modules` across ~40 worktrees), so a
   new dependency cannot be introduced in this environment.
2. **The runtime cannot run a raw Kafka client.** The app deploys to Cloudflare
   Workers. KafkaJS uses Node `net`/TLS raw TCP sockets and does not run on
   Workers. The plan's designated guard, `createHostValidationFetch`
   (`src/lib/browser-connections/host-url.ts`), is an **HTTP-fetch** wrapper — it
   even throws `WORKER_DNS_PINNING_ERROR` for non-IP hostnames on Workers. It
   cannot guard a broker TCP socket; it's the wrong primitive for this design.
3. **The plan's premise about the read side is inaccurate.** There is no
   `src/lib/kafka/` read client to reuse. Kafka consumer data is read from
   ClickHouse `system.kafka_consumers` via a `QueryConfig`
   (`src/lib/query-config/system/kafka-consumers.ts`). These are ClickHouse
   **Kafka table-engine** consumers driven by ClickHouse — not standalone,
   app-managed Kafka consumer groups. There is no existing broker connection to
   extend.

Together these trigger the plan's explicit STOP condition — *"The installed
Kafka client cannot perform even offset reset server-side (then the whole control
surface is `not-supported`; report rather than fake it)"* — and its header rule
*"If a STOP condition occurs, stop and report — do not improvise."*

## Recommended re-scope (needs a human/product decision — NOT built here)

Because these are ClickHouse Kafka **table-engine** consumers, the
architecturally-native control is ClickHouse DDL via the existing `writeQuery`
path — no Kafka broker, no new outbound, works on Workers + self-host:

- **Pause** → `DETACH TABLE <db>.<table>` (stops the engine's background consumer)
- **Resume** → `ATTACH TABLE <db>.<table>`
- **Reset-offset** → **no clean single-DDL analog** for the Kafka engine; stays
  `not-supported` even under this re-scope.

It would follow the existing destructive-control conventions: env-gated off by
default (like `src/lib/ai/agent/tools/control-tools.ts`), an ACK confirm dialog
in the data-table row action, an authenticated `POST` route, and `logEvent`
audit of actor/action/result.

**Two honesty caveats on the re-scope (do not assume away):**
1. Reset-offset is not deliverable regardless — pause/resume at most.
2. Whether `DETACH`/`ATTACH` cleanly pauses+resumes a Kafka-engine consumer
   **without** offset or MV-pipeline side effects needs real verification against
   `docs/clickhouse-schemas/` behavior — this is **unverified**, flagged not
   asserted.

Crucially, this re-scope turns a read-only monitor into something that runs
`DETACH TABLE` on a production Kafka pipeline — a **destructive production
capability** and a product decision above an executor's authority. In this swarm
the only required check is compile-only, so it must **not** be built and merged
autonomously.

## Ask

Approve one of: (a) re-scope plan 42 to the ClickHouse-native
`DETACH`/`ATTACH` control above (I can implement it once approved), or (b) defer
plan 42 until a Workers-compatible Kafka admin path (e.g. an HTTP admin proxy
service) exists. Until then this stays HELD.
