### PR TITLE
feat(mutations): surface parts_postpone_reasons (ClickHouse 26.2+)

### DIFF
--- a/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/catalog/merges/mutations.ts
@@ -13,7 +13,8 @@ export const mutationsDeclarative: DeclarativeQueryConfig = {
     'Information about mutations of MergeTree tables and their progress',
   // Version-aware queries (oldest → newest)
   // 25.12 adds parts_in_progress_names: names of parts currently being mutated.
-  // The expanded row panel surfaces this field (expandable below).
+  // 26.2 adds parts_postpone_reasons: why parts were postponed from mutating.
+  // The expanded row panel surfaces both fields (expandable below).
   sql: [
     {
       since: '19.1',
@@ -64,6 +65,32 @@ export const mutationsDeclarative: DeclarativeQueryConfig = {
         ORDER BY is_done ASC, is_stuck DESC, create_time DESC
       `,
     },
+    {
+      since: '26.2',
+      description:
+        'Includes parts_postpone_reasons: why parts were postponed from mutating',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          parts_in_progress_names,
+          parts_postpone_reasons,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${600}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
   ],
   columns: [
     'is_done',
@@ -86,8 +113,9 @@ export const mutationsDeclarative: DeclarativeQueryConfig = {
     elapsed: 'duration',
     readable_parts_to_do: 'background-bar',
   },
-  // Expanding a row surfaces parts_to_do_names and parts_in_progress_names
-  // (in CH 25.12+) in the full-width detail panel.
+  // Expanding a row surfaces parts_to_do_names, parts_in_progress_names
+  // (CH 25.12+), and parts_postpone_reasons (CH 26.2+) in the full-width
+  // detail panel.
   expandable: {
     type: 'config-details',
     primaryColumns: [

--- a/apps/dashboard/src/lib/query-config/merges/mutations.test.ts
+++ b/apps/dashboard/src/lib/query-config/merges/mutations.test.ts
@@ -74,8 +74,9 @@ describe('card config', () => {
 // ---------------------------------------------------------------------------
 
 describe('SQL content', () => {
-  // sql is now a versioned array (VersionedSql[]) — two entries: 19.1 base
-  // and 25.12 which adds parts_in_progress_names.
+  // sql is now a versioned array (VersionedSql[]) — three entries: 19.1 base,
+  // 25.12 which adds parts_in_progress_names, and 26.2 which adds
+  // parts_postpone_reasons.
   const sqlField = mutationsConfig.sql
   const sqlEntries = sqlField as Array<{
     since: string
@@ -85,11 +86,18 @@ describe('SQL content', () => {
   // Combined SQL for content assertions that apply across all versions
   const allSql = sqlEntries.map((e) => e.sql).join('\n')
 
-  test('sql is a versioned array with 2 entries (19.1 base, 25.12 adds parts_in_progress_names)', () => {
+  test('sql is a versioned array with 3 entries (19.1 base, 25.12 adds parts_in_progress_names, 26.2 adds parts_postpone_reasons)', () => {
     expect(Array.isArray(sqlField)).toBe(true)
-    expect(sqlEntries.length).toBe(2)
+    expect(sqlEntries.length).toBe(3)
     expect(sqlEntries[0].since).toBe('19.1')
     expect(sqlEntries[1].since).toBe('25.12')
+    expect(sqlEntries[2].since).toBe('26.2')
+  })
+
+  test('26.2 variant selects parts_postpone_reasons; older variants do not', () => {
+    expect(sqlEntries[2].sql).toContain('parts_postpone_reasons')
+    expect(sqlEntries[0].sql).not.toContain('parts_postpone_reasons')
+    expect(sqlEntries[1].sql).not.toContain('parts_postpone_reasons')
   })
 
   test('queries system.mutations', () => {

--- a/apps/dashboard/src/lib/query-config/merges/mutations.ts
+++ b/apps/dashboard/src/lib/query-config/merges/mutations.ts
@@ -16,7 +16,8 @@ export const mutationsConfig: QueryConfig = {
     'Information about mutations of MergeTree tables and their progress',
   // Version-aware queries (oldest → newest)
   // 25.12 adds parts_in_progress_names: names of parts currently being mutated.
-  // The expanded row panel surfaces this field (expandable: true below).
+  // 26.2 adds parts_postpone_reasons: why parts were postponed from mutating.
+  // The expanded row panel surfaces both fields (expandable: true below).
   sql: [
     {
       since: '19.1',
@@ -67,6 +68,32 @@ export const mutationsConfig: QueryConfig = {
         ORDER BY is_done ASC, is_stuck DESC, create_time DESC
       `,
     },
+    {
+      since: '26.2',
+      description:
+        'Includes parts_postpone_reasons: why parts were postponed from mutating',
+      sql: `
+        SELECT
+          database || '.' || table as table,
+          mutation_id,
+          command,
+          create_time,
+          now() - create_time AS elapsed,
+          parts_to_do,
+          formatReadableQuantity(parts_to_do) AS readable_parts_to_do,
+          round(100 * parts_to_do / nullIf(max(parts_to_do) OVER (), 0), 2) as pct_parts_to_do,
+          parts_to_do_names,
+          parts_in_progress_names,
+          parts_postpone_reasons,
+          is_done,
+          if(is_done = 0 AND parts_to_do > 0 AND (now() - create_time) > ${STUCK_THRESHOLD_SECONDS}, 1, 0) AS is_stuck,
+          latest_failed_part,
+          latest_fail_time,
+          latest_fail_reason
+        FROM system.mutations
+        ORDER BY is_done ASC, is_stuck DESC, create_time DESC
+      `,
+    },
   ],
   columns: [
     'is_done',
@@ -89,8 +116,9 @@ export const mutationsConfig: QueryConfig = {
     elapsed: ColumnFormat.Duration,
     readable_parts_to_do: ColumnFormat.BackgroundBar,
   },
-  // Expanding a row surfaces parts_to_do_names and parts_in_progress_names
-  // (in CH 25.12+) in the full-width JSON detail panel.
+  // Expanding a row surfaces parts_to_do_names, parts_in_progress_names
+  // (CH 25.12+), and parts_postpone_reasons (CH 26.2+) in the full-width
+  // JSON detail panel.
   expandable: true,
   rowClassName: (row) => {
     const isStuck = Number(row.is_stuck || 0)

--- a/docs/clickhouse-schemas/tables/mutations.md
+++ b/docs/clickhouse-schemas/tables/mutations.md
@@ -14,7 +14,7 @@ table: system.mutations
 ## chmonitor usage
 
 - Mutations config gates real `parts_in_progress_names` at `since: '25.12'` (older variants stub `[] AS parts_in_progress_names`).
-- `parts_postpone_reasons` is documented for a follow-up UI column.
+- Mutations config gates `parts_postpone_reasons` at `since: '26.2'`; the expanded row detail panel surfaces it.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Add a `since: '26.2'` VersionedSql variant to `mutations.ts` (legacy) and `declarative/catalog/merges/mutations.ts` selecting `system.mutations.parts_postpone_reasons` (upstream ClickHouse PR #92206)
- Older variants (19.1, 25.12) fall back unchanged; the new field is surfaced via the row expand panel, same pattern as `parts_in_progress_names` (25.12+)
- Update `docs/clickhouse-schemas/tables/mutations.md` usage note
- Extend `mutations.test.ts` for the 3-entry versioned SQL array

Fixes #2859

## Test plan
- [x] `bun test src/lib/query-config/merges/mutations.test.ts src/lib/query-config/version-compatibility.test.ts src/lib/query-config/declarative/catalog/merges/merges-catalog.test.ts` — 56 pass
- [x] `pnpm run type-check` — clean

https://claude.ai/code/session_01Ug4jivQ5pZtu89C1B6wMRC