### PR TITLE
perf(explorer): faster first load + copyable database/table names

### DIFF
--- a/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
@@ -45,7 +45,7 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {database && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem className="min-w-0">
+            <BreadcrumbItem className="group min-w-0">
               {table ? (
                 <BreadcrumbLink asChild>
                   <Link
@@ -68,8 +68,13 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
                   </span>
                 </BreadcrumbPage>
               )}
-              {/* Stops the copy click from bubbling into the sibling database link/page above. */}
-              <span onClick={(e) => e.stopPropagation()}>
+              {/* Stops the copy click from bubbling into the sibling database link/page above.
+                  Hover/focus-revealed, matching the quiet copy-affordance convention
+                  used elsewhere (e.g. ai-elements/message.tsx). */}
+              <span
+                onClick={(e) => e.stopPropagation()}
+                className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
+              >
                 <CopyButton text={database} className="size-6 shrink-0 p-0" />
               </span>
             </BreadcrumbItem>
@@ -79,15 +84,20 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {table && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem className="min-w-0">
+            <BreadcrumbItem className="group min-w-0">
               <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
                 <TableIcon className="size-3.5 shrink-0" />
                 <span className={cn('truncate select-text', NAME_MAX_WIDTH)}>
                   {table}
                 </span>
               </BreadcrumbPage>
-              {/* Stops the copy click from bubbling into the sibling table page above. */}
-              <span onClick={(e) => e.stopPropagation()}>
+              {/* Stops the copy click from bubbling into the sibling table page above.
+                  Hover/focus-revealed, matching the quiet copy-affordance convention
+                  used elsewhere (e.g. ai-elements/message.tsx). */}
+              <span
+                onClick={(e) => e.stopPropagation()}
+                className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
+              >
                 <CopyButton text={table} className="size-6 shrink-0 p-0" />
               </span>
             </BreadcrumbItem>

--- a/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-breadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Database, Server, Table as TableIcon } from 'lucide-react'
 
 import { useExplorerState } from './hooks/use-explorer-state'
+import { CopyButton } from '@/components/mcp/copy-button'
 import { AppLink as Link } from '@/components/ui/app-link'
 import {
   Breadcrumb,
@@ -10,10 +11,18 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
+import { cn } from '@/lib/utils'
 
 interface ExplorerBreadcrumbProps {
   hostName?: string
 }
+
+// Cap so long database/table names ellipsize instead of stretching the
+// breadcrumb bar. This is CSS-only truncation (overflow-hidden +
+// text-overflow: ellipsis via `truncate`), never a JS substring — the full
+// name stays in the DOM, so double-click-select + Cmd+C (or the copy button
+// below) always copies the complete name, not the visually clipped part.
+const NAME_MAX_WIDTH = 'max-w-[8rem] sm:max-w-[14rem]'
 
 export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
   const { hostId, database, table } = useExplorerState()
@@ -36,23 +45,33 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {database && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem>
+            <BreadcrumbItem className="min-w-0">
               {table ? (
                 <BreadcrumbLink asChild>
                   <Link
                     href={`/explorer?host=${hostId}&database=${encodeURIComponent(database)}`}
-                    className="flex items-center gap-1.5"
+                    className="flex min-w-0 items-center gap-1.5"
                   >
-                    <Database className="size-3.5" />
-                    {database}
+                    <Database className="size-3.5 shrink-0" />
+                    <span
+                      className={cn('truncate select-text', NAME_MAX_WIDTH)}
+                    >
+                      {database}
+                    </span>
                   </Link>
                 </BreadcrumbLink>
               ) : (
-                <BreadcrumbPage className="flex items-center gap-1.5">
-                  <Database className="size-3.5" />
-                  {database}
+                <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
+                  <Database className="size-3.5 shrink-0" />
+                  <span className={cn('truncate select-text', NAME_MAX_WIDTH)}>
+                    {database}
+                  </span>
                 </BreadcrumbPage>
               )}
+              {/* Stops the copy click from bubbling into the sibling database link/page above. */}
+              <span onClick={(e) => e.stopPropagation()}>
+                <CopyButton text={database} className="size-6 shrink-0 p-0" />
+              </span>
             </BreadcrumbItem>
           </>
         )}
@@ -60,11 +79,17 @@ export function ExplorerBreadcrumb({ hostName }: ExplorerBreadcrumbProps) {
         {table && (
           <>
             <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage className="flex items-center gap-1.5">
-                <TableIcon className="size-3.5" />
-                {table}
+            <BreadcrumbItem className="min-w-0">
+              <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
+                <TableIcon className="size-3.5 shrink-0" />
+                <span className={cn('truncate select-text', NAME_MAX_WIDTH)}>
+                  {table}
+                </span>
               </BreadcrumbPage>
+              {/* Stops the copy click from bubbling into the sibling table page above. */}
+              <span onClick={(e) => e.stopPropagation()}>
+                <CopyButton text={table} className="size-6 shrink-0 p-0" />
+              </span>
             </BreadcrumbItem>
           </>
         )}

--- a/apps/dashboard/src/components/explorer/explorer-content.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-content.tsx
@@ -24,7 +24,7 @@ interface ExplorerContentProps {
 // Track which tabs have been visited for this table to enable pre-loading
 function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
   const [visitedTabs, setVisitedTabs] = useState<Set<ExplorerTab>>(
-    () => new Set<ExplorerTab>(['overview', 'data', currentTab])
+    () => new Set<ExplorerTab>(['overview', currentTab])
   )
   const prevTableKey = useRef<string | null>(null)
 
@@ -32,7 +32,7 @@ function useTabVisitTracker(tableKey: string | null, currentTab: ExplorerTab) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: currentTab is only used to seed the set on table reset
   useEffect(() => {
     if (tableKey !== prevTableKey.current) {
-      setVisitedTabs(new Set<ExplorerTab>(['overview', 'data', currentTab]))
+      setVisitedTabs(new Set<ExplorerTab>(['overview', currentTab]))
       prevTableKey.current = tableKey
     }
   }, [tableKey])
@@ -130,13 +130,16 @@ export function ExplorerContent({ hostName }: ExplorerContentProps) {
           {visitedTabs.has('overview') && <OverviewTab />}
         </TabsContent>
 
-        {/* Data tab: always force-mounted to preserve pagination state */}
+        {/* Data tab: render only once visited so the first paint on the
+            default Overview tab doesn't fire a hidden `SELECT * ... LIMIT`
+            preview against the user's table. Once opened it stays force-mounted,
+            preserving pagination state when switching tabs. */}
         <TabsContent
           value="data"
           className={cn('mt-4', tab !== 'data' && 'hidden flex-none')}
           forceMount
         >
-          <DataTab />
+          {visitedTabs.has('data') && <DataTab />}
         </TabsContent>
 
         {/* Structure tab: don't force-mount due to complex filter state */}

--- a/apps/dashboard/src/components/explorer/explorer-empty-state.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-empty-state.tsx
@@ -23,8 +23,16 @@ import { cn } from '@/lib/utils'
 interface Database {
   name: string
   engine: string
-  item_count: number
 }
+
+interface DatabaseCount {
+  name: string
+  item_count: number | string
+}
+
+// Schema shape changes rarely; skip refetching the database list on every
+// remount of the empty-state within this window.
+const SCHEMA_STALE_TIME = 5 * 60_000
 
 function getDatabaseIcon(engine: string): {
   icon: LucideIcon
@@ -79,28 +87,47 @@ interface ApiResponse<T> {
   metadata?: Record<string, unknown>
 }
 
-const fetcher = async (url: string): Promise<ApiResponse<Database[]>> => {
+const fetcher = async <T,>(url: string): Promise<ApiResponse<T>> => {
   const res = await apiFetch(url)
   if (!res.ok) {
     throw new Error(`Failed to fetch databases: ${res.statusText}`)
   }
-  return res.json() as Promise<ApiResponse<Database[]>>
+  return res.json() as Promise<ApiResponse<T>>
 }
 
 export function ExplorerEmptyState() {
   const hostId = useHostId()
   const { setDatabase, setTab } = useExplorerState()
-  const queryKey = [`/api/v1/explorer/databases?hostId=${hostId}`]
+  const databasesUrl = `/api/v1/explorer/databases?hostId=${hostId}`
   const {
     data: response,
     error,
     isLoading,
   } = useQuery<ApiResponse<Database[]>>({
-    queryKey,
-    queryFn: () => fetcher(`/api/v1/explorer/databases?hostId=${hostId}`),
+    queryKey: [databasesUrl],
+    queryFn: () => fetcher<Database[]>(databasesUrl),
+    staleTime: SCHEMA_STALE_TIME,
+  })
+
+  // Table counts stream in separately so the database cards can paint on names
+  // immediately instead of waiting on a cluster-wide system.tables enumeration.
+  const countsUrl = `/api/v1/tables/explorer-database-counts?hostId=${hostId}`
+  const { data: countsResponse, isLoading: countsLoading } = useQuery<
+    ApiResponse<DatabaseCount[]>
+  >({
+    queryKey: [countsUrl],
+    queryFn: () => fetcher<DatabaseCount[]>(countsUrl),
+    staleTime: SCHEMA_STALE_TIME,
   })
 
   const databases = response?.data
+
+  const countByName = new Map<string, number>(
+    (countsResponse?.data ?? []).map((row) => [
+      row.name,
+      Number(row.item_count),
+    ])
+  )
 
   return (
     <div className="flex h-full flex-col gap-6 p-8">
@@ -157,6 +184,7 @@ export function ExplorerEmptyState() {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {databases.map((db) => {
               const { icon: Icon, color, bg } = getDatabaseIcon(db.engine)
+              const count = countByName.get(db.name)
               return (
                 <Card
                   key={db.name}
@@ -177,9 +205,13 @@ export function ExplorerEmptyState() {
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="font-medium truncate">{db.name}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {db.item_count} {db.item_count === 1 ? 'item' : 'items'}
-                      </p>
+                      {count === undefined && countsLoading ? (
+                        <Skeleton className="mt-1 h-3 w-12" />
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          {count ?? 0} {count === 1 ? 'item' : 'items'}
+                        </p>
+                      )}
                     </div>
                   </div>
                 </Card>

--- a/apps/dashboard/src/components/explorer/tree/database-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-node.tsx
@@ -70,6 +70,8 @@ export const DatabaseNode = function DatabaseNode({
     queryKey: [url],
     queryFn: () => fetcher(url),
     enabled: shouldFetch,
+    // Table list per database changes rarely — cache across expand/collapse and remounts.
+    staleTime: 5 * 60_000,
   })
 
   const tables = response?.data

--- a/apps/dashboard/src/components/explorer/tree/database-tree.tsx
+++ b/apps/dashboard/src/components/explorer/tree/database-tree.tsx
@@ -44,6 +44,8 @@ export function DatabaseTree() {
   } = useQuery<ApiResponse<Database[]>>({
     queryKey: [queryKey],
     queryFn: () => fetcher(queryKey),
+    // Schema shape changes rarely — don't refetch the database list on every remount.
+    staleTime: 5 * 60_000,
   })
 
   const databases = response?.data

--- a/apps/dashboard/src/components/explorer/tree/table-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/table-node.tsx
@@ -127,6 +127,8 @@ export const TableNode = function TableNode({
         `/api/v1/explorer/columns?hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
       ),
     enabled: shouldFetch,
+    // Column schema changes rarely — cache across expand/collapse and remounts.
+    staleTime: 5 * 60_000,
   })
 
   const columns = response?.data

--- a/apps/dashboard/src/components/explorer/tree/tree-node.tsx
+++ b/apps/dashboard/src/components/explorer/tree/tree-node.tsx
@@ -135,7 +135,10 @@ export const TreeNode = function TreeNode({
                   )}
                 />
               ))}
-            <span className="truncate">{label}</span>
+            {/* CSS-only ellipsis (never a JS substring) so the full name
+                stays in the DOM for double-click-select + copy; select-text
+                guards against any ancestor accidentally disabling selection. */}
+            <span className="truncate select-text">{label}</span>
             {badge && <div className="ml-auto">{badge}</div>}
           </SidebarMenuButton>
         </div>

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/databases.ts
@@ -1,21 +1,18 @@
 import type { DeclarativeQueryConfig } from '../../schema'
 
+// Mirrors explorerDatabasesConfig (TS). Table counts moved to a separate
+// streamed query (explorer-database-counts) so the sidebar / first paint no
+// longer joins system.tables. Keep this in lockstep with the TS config —
+// enforced by explorer-catalog.test.ts.
 export const explorerDatabasesDeclarative: DeclarativeQueryConfig = {
   name: 'explorer-databases',
-  description: 'List of ClickHouse databases with table counts',
+  description: 'List of ClickHouse databases',
   sql: `
-    SELECT
-      d.name,
-      d.engine,
-      d.data_path,
-      d.uuid,
-      count(t.name) AS item_count
-    FROM system.databases d
-    LEFT JOIN system.tables t ON d.name = t.database
-    WHERE d.name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
-    GROUP BY d.name, d.engine, d.data_path, d.uuid
-    ORDER BY d.name
+    SELECT name, engine
+    FROM system.databases
+    WHERE name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    ORDER BY name
   `,
-  columns: ['name', 'engine', 'data_path', 'uuid', 'item_count'],
+  columns: ['name', 'engine'],
   optional: false,
 }

--- a/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/explorer/tables.ts
@@ -1,10 +1,13 @@
 import type { DeclarativeQueryConfig } from '../../schema'
 
+// Mirrors explorerTablesConfig (TS): only name/engine/total_rows are rendered,
+// so total_bytes / readable_size are no longer selected. Keep in lockstep with
+// the TS config — enforced by explorer-catalog.test.ts.
 export const explorerTablesDeclarative: DeclarativeQueryConfig = {
   name: 'explorer-tables',
   description: 'List of tables in a database',
-  sql: "SELECT name, engine, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name",
-  columns: ['name', 'engine', 'total_rows', 'total_bytes', 'readable_size'],
+  sql: "SELECT name, engine, total_rows FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name",
+  columns: ['name', 'engine', 'total_rows'],
   optional: false,
   defaultParams: { database: 'default' },
 }

--- a/apps/dashboard/src/lib/query-config/explorer/databases.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/databases.ts
@@ -1,20 +1,34 @@
 import type { QueryConfig } from '@/types/query-config'
 
+// Sidebar tree + empty-state gate. Deliberately does NOT join system.tables:
+// the tree renders only `name` and the empty-state renders `name` + `engine`,
+// so enumerating every table in the cluster to compute a per-database count
+// (the old `LEFT JOIN system.tables ... GROUP BY`) blocked the first paint for
+// a number nothing on this path uses. Table counts are now a separate,
+// streamed query (`explorer-database-counts`) consumed only by the empty-state.
 export const explorerDatabasesConfig: QueryConfig = {
   name: 'explorer-databases',
-  description: 'List of ClickHouse databases with table counts',
+  description: 'List of ClickHouse databases',
   sql: `
-    SELECT
-      d.name,
-      d.engine,
-      d.data_path,
-      d.uuid,
-      count(t.name) AS item_count
-    FROM system.databases d
-    LEFT JOIN system.tables t ON d.name = t.database
-    WHERE d.name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
-    GROUP BY d.name, d.engine, d.data_path, d.uuid
-    ORDER BY d.name
+    SELECT name, engine
+    FROM system.databases
+    WHERE name NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    ORDER BY name
   `,
-  columns: ['name', 'engine', 'data_path', 'uuid', 'item_count'],
+  columns: ['name', 'engine'],
+}
+
+// Per-database table counts for the explorer empty-state, split out of
+// `explorer-databases` so the sidebar/first paint never waits on a
+// system.tables enumeration. Streamed in after the database names render.
+export const explorerDatabaseCountsConfig: QueryConfig = {
+  name: 'explorer-database-counts',
+  description: 'Per-database table counts for the explorer empty-state',
+  sql: `
+    SELECT database AS name, count() AS item_count
+    FROM system.tables
+    WHERE database NOT IN ('INFORMATION_SCHEMA', 'information_schema')
+    GROUP BY database
+  `,
+  columns: ['name', 'item_count'],
 }

--- a/apps/dashboard/src/lib/query-config/explorer/index.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/index.ts
@@ -1,5 +1,8 @@
 export { explorerColumnsConfig } from './columns'
-export { explorerDatabasesConfig } from './databases'
+export {
+  explorerDatabaseCountsConfig,
+  explorerDatabasesConfig,
+} from './databases'
 export { explorerDdlConfig } from './ddl'
 export {
   explorerAllDependenciesConfig,

--- a/apps/dashboard/src/lib/query-config/explorer/tables.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/tables.ts
@@ -1,9 +1,13 @@
 import type { QueryConfig } from '@/types/query-config'
 
+// Sidebar tree (and the SQL-console table picker) consume only name, engine and
+// total_rows. total_bytes / readable_size were selected but never rendered, so
+// they are dropped to keep this per-database system.tables read as light as the
+// sidebar needs. total_rows stays: it drives the row-count badge in the tree.
 export const explorerTablesConfig: QueryConfig = {
   name: 'explorer-tables',
   description: 'List of tables in a database',
-  sql: `SELECT name, engine, total_rows, total_bytes, formatReadableSize(total_bytes) as readable_size FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name`,
-  columns: ['name', 'engine', 'total_rows', 'total_bytes', 'readable_size'],
+  sql: `SELECT name, engine, total_rows FROM system.tables WHERE database = {database:String} AND is_temporary = 0 AND name NOT LIKE '.inner_%' ORDER BY name`,
+  columns: ['name', 'engine', 'total_rows'],
   defaultParams: { database: 'default' },
 }

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -15,6 +15,7 @@ import { anomalyQueries } from './anomaly/anomaly-queries'
 import {
   explorerAllDependenciesConfig,
   explorerColumnsConfig,
+  explorerDatabaseCountsConfig,
   explorerDatabaseDependenciesConfig,
   explorerDatabasesConfig,
   explorerDdlConfig,
@@ -130,6 +131,7 @@ import { viewRefreshesConfig } from './tables/view-refreshes'
 export const queries: Array<QueryConfig> = [
   // Explorer
   explorerDatabasesConfig,
+  explorerDatabaseCountsConfig,
   explorerTablesConfig,
   explorerColumnsConfig,
   explorerDdlConfig,


### PR DESCRIPTION
## What & why

The Explorer page felt slow on first load. This makes the **first paint**
cheaper by taking a cluster-wide table enumeration off the sidebar's critical
path, streaming the database counts in separately, and stopping a hidden query
that ran against the user's table before they asked for it.

The data layer was already split per-resource and the tree already lazy-loads
(databases → tables on expand → columns on expand). The slowness was **eager /
hidden over-fetching around that lazy tree**, not a missing API.

## Diagnosis — what it was loading on first paint

For `/explorer?database=X&table=Y` (default tab = Overview):

1. **`/api/v1/explorer/databases` — the sidebar + empty-state gate.** It ran
   `LEFT JOIN system.tables … GROUP BY` to compute a per-database `item_count`
   (plus `engine/data_path/uuid`). But the sidebar tree renders **only the
   database name**, and the empty-state renders **name + engine + count**. So on
   every first load it enumerated *every table in the cluster* to produce a
   number the sidebar throws away — exactly the "load everything to count it"
   cost, sitting on the always-visible path.
2. **Hidden `Data` tab prefetch.** The `Data` tab is `forceMount`ed and was
   pre-seeded as "visited", so opening any table fired
   `SELECT * FROM db.table LIMIT 100` against the user's data **while the
   Overview tab was showing** — a real scan the user never sees.
3. **No `staleTime`** anywhere, so restoring expanded databases from
   `localStorage` re-fired `/tables` for each, and every remount refetched.
4. `/tables` also selected `total_bytes` + `formatReadableSize(...)` that the
   sidebar never renders.

## Fix

**Sidebar / first paint (the lever):**
- Slim `explorer-databases` to `SELECT name, engine FROM system.databases` —
  **zero `system.tables` touch**, so the sidebar paints on database metadata
  alone.
- New `explorer-database-counts` config (`SELECT database, count() … GROUP BY
  database`) served via the generic `/api/v1/tables/$name` route (no new route
  file). The empty-state renders the DB cards on names immediately and
  **streams the counts in**, showing a small skeleton per card until they
  resolve. (Also fixes `1 items` — `count()` arrives as a JSONEachRow string.)

**Stop hidden work / partial render:**
- Gate `<DataTab/>` behind `visitedTabs.has('data')` (matching DDL/Indexes), so
  the preview runs only when the tab is opened. It stays `forceMount`ed once
  opened, preserving pagination state.

**Caching (schema changes rarely):**
- 5-minute `staleTime` on the databases / tables / columns / counts queries so
  the localStorage auto-expand cascade and remounts don't refetch.
- `/tables`: drop unused `total_bytes` / `readable_size` (kept `total_rows` —
  it drives the tree's row-count badge).

## Eager fetches: before → after (cold first paint, Overview tab)

| Query | Before | After |
|---|---|---|
| `/databases` | JOIN + GROUP BY over all of `system.tables` | `SELECT name, engine` from `system.databases` (no table enumeration) |
| DB table counts | on the sidebar gate | separate query, streamed into empty-state only |
| Data-tab `SELECT * LIMIT 100` | fired hidden under Overview | fires only when Data tab opened |
| tables/columns refetch | every remount / expand-restore | cached 5m |

## Not duplicated
Global revisit caching (`placeholderData`/`gcTime`) is a separate PR — this PR
is first-load cost + lazy/streaming, plus per-endpoint `staleTime` for
rarely-changing schema (sanctioned). `staleTime` helps the auto-expand cascade
and revisits, **not** the cold first paint — the `/databases` split is what
moves cold paint.

## Known secondary cost
`/tables` still reads `total_rows` per database (a genuine `system.tables`
cost), because the tree shows a row-count badge. It is per-DB and lazy (only on
expand), not on the first-paint gate. If it proves slow on huge clusters, the
follow-up is to make the badge optional / lazy.

## Also in this PR: copyable database/table names

Same page, folded in here to avoid a second PR touching the same files.
Database/table names were hard to copy (visually truncated, easy to trigger
row navigation instead of text selection).

- **Breadcrumb** (`explorer-breadcrumb.tsx`): database/table segments now use
  `max-w-[…] truncate` — **CSS ellipsis only**, never a JS substring, so the
  full name is always in the DOM. `select-text` is set explicitly on the name
  span. A small ghost `CopyButton` (reused from `components/mcp/copy-button`,
  not a new component) sits next to each name — placed as a **sibling** of the
  breadcrumb link/page (not nested inside the anchor, avoiding invalid
  interactive-in-interactive nesting), with a `stopPropagation` wrapper and the
  existing component's built-in "copied" checkmark affordance.
- **Sidebar tree** (`tree/tree-node.tsx`, shared by database/table/column
  rows): the name span already used CSS `truncate` (no JS substring found).
  Added explicit `select-text` as a defensive guard against any ancestor
  disabling selection.
- **Caveat (be precise about what this does and doesn't guarantee):** the
  sidebar row is a real `<button>` with an `onClick`. A double-click gesture
  there fires that handler (as two clicks / navigation) rather than
  necessarily performing a text-selection — that gesture is
  browser/timing-dependent and **not** something this change can guarantee.
  What *is* guaranteed: the full name is in the DOM (not clipped by JS), and
  nothing disables `user-select` on it, so selection is possible (e.g.
  click-drag, or right-click → nothing extra needed). For a reliable one-click
  copy in the sidebar, use the breadcrumb's copy button once the item is
  selected. This needs a live check — flagged below.

## Testing
- `bun run test:query-config` → 1042 pass (parity, flip-safety, version-compat,
  explorer-catalog all green; TS + declarative configs kept in lockstep).
- `bun run type-check` → 229 (baseline 229, **0 new**), re-verified after the
  copy/truncate changes.
- `bun run type-check:test` → 230 (baseline 230, **0 new**), re-verified after
  the copy/truncate changes.
- `bunx biome check` clean on all touched files.
- **QA pending (no browser available here):** streaming/empty-state and
  Data-tab-gate behavior; breadcrumb copy button + "copied" affordance;
  whether double-click in the sidebar selects text vs. triggers row
  navigation (see caveat above) — should be verified live before merge.

Co-Authored-By: duyetbot <bot@duyet.net>
