### PR TITLE
fix(ci): use shared node-based ARM64 Dockerfile for latest/release images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       id-token: write
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Login to Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
@@ -146,20 +149,9 @@ jobs:
           docker cp "$CONTAINER:/app/." /tmp/cross-build/
           docker rm "$CONTAINER"
 
-          # Create minimal Dockerfile for ARM64 (just copies pre-built JS artifacts)
-          cat > /tmp/cross-build/Dockerfile <<'EOFX'
-          FROM oven/bun:1-alpine
-          WORKDIR /app
-          ENV NODE_ENV=production \
-              PORT=3000 \
-              HOSTNAME="0.0.0.0"
-          RUN addgroup --system --gid 1001 app && \
-              adduser --system --uid 1001 app
-          COPY --chown=app:app . ./
-          USER app
-          EXPOSE 3000
-          CMD ["node", "server.js"]
-          EOFX
+          # Use the shared, checked-in ARM64 wrapper Dockerfile (see
+          # Dockerfile.arm64 for why) rather than an inline heredoc copy.
+          cp "$GITHUB_WORKSPACE/Dockerfile.arm64" /tmp/cross-build/Dockerfile
 
       - name: Build and push ARM64 image
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
+
       - name: Login to Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
@@ -133,24 +138,9 @@ jobs:
           docker cp "$CONTAINER:/app/." /tmp/cross-build/
           docker rm "$CONTAINER"
 
-          # Create minimal Dockerfile for ARM64 (just copies pre-built JS artifacts)
-          cat > /tmp/cross-build/Dockerfile <<'EOFX'
-          FROM node:24-alpine
-          WORKDIR /app
-          ENV NODE_ENV=production \
-              PORT=3000 \
-              HOST="0.0.0.0"
-          RUN apk add --no-cache libc6-compat curl && \
-              addgroup -S -g 1001 app && \
-              adduser -S -u 1001 -G app app && \
-              chown -R app:app /app
-          COPY --chown=app:app . ./
-          USER app
-          EXPOSE 3000
-          HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=30s \
-            CMD curl -sf http://localhost:3000/healthz || exit 1
-          CMD ["node", "server/index.mjs"]
-          EOFX
+          # Use the shared, checked-in ARM64 wrapper Dockerfile (see
+          # Dockerfile.arm64 for why) rather than an inline heredoc copy.
+          cp "$GITHUB_WORKSPACE/Dockerfile.arm64" /tmp/cross-build/Dockerfile
 
       - name: Build and push ARM64 image
         uses: docker/build-push-action@v7

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,35 @@
+# Dockerfile for the ARM64 leg of the multi-arch image build.
+#
+# We cross-compile ARM64 by extracting the pre-built JS artifacts (server/,
+# node_modules/, etc.) from the already-built AMD64 image (see
+# `.github/workflows/ci.yml` / `.github/workflows/release.yml`,
+# `build-docker-arm64` jobs) rather than re-running the full Rust+Node build
+# under QEMU, which is far slower. This file is the SHARED, checked-in
+# Dockerfile for that step — both ci.yml (latest/main/edge tags) and
+# release.yml (versioned tags) COPY it into the extracted build context and
+# build from it.
+#
+# Historically each workflow inlined its own copy via a heredoc, and they
+# drifted: ci.yml's copy stayed on `oven/bun:1-alpine` with `CMD ["node",
+# "server.js"]`, which no longer matches the v0.3 TanStack Start output
+# (`server/index.mjs`) or the node:24-alpine runtime used by release.yml.
+# That drift silently broke the `latest`/`main` ARM64 image on ghcr.io.
+# See: https://github.com/chmonitor/chmonitor/issues/2862
+#
+# Keep this file the single source of truth for the ARM64 wrapper image —
+# do not reintroduce a heredoc copy in either workflow.
+FROM node:24-alpine
+WORKDIR /app
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOST="0.0.0.0"
+RUN apk add --no-cache libc6-compat curl && \
+    addgroup -S -g 1001 app && \
+    adduser -S -u 1001 -G app app && \
+    chown -R app:app /app
+COPY --chown=app:app . ./
+USER app
+EXPOSE 3000
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=30s \
+  CMD curl -sf http://localhost:3000/healthz || exit 1
+CMD ["node", "server/index.mjs"]


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`'s `build-docker-arm64` job (the leg that publishes `latest`/`main`/`edge` on every push to `main`) generated a **stale inline Dockerfile** via heredoc: `FROM oven/bun:1-alpine` + `CMD ["node", "server.js"]` + `HOSTNAME=0.0.0.0`. The v0.3 TanStack Start build output is `server/index.mjs`, and the correct runtime is `node:24-alpine` — this heredoc never got updated when the app migrated, so the `latest` ARM64 image on ghcr.io has been broken (crashes on startup / wrong entrypoint).
- `.github/workflows/release.yml`'s `build-docker-arm64` job already had the **correct** heredoc (`node:24-alpine`, `HOST=0.0.0.0`, `apk add libc6-compat curl`, curl-based `/healthz` HEALTHCHECK, `CMD ["node","server/index.mjs"]`) — the two workflows drifted apart because each inlined its own copy of essentially the same Dockerfile.
- Fix: extract the correct Dockerfile content into a single checked-in `Dockerfile.arm64` at the repo root, and have both `ci.yml` and `release.yml` copy it into the extracted cross-build context (`cp "$GITHUB_WORKSPACE/Dockerfile.arm64" /tmp/cross-build/Dockerfile`) instead of each maintaining its own heredoc. Both jobs now also check out the repo (needed to have `Dockerfile.arm64` available) — `release.yml` uses the same `ref` pattern as its sibling jobs.

## Second symptom noted in #2862 (missing `0.3.0` ghcr tag)

The issue also reports that versioned `ghcr.io/chmonitor/chmonitor:0.3.0` images are missing. That is **not** caused by this drift — the `v0.3.0` release build itself failed at that tag (a since-fixed build issue), so `release.yml` never completed for that tag. This PR does not (and cannot) retroactively publish `0.3.0`; versioned `0.3.x` images will start appearing again with the next release (`v0.3.1`).

Fixes #2862

## Test plan

- [x] Validated both workflow YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Manually diffed the extracted `Dockerfile.arm64` content against release.yml's previously-correct heredoc (identical)
- [ ] CI: `build-docker-arm64` job in `ci.yml` on next push to `main` will publish a corrected `latest`/`main`/`edge` ARM64 image (self-verifying once merged)

https://claude.ai/code/session_01Ug4jivQ5pZtu89C1B6wMRC