### PR TITLE
feat(agent): rank AnyRouter models by usage for auto pick

### DIFF
--- a/apps/dashboard/src/lib/ai/__tests__/agent-model-registry.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/agent-model-registry.test.ts
@@ -100,13 +100,14 @@ describe('resolveDefaultAgentModel', () => {
   const setEnv = (vars: Record<string, string | undefined>) => env.set(vars)
   afterEach(() => env.restore())
 
-  test('returns DEFAULT_AGENT_MODEL when ANYROUTER_API_KEY is set', () => {
+  test('returns anyrouter:auto when ANYROUTER_API_KEY is set', () => {
     setEnv({
       ANYROUTER_API_KEY: 'ar-key',
       LLM_API_KEY: undefined,
       OPENROUTER_API_KEY: undefined,
     })
-    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+    // Dynamic top-by-usage alias; agent route resolves to a concrete model.
+    expect(resolveDefaultAgentModel()).toBe('anyrouter:auto')
   })
 
   test('returns FALLBACK_AGENT_MODEL when only LLM_API_KEY is set', () => {
@@ -133,7 +134,7 @@ describe('resolveDefaultAgentModel', () => {
       LLM_API_KEY: 'llm-key',
       OPENROUTER_API_KEY: undefined,
     })
-    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+    expect(resolveDefaultAgentModel()).toBe('anyrouter:auto')
   })
 
   test('falls back to DEFAULT_AGENT_MODEL when no keys are configured', () => {

--- a/apps/dashboard/src/lib/ai/__tests__/anyrouter-dynamic-models.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/anyrouter-dynamic-models.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Unit tests for AnyRouter dynamic catalog ranking + fail-soft merge.
+ * Fixtures mirror the public anyrouter.dev contract (list item + metrics
+ * request_count). No live network.
+ */
+
+import {
+  __resetAnyRouterDynamicCachesForTests,
+  ANYROUTER_AUTO_MODEL_ID,
+  type AnyRouterModelListItem,
+  buildAnyRouterAutoEntry,
+  buildAnyRouterDynamicModels,
+  extractPreferredRouters,
+  isAgentToolCapable,
+  isAnyRouterAutoModelId,
+  isAnyRouterRouterAlias,
+  loadAnyRouterDynamicModelEntries,
+  mergeAnyRouterDynamicModels,
+  pickTopUsageModelId,
+  type RankInput,
+  rankedToAgentModelEntry,
+  rankModelsByUsage,
+  selectMetricsCandidates,
+} from '../anyrouter-dynamic-models'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+function model(
+  partial: Partial<AnyRouterModelListItem> & { id: string }
+): AnyRouterModelListItem {
+  return {
+    name: partial.id,
+    context_length: 128_000,
+    capabilities: ['chat', 'streaming', 'function-calling'],
+    supported_parameters: ['max_tokens', 'temperature'],
+    ...partial,
+  }
+}
+
+const FIXTURE_CATALOG: AnyRouterModelListItem[] = [
+  model({
+    id: 'anyrouter/agent',
+    description: 'Agent router',
+    capabilities: ['chat', 'streaming', 'function-calling'],
+  }),
+  model({
+    id: 'anyrouter/free',
+    description: 'Free router',
+    capabilities: ['chat', 'streaming', 'function-calling'],
+  }),
+  model({
+    id: 'anyrouter/coding',
+    description: 'Coding router',
+    capabilities: ['chat', 'streaming', 'coding', 'function-calling'],
+  }),
+  model({
+    id: 'popular/tool-model',
+    description: 'Popular tool model',
+    capabilities: ['chat', 'function-calling', 'coding'],
+    pricing: { input_per_1m: 0.1, output_per_1m: 0.3 },
+  }),
+  model({
+    id: 'mid/tool-model',
+    description: 'Mid usage tool model',
+    capabilities: ['chat', 'function-calling'],
+    pricing: { input_per_1m: 1, output_per_1m: 2 },
+  }),
+  model({
+    id: 'rare/tool-model',
+    description: 'Rare tool model',
+    capabilities: ['chat', 'function-calling', 'coding'],
+  }),
+  model({
+    id: 'chat-only/no-tools',
+    description: 'Chat only — not agent-usable',
+    capabilities: ['chat', 'streaming'],
+    supported_parameters: ['max_tokens'],
+  }),
+  model({
+    id: 'param-tools/legacy',
+    description: 'Tools via supported_parameters only',
+    capabilities: ['chat'],
+    supported_parameters: ['tools', 'tool_choice', 'max_tokens'],
+  }),
+]
+
+const FIXTURE_METRICS: Record<string, number> = {
+  'popular/tool-model': 5000,
+  'mid/tool-model': 200,
+  'rare/tool-model': 3,
+  'param-tools/legacy': 900,
+  // chat-only intentionally omitted
+}
+
+function createMockFetch(opts?: {
+  listStatus?: number
+  metricsFailIds?: Set<string>
+  throwList?: boolean
+}): typeof fetch {
+  const listStatus = opts?.listStatus ?? 200
+  const metricsFail = opts?.metricsFailIds ?? new Set<string>()
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/models') || url.includes('/models?')) {
+      if (opts?.throwList) throw new Error('network down')
+      return new Response(JSON.stringify({ data: FIXTURE_CATALOG }), {
+        status: listStatus,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    const metricsMatch = url.match(/\/models\/([^/]+)\/metrics$/)
+    if (metricsMatch) {
+      const id = decodeURIComponent(metricsMatch[1]!)
+      if (metricsFail.has(id) || !(id in FIXTURE_METRICS)) {
+        return new Response(
+          JSON.stringify({ error: { code: 'model_not_found' } }),
+          { status: 404 }
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          model_id: id,
+          request_count: FIXTURE_METRICS[id],
+          success_count: FIXTURE_METRICS[id],
+          error_count: 0,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    }
+    return new Response('not found', { status: 404 })
+  }) as typeof fetch
+}
+
+beforeEach(() => {
+  __resetAnyRouterDynamicCachesForTests()
+})
+
+afterEach(() => {
+  __resetAnyRouterDynamicCachesForTests()
+  delete process.env.ANYROUTER_API_KEY
+  delete process.env.ANYROUTER_DYNAMIC_MODELS
+  delete process.env.ANYROUTER_TOP_MODELS_N
+  delete process.env.ANYROUTER_METRICS_CANDIDATE_CAP
+})
+
+// ── pure capability / filter ─────────────────────────────────────────────────
+
+describe('isAgentToolCapable / router helpers', () => {
+  test('detects function-calling capability', () => {
+    expect(
+      isAgentToolCapable(model({ id: 'x', capabilities: ['function-calling'] }))
+    ).toBe(true)
+  })
+
+  test('detects tools via supported_parameters', () => {
+    expect(
+      isAgentToolCapable(
+        model({
+          id: 'x',
+          capabilities: ['chat'],
+          supported_parameters: ['tools'],
+        })
+      )
+    ).toBe(true)
+  })
+
+  test('rejects chat-only models', () => {
+    expect(
+      isAgentToolCapable(
+        model({
+          id: 'x',
+          capabilities: ['chat'],
+          supported_parameters: ['max_tokens'],
+        })
+      )
+    ).toBe(false)
+  })
+
+  test('identifies router aliases and auto ids', () => {
+    expect(isAnyRouterRouterAlias('anyrouter/agent')).toBe(true)
+    expect(isAnyRouterRouterAlias('google/gemma')).toBe(false)
+    expect(isAnyRouterAutoModelId(ANYROUTER_AUTO_MODEL_ID)).toBe(true)
+    expect(isAnyRouterAutoModelId('anyrouter:google/gemma')).toBe(false)
+  })
+})
+
+// ── candidate selection ──────────────────────────────────────────────────────
+
+describe('selectMetricsCandidates', () => {
+  test('excludes router aliases and non-tool models, prefers coding', () => {
+    const selected = selectMetricsCandidates(FIXTURE_CATALOG, 10)
+    const ids = selected.map((m) => m.id)
+    expect(ids).not.toContain('anyrouter/agent')
+    expect(ids).not.toContain('chat-only/no-tools')
+    // coding-capable tool models come first
+    expect(ids[0]).toBe('popular/tool-model')
+    expect(ids).toContain('param-tools/legacy')
+  })
+
+  test('respects maxCandidates cap', () => {
+    expect(selectMetricsCandidates(FIXTURE_CATALOG, 2)).toHaveLength(2)
+    expect(selectMetricsCandidates(FIXTURE_CATALOG, 0)).toHaveLength(0)
+  })
+})
+
+// ── rank by usage ────────────────────────────────────────────────────────────
+
+describe('rankModelsByUsage', () => {
+  const rows: RankInput[] = FIXTURE_CATALOG.filter(
+    (m) => !isAnyRouterRouterAlias(m.id)
+  ).map((m) => ({
+    model: m,
+    requestCount: FIXTURE_METRICS[m.id] ?? null,
+  }))
+
+  test('sorts higher request_count first', () => {
+    const ranked = rankModelsByUsage(rows, 10)
+    expect(ranked.map((r) => r.modelId)).toEqual([
+      'popular/tool-model',
+      'param-tools/legacy',
+      'mid/tool-model',
+      'rare/tool-model',
+    ])
+    expect(ranked[0]!.requestCount).toBe(5000)
+  })
+
+  test('excludes non-tool models even if they had metrics', () => {
+    const withChatOnly: RankInput[] = [
+      ...rows,
+      {
+        model: model({
+          id: 'chat-only/no-tools',
+          capabilities: ['chat'],
+          supported_parameters: ['max_tokens'],
+        }),
+        requestCount: 999_999,
+      },
+    ]
+    const ranked = rankModelsByUsage(withChatOnly, 10)
+    expect(ranked.map((r) => r.modelId)).not.toContain('chat-only/no-tools')
+  })
+
+  test('models without metrics rank last', () => {
+    const mixed: RankInput[] = [
+      {
+        model: model({
+          id: 'no-metrics/a',
+          capabilities: ['function-calling'],
+        }),
+        requestCount: null,
+      },
+      {
+        model: model({
+          id: 'has-metrics/b',
+          capabilities: ['function-calling'],
+        }),
+        requestCount: 10,
+      },
+      {
+        model: model({
+          id: 'no-metrics/c',
+          capabilities: ['function-calling'],
+        }),
+        requestCount: undefined,
+      },
+    ]
+    const ranked = rankModelsByUsage(mixed, 10)
+    expect(ranked.map((r) => r.modelId)).toEqual([
+      'has-metrics/b',
+      'no-metrics/a',
+      'no-metrics/c',
+    ])
+  })
+
+  test('limit N caps the dynamic top list', () => {
+    expect(rankModelsByUsage(rows, 2)).toHaveLength(2)
+    expect(rankModelsByUsage(rows, 2)[0]!.modelId).toBe('popular/tool-model')
+    expect(rankModelsByUsage(rows, 0)).toHaveLength(0)
+  })
+})
+
+// ── routers + auto + merge ───────────────────────────────────────────────────
+
+describe('routers, auto, merge', () => {
+  test('extractPreferredRouters keeps preferred order when present', () => {
+    const routers = extractPreferredRouters(FIXTURE_CATALOG)
+    expect(routers.map((r) => r.modelId)).toEqual([
+      'anyrouter/agent',
+      'anyrouter/free',
+      'anyrouter/coding',
+    ])
+    expect(routers.every((r) => r.isRouterAlias)).toBe(true)
+  })
+
+  test('pickTopUsageModelId prefers positive usage tool models', () => {
+    const ranked = rankModelsByUsage(
+      FIXTURE_CATALOG.filter((m) => !isAnyRouterRouterAlias(m.id)).map((m) => ({
+        model: m,
+        requestCount: FIXTURE_METRICS[m.id] ?? null,
+      })),
+      5
+    )
+    expect(pickTopUsageModelId(ranked)).toBe('anyrouter:popular/tool-model')
+  })
+
+  test('buildAnyRouterAutoEntry documents current top model', () => {
+    const auto = buildAnyRouterAutoEntry('popular/tool-model')
+    expect(auto.id).toBe(ANYROUTER_AUTO_MODEL_ID)
+    expect(auto.description).toContain('popular/tool-model')
+  })
+
+  test('merge keeps static on id collision and prepends dynamic-only', () => {
+    const staticModels = [
+      {
+        id: 'anyrouter:mid/tool-model',
+        label: 'static-mid',
+      },
+      { id: 'openrouter:openrouter/free', label: 'or-free' },
+    ]
+    const dynamic = [
+      { id: ANYROUTER_AUTO_MODEL_ID, label: 'auto' },
+      { id: 'anyrouter:popular/tool-model', label: 'dyn-popular' },
+      { id: 'anyrouter:mid/tool-model', label: 'dyn-mid-should-lose' },
+    ]
+    const merged = mergeAnyRouterDynamicModels(staticModels, dynamic)
+    expect(merged.map((m) => m.id)).toEqual([
+      ANYROUTER_AUTO_MODEL_ID,
+      'anyrouter:popular/tool-model',
+      'anyrouter:mid/tool-model',
+      'openrouter:openrouter/free',
+    ])
+    expect(merged.find((m) => m.id === 'anyrouter:mid/tool-model')?.label).toBe(
+      'static-mid'
+    )
+  })
+
+  test('rankedToAgentModelEntry sets provider anyrouter + usage metadata', () => {
+    const ranked = rankModelsByUsage(
+      [
+        {
+          model: model({
+            id: 'popular/tool-model',
+            capabilities: ['function-calling'],
+          }),
+          requestCount: 42,
+        },
+      ],
+      1
+    )[0]!
+    const entry = rankedToAgentModelEntry(ranked, 0)
+    expect(entry.provider).toBe('anyrouter')
+    expect(entry.id).toBe('anyrouter:popular/tool-model')
+    expect(entry.dynamic).toBe(true)
+    expect(entry.usageRank).toBe(1)
+    expect(entry.requestCount).toBe(42)
+    expect(entry.supportsTools).toBe(true)
+  })
+})
+
+// ── I/O with mock fetch ──────────────────────────────────────────────────────
+
+describe('buildAnyRouterDynamicModels (mocked fetch)', () => {
+  test('produces auto + routers + usage-ordered anyrouter entries', async () => {
+    process.env.ANYROUTER_API_KEY = 'test-key'
+    const { entries, topUsageId } = await buildAnyRouterDynamicModels({
+      fetchImpl: createMockFetch(),
+      forceRefresh: true,
+      topN: 3,
+      candidateCap: 10,
+    })
+
+    expect(entries[0]!.id).toBe(ANYROUTER_AUTO_MODEL_ID)
+    expect(entries.some((e) => e.modelId === 'anyrouter/agent')).toBe(true)
+    const usage = entries.filter((e) => e.source === 'usage-ranked')
+    expect(usage.map((u) => u.modelId)).toEqual([
+      'popular/tool-model',
+      'param-tools/legacy',
+      'mid/tool-model',
+    ])
+    expect(topUsageId).toBe('anyrouter:popular/tool-model')
+    // auto description mentions the live top model
+    expect(entries[0]!.description).toContain('popular/tool-model')
+  })
+
+  test('auto pick resolves to top-ranked dynamic model from fixtures', async () => {
+    const { topUsageId } = await buildAnyRouterDynamicModels({
+      fetchImpl: createMockFetch(),
+      forceRefresh: true,
+    })
+    expect(topUsageId).toBe('anyrouter:popular/tool-model')
+    expect(topUsageId).not.toBe('anyrouter:rare/tool-model')
+  })
+
+  test('list failure throws from build (caller fail-softs)', async () => {
+    await expect(
+      buildAnyRouterDynamicModels({
+        fetchImpl: createMockFetch({ listStatus: 503 }),
+        forceRefresh: true,
+      })
+    ).rejects.toThrow(/AnyRouter models list error: 503/)
+  })
+
+  test('loadAnyRouterDynamicModelEntries returns [] on fetch throw (fail-soft)', async () => {
+    process.env.ANYROUTER_API_KEY = 'test-key'
+    const entries = await loadAnyRouterDynamicModelEntries({
+      fetchImpl: createMockFetch({ throwList: true }),
+      forceRefresh: true,
+    })
+    expect(entries).toEqual([])
+  })
+
+  test('loadAnyRouterDynamicModelEntries returns [] when AnyRouter unconfigured', async () => {
+    delete process.env.ANYROUTER_API_KEY
+    const entries = await loadAnyRouterDynamicModelEntries({
+      forceRefresh: true,
+    })
+    expect(entries).toEqual([])
+  })
+
+  test('missing metrics for some candidates still ranks the rest', async () => {
+    const { entries } = await buildAnyRouterDynamicModels({
+      fetchImpl: createMockFetch({
+        metricsFailIds: new Set(['mid/tool-model']),
+      }),
+      forceRefresh: true,
+      topN: 5,
+    })
+    const usage = entries.filter((e) => e.source === 'usage-ranked')
+    expect(usage[0]!.modelId).toBe('popular/tool-model')
+    // mid still present (candidate) but with requestCount 0 → after scored ones
+    const mid = usage.find((u) => u.modelId === 'mid/tool-model')
+    expect(mid?.requestCount).toBe(0)
+  })
+})
+
+// ── endpoint-style merge simulation ──────────────────────────────────────────
+
+describe('models endpoint merge simulation', () => {
+  test('with AnyRouter configured, dynamic entries prepend and order by usage', async () => {
+    process.env.ANYROUTER_API_KEY = 'ar-key'
+    const dynamic = await loadAnyRouterDynamicModelEntries({
+      fetchImpl: createMockFetch(),
+      forceRefresh: true,
+      topN: 2,
+    })
+    const staticModels = [
+      {
+        id: 'anyrouter:google/gemma-4-26b-a4b-it',
+        modelId: 'google/gemma-4-26b-a4b-it',
+        provider: 'anyrouter',
+        name: 'google/gemma-4-26b-a4b-it',
+        description: 'static',
+        contextLength: 262_144,
+        formattedContextLength: '262K',
+        isFree: false,
+        available: true,
+      },
+      {
+        id: 'openrouter:openrouter/free',
+        modelId: 'openrouter/free',
+        provider: 'openrouter',
+        name: 'openrouter/free',
+        description: 'static or',
+        contextLength: 200_000,
+        formattedContextLength: '200K',
+        isFree: true,
+        available: true,
+      },
+    ]
+    const merged = mergeAnyRouterDynamicModels(staticModels, dynamic)
+    expect(merged[0]!.id).toBe(ANYROUTER_AUTO_MODEL_ID)
+    expect(merged.some((m) => m.id === 'anyrouter:popular/tool-model')).toBe(
+      true
+    )
+    // usage order among dynamic concrete models
+    const dynConcrete = merged.filter(
+      (m) =>
+        m.id.startsWith('anyrouter:') &&
+        m.id !== ANYROUTER_AUTO_MODEL_ID &&
+        !m.id.startsWith('anyrouter:anyrouter/')
+    )
+    const popularIdx = dynConcrete.findIndex(
+      (m) => m.id === 'anyrouter:popular/tool-model'
+    )
+    const legacyIdx = dynConcrete.findIndex(
+      (m) => m.id === 'anyrouter:param-tools/legacy'
+    )
+    expect(popularIdx).toBeGreaterThanOrEqual(0)
+    expect(legacyIdx).toBeGreaterThan(popularIdx)
+    // static still present
+    expect(
+      merged.some((m) => m.id === 'anyrouter:google/gemma-4-26b-a4b-it')
+    ).toBe(true)
+    expect(merged.some((m) => m.id === 'openrouter:openrouter/free')).toBe(true)
+  })
+
+  test('unconfigured / throw keeps static registry path working', async () => {
+    delete process.env.ANYROUTER_API_KEY
+    const dynamic = await loadAnyRouterDynamicModelEntries({
+      forceRefresh: true,
+    })
+    expect(dynamic).toEqual([])
+    const staticModels = [
+      { id: 'openrouter:openrouter/free', provider: 'openrouter' },
+    ]
+    const merged = mergeAnyRouterDynamicModels(staticModels, dynamic)
+    expect(merged).toEqual(staticModels)
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent-model-registry.ts
+++ b/apps/dashboard/src/lib/ai/agent-model-registry.ts
@@ -36,17 +36,26 @@ export const FALLBACK_AGENT_MODEL = 'openrouter/free'
 /**
  * Resolve the best default model for the current deployment.
  *
- * Server-only — reads provider env vars. The preferred default
- * (`DEFAULT_AGENT_MODEL`, AnyRouter Gemma) requires `ANYROUTER_API_KEY`.
- * If AnyRouter is not configured, fall back to OpenRouter's free
- * auto-router which works with the documented `LLM_API_KEY`-only setup.
+ * Server-only — reads provider env vars.
+ *
+ * When AnyRouter is configured, prefer `anyrouter:auto` — the models endpoint
+ * and agent route resolve it to the current top tool-capable model by
+ * AnyRouter usage (`request_count`), falling back to {@link DEFAULT_AGENT_MODEL}
+ * (curated Gemma) if the dynamic catalog is unavailable.
+ *
+ * If AnyRouter is not configured, fall back to OpenRouter's free auto-router
+ * which works with the documented `LLM_API_KEY`-only setup.
  */
 export function resolveDefaultAgentModel(): string {
-  if (process.env.ANYROUTER_API_KEY) return DEFAULT_AGENT_MODEL
+  if (process.env.ANYROUTER_API_KEY) {
+    // Lazy import-free constant — keep registry free of the dynamic module
+    // cycle (dynamic-models imports isFreeAgentModel from this file).
+    return 'anyrouter:auto'
+  }
   if (process.env.LLM_API_KEY || process.env.OPENROUTER_API_KEY) {
     return FALLBACK_AGENT_MODEL
   }
-  // No provider configured — return the preferred default; the caller's
+  // No provider configured — return the curated static default; the caller's
   // provider preflight will surface a clear 503 if it actually runs.
   return DEFAULT_AGENT_MODEL
 }

--- a/apps/dashboard/src/lib/ai/agent-models.test.ts
+++ b/apps/dashboard/src/lib/ai/agent-models.test.ts
@@ -51,9 +51,12 @@ describe('resolveDefaultAgentModel', () => {
     if (originalOpenRouter) process.env.OPENROUTER_API_KEY = originalOpenRouter
   })
 
-  test('prefers AnyRouter Gemma when ANYROUTER_API_KEY is set', () => {
+  test('prefers anyrouter:auto when ANYROUTER_API_KEY is set', () => {
     process.env.ANYROUTER_API_KEY = 'ar-test'
-    expect(resolveDefaultAgentModel()).toBe(DEFAULT_AGENT_MODEL)
+    // Auto resolves at request time to top-by-usage; static Gemma is the
+    // fail-soft concrete fallback (DEFAULT_AGENT_MODEL).
+    expect(resolveDefaultAgentModel()).toBe('anyrouter:auto')
+    expect(DEFAULT_AGENT_MODEL).toBe('anyrouter:google/gemma-4-26b-a4b-it')
   })
 
   test('falls back to openrouter/free when only LLM_API_KEY is set', () => {

--- a/apps/dashboard/src/lib/ai/agent/provider-chat-model.ts
+++ b/apps/dashboard/src/lib/ai/agent/provider-chat-model.ts
@@ -7,7 +7,11 @@
 
 import type { LanguageModel } from 'ai'
 
-import { resolveDefaultAgentModel } from '../agent-model-registry'
+import {
+  DEFAULT_AGENT_MODEL,
+  resolveDefaultAgentModel,
+} from '../agent-model-registry'
+import { isAnyRouterAutoModelId } from '../anyrouter-dynamic-models'
 import { parseModelId, resolveProvider } from '../providers'
 import { createOpenAI } from '@ai-sdk/openai'
 import { createAnyRouter } from '@anyr/ai-sdk-provider'
@@ -96,8 +100,15 @@ export function resolveAgentChatModel({
    */
   readonly apiKey?: string
 }): ResolvedAgentChatModel {
-  const resolved = resolveProvider(model, apiKey)
-  const { model: modelId } = parseModelId(model)
+  // Sync safety net: callers (agent route / followups) should resolve
+  // `anyrouter:auto` asynchronously first. If auto still arrives here (e.g.
+  // DEFAULT_MODEL module init, tests), fall back to the curated static model
+  // rather than sending the literal id `auto` upstream.
+  const effectiveModel = isAnyRouterAutoModelId(model)
+    ? DEFAULT_AGENT_MODEL
+    : model
+  const resolved = resolveProvider(effectiveModel, apiKey)
+  const { model: modelId } = parseModelId(effectiveModel)
 
   if (resolved.isOpenRouter) {
     const meta = getAppMetadata(referer)

--- a/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
+++ b/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
@@ -15,9 +15,18 @@
  * metrics for the entire ~180-model catalog on every request.
  */
 
-import { isFreeAgentModel } from './agent-model-registry'
 import { isProviderConfigured } from './providers'
 import { formatCompactNumber } from '@/lib/format-number'
+
+/**
+ * Local free-tier check — intentionally duplicated from
+ * `isFreeAgentModel` in agent-model-registry so this module does not
+ * import the registry (agent route tests mock that module and would
+ * otherwise break on a missing named export during dynamic load).
+ */
+function isFreeTierModelId(modelId: string): boolean {
+  return modelId === 'openrouter/free' || modelId.endsWith(':free')
+}
 
 // ── Types (AnyRouter public catalog shape) ───────────────────────────────────
 
@@ -186,7 +195,7 @@ function parsePricePerMillion(
 }
 
 function isListedAsFree(model: AnyRouterModelListItem): boolean {
-  if (isFreeAgentModel(model.id)) return true
+  if (isFreeTierModelId(model.id)) return true
   const pair = readPricePair(model.pricing)
   if (pair && pair.input === 0 && pair.output === 0) return true
   return false

--- a/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
+++ b/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
@@ -1,0 +1,664 @@
+/**
+ * AnyRouter dynamic catalog + usage ranking for the agent model picker.
+ *
+ * ## API contract (verified against anyrouter.dev, 2026-08-09)
+ *
+ * - `GET {base}/models` returns `{ data: AnyRouterModelListItem[] }`. Query
+ *   params like `sort=usage` / `order=usage` are **not** supported — the list
+ *   order is the same catalog order regardless.
+ * - Per-model usage lives at `GET {base}/models/{id}/metrics` → field
+ *   `request_count` (and success/error/latency stats). Router aliases
+ *   (`anyrouter/agent`, `anyrouter/free`, …) often 404 metrics; rank real
+ *   model ids only, and surface routers as explicit non-ranked choices.
+ *
+ * Candidate scoring is capped + cached so the models endpoint never fetches
+ * metrics for the entire ~180-model catalog on every request.
+ */
+
+import { isFreeAgentModel } from './agent-model-registry'
+import { isProviderConfigured } from './providers'
+import { formatCompactNumber } from '@/lib/format-number'
+
+// ── Types (AnyRouter public catalog shape) ───────────────────────────────────
+
+/**
+ * Subset of `GET /api/v1/models` list items we actually read.
+ * Extra fields are ignored.
+ */
+export interface AnyRouterModelListItem {
+  id: string
+  name?: string
+  description?: string
+  context_length?: number
+  capabilities?: string[]
+  supported_parameters?: string[]
+  category?: string
+  pricing?: {
+    prompt?: string | number
+    completion?: string | number
+    input_per_1m?: number
+    output_per_1m?: number
+  }
+  architecture?: {
+    input_modalities?: string[]
+    output_modalities?: string[]
+    modality?: string | string[]
+  }
+  top_provider?: {
+    max_completion_tokens?: number | null
+  }
+}
+
+/** Subset of `GET /api/v1/models/{id}/metrics`. */
+export interface AnyRouterModelMetrics {
+  model_id?: string
+  request_count?: number
+  success_count?: number
+  error_count?: number
+}
+
+/** Ranked candidate ready to merge into the agent models list. */
+export interface RankedAnyRouterModel {
+  /** Upstream model id (e.g. `google/gemma-4-26b-a4b-it`) */
+  modelId: string
+  /** Full agent id `anyrouter:{modelId}` */
+  id: string
+  name: string
+  description: string
+  contextLength: number
+  maxOutputTokens?: number
+  isFree: boolean
+  supportsTools: boolean
+  supportsStreaming: boolean
+  supportsVision: boolean
+  pricing?: { inputPerMillion: number; outputPerMillion: number }
+  /** Usage score used for ordering; missing metrics → 0 */
+  requestCount: number
+  /** True when this entry is a router alias (anyrouter/*), not a concrete model */
+  isRouterAlias: boolean
+  /** Source of the entry */
+  source: 'usage-ranked' | 'router-alias' | 'auto'
+}
+
+/** Shape shared with GET /api/v1/agents/models. */
+export interface AgentModelListEntry {
+  id: string
+  modelId: string
+  provider: string
+  name: string
+  description: string
+  contextLength: number
+  formattedContextLength: string
+  maxOutputTokens?: number
+  formattedMaxOutputTokens?: string
+  isFree: boolean
+  available: boolean
+  pricing?: { inputPerMillion: number; outputPerMillion: number }
+  supportsTools?: boolean
+  supportsStreaming?: boolean
+  supportsVision?: boolean
+  /** Optional usage rank metadata (dynamic AnyRouter only). */
+  usageRank?: number
+  requestCount?: number
+  dynamic?: boolean
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Synthetic picker id: resolves at request time to the current top-by-usage model. */
+export const ANYROUTER_AUTO_MODEL_ID = 'anyrouter:auto'
+
+/** Router aliases we always surface when present in the catalog. */
+export const ANYROUTER_PREFERRED_ROUTER_IDS = [
+  'anyrouter/agent',
+  'anyrouter/free',
+  'anyrouter/coding',
+] as const
+
+/** Default max models to score with metrics (bounded fan-out). */
+export const DEFAULT_METRICS_CANDIDATE_CAP = 24
+
+/** Default max usage-ranked models to merge into the picker. */
+export const DEFAULT_TOP_N = 8
+
+/** In-memory cache TTL for list + metrics aggregate (ms). Matches CDN ~300s. */
+export const ANYROUTER_DYNAMIC_CACHE_TTL_MS = 300_000
+
+/** Concurrency for per-model metrics fetches. */
+const METRICS_CONCURRENCY = 6
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * True when the model can drive the agent tool loop.
+ * Prefer `capabilities` (`function-calling`); fall back to
+ * `supported_parameters` tools/tool_choice (OpenRouter-style).
+ */
+export function isAgentToolCapable(model: AnyRouterModelListItem): boolean {
+  const caps = model.capabilities ?? []
+  if (caps.some((c) => c.toLowerCase() === 'function-calling')) return true
+  const params = model.supported_parameters ?? []
+  return params.includes('tools') || params.includes('tool_choice')
+}
+
+/** Router / auto-routing catalog ids (no concrete upstream model). */
+export function isAnyRouterRouterAlias(modelId: string): boolean {
+  return modelId.startsWith('anyrouter/')
+}
+
+export function isAnyRouterAutoModelId(fullId: string): boolean {
+  // `anyrouter:auto` (preferred) or bare `auto` under anyrouter provider.
+  if (fullId === ANYROUTER_AUTO_MODEL_ID) return true
+  if (fullId === 'auto') return true
+  const colon = fullId.indexOf(':')
+  if (colon <= 0) return false
+  const provider = fullId.slice(0, colon)
+  const model = fullId.slice(colon + 1)
+  return (
+    provider === 'anyrouter' && (model === 'auto' || model === 'anyrouter/auto')
+  )
+}
+
+function readPricePair(
+  pricing: AnyRouterModelListItem['pricing']
+): { input: number; output: number } | null {
+  if (!pricing) return null
+  const input =
+    typeof pricing.input_per_1m === 'number'
+      ? pricing.input_per_1m
+      : Number(pricing.prompt)
+  const output =
+    typeof pricing.output_per_1m === 'number'
+      ? pricing.output_per_1m
+      : Number(pricing.completion)
+  if (!Number.isFinite(input) || !Number.isFinite(output)) return null
+  return { input, output }
+}
+
+function parsePricePerMillion(
+  pricing: AnyRouterModelListItem['pricing']
+): { inputPerMillion: number; outputPerMillion: number } | undefined {
+  const pair = readPricePair(pricing)
+  if (!pair) return undefined
+  // Omit zero/zero so free models follow free-tier UX.
+  if (pair.input === 0 && pair.output === 0) return undefined
+  return { inputPerMillion: pair.input, outputPerMillion: pair.output }
+}
+
+function isListedAsFree(model: AnyRouterModelListItem): boolean {
+  if (isFreeAgentModel(model.id)) return true
+  const pair = readPricePair(model.pricing)
+  if (pair && pair.input === 0 && pair.output === 0) return true
+  return false
+}
+
+function supportsVision(model: AnyRouterModelListItem): boolean {
+  const modalities = model.architecture?.input_modalities ?? []
+  if (modalities.some((m) => m.toLowerCase().includes('image'))) return true
+  const caps = model.capabilities ?? []
+  return caps.some((c) => c.toLowerCase() === 'vision')
+}
+
+function supportsStreaming(model: AnyRouterModelListItem): boolean {
+  const outs = model.architecture?.output_modalities
+  if (outs?.includes('text')) return true
+  const caps = model.capabilities ?? []
+  return caps.some((c) => c.toLowerCase() === 'streaming')
+}
+
+/**
+ * Pick a bounded set of catalog models to fetch metrics for.
+ * Prefer tool-capable + coding; skip router aliases (metrics usually 404).
+ */
+export function selectMetricsCandidates(
+  models: readonly AnyRouterModelListItem[],
+  maxCandidates: number = DEFAULT_METRICS_CANDIDATE_CAP
+): AnyRouterModelListItem[] {
+  if (maxCandidates <= 0) return []
+
+  const toolCapable = models.filter(
+    (m) => m.id && !isAnyRouterRouterAlias(m.id) && isAgentToolCapable(m)
+  )
+
+  // Prefer coding-capable within the tool-capable set, preserve relative order.
+  const coding: AnyRouterModelListItem[] = []
+  const rest: AnyRouterModelListItem[] = []
+  for (const m of toolCapable) {
+    const caps = m.capabilities ?? []
+    if (caps.some((c) => c.toLowerCase() === 'coding')) coding.push(m)
+    else rest.push(m)
+  }
+
+  return [...coding, ...rest].slice(0, maxCandidates)
+}
+
+export interface RankInput {
+  model: AnyRouterModelListItem
+  /** `request_count` from metrics; undefined / null means missing. */
+  requestCount?: number | null
+}
+
+/**
+ * Rank tool-capable models by usage (`request_count` desc).
+ * Models without metrics rank last (stable by original order among ties).
+ * Non-tool models are excluded from the ranked set.
+ */
+export function rankModelsByUsage(
+  rows: readonly RankInput[],
+  limit: number = DEFAULT_TOP_N
+): RankedAnyRouterModel[] {
+  if (limit <= 0) return []
+
+  const eligible = rows
+    .map((row, index) => ({ row, index }))
+    .filter(
+      ({ row }) =>
+        row.model.id &&
+        !isAnyRouterRouterAlias(row.model.id) &&
+        isAgentToolCapable(row.model)
+    )
+
+  eligible.sort((a, b) => {
+    const aCount =
+      typeof a.row.requestCount === 'number' &&
+      Number.isFinite(a.row.requestCount)
+        ? a.row.requestCount
+        : -1
+    const bCount =
+      typeof b.row.requestCount === 'number' &&
+      Number.isFinite(b.row.requestCount)
+        ? b.row.requestCount
+        : -1
+    if (bCount !== aCount) return bCount - aCount
+    return a.index - b.index
+  })
+
+  return eligible.slice(0, limit).map(({ row }) =>
+    listItemToRanked(row.model, {
+      requestCount:
+        typeof row.requestCount === 'number' &&
+        Number.isFinite(row.requestCount)
+          ? row.requestCount
+          : 0,
+      source: 'usage-ranked',
+      isRouterAlias: false,
+    })
+  )
+}
+
+function listItemToRanked(
+  model: AnyRouterModelListItem,
+  opts: {
+    requestCount: number
+    source: RankedAnyRouterModel['source']
+    isRouterAlias: boolean
+  }
+): RankedAnyRouterModel {
+  const pricing = parsePricePerMillion(model.pricing)
+  const maxOut = model.top_provider?.max_completion_tokens
+  return {
+    modelId: model.id,
+    id: `anyrouter:${model.id}`,
+    name: model.name || model.id,
+    description:
+      model.description?.trim() ||
+      (opts.isRouterAlias
+        ? `AnyRouter router: ${model.id}`
+        : `AnyRouter: ${model.id}`),
+    contextLength: model.context_length ?? 128_000,
+    ...(typeof maxOut === 'number' && maxOut > 0
+      ? { maxOutputTokens: maxOut }
+      : {}),
+    isFree: isListedAsFree(model),
+    supportsTools: isAgentToolCapable(model),
+    supportsStreaming: supportsStreaming(model),
+    supportsVision: supportsVision(model),
+    ...(pricing ? { pricing } : {}),
+    requestCount: opts.requestCount,
+    isRouterAlias: opts.isRouterAlias,
+    source: opts.source,
+  }
+}
+
+/**
+ * Pull preferred router aliases from the catalog when present.
+ * Order follows ANYROUTER_PREFERRED_ROUTER_IDS.
+ */
+export function extractPreferredRouters(
+  models: readonly AnyRouterModelListItem[]
+): RankedAnyRouterModel[] {
+  const byId = new Map(models.map((m) => [m.id, m]))
+  const out: RankedAnyRouterModel[] = []
+  for (const id of ANYROUTER_PREFERRED_ROUTER_IDS) {
+    const item = byId.get(id)
+    if (!item) continue
+    out.push(
+      listItemToRanked(item, {
+        requestCount: 0,
+        source: 'router-alias',
+        isRouterAlias: true,
+      })
+    )
+  }
+  return out
+}
+
+/** Synthetic auto entry for the picker (not a real upstream model id). */
+export function buildAnyRouterAutoEntry(
+  topModelId: string | null
+): RankedAnyRouterModel {
+  const tip = topModelId
+    ? `Currently resolves to ${topModelId} (top tool-capable by usage).`
+    : 'Resolves to the highest-usage tool-capable model on AnyRouter, with a static fallback if the catalog is unavailable.'
+  return {
+    modelId: 'auto',
+    id: ANYROUTER_AUTO_MODEL_ID,
+    name: 'Auto (top by usage)',
+    description: `Auto-pick top AnyRouter model by usage. ${tip}`,
+    contextLength: 200_000,
+    isFree: true,
+    supportsTools: true,
+    supportsStreaming: true,
+    supportsVision: false,
+    requestCount: 0,
+    isRouterAlias: false,
+    source: 'auto',
+  }
+}
+
+export function rankedToAgentModelEntry(
+  ranked: RankedAnyRouterModel,
+  rankIndex?: number
+): AgentModelListEntry {
+  return {
+    id: ranked.id,
+    modelId: ranked.modelId,
+    provider: 'anyrouter',
+    name: ranked.name,
+    description: ranked.description,
+    contextLength: ranked.contextLength,
+    formattedContextLength: formatCompactNumber(ranked.contextLength),
+    ...(ranked.maxOutputTokens
+      ? {
+          maxOutputTokens: ranked.maxOutputTokens,
+          formattedMaxOutputTokens: formatCompactNumber(ranked.maxOutputTokens),
+        }
+      : {}),
+    isFree: ranked.isFree,
+    available: isProviderConfigured('anyrouter'),
+    ...(ranked.pricing ? { pricing: ranked.pricing } : {}),
+    supportsTools: ranked.supportsTools,
+    supportsStreaming: ranked.supportsStreaming,
+    supportsVision: ranked.supportsVision,
+    dynamic: true,
+    ...(typeof rankIndex === 'number' ? { usageRank: rankIndex + 1 } : {}),
+    ...(ranked.source === 'usage-ranked'
+      ? { requestCount: ranked.requestCount }
+      : {}),
+  }
+}
+
+/**
+ * Merge dynamic AnyRouter entries with the static/registry list.
+ *
+ * Win rules:
+ * - Dedupe by full `id` (`anyrouter:…`).
+ * - Static/registry entries win when the same id already exists (curated copy).
+ * - Dynamic-only ids are inserted at the front (auto → routers → usage-ranked).
+ */
+export function mergeAnyRouterDynamicModels<T extends { id: string }>(
+  staticModels: readonly T[],
+  dynamicModels: readonly T[]
+): T[] {
+  const seen = new Set(staticModels.map((m) => m.id))
+  const extras = dynamicModels.filter((m) => !seen.has(m.id))
+  return [...extras, ...staticModels]
+}
+
+/**
+ * Pure selection of the auto-resolved model id from a ranked list.
+ * Returns the first usage-ranked (or first tool-capable) full id, or null.
+ */
+export function pickTopUsageModelId(
+  ranked: readonly RankedAnyRouterModel[]
+): string | null {
+  const usage = ranked.find(
+    (m) => m.source === 'usage-ranked' && m.supportsTools && m.requestCount > 0
+  )
+  if (usage) return usage.id
+  const anyUsage = ranked.find(
+    (m) => m.source === 'usage-ranked' && m.supportsTools
+  )
+  if (anyUsage) return anyUsage.id
+  return null
+}
+
+// ── I/O + cache ──────────────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  value: T
+  expiresAt: number
+}
+
+let catalogCache: CacheEntry<AnyRouterModelListItem[]> | null = null
+let rankedCache: CacheEntry<{
+  ranked: RankedAnyRouterModel[]
+  topId: string | null
+}> | null = null
+
+/** Test-only: clear in-memory caches. */
+export function __resetAnyRouterDynamicCachesForTests(): void {
+  catalogCache = null
+  rankedCache = null
+}
+
+function anyRouterBaseURL(): string {
+  return (
+    process.env.ANYROUTER_API_BASE?.trim() || 'https://anyrouter.dev/api/v1'
+  ).replace(/\/$/, '')
+}
+
+function anyRouterHeaders(): HeadersInit {
+  const key = process.env.ANYROUTER_API_KEY?.trim()
+  return {
+    Accept: 'application/json',
+    ...(key ? { Authorization: `Bearer ${key}` } : {}),
+  }
+}
+
+/**
+ * Whether dynamic AnyRouter enrichment should run.
+ * Fail-closed: requires AnyRouter provider configured (API key present).
+ * Optional kill-switch: ANYROUTER_DYNAMIC_MODELS=false|0|off.
+ */
+export function isAnyRouterDynamicEnabled(): boolean {
+  const flag = process.env.ANYROUTER_DYNAMIC_MODELS?.trim().toLowerCase()
+  if (flag === 'false' || flag === '0' || flag === 'off' || flag === 'no') {
+    return false
+  }
+  return isProviderConfigured('anyrouter')
+}
+
+export function getDynamicTopN(): number {
+  const raw = process.env.ANYROUTER_TOP_MODELS_N?.trim()
+  if (!raw) return DEFAULT_TOP_N
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_TOP_N
+  return Math.min(n, 32)
+}
+
+export function getMetricsCandidateCap(): number {
+  const raw = process.env.ANYROUTER_METRICS_CANDIDATE_CAP?.trim()
+  if (!raw) return DEFAULT_METRICS_CANDIDATE_CAP
+  const n = Number.parseInt(raw, 10)
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_METRICS_CANDIDATE_CAP
+  return Math.min(n, 64)
+}
+
+export async function fetchAnyRouterCatalog(
+  fetchImpl: typeof fetch = fetch
+): Promise<AnyRouterModelListItem[]> {
+  const now = Date.now()
+  if (catalogCache && catalogCache.expiresAt > now) {
+    return catalogCache.value
+  }
+
+  const url = `${anyRouterBaseURL()}/models`
+  const response = await fetchImpl(url, { headers: anyRouterHeaders() })
+  if (!response.ok) {
+    throw new Error(`AnyRouter models list error: ${response.status}`)
+  }
+  const body = (await response.json()) as {
+    data?: AnyRouterModelListItem[]
+  }
+  const data = Array.isArray(body.data) ? body.data : []
+  catalogCache = {
+    value: data,
+    expiresAt: now + ANYROUTER_DYNAMIC_CACHE_TTL_MS,
+  }
+  return data
+}
+
+export async function fetchAnyRouterMetrics(
+  modelId: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<AnyRouterModelMetrics | null> {
+  const encoded = encodeURIComponent(modelId)
+  const url = `${anyRouterBaseURL()}/models/${encoded}/metrics`
+  try {
+    const response = await fetchImpl(url, { headers: anyRouterHeaders() })
+    if (!response.ok) return null
+    return (await response.json()) as AnyRouterModelMetrics
+  } catch {
+    return null
+  }
+}
+
+async function mapPool<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) return []
+  const results: R[] = new Array(items.length)
+  let next = 0
+  async function worker() {
+    while (next < items.length) {
+      const i = next++
+      results[i] = await fn(items[i]!)
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker()
+  )
+  await Promise.all(workers)
+  return results
+}
+
+export interface BuildDynamicOptions {
+  fetchImpl?: typeof fetch
+  topN?: number
+  candidateCap?: number
+  /** Skip cache (tests). */
+  forceRefresh?: boolean
+}
+
+/**
+ * Fetch catalog + bounded metrics, rank, and return ranked dynamic entries
+ * (auto + routers + top-N usage). Fail-soft callers should catch.
+ */
+export async function buildAnyRouterDynamicModels(
+  options: BuildDynamicOptions = {}
+): Promise<{
+  entries: RankedAnyRouterModel[]
+  topUsageId: string | null
+}> {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const topN = options.topN ?? getDynamicTopN()
+  const candidateCap = options.candidateCap ?? getMetricsCandidateCap()
+  const now = Date.now()
+
+  if (!options.forceRefresh && rankedCache && rankedCache.expiresAt > now) {
+    return {
+      entries: rankedCache.value.ranked,
+      topUsageId: rankedCache.value.topId,
+    }
+  }
+
+  const catalog = await fetchAnyRouterCatalog(fetchImpl)
+  const candidates = selectMetricsCandidates(catalog, candidateCap)
+
+  const metrics = await mapPool(candidates, METRICS_CONCURRENCY, async (m) => {
+    const met = await fetchAnyRouterMetrics(m.id, fetchImpl)
+    return {
+      model: m,
+      requestCount:
+        typeof met?.request_count === 'number' ? met.request_count : null,
+    } satisfies RankInput
+  })
+
+  // Also include candidate rows that somehow weren't fetched — should not happen.
+  const rankedUsage = rankModelsByUsage(metrics, topN)
+  const routers = extractPreferredRouters(catalog)
+  const topUsageId = pickTopUsageModelId(rankedUsage)
+  const auto = buildAnyRouterAutoEntry(
+    topUsageId ? topUsageId.replace(/^anyrouter:/, '') : null
+  )
+
+  const entries = [auto, ...routers, ...rankedUsage]
+  rankedCache = {
+    value: { ranked: entries, topId: topUsageId },
+    expiresAt: now + ANYROUTER_DYNAMIC_CACHE_TTL_MS,
+  }
+
+  return { entries, topUsageId }
+}
+
+/**
+ * Resolve `anyrouter:auto` to a concrete `anyrouter:{modelId}`.
+ * Returns null when dynamic ranking is unavailable (caller uses static default).
+ */
+export async function resolveAnyRouterAutoModelId(
+  options: BuildDynamicOptions = {}
+): Promise<string | null> {
+  if (!isAnyRouterDynamicEnabled() && !options.fetchImpl) {
+    // Still allow explicit resolve when tests inject fetchImpl without env.
+    if (!options.forceRefresh && !rankedCache) return null
+  }
+  try {
+    // Use cache when warm; otherwise build (may no-op if unconfigured and no fetch).
+    if (!isAnyRouterDynamicEnabled() && !options.fetchImpl) return null
+    const { topUsageId } = await buildAnyRouterDynamicModels(options)
+    return topUsageId
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fail-soft helper for the models endpoint: returns [] when disabled or on error.
+ */
+export async function loadAnyRouterDynamicModelEntries(
+  options: BuildDynamicOptions = {}
+): Promise<AgentModelListEntry[]> {
+  if (!isAnyRouterDynamicEnabled() && !options.fetchImpl) return []
+  try {
+    const { entries } = await buildAnyRouterDynamicModels(options)
+    let usageIndex = 0
+    return entries.map((e) => {
+      if (e.source === 'usage-ranked') {
+        const entry = rankedToAgentModelEntry(e, usageIndex)
+        usageIndex += 1
+        return entry
+      }
+      return rankedToAgentModelEntry(e)
+    })
+  } catch (error) {
+    console.warn(
+      '[Agent] AnyRouter dynamic models unavailable:',
+      error instanceof Error ? error.message : error
+    )
+    return []
+  }
+}

--- a/apps/dashboard/src/lib/hooks/use-agent-model.ts
+++ b/apps/dashboard/src/lib/hooks/use-agent-model.ts
@@ -12,7 +12,6 @@
 
 import { useEffect, useState } from 'react'
 import {
-  DEFAULT_AGENT_MODEL,
   getAllModelOptions,
   MODEL_REGISTRY,
 } from '@/lib/ai/agent-model-registry'
@@ -22,13 +21,19 @@ import {
   type ModelPricing,
   type OpenAIModel,
 } from '@/lib/ai/agent-models'
+import { ANYROUTER_AUTO_MODEL_ID } from '@/lib/ai/anyrouter-dynamic-models'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export type { OpenAIModel } from '@/lib/ai/agent-models'
 
 const MODEL_STORAGE_KEY = 'clickhouse-monitor-agent-model'
 
-const DEFAULT_MODEL = DEFAULT_AGENT_MODEL
+/**
+ * Client default when no saved selection exists.
+ * Prefer the AnyRouter auto alias (resolved server-side to top-by-usage);
+ * curated Gemma remains the static registry fallback for offline/static lists.
+ */
+const DEFAULT_MODEL = ANYROUTER_AUTO_MODEL_ID
 
 /**
  * Ensure a model identifier is in `provider:model` form.

--- a/apps/dashboard/src/routes/api/v1/__tests__/agent-quota-release.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/agent-quota-release.test.ts
@@ -47,7 +47,14 @@ mock.module('@/lib/ai/providers', () => ({
   getProviderName: () => 'Test Provider',
 }))
 mock.module('@/lib/ai/agent-model-registry', () => ({
+  DEFAULT_AGENT_MODEL: 'test/test-model',
   resolveDefaultAgentModel: () => 'test/test-model',
+  isFreeAgentModel: () => false,
+}))
+mock.module('@/lib/ai/anyrouter-dynamic-models', () => ({
+  isAnyRouterAutoModelId: () => false,
+  resolveAnyRouterAutoModelId: async () => null,
+  loadAnyRouterDynamicModelEntries: async () => [],
 }))
 
 // --- custom MCP servers: none ------------------------------------------------

--- a/apps/dashboard/src/routes/api/v1/__tests__/agent.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/agent.test.ts
@@ -82,7 +82,14 @@ mock.module('@/lib/ai/providers', () => ({
   getProviderName: () => 'Test Provider',
 }))
 mock.module('@/lib/ai/agent-model-registry', () => ({
+  DEFAULT_AGENT_MODEL: 'test/test-model',
   resolveDefaultAgentModel: () => 'test/test-model',
+  isFreeAgentModel: () => false,
+}))
+mock.module('@/lib/ai/anyrouter-dynamic-models', () => ({
+  isAnyRouterAutoModelId: () => false,
+  resolveAnyRouterAutoModelId: async () => null,
+  loadAnyRouterDynamicModelEntries: async () => [],
 }))
 
 // --- custom MCP servers -------------------------------------------------------

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -52,7 +52,14 @@ import {
   loadUserRegisteredServers,
   mergeMcpServers,
 } from '@/lib/ai/agent/mcp/connect-custom-servers'
-import { resolveDefaultAgentModel } from '@/lib/ai/agent-model-registry'
+import {
+  DEFAULT_AGENT_MODEL,
+  resolveDefaultAgentModel,
+} from '@/lib/ai/agent-model-registry'
+import {
+  isAnyRouterAutoModelId,
+  resolveAnyRouterAutoModelId,
+} from '@/lib/ai/anyrouter-dynamic-models'
 import {
   getProviderName,
   isProviderConfigured,
@@ -519,10 +526,19 @@ async function handlePost(request: Request): Promise<Response> {
       ? Math.max(0, Math.trunc(rawHostId))
       : 0
   const configuredModel = process.env.LLM_MODEL?.trim()
-  const model =
+  let model =
     typeof body.model === 'string' && body.model.trim().length > 0
       ? body.model.trim()
       : configuredModel || resolveDefaultAgentModel()
+
+  // `anyrouter:auto` is a picker alias — resolve to the current top-by-usage
+  // tool-capable model (cached) before provider preflight / chat setup.
+  // Fail-soft: curated DEFAULT_AGENT_MODEL when the dynamic catalog is down.
+  if (isAnyRouterAutoModelId(model)) {
+    const top = await resolveAnyRouterAutoModelId()
+    // Fail-soft to curated static default (not `anyrouter:auto` again).
+    model = top ?? DEFAULT_AGENT_MODEL
+  }
 
   // BYOK: the user may supply their own provider API key. When present and
   // valid, it (a) overrides the deployment's env key for this request and (b)

--- a/apps/dashboard/src/routes/api/v1/agent/followups.ts
+++ b/apps/dashboard/src/routes/api/v1/agent/followups.ts
@@ -24,6 +24,11 @@ import {
   DEFAULT_MODEL,
   resolveAgentChatModel,
 } from '@/lib/ai/agent/provider-chat-model'
+import { DEFAULT_AGENT_MODEL } from '@/lib/ai/agent-model-registry'
+import {
+  isAnyRouterAutoModelId,
+  resolveAnyRouterAutoModelId,
+} from '@/lib/ai/anyrouter-dynamic-models'
 import {
   getProviderName,
   isProviderConfigured,
@@ -294,10 +299,14 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  const model =
+  let model =
     typeof body.model === 'string' && body.model.trim().length > 0
       ? body.model.trim()
       : DEFAULT_MODEL
+  if (isAnyRouterAutoModelId(model)) {
+    const top = await resolveAnyRouterAutoModelId()
+    model = top ?? DEFAULT_AGENT_MODEL
+  }
   const { provider: requestedProvider } = parseModelId(model)
 
   if (!isProviderConfigured(requestedProvider)) {

--- a/apps/dashboard/src/routes/api/v1/agents/models.ts
+++ b/apps/dashboard/src/routes/api/v1/agents/models.ts
@@ -6,6 +6,8 @@
  * Returns available models grouped by provider.
  * Generates all valid `provider:model` combinations from MODEL_REGISTRY.
  * Enriches OpenRouter models with capability data from their API.
+ * When AnyRouter is configured, also merges a **dynamic** top-by-usage set
+ * from AnyRouter's public catalog + per-model metrics (fail-soft).
  *
  * Ported from apps/dashboard/app/api/v1/agents/models/route.ts.
  * - next/server NextResponse.json(x, init) -> Response.json(x, init).
@@ -21,6 +23,11 @@ import {
   getModelRegistry,
   isFreeAgentModel,
 } from '@/lib/ai/agent-model-registry'
+import {
+  type AgentModelListEntry,
+  loadAnyRouterDynamicModelEntries,
+  mergeAnyRouterDynamicModels,
+} from '@/lib/ai/anyrouter-dynamic-models'
 import { isProviderConfigured, PROVIDERS } from '@/lib/ai/providers'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 import { formatCompactNumber } from '@/lib/format-number'
@@ -30,32 +37,7 @@ const OPENROUTER_MODELS_API =
 const OPENROUTER_REFERER = process.env.OPENROUTER_REFERER
 const OPENROUTER_APP_NAME = process.env.OPENROUTER_APP_NAME
 
-interface ModelCapability {
-  /** Combined ID in `provider:model` format */
-  id: string
-  /** Provider-agnostic model ID */
-  modelId: string
-  /** Provider ID */
-  provider: string
-  /** Display name */
-  name: string
-  description: string
-  contextLength: number
-  formattedContextLength: string
-  /** Max completion (output) tokens, when the upstream API reports it. */
-  maxOutputTokens?: number
-  formattedMaxOutputTokens?: string
-  isFree: boolean
-  /** True when the Worker has an API key configured for this provider. */
-  available: boolean
-  pricing?: {
-    inputPerMillion: number
-    outputPerMillion: number
-  }
-  supportsTools?: boolean
-  supportsStreaming?: boolean
-  supportsVision?: boolean
-}
+type ModelCapability = AgentModelListEntry
 
 /**
  * Fetch OpenRouter model metadata for capability enrichment.
@@ -194,7 +176,7 @@ function buildStaticModels(): ModelCapability[] {
   return filterByConfiguredProviders(full)
 }
 
-async function buildModels(): Promise<ModelCapability[]> {
+async function buildRegistryModels(): Promise<ModelCapability[]> {
   let orCapabilities: Map<string, Record<string, unknown>> | undefined
 
   try {
@@ -242,6 +224,26 @@ async function buildModels(): Promise<ModelCapability[]> {
   }
 
   return filterByConfiguredProviders(full)
+}
+
+/**
+ * Build the full models list: static registry (+ OpenRouter enrichment) merged
+ * with AnyRouter dynamic top-by-usage when that provider is configured.
+ * AnyRouter list/metrics failures are fail-soft — static list still returns.
+ */
+async function buildModels(): Promise<ModelCapability[]> {
+  const [registryModels, dynamicAnyRouter] = await Promise.all([
+    buildRegistryModels(),
+    loadAnyRouterDynamicModelEntries(),
+  ])
+
+  if (dynamicAnyRouter.length === 0) {
+    return registryModels
+  }
+
+  return filterByConfiguredProviders(
+    mergeAnyRouterDynamicModels(registryModels, dynamicAnyRouter)
+  )
 }
 
 function getConfiguredProviders(): string[] {

--- a/docs/content/guide/ai-agent/configuration.mdx
+++ b/docs/content/guide/ai-agent/configuration.mdx
@@ -37,6 +37,21 @@ Set the key for each provider you want to use. Only providers with a key configu
 | `NVIDIA_API_BASE` | NVIDIA NIM | NIM base URL (defaults to NVIDIA's hosted endpoint). |
 | `ANYROUTER_API_KEY` | AnyRouter | AnyRouter API key. |
 | `ANYROUTER_API_BASE` | AnyRouter | AnyRouter base URL. |
+| `ANYROUTER_DYNAMIC_MODELS` | AnyRouter | Set to `false` / `0` / `off` to disable live catalog enrichment (static registry only). On by default when `ANYROUTER_API_KEY` is set. |
+| `ANYROUTER_TOP_MODELS_N` | AnyRouter | Max usage-ranked models to add to the picker (default `8`, max `32`). |
+| `ANYROUTER_METRICS_CANDIDATE_CAP` | AnyRouter | Max catalog models to score via `/models/{id}/metrics` (default `24`, max `64`). |
+
+### AnyRouter dynamic models (usage ranking)
+
+When `ANYROUTER_API_KEY` is set, `GET /api/v1/agents/models` also loads AnyRouter’s public catalog (`GET {ANYROUTER_API_BASE}/models`) and ranks a **bounded** set of tool-capable models by real usage (`GET .../models/{id}/metrics` → `request_count`). List-level `sort=usage` is not supported by AnyRouter — ranking is always metrics-based.
+
+The picker then includes:
+
+1. **`anyrouter:auto`** — default when AnyRouter is configured. The agent route resolves it at request time to the current top tool-capable model by usage (cached ~5 minutes), falling back to the curated static default (`anyrouter:google/gemma-4-26b-a4b-it`) if the catalog/metrics are unavailable.
+2. **Router aliases** when present in the catalog — e.g. `anyrouter/agent`, `anyrouter/free`, `anyrouter/coding`.
+3. **Top-N concrete models** by `request_count` (function-calling preferred).
+
+Failures are fail-soft: OpenRouter-only / OSS deploys without AnyRouter keep the static `MODEL_REGISTRY` path with no live dependency on anyrouter.dev.
 
 ## Extra models
 


### PR DESCRIPTION
## Summary
- When AnyRouter is configured, `GET /api/v1/agents/models` merges a **dynamic** top-by-usage set from AnyRouter’s public catalog (`GET /models`) ranked by per-model metrics (`GET /models/{id}/metrics` → `request_count`). List-level `sort=usage` is **not** supported by AnyRouter (same catalog order); ranking is metrics-based.
- Tool/function-calling models are preferred; candidate set and top-N are capped + cached (~5 min) so the endpoint never scores the full catalog.
- **`anyrouter:auto`** is the default when `ANYROUTER_API_KEY` is set: the agent route resolves it at request time to the current top usage model, failing soft to curated `anyrouter:google/gemma-4-26b-a4b-it`.
- Preferred router aliases (`anyrouter/agent`, `anyrouter/free`, `anyrouter/coding`) are included when present in the catalog.
- Fail-soft: unconfigured AnyRouter or list/metrics errors leave the static registry (+ OpenRouter enrichment) working.

## Test plan
- [x] Unit tests for pure rank/filter/merge + mock fetch fail-soft (`anyrouter-dynamic-models.test.ts`)
- [x] Updated `resolveDefaultAgentModel` expectations for `anyrouter:auto`
- [x] Agent route mocks updated so full dashboard unit suite stays green
- [ ] Smoke: with `ANYROUTER_API_KEY`, open agent model picker and confirm auto + top models appear
- [ ] Smoke: select `anyrouter:auto` and send a message; server resolves to a concrete model