### PR TITLE
feat(blog): add 8 SEO posts from GSC keyword expansion

### DIFF
--- a/apps/blog/src/content/blog/ch-ui-quickstart.md
+++ b/apps/blog/src/content/blog/ch-ui-quickstart.md
@@ -1,0 +1,76 @@
+---
+title: "5 min of ClickHouse: ch-ui — a lightweight ClickHouse dashboard"
+description: "What ch-ui is, how to run it with Docker, what it shows, and when a full monitoring tool like chmonitor is the better choice."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+ch-ui is a lightweight web UI for ClickHouse. It gives you a table browser, a query editor, and query history — enough for ad-hoc exploration without a full monitoring setup. This post covers what it does, how to run it, and where it fits alongside chmonitor.
+
+## What ch-ui is
+
+ch-ui (also referenced as `altinity-clickhouse-web` or `clickhouse-web` in some distributions) is an open-source browser-based interface for ClickHouse. It's not a monitoring tool — it's a development and exploration tool.
+
+**What it gives you:**
+- Query editor with result table view
+- Table browser with column types and row counts
+- Query history per session
+
+**What it doesn't give you:**
+- Historical metrics over time
+- Merge tracking
+- Replication monitoring
+- Multi-host dashboards
+- Alerts
+
+## Running with Docker
+
+```bash
+docker run -d \
+  --name ch-ui \
+  -p 8124:8123 \
+  -e CLICKHOUSE_HOST=your-clickhouse-host \
+  -e CLICKHOUSE_PORT=8123 \
+  -e CLICKHOUSE_USER=default \
+  -e CLICKHOUSE_PASSWORD=your-password \
+  ghcr.io/altinity/clickhouse-web:latest
+```
+
+Open `http://localhost:8124` and you're in the query editor.
+
+## When ch-ui is the right tool
+
+- Ad-hoc SQL exploration against a dev/test cluster
+- Quick schema inspection (what columns does this table have?)
+- Running one-off diagnostic queries without SSH
+- Sharing a query result with a teammate via browser
+
+## When you need more
+
+As soon as you need to know:
+- Is replication lagging right now?
+- Which query consumed the most memory yesterday?
+- How many parts does this table have, and is merge activity healthy?
+- What does query latency look like over the last 24 hours?
+
+…you need a monitoring tool. ch-ui shows you the current state of a query result, not trends over time.
+
+## ch-ui + chmonitor together
+
+They complement each other well:
+
+- **ch-ui**: ad-hoc queries, schema exploration, quick debugging
+- **chmonitor**: historical metrics, merge tracking, replication monitoring, slow query ranking, multi-host overview
+
+chmonitor gives you the time-series view that ch-ui doesn't. ch-ui gives you the SQL scratchpad that chmonitor doesn't.
+
+## How chmonitor complements this
+
+chmonitor's [Queries](https://docs.chmonitor.dev/guide/features/queries) page ranks queries by execution time and memory usage over time — the view ch-ui doesn't provide. The [Health](https://docs.chmonitor.dev/guide/features/health) page tracks replication, merges, and disk in a single grid for every host. The AI agent can run the same diagnostic queries you'd type into ch-ui, but across all hosts in your cluster.
+
+## Related
+
+- Docs: [Queries feature](https://docs.chmonitor.dev/guide/features/queries)
+- Docs: [Health page](https://docs.chmonitor.dev/guide/features/health)
+- Docs: [Docker deployment](https://docs.chmonitor.dev/operate/deploy/docker)
+- Next in the series: [The two kinds of ClickHouse indexes](/clickhouse-indexes-guide/)

--- a/apps/blog/src/content/blog/clickhouse-ai-agent-capabilities.md
+++ b/apps/blog/src/content/blog/clickhouse-ai-agent-capabilities.md
@@ -1,0 +1,91 @@
+---
+title: "5 min of ClickHouse: what an AI agent can actually do with your ClickHouse data"
+description: "AI agents for ClickHouse are not just chatbots — they're structured tools that can run queries, analyze patterns, and surface problems. Here's what's actually possible and where the line is."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+"AI agent for ClickHouse" is a phrase that covers a wide range of capabilities. Some agents are chat wrappers around a single query. Others are tool-calling systems that can inspect system tables, run queries, and take action. This post covers what's actually possible today and where the line is between useful and dangerous.
+
+## What "AI agent" means in this context
+
+An AI agent in the ClickHouse space is a system that:
+1. Reads system tables (`query_log`, `merges`, `replicas`, etc.)
+2. Runs diagnostic queries against your data
+3. Analyzes the results and presents findings
+4. Optionally takes action (with your confirmation)
+
+The key word is **tool-calling**. The agent doesn't generate SQL and hope — it uses structured tools that validate inputs, handle errors, and return typed results. The MCP protocol is the transport layer for those tools.
+
+## What the agent CAN do
+
+- **Run diagnostic queries**: "show me the slowest queries in the last 6 hours"
+- **Analyze query patterns**: "this query shape has been getting slower over the last week"
+- **Suggest schema improvements**: "adding a skip index on this column would skip 80% of parts"
+- **Check cluster health**: "replica X is readonly with queue_size = 45"
+- **Explain errors**: "MEMORY_LIMIT_EXCEEDED here is caused by GROUP BY on a 2M distinct key"
+- **Compare versions**: "your cluster is on 23.8, this feature requires 24.3"
+
+## What the agent CANNOT do
+
+- **Schema migrations without review**: an agent can suggest `ALTER TABLE`, but it shouldn't execute DDL on production without your approval
+- **DELETE / DROP operations**: destructive operations require explicit confirmation
+- **Production writes**: an agent monitoring read-only shouldn't insert data
+- **Cross-cluster operations**: an agent scoped to one ClickHouse instance shouldn't act on another
+
+## The MCP protocol briefly
+
+MCP (Model Context Protocol) is a standard for exposing tools to AI models. In the ClickHouse context:
+
+- Each system table query is a **tool** with a typed input (date range, table name, host)
+- The model calls the tool, gets structured results back
+- The model synthesizes those results into a human-readable answer
+
+This matters because it means the agent isn't generating SQL from a prompt and hoping it parses — it's calling a validated function with known return types.
+
+```json
+{
+  "tool": "query_slow_queries",
+  "arguments": {
+    "hostId": "production",
+    "since": "6h",
+    "min_elapsed": 1.0
+  }
+}
+```
+
+The tool returns typed results. The model explains them.
+
+## When it's useful vs when manual SQL is better
+
+**Agent is useful when:**
+- You don't know the exact system table name or column
+- You want a natural language summary of a complex diagnostic
+- You're exploring across multiple system tables at once
+- You want a repeatable diagnostic workflow ("every morning, check merge health")
+
+**Manual SQL is better when:**
+- You know exactly what you need and just need the data
+- You're writing a one-off investigation query
+- You need full control over the exact query plan and settings
+- You're debugging a specific edge case the agent hasn't been trained on
+
+## Setting one up
+
+The MCP server for ClickHouse exposes tools for:
+- Running queries against any configured host
+- Reading system tables (query_log, merges, replicas, parts, etc.)
+- Getting cluster metadata
+- Checking version and configuration
+
+The chmonitor agent connects to this via the built-in MCP endpoint. For standalone setups, the MCP server runs as a thin proxy that validates queries and returns results in a format the model can reason about.
+
+## How chmonitor does this
+
+chmonitor's AI agent has 20+ tools covering schema inspection, query execution, health checks, and optimization suggestions. It reads from the same system tables you would query manually, but it does so with typed inputs and structured outputs. The [AI Agent docs](https://docs.chmonitor.dev/guide/ai-agent) cover setup and configuration.
+
+## Related
+
+- Docs: [AI Agent setup](https://docs.chmonitor.dev/guide/ai-agent)
+- Docs: [MCP Server](https://docs.chmonitor.dev/guide/guides/mcp-server)
+- Previous in the series: [What to monitor in ClickHouse](/clickhouse-monitoring-101/)

--- a/apps/blog/src/content/blog/clickhouse-cost-optimization.md
+++ b/apps/blog/src/content/blog/clickhouse-cost-optimization.md
@@ -1,0 +1,120 @@
+---
+title: "5 min of ClickHouse: practical cost optimization without changing your schema"
+description: "Where ClickHouse actually costs money, how to find the expensive queries from system.query_log, and the TTL and merge-tuning levers that move storage costs."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+"Cost optimization" for ClickHouse usually means two things: the compute dollars spent running queries, and the storage dollars spent holding data. The lever for each is different, and the cheapest fix is almost always not what you think.
+
+## Where the cost actually is
+
+| Cost type | Primary driver | Primary lever |
+|---|---|---|
+| Compute | Large scans, expensive aggregations | Query rewrite, TTL, partition pruning |
+| Storage | Retention policy, part count, merge overhead | TTL, merge tuning, compression |
+| Memory pressure | GROUP BY / JOIN hash tables | Spill-to-disk settings, approximation functions |
+
+## Find the expensive queries
+
+```sql
+-- Top 20 queries by bytes read in the last 24h
+SELECT query_id, user,
+       formatReadableSize(sum(read_bytes)) AS total_read,
+       formatReadableSize(sum(written_bytes)) AS total_written,
+       count() AS exec_count,
+       round(avg(elapsed), 2) AS avg_elapsed
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 24 HOUR
+  AND type = 'QueryFinish'
+GROUP BY query_id, user
+ORDER BY sum(read_bytes) DESC
+LIMIT 20;
+```
+
+`read_bytes` is your cost signal. A query reading 100GB per run is costing you money every time it executes, regardless of how fast it returns.
+
+## TTL: the cheapest storage lever
+
+If you haven't set TTL on your tables, that's where most storage cost lives. Every row stored beyond its useful lifetime is a direct dollar cost.
+
+```sql
+-- Check current TTL on a table
+SELECT name, value
+FROM system.merge_tree_settings
+WHERE name = 'ttl';
+
+-- Set a TTL on a table
+ALTER TABLE events
+  MODIFY TTL event_date + INTERVAL 90 DAY;
+```
+
+TTL deletes data at merge time, not immediately — rows disappear when a part covering them is merged. That's fine for cost purposes, but don't rely on TTL for compliance deletes.
+
+## Part size and merge overhead
+
+ClickHouse's merge process is where CPU cost accumulates. Small parts (from frequent small inserts) force frequent merges:
+
+```sql
+-- Average part count and size per table
+SELECT database, table,
+       count() AS part_count,
+       round(avg(bytes_on_disk), 2) AS avg_part_bytes,
+       formatReadableSize(sum(bytes_on_disk)) AS total_size
+FROM system.parts
+WHERE active = 1
+GROUP BY database, table
+ORDER BY part_count DESC;
+```
+
+**Target**: part count below ~300 active parts per partition, average part size between 50MB–150MB. If you're at 1000+ small parts, the merge thread is burning CPU you don't need.
+
+## Query patterns that are expensive
+
+Three patterns appear repeatedly in `read_bytes` rankings:
+
+1. **Large scans without partition pruning**: `SELECT * FROM events` on a table with a date column — the WHERE clause is missing.
+2. **High-cardinality GROUP BY**: `GROUP BY user_id` on a table with 10M distinct users builds a hash table before emitting anything.
+3. **JOINs with the wrong side**: ClickHouse builds the hash table from the right table. Put the smaller table on the right.
+
+```sql
+-- Check cardinality before grouping
+SELECT uniq(user_id) AS distinct_users,
+       count() AS total_rows
+FROM events;
+```
+
+If `distinct_users` is close to `total_rows`, GROUP BY is doing almost nothing useful — consider whether the aggregation is necessary.
+
+## When to materialize vs query live
+
+Materialized views pre-compute aggregations at insert time. They cost CPU at insert time but save CPU at query time. If a query runs 100x more often than new data arrives, a materialized view pays for itself.
+
+If a query runs once per day against fresh data, materializing it is overhead.
+
+## Monitor cost over time
+
+Track `read_bytes` and `query_time` trends over time — not just spot checks. A query pattern that was cheap at 1M rows/day becomes expensive at 100M rows/day, and the ramp-up is gradual.
+
+```sql
+-- Daily query volume
+SELECT toDate(event_time) AS day,
+       count() AS queries,
+       formatReadableSize(sum(read_bytes)) AS total_read,
+       round(avg(elapsed), 2) AS avg_elapsed
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 30 DAY
+  AND type = 'QueryFinish'
+GROUP BY day ORDER BY day;
+```
+
+## How chmonitor surfaces this
+
+[Expensive Queries](https://docs.chmonitor.dev/guide/features/queries) ranks queries by read bytes and execution time, so you can find the actual cost drivers without hand-crafting aggregation queries. [Merge Performance](https://docs.chmonitor.dev/guide/features/parts) shows part counts and merge activity over time, so small-part problems are visible before they burn CPU.
+
+## Related
+
+- Docs: [Expensive Queries](https://docs.chmonitor.dev/guide/features/queries)
+- Docs: [Merge Performance](https://docs.chmonitor.dev/guide/features/parts)
+- Docs: [Troubleshooting](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Next in the series: [Views vs materialized views — and when projections are better](/clickhouse-materialized-views-guide/)

--- a/apps/blog/src/content/blog/clickhouse-grant-permissions.md
+++ b/apps/blog/src/content/blog/clickhouse-grant-permissions.md
@@ -1,0 +1,112 @@
+---
+title: "5 min of ClickHouse: GRANT permissions without giving away the keys"
+description: "The ClickHouse GRANT syntax you actually use, a least-privilege monitoring user pattern, and how FLUSH PRIVILEGES fits in."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+`GRANT` in ClickHouse is simpler than in Postgres but the mistake pattern is the same: a monitoring user with `ALL PRIVILEGES` "just to make it work." It works — until it doesn't. This post covers the syntax, a practical least-privilege pattern, and what `FLUSH PRIVILEGES` actually does.
+
+## The GRANT syntax
+
+```sql
+-- Grant on a single table
+GRANT SELECT ON my_db.events TO monitoring_user;
+
+-- Grant on an entire database
+GRANT SELECT ON my_db.* TO monitoring_user;
+
+-- Grant CREATE + INSERT on a database (e.g. for materialized views)
+GRANT CREATE TABLE, INSERT ON my_db.* TO monitoring_user;
+
+-- Multiple privileges at once
+GRANT SELECT, SHOW TABLES ON my_db.* TO monitoring_user;
+```
+
+Revoke the same way:
+
+```sql
+REVOKE SELECT ON my_db.* FROM monitoring_user;
+```
+
+## What privileges a monitoring user actually needs
+
+A read-only monitoring user only needs:
+
+| Privilege | Purpose |
+|---|---|
+| `SELECT` | Read system tables and any tables you want to surface in dashboards |
+| `SHOW TABLES` | List tables in a database |
+| `SHOW COLUMNS` | Inspect table schemas |
+
+That's it. No `INSERT`, no `CREATE TABLE`, no `ALTER`, no `DROP`.
+
+```sql
+-- Create the user (if not using an auth system that manages users)
+CREATE USER monitoring_user IDENTIFIED WITH plaintext_password BY 'secure-password';
+
+-- Grant the minimum
+GRANT SELECT, SHOW TABLES, SHOW COLUMNS ON my_db.* TO monitoring_user;
+```
+
+## The principle of least privilege for monitoring
+
+ClickHouse's monitoring tools need read access to system tables. The system tables a typical monitoring setup queries:
+
+- `system.query_log` — finished and running queries
+- `system.processes` — currently running queries
+- `system.merges` — active merge operations
+- `system.replicas` — replication status
+- `system.parts` — data parts per table
+- `system.settings` — current server settings
+- `system.asynchronous_metrics` — resource usage (CPU, memory, disk)
+- `system.errors` — recent errors
+- `system.metrics` — current metric values
+- `system.disk_usage` — disk space
+
+Granting `SELECT` on `my_db.*` covers the application tables. System tables are accessible to all users by default — no separate grant needed.
+
+```sql
+-- Verify the user can see what they need
+SET user = 'monitoring_user';
+SELECT count() FROM system.query_log LIMIT 1;
+SELECT count() FROM system.processes LIMIT 1;
+SELECT count() FROM system.replicas LIMIT 1;
+```
+
+## When you need CREATE TABLE
+
+Materialized views require the monitoring user to have `CREATE TABLE` and `INSERT` on the target database. If you're using chmonitor's advisor tools to suggest MV-backed rollups, the agent needs those grants on the database where it creates the target table.
+
+```sql
+-- For MV creation only, not general INSERT
+GRANT CREATE TABLE, INSERT ON my_db.* TO monitoring_user;
+```
+
+Keep this scoped to the database where MVs are actually created, not `*.*`.
+
+## FLUSH PRIVILEGES
+
+In ClickHouse, `GRANT` and `REVOKE` are applied immediately — there is no `FLUSH PRIVILEGES` statement. Privilege changes take effect without a reload. If you see documentation referencing it, that's from the MySQL world; ClickHouse doesn't need it.
+
+If you're using an external auth system (LDAP, Kerberos) alongside ClickHouse's internal user management, the external system handles its own privilege refresh — ClickHouse's internal grants are always live.
+
+## Auditing what a user can do
+
+```sql
+-- What grants does monitoring_user have?
+SHOW GRANTS FOR monitoring_user;
+
+-- Full grant tree including role grants
+SELECT * FROM system.grants WHERE user_name = 'monitoring_user';
+```
+
+## How chmonitor surfaces this
+
+chmonitor's connection form validates that the monitoring user can read the system tables it needs before saving the connection. If a grant is missing, it reports which table is inaccessible. The [ClickHouse User & Grants docs](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements) walk through the exact grants for a read-only monitoring user.
+
+## Related
+
+- Docs: [ClickHouse User & Grants](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements)
+- Docs: [Troubleshooting guide](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Previous in the series: [Escaping MEMORY_LIMIT_EXCEEDED](/clickhouse-memory-limit-exceeded/)

--- a/apps/blog/src/content/blog/clickhouse-indexes-guide.md
+++ b/apps/blog/src/content/blog/clickhouse-indexes-guide.md
@@ -1,0 +1,136 @@
+---
+title: "5 min of ClickHouse: the two kinds of indexes and when each one actually helps"
+description: "ClickHouse has primary keys and skip indexes, and they do completely different things. Here's what index_granularity means, and how bloom_filter, tokenbf_v1, and minmax skip indexes actually help your queries."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+Most ClickHouse users encounter two things called "indexes": the primary key (which orders data) and skip indexes (which let the engine skip data blocks). They're often confused because they do completely different things. Understanding both is the difference between a table that scans 10GB per query and one that scans 100MB.
+
+## The primary key / sorting key
+
+ClickHouse's primary key is not a uniqueness constraint. It's a **sort order**. Data is stored on disk in the order defined by the primary key, and queries with matching WHERE clauses can skip whole parts.
+
+```sql
+CREATE TABLE events (
+    event_date Date,
+    user_id UInt64,
+    event_type String,
+    payload String
+) ENGINE = MergeTree
+ORDER BY (event_date, user_id);
+```
+
+The `ORDER BY` above means events are physically stored sorted by date, then by user_id. A query filtering on `event_date = '2026-08-05'` can skip all parts that don't contain that date.
+
+### index_granularity
+
+`index_granularity` (default: 8192) controls how many rows share one primary-key index entry. A lower granularity means a finer index — more index entries, more skip precision, more memory for the index. A higher granularity means fewer entries, less index memory, coarser skipping.
+
+For most workloads, the default is fine. You rarely need to change it.
+
+```sql
+-- Check current setting
+SELECT name, value, changed
+FROM system.merge_tree_settings
+WHERE name = 'index_granularity';
+```
+
+## Skip indexes (data skipping indices)
+
+Skip indexes are secondary indexes stored alongside each data part. They describe the *range of values* in each granule of rows, so the engine can skip granules that can't match the WHERE clause.
+
+### minmax
+
+The simplest skip index. Stores min/max per column per granule. Only useful for range queries on low-cardinality columns (dates, small enums).
+
+```sql
+ALTER TABLE events
+  ADD INDEX idx_event_date event_date TYPE minmax GRANULARITY 4;
+```
+
+### bloom_filter
+
+The most useful skip index. A probabilistic data structure that answers "might this value be in this granule?" — false positives, no false negatives. Effective on columns used with `=` or `IN`.
+
+```sql
+ALTER TABLE events
+  ADD INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4;
+```
+
+### tokenbf_v1
+
+A bloom filter over *tokenized* values. Useful for columns where you search with `LIKE '%substring%'` or `match`. Tokenizes the value at index time so substring searches skip non-matching granules.
+
+```sql
+ALTER TABLE events
+  ADD INDEX idx_payload payload TYPE tokenbf_v1(256, 3, 0) GRANULARITY 4;
+```
+
+Parameters: `capacity` (expected distinct tokens), `num_hash_functions` (3–5 typical), `seed`. Higher capacity = more memory per granule.
+
+### set / minmax_sketch
+
+`set` stores the set of distinct values per granule (good for `IN` with small value lists). `minmax_sketch` is a compressed minmax for wide tables.
+
+## When skip indexes help
+
+Skip indexes help when:
+- Your WHERE clause filters on a column that is NOT part of the primary key
+- The column has low-to-medium cardinality relative to row count
+- The query scans many parts that can be skipped
+
+```sql
+-- Check if a skip index is being used
+EXPLAIN indexes = 1
+SELECT count()
+FROM events
+WHERE user_id = 12345;
+```
+
+The plan shows `idx_user_id` if the bloom filter was consulted.
+
+## When they don't help
+
+- The column is already in the primary key — the primary key is a better skip mechanism
+- The column is high-cardinality (e.g. UUID) — bloom filters give few true negatives
+- The query returns most rows regardless — skipping a few granules doesn't save much
+
+## Adding and removing
+
+```sql
+-- Add a skip index
+ALTER TABLE events ADD INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4;
+
+-- Remove it
+ALTER TABLE events DROP INDEX idx_user_id;
+
+-- Check existing skip indexes
+SELECT name, type, granularity
+FROM system.data_skipping_indices
+WHERE database = 'my_db';
+```
+
+## Practical example
+
+If you often query `events` by `user_id` and `user_id` is not in your primary key:
+
+```sql
+-- Current: primary key is (event_date), user_id is buried in payload
+-- Query: SELECT ... WHERE user_id = 123 — scans all dates
+
+ALTER TABLE events
+  ADD INDEX idx_user_id user_id TYPE bloom_filter GRANULARITY 4;
+```
+
+After the next merge, new parts carry the bloom filter. Existing parts get it at merge time too. Queries that filter by user_id will skip granules that don't contain that user.
+
+## How chmonitor surfaces this
+
+The [Explorer](https://docs.chmonitor.dev/guide/features/explorer) page surfaces `system.data_skipping_indices` so you can see which tables have skip indexes and which might benefit from one on a frequently filtered column.
+
+## Related
+
+- Docs: [Explorer feature](https://docs.chmonitor.dev/guide/features/explorer)
+- Docs: [Troubleshooting](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Next in the series: [ch-ui — a lightweight ClickHouse dashboard](/ch-ui-quickstart/)

--- a/apps/blog/src/content/blog/clickhouse-materialized-views-guide.md
+++ b/apps/blog/src/content/blog/clickhouse-materialized-views-guide.md
@@ -1,0 +1,114 @@
+---
+title: "5 min of ClickHouse: views vs materialized views — when projections are the better choice"
+description: "Regular views, materialized views, and projections each solve a different problem. Here's how to decide which one your query pattern actually needs."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+Three objects, one question: "I run this query shape a lot — can ClickHouse pre-organize it?" The answer depends on whether you need speed at query time, speed at insert time, or both.
+
+## Regular VIEW
+
+A regular `VIEW` is just a stored SELECT. It runs the query every time you query it.
+
+```sql
+CREATE VIEW active_users AS
+SELECT user_id, max(event_time) AS last_seen
+FROM events
+WHERE is_active = 1
+GROUP BY user_id;
+```
+
+**Cost**: zero storage overhead, zero insert overhead, full query cost every time.
+**Use when**: the query is cheap enough to run live, or you want always-fresh results.
+
+## MATERIALIZED VIEW
+
+A materialized view runs the SELECT against the *newly inserted block* and writes the result into a separate target table. The target table is a real table you query with a `-Merge` suffix for aggregate states.
+
+```sql
+-- Target table (you create this)
+CREATE TABLE events_daily (
+    event_date Date,
+    event_type String,
+    cnt UInt64
+) ENGINE = SummingMergeTree
+ORDER BY (event_date, event_type);
+
+-- Materialized view
+CREATE MATERIALIZED VIEW mv_events_daily
+TO events_daily AS
+SELECT event_date, event_type, count() AS cnt
+FROM events
+GROUP BY event_date, event_type;
+```
+
+**Cost**: extra write at insert time, extra storage for the target table.
+**Use when**: the aggregation is expensive and the source table is appended to frequently.
+
+Query it with the `-Merge` combinator for `AggregatingMergeTree` targets, or directly for `SummingMergeTree`:
+
+```sql
+SELECT event_date, event_type, sum(cnt)
+FROM events_daily
+GROUP BY event_date, event_type;
+```
+
+## PROJECTION
+
+A projection is an alternate sort order for the *same table* — a second physical copy stored pre-sorted. The query optimizer picks it automatically when it's a better match than the base ORDER BY.
+
+```sql
+ALTER TABLE events
+  ADD PROJECTION proj_by_user_day (
+      SELECT * ORDER BY user_id, event_date
+  );
+ALTER TABLE events MATERIALIZE PROJECTION proj_by_user_day;
+```
+
+**Cost**: roughly doubles storage for the projected columns; maintained automatically by ClickHouse.
+**Use when**: you have a common filter pattern that doesn't match the base ORDER BY.
+
+Verify it's being used:
+
+```sql
+EXPLAIN indexes = 1
+SELECT user_id, event_date, count()
+FROM events
+WHERE user_id = 123 AND event_date >= '2026-01-01'
+GROUP BY user_id, event_date;
+```
+
+The plan will name the projection when it's selected.
+
+## Decision guide
+
+| Scenario | Best choice |
+|---|---|
+| Query is cheap, always wants fresh data | Regular VIEW |
+| Heavy aggregation on an append-only table | MATERIALIZED VIEW |
+| Query pattern needs a different sort order than the base table | PROJECTION |
+| Pre-aggregated rollups across tables | MATERIALIZED VIEW with JOIN |
+| Filter optimization without schema changes | PROJECTION |
+
+## Common MV gotchas
+
+- **Schema changes**: if you `ALTER TABLE` the source, the MV target doesn't auto-update. You must `DROP MATERIALIZED VIEW` and recreate it, or accept stale data.
+- **Dependencies**: dropping the target table breaks the MV silently. Check `system.tables` for `materialized_view` engine entries before dropping anything.
+- **Ordering**: MV target ORDER BY must match the GROUP BY keys in the MV query for SummingMergeTree to collapse correctly.
+
+## Common projection gotchas
+
+- **Storage cost**: each projection duplicates its columns. Two projections on a wide table = 3x storage for those columns.
+- **Merge time**: projections are materialized during merges. Very large projections slow down merges.
+- **Partial projections**: you can project a subset of columns to reduce duplication.
+
+## How chmonitor surfaces this
+
+chmonitor's [query advisor](https://docs.chmonitor.dev/guide/ai-agent) can detect when a materialized view would help a slow query pattern, and the [query config system](https://docs.chmonitor.dev/guide/features/queries) surfaces query performance so you can decide whether pre-computation is worth the storage.
+
+## Related
+
+- Docs: [Query Optimization Advisor](https://docs.chmonitor.dev/guide/ai-agent)
+- Docs: [Expensive Queries](https://docs.chmonitor.dev/guide/features/queries)
+- Previous in the series: [Practical cost optimization](/clickhouse-cost-optimization/)

--- a/apps/blog/src/content/blog/clickhouse-monitoring-101.md
+++ b/apps/blog/src/content/blog/clickhouse-monitoring-101.md
@@ -1,0 +1,119 @@
+---
+title: "5 min of ClickHouse: what to monitor (and what not to)"
+description: "The four things that actually matter in ClickHouse monitoring, what system tables to check, and why a Grafana dashboard is not the goal — visibility is."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+ClickHouse has a lot of system tables. If you wire all of them into Grafana, you get a dashboard that shows everything and alerts on nothing. The practical approach is to monitor four things: query performance, merge activity, replication health, and disk/part count. Everything else is context for those four.
+
+## The four things that matter
+
+### 1. Query performance
+
+The system table: `system.query_log`. This is where slow queries, errors, and memory spikes land.
+
+```sql
+-- Slower than 1 second in the last hour
+SELECT query_id, user, elapsed, read_rows, read_bytes,
+       substring(query, 1, 120) AS query
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+  AND type = 'QueryFinish'
+  AND elapsed > 1
+ORDER BY elapsed DESC
+LIMIT 20;
+```
+
+What to watch: `elapsed` trending up on the same query shape, or new query shapes appearing in the slow list.
+
+### 2. Merge activity
+
+The system table: `system.merges`. Merges are ClickHouse's background compaction. When they pile up, it means either parts are too small or the server can't keep up.
+
+```sql
+SELECT database, table,
+       round(progress * 100, 2) AS pct,
+       elapsed,
+       formatReadableSize(total_size_bytes_compressed) AS total_size
+FROM system.merges
+ORDER BY elapsed DESC;
+```
+
+What to watch: merge count staying above ~3-4 per table for more than a few minutes, or merges with `elapsed` in the hours range.
+
+### 3. Replication health
+
+The system table: `system.replicas`. If a replica falls behind, reads keep working but writes stop on that replica, and data diverges.
+
+```sql
+SELECT database, table, replica_name,
+       is_leader, is_readonly,
+       future_parts, queue_size,
+       absolute_delay
+FROM system.replicas
+WHERE is_readonly = 1 OR queue_size > 10;
+```
+
+What to watch: `is_readonly = 1` (replica is not accepting writes) or `queue_size` growing without draining.
+
+### 4. Disk and part count
+
+The system table: `system.parts` and `system.disk_usage`.
+
+```sql
+-- Active part count per table
+SELECT database, table, count() AS parts,
+       formatReadableSize(sum(bytes_on_disk)) AS size
+FROM system.parts
+WHERE active = 1
+GROUP BY database, table
+ORDER BY parts DESC;
+
+-- Disk space
+SELECT name, path, formatReadableSize(total_space) AS total,
+       formatReadableSize(free_space) AS free,
+       round(free_space / total_space * 100, 1) AS pct_free
+FROM system.disks;
+```
+
+What to watch: part count above 300-500 per partition (indicates small parts from frequent small inserts), free space dropping below 20%.
+
+## What NOT to alert on
+
+- **CPU usage alone**: ClickHouse is designed to use available CPU. High CPU during merges is expected, not an incident.
+- **Memory usage alone**: ClickHouse allocates memory dynamically. Memory trending up during a large query is normal.
+- **Every system.errors entry**: some errors are transient (network hiccup to a replica). Alert on spike rate, not individual entries.
+
+## Multi-host monitoring
+
+If you run multiple ClickHouse hosts, you need one dashboard that shows all four categories across all hosts, not a separate tab per host. The mental model is: "is the cluster healthy?" not "is host 3 healthy?"
+
+chmonitor shows all four categories in a single view across every configured host — `system.query_log` and `system.merges` on one page, `system.replicas` and `system.disks` on the Health page, all filtered by host.
+
+## The query_log is your primary data source
+
+Almost every useful signal lives in `system.query_log`. Slow queries, errors, memory usage, read bytes, rows read — it's all there. Before adding any other system table to your monitoring, make sure you're extracting everything you need from `query_log` first.
+
+```sql
+-- Daily query volume trend (watch for sudden drops = monitoring gap)
+SELECT toDate(event_time) AS day,
+       count() AS queries,
+       round(avg(elapsed), 2) AS avg_elapsed,
+       formatReadableSize(sum(read_bytes)) AS total_read
+FROM system.query_log
+WHERE event_time > now() - INTERVAL 30 DAY
+  AND type = 'QueryFinish'
+GROUP BY day ORDER BY day;
+```
+
+## How chmonitor surfaces this
+
+chmonitor's [Overview](https://docs.chmonitor.dev/guide/features/overview) page combines query performance, merge activity, replication status, and disk usage in a single dashboard across all hosts. The AI agent can drill into any anomaly with natural language — "show me queries slower than 5s in the last 6 hours" — without hand-crafting aggregation queries.
+
+## Related
+
+- Docs: [Overview feature](https://docs.chmonitor.dev/guide/features/overview)
+- Docs: [Queries feature](https://docs.chmonitor.dev/guide/features/queries)
+- Docs: [Health page](https://docs.chmonitor.dev/guide/features/health)
+- Next in the series: [Materialized views vs projections](/clickhouse-materialized-views-guide/)

--- a/apps/blog/src/content/blog/clickhouse-upgrade-checklist.md
+++ b/apps/blog/src/content/blog/clickhouse-upgrade-checklist.md
@@ -1,0 +1,84 @@
+---
+title: "5 min of ClickHouse: a ClickHouse upgrade checklist that doesn't break monitoring"
+description: "Pre-upgrade checks, the system-table changes that light up new dashboard pages at each version, and post-upgrade grant verification — so you upgrade ClickHouse without losing visibility."
+date: 2026-08-05
+tag: 5 min of ClickHouse
+---
+
+ClickHouse upgrades are usually smooth, but the thing that breaks is almost always monitoring — not the data. A missing system table after a version jump, a grant that no longer applies, or a replica that never rejoins replication. This checklist covers what to verify before and after.
+
+## Before the upgrade
+
+```sql
+-- Current version
+SELECT version();
+
+-- Stuck mutations (wait or cancel before upgrading a replica)
+SELECT database, table, command, parts_to_do, is_done
+FROM system.mutations WHERE is_done = 0 ORDER BY create_time DESC;
+
+-- Active merges (should drain before upgrading)
+SELECT database, table, round(progress * 100, 2) AS pct, elapsed
+FROM system.merges ORDER BY elapsed DESC;
+
+-- Replication health
+SELECT database, table, replica_name, is_leader, is_readonly, future_parts, queue_size
+FROM system.replicas WHERE is_readonly = 1 OR queue_size > 10;
+```
+
+Back up settings you'll compare after:
+
+```sql
+SELECT * FROM system.merge_tree_settings INTO OUTFILE 'merge_tree_settings_before.csv' FORMAT CSV;
+SELECT * FROM system.settings INTO OUTFILE 'settings_before.csv' FORMAT CSV;
+```
+
+## System tables that appear at each version
+
+ClickHouse adds system tables across versions. chmonitor uses versioned SQL (`since` per query config) to automatically pick the right query, but it's useful to know what lights up:
+
+| Upgrade | New system tables / tables |
+|---|---|
+| 22.x → 23.x | `system.query_views_log`, `system.moves`, `system.dropped_tables`, `system.session_log` |
+| 23.x → 24.x | `system.user_processes`, `system.part_log`, `system.query_metric_log`, `system.query_cache`, `system.data_skipping_indices`, `system.view_refreshes` |
+| 24.x → 25.x | `system.distributed_ddl_queue`, additional async metrics, `system.replicated_merge_tree_settings` |
+
+Each new table unlocks new dashboard pages in chmonitor automatically.
+
+## After the upgrade
+
+Verify the connection is intact:
+
+```sql
+SELECT count() FROM system.query_log LIMIT 1;
+SELECT count() FROM system.processes LIMIT 1;
+SELECT count() FROM system.replicas LIMIT 1;
+```
+
+If any of these return 0 or error, the grants changed. ClickHouse occasionally tightens system-table visibility across majors — re-apply grants if the monitoring user lost access.
+
+Check replication rejoined:
+
+```sql
+SELECT database, table, replica_name, is_readonly, queue_size
+FROM system.replicas;
+```
+
+Roll forward one replica at a time. Confirm each rejoins (`is_readonly = 0`, `queue_size` draining) before touching the next.
+
+## Common gotchas
+
+- **system.part_log** requires `allow_experimental_part_log` on some older 23.x builds — chmonitor handles this gracefully by marking the Parts page optional when the table is missing.
+- **Grant syntax** changed in 23.x for some edge cases. Re-apply grants from a backup if you get "not found" errors after a major upgrade.
+- **Settings files** (`users.xml`, `merged.xml`) — if you manage these in config management, diff them against the version-specific defaults. New versions sometimes add new required settings.
+
+## How chmonitor surfaces this
+
+chmonitor stays connected through upgrades using version-aware queries. The [Health](https://docs.chmonitor.dev/guide/features/health) page highlights missing system tables and replication issues immediately after a version cutover. The AI agent can compare the system tables your version supports against what the dashboard expects and flag anything still absent.
+
+## Related
+
+- Docs: [ClickHouse User & Grants](https://docs.chmonitor.dev/guide/getting-started/clickhouse-requirements)
+- Docs: [Troubleshooting](https://docs.chmonitor.dev/guide/guides/troubleshooting)
+- Docs: [K8s health probes](https://docs.chmonitor.dev/operate/deploy/k8s#health-probes)
+- Previous in the series: [GRANT permissions without giving away the keys](/clickhouse-grant-permissions/)


### PR DESCRIPTION
Adds 8 blog posts targeting high-impression Google Search Console queries:

**Posts:**
1. `clickhouse-grant-permissions.md` — GRANT syntax, least-privilege monitoring user, flush+reload
2. `clickhouse-upgrade-checklist.md` — pre/post upgrade checks, system table changes per version
3. `clickhouse-cost-optimization.md` — read_bytes from query_log, TTL, part size, merge overhead
4. `clickhouse-materialized-views-guide.md` — VIEW vs MV vs projection decision guide
5. `clickhouse-indexes-guide.md` — primary key/granularity + skip indexes (bloom_filter, tokenbf_v1)
6. `ch-ui-quickstart.md` — ch-ui Docker quickstart, vs chmonitor
7. `clickhouse-monitoring-101.md` — the 4 things that matter (query_log, merges, replicas, disk)
8. `clickhouse-ai-agent-capabilities.md` — what an agent can/can't do, MCP protocol

All follow the existing "5 min of ClickHouse" format with SQL examples and a chmonitor hook at the end.

Co-Authored-By: duyetbot <bot@duyet.net>