### PR TITLE
ci: align ClickHouse test image pins with current LTS/stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ env:
 jobs:
   # build/lint run `turbo build` (vite + tsc) and `turbo lint` (biome) — neither
   # connects to ClickHouse, but base.yml attaches a clickhouse_<ver> service per
-  # matrix leg. Pin them to a single, actively-used fixture tag (25.1, same as the
-  # docker jobs) instead of the default ["24.5","24.6"] matrix: this halves their
+  # matrix leg. Pin them to a single, actively-used fixture tag (25.8 LTS, same as
+  # the docker jobs) instead of the default ["24.5","24.6"] matrix: this halves their
   # CI time and avoids a flaky `manifest unknown` GHCR pull of the unused 24.5
   # image gating the Docker `latest` publish. (Fully decoupling the DB service
   # from non-docker job-types is a follow-up.)
@@ -39,14 +39,14 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       job-type: build
-      clickhouse-versions: '["25.1"]'
+      clickhouse-versions: '["25.8"]'
 
   lint:
     name: lint
     uses: ./.github/workflows/base.yml
     with:
       job-type: lint
-      clickhouse-versions: '["25.1"]'
+      clickhouse-versions: '["25.8"]'
 
   depcruise:
     name: depcruise
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker
-      clickhouse-versions: '["25.1"]'
+      clickhouse-versions: '["25.8"]'
       platforms: linux/amd64
       push-image: false
       skip-rust: false
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/base.yml
     with:
       job-type: docker
-      clickhouse-versions: '["25.1"]'
+      clickhouse-versions: '["25.8"]'
       platforms: linux/amd64
       push-image: true
       tag-suffix: -amd64
@@ -239,7 +239,7 @@ jobs:
 
     services:
       clickhouse:
-        image: ghcr.io/duyet/docker-images:clickhouse_24.5
+        image: ghcr.io/duyet/docker-images:clickhouse_25.8
         ports:
           - 8123:8123
           - 9000:9000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,7 @@ jobs:
 
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server:26.2
+        image: clickhouse/clickhouse-server:26.7
         ports:
           - 8123:8123
         options: >-
@@ -173,7 +173,7 @@ jobs:
           CLICKHOUSE_SKIP_USER_SETUP: 1
 
       keeper:
-        image: clickhouse/clickhouse-keeper:26.2
+        image: clickhouse/clickhouse-keeper:26.7
         options: >-
           --health-cmd "clickhouse-keeper client -h 127.0.0.1 -p 9181 -q 'ruok' 2>/dev/null | grep -q imok || exit 1"
           --health-interval 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: ghcr.io/duyet/docker-images:clickhouse_25.1
+    image: ghcr.io/duyet/docker-images:clickhouse_25.8
     ports:
       - "8123:8123"
       - "9000:9000"


### PR DESCRIPTION
## Summary

Aligns CI/local ClickHouse image pins with current LTS/stable, per #2858.

## Tag availability (verified 2026-08-11)

| Registry | Tag | Available? |
|----------|-----|------------|
| Docker Hub `clickhouse/clickhouse-server` | 26.3 | Yes |
| Docker Hub `clickhouse/clickhouse-server` | 26.7 | Yes |
| Docker Hub `clickhouse/clickhouse-keeper` | 26.7 | Yes |
| `ghcr.io/duyet/docker-images` | `clickhouse_25.8` | Yes (newest LTS on this mirror) |
| `ghcr.io/duyet/docker-images` | `clickhouse_26.3` | **No** (404) |
| `ghcr.io/duyet/docker-images` | `clickhouse_26.7` | **No** (404) |

The `ghcr.io/duyet/docker-images` mirror currently tops out at `clickhouse_25.8` — no `26.x` tags exist there yet. Per the issue's conservative guidance ("do not switch a reference to a tag that doesn't exist"), the two workflows/compose file that use this mirror are pinned to `25.8` (current LTS on that mirror) instead of jumping to `26.x`. `test.yml` pulls `clickhouse/clickhouse-server`/`clickhouse-keeper` directly from Docker Hub, where `26.7` (current stable) is confirmed available, so that one goes to `26.7`.

## Changes

- `.github/workflows/ci.yml`: `build`/`lint`/`build-docker-pr`/`build-docker-amd64` matrix legs `25.1` → `25.8`; `validate-docker` service `clickhouse_24.5` → `clickhouse_25.8`; updated the stale comment referencing the `25.1` pin
- `.github/workflows/test.yml`: `test-queries-config` server + keeper `26.2` → `26.7`
- `docker-compose.yml`: `clickhouse_25.1` → `clickhouse_25.8`

No matrix expansion — kept to a single leg per job/file as the issue requested.

Fixes #2858

https://claude.ai/code/session_01Ug4jivQ5pZtu89C1B6wMRC