### PR TITLE
fix(deploy): skip schedules API entirely — account over free cron budget

### DIFF
--- a/apps/cloud-hooks/src/cron.test.ts
+++ b/apps/cloud-hooks/src/cron.test.ts
@@ -14,21 +14,17 @@
 import { isDailyTick, isWeeklyTick, OPS_SWEEP_CRON } from './index'
 import { describe, expect, test } from 'bun:test'
 
-/** The `crons = [...]` array from wrangler.toml, parsed without a TOML dep. */
-async function configuredCrons(): Promise<string[]> {
-  const toml = await Bun.file(
-    new URL('../wrangler.toml', import.meta.url)
-  ).text()
-  const match = toml.match(/^crons\s*=\s*\[(.*?)\]/ms)
-  if (!match) throw new Error('no `crons = [...]` found in wrangler.toml')
-  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
-}
-
 describe('cron triggers', () => {
-  test('the single configured schedule is exactly OPS_SWEEP_CRON', async () => {
-    // More than one schedule would blow the 5-per-account free-plan budget
-    // (dashboard 4 + hooks 1) and break the dashboard's own deploy.
-    expect(await configuredCrons()).toEqual([OPS_SWEEP_CRON])
+  test('wrangler.toml declares NO crons — schedules PUT must be skipped', async () => {
+    // The account is over the Workers Free 5-crons-per-account budget, so ANY
+    // schedules PUT (even `crons = []`) fails after a successful upload and
+    // turns the deploy red. Wrangler only skips the schedules API when the
+    // key is absent. Re-adding a `crons = [...]` line reintroduces the CI
+    // failure — see the wrangler.toml note.
+    const toml = await Bun.file(
+      new URL('../wrangler.toml', import.meta.url)
+    ).text()
+    expect(toml).not.toMatch(/^\s*crons\s*=/m)
   })
 
   test('the sweep cadence actually produces the report ticks', () => {

--- a/apps/cloud-hooks/wrangler.toml
+++ b/apps/cloud-hooks/wrangler.toml
@@ -75,16 +75,18 @@ minify = true
 [observability]
 enabled = true
 
-# Single cron trigger. The Workers Free plan caps cron triggers at 5 PER
-# ACCOUNT and the dashboard Worker uses 4, so this Worker gets exactly one:
-#   "*/15 * * * *"   ops sweep — health probes, Worker exceptions → GitHub
-#                    issues, and new GitHub issues → Telegram.
-# The daily digest (00:00 UTC tick) and weekly report (Monday 01:00 UTC tick)
-# are dispatched off `event.scheduledTime` inside this schedule — see
-# OPS_SWEEP_CRON / isDailyTick / isWeeklyTick in src/index.ts. The string must
-# match OPS_SWEEP_CRON character for character.
-[triggers]
-crons = ["*/15 * * * *"]
+# NO [triggers] block — deliberate. This account is over the Workers Free
+# 5-crons-per-account budget, so ANY schedules PUT (even `crons = []`) fails
+# after a successful script upload and turns the deploy red (same issue as
+# preview-chmonitor-dash — see apps/dashboard/scripts/patch-wrangler-env.ts).
+# Omitting the key makes wrangler skip the schedules API entirely and leaves
+# the already-attached crons in place.
+#
+# The scheduled() handler no longer routes on cron strings: every tick runs
+# the ops sweep, and the daily digest (00:00 UTC tick) / weekly report
+# (Monday 01:00 UTC tick) dispatch off `event.scheduledTime` — see
+# OPS_SWEEP_CRON / isDailyTick / isWeeklyTick in src/index.ts. If the account
+# ever regains cron budget, re-attach `[triggers] crons = ["*/15 * * * *"]`.
 
 # Custom domain — auto-provisions the hooks.chmonitor.dev DNS record on the
 # managed zone (same pattern as the dashboard's dash.chmonitor.dev). The
@@ -129,6 +131,8 @@ id = "a1d9bd2c4377493eac5b5d4ad04dcc34"
 # ─────────────────────────────────────────────────────────────────────────────
 [env.preview]
 name = "preview-chmonitor-hooks"
+# No [env.preview.triggers] either — see the top-level note: any schedules
+# PUT (including an empty one) fails on this account.
 
 [[env.preview.d1_databases]]
 binding = "CHM_CLOUD_D1"

--- a/apps/dashboard/scripts/patch-wrangler-env.ts
+++ b/apps/dashboard/scripts/patch-wrangler-env.ts
@@ -126,16 +126,16 @@ generated.name = config.name
 generated.routes = config.routes
 generated.vars = vars
 
-// Preview must not touch CF cron schedules. Even `crons: []` still calls
-// PUT .../schedules, which fails on this account for preview-chmonitor-dash
-// (required `dashboard` check exits 1 after a successful script upload).
-// Dropping the triggers key entirely makes wrangler skip the schedules API.
-// Production keeps [triggers] from the vite-generated config.
-// Cron HTTP routes still work on preview with CRON_SECRET; only CF attachment
-// is skipped.
-if (isPreview) {
-  delete generated.triggers
-}
+// Deploys must not touch CF cron schedules AT ALL. The account is over the
+// Workers Free 5-crons-per-account budget, so ANY schedules PUT (even
+// `crons: []`) fails after a successful script upload and exits the deploy
+// with code 1 (first seen on preview-chmonitor-dash; since 2026-08-11 it hits
+// production too — cloud-hooks' crons pushed the account further over budget).
+// Dropping the triggers key entirely makes wrangler skip the schedules API;
+// the crons already attached to the deployed workers stay in place.
+// Cron HTTP routes still work with CRON_SECRET; only CF (re)attachment is
+// skipped. If the account regains cron budget, restore the preview-only guard.
+delete generated.triggers
 
 // --- Patch D1 databases ---
 const conversationsDbId = (
@@ -188,6 +188,6 @@ console.log(`   routes: ${config.routes.map((r) => r.pattern).join(', ')}`)
 console.log(
   `   vars: ${Object.keys(vars).length} keys (from .env.production${isPreview ? ' + .env.preview' : ''})`
 )
-if (isPreview) {
-  console.log('   triggers: omitted (preview skips schedules API)')
-}
+console.log(
+  '   triggers: omitted (schedules API skipped — account cron budget)'
+)

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -224,6 +224,13 @@ simple = { limit = 30, period = 60 }
 #     .env.example): when falsy the route no-ops (200); when unset it defaults to
 #     enabled iff CRON_SECRET is configured. 10 min (not 5) leaves CPU headroom
 #     since the sweep also generates AI insights per host.
+# NOTE: these schedules are DOCUMENTATION + the currently-attached state; the
+# deploy does not (re)apply them. scripts/patch-wrangler-env.ts drops the
+# triggers key from the generated config because any schedules PUT fails while
+# the account is over the Workers Free 5-crons-per-account budget (deploy would
+# exit 1 after a successful upload). The crons below stay attached from earlier
+# deploys. Changing this array therefore has NO effect until the account has
+# cron budget again and the patch-script guard is removed.
 # ─────────────────────────────────────────────────────────────────────────────
 [triggers]
 crons = ["0 3 * * *", "0 8 * * 1", "0 8 1 * *", "*/10 * * * *"]


### PR DESCRIPTION
Follow-up to #2866, which merged before this commit landed on the branch.

Any schedules PUT (even `crons = []`) fails while the account exceeds the Workers Free 5-crons-per-account limit, exiting deploys with code 1 after a successful upload — this is what still fails the main `Deploy to Cloudflare Workers` run (now on the `cloud-hooks` job).

- Dashboard: `patch-wrangler-env.ts` drops the `triggers` key for ALL deploys (was preview-only) → wrangler skips the schedules API; the 4 attached crons stay live.
- cloud-hooks: `[triggers]` block removed (both envs) for the same reason; the time-based `scheduled()` dispatch from #2866 works regardless of which cron strings stay attached.
- `cron.test.ts` pins the no-crons-in-wrangler.toml invariant.

Restore declared crons once the account is upgraded to Workers Paid or account-wide crons are trimmed to ≤5.

https://claude.ai/code/session_01Ug4jivQ5pZtu89C1B6wMRC