### PR TITLE
fix(agent): hide unconfigured providers and parse chat auth errors

### DIFF
--- a/apps/dashboard/src/components/agents/welcome/agent-model-picker.tsx
+++ b/apps/dashboard/src/components/agents/welcome/agent-model-picker.tsx
@@ -162,7 +162,8 @@ export function AgentModelPicker({
   variant = 'toolbar',
   className,
 }: AgentModelPickerProps) {
-  const { model, models, setModel } = useAgentModel()
+  const { model, models, setModel, noProvidersConfigured, modelsLoaded } =
+    useAgentModel()
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
 
@@ -182,6 +183,21 @@ export function AgentModelPicker({
     }
     return Array.from(map.entries())
   }, [models, search])
+
+  if (modelsLoaded && noProvidersConfigured) {
+    return (
+      <div
+        className={cn(
+          'text-muted-foreground border-input flex min-h-10 w-full items-center rounded-md border border-dashed px-3 py-2 text-[11px] leading-snug',
+          variant === 'toolbar' && 'h-7 min-h-0 border-0 px-2 py-0',
+          className
+        )}
+      >
+        No LLM provider configured — set OPENROUTER_API_KEY, ANYROUTER_API_KEY,
+        or NVIDIA_API_KEY
+      </div>
+    )
+  }
 
   if (!selected) {
     return null

--- a/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
@@ -18,6 +18,7 @@ import {
 import { ComposerToolbar } from '@/components/agents/welcome/composer-toolbar'
 import { PageContextChip } from '@/components/assistant-ui/-thread/page-context-chip'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
+import { useAgentModel } from '@/lib/hooks/use-agent-model'
 import { track } from '@/lib/telemetry'
 import { cn } from '@/lib/utils'
 
@@ -64,16 +65,34 @@ export function WelcomeComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
   const { ensureAuthed } = useAgentAuthGate()
+  const { noProvidersConfigured } = useAgentModel()
   const [contextItems, setContextItems] = useState<ContextItem[]>([])
 
   return (
     <div className="flex flex-col gap-2">
+      {noProvidersConfigured ? (
+        <div
+          role="status"
+          className="border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-100 rounded-lg border px-3 py-2 text-sm"
+        >
+          <p className="font-medium">LLM provider not configured</p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            Set one of{' '}
+            <code className="font-mono text-[11px]">OPENROUTER_API_KEY</code>{' '}
+            (or <code className="font-mono text-[11px]">LLM_API_KEY</code>),{' '}
+            <code className="font-mono text-[11px]">ANYROUTER_API_KEY</code>, or{' '}
+            <code className="font-mono text-[11px]">NVIDIA_API_KEY</code> on this
+            deployment so the agent can answer.
+          </p>
+        </div>
+      ) : null}
       <PageContextChip className="self-start" />
       <PromptInputTextareaWithMentions
         isLoading={isRunning}
         onResolvedSubmit={(text) => {
           const trimmed = text.trim()
           if (!trimmed) return
+          if (noProvidersConfigured) return
           if (!ensureAuthed()) return
           const block = formatContextBlock(contextItems)
           const full = block ? `${block}\n\n${trimmed}` : trimmed
@@ -102,16 +121,30 @@ export function ThreadComposer() {
   const threadRuntime = useThreadRuntime()
   const isRunning = useThread((thread) => thread.isRunning)
   const { ensureAuthed } = useAgentAuthGate()
+  const { noProvidersConfigured } = useAgentModel()
   const [contextItems, setContextItems] = useState<ContextItem[]>([])
 
   return (
     <div className="flex w-full flex-col gap-1.5">
+      {noProvidersConfigured ? (
+        <div
+          role="status"
+          className="border-amber-500/40 bg-amber-500/10 text-amber-950 dark:text-amber-100 rounded-lg border px-3 py-2 text-sm"
+        >
+          <p className="font-medium">LLM provider not configured</p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            Set OPENROUTER_API_KEY (or LLM_API_KEY), ANYROUTER_API_KEY, or
+            NVIDIA_API_KEY so the agent can answer.
+          </p>
+        </div>
+      ) : null}
       <PageContextChip className="self-start" />
       <PromptInputTextareaWithMentions
         isLoading={isRunning}
         onResolvedSubmit={(text) => {
           const trimmed = text.trim()
           if (!trimmed) return
+          if (noProvidersConfigured) return
           if (!ensureAuthed()) return
           const block = formatContextBlock(contextItems)
           const full = block ? `${block}\n\n${trimmed}` : trimmed

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -56,7 +56,6 @@ import {
   ActionBarPrimitive,
   BranchPickerPrimitive,
   ComposerPrimitive,
-  ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
   useMessage,
@@ -81,7 +80,9 @@ import {
 } from '@/components/ui/message-scroller'
 import {
   type AgentError,
+  classifyError,
   extractAgentErrorFromParts,
+  parseAgentError,
 } from '@/lib/ai/agent/errors'
 import { getFollowUpPrompts } from '@/lib/ai/agent/follow-up-prompts'
 import { resolveConversationBackend } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
@@ -329,15 +330,97 @@ function LoadingIndicator() {
 // Task #5: MessageError using ErrorPrimitive
 // ---------------------------------------------------------------------------
 
+/**
+ * Render a classified agent error (message + actionable suggestion). Shared by
+ * runtime HTTP errors (`MessagePrimitive.Error`) and streamed `data-error` parts.
+ */
+function AgentErrorAlert({ agentError }: { agentError: AgentError }) {
+  return (
+    <div
+      role="alert"
+      className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+        <div className="min-w-0 space-y-1">
+          <p className="font-medium break-words">{agentError.message}</p>
+          {agentError.suggestion ? (
+            <p className="text-destructive/80 text-xs break-words">
+              {agentError.suggestion}
+            </p>
+          ) : null}
+          {agentError.code ? (
+            <p className="text-destructive/60 font-mono text-[10px]">
+              {agentError.code}
+              {agentError.provider ? ` · ${agentError.provider}` : ''}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Parse the runtime error payload (often a stringified `{ error: AgentError }`
+ * JSON body from the agent route) into a structured alert. Falls back to
+ * {@link classifyError} for plain text / non-AgentError shapes so we never dump
+ * raw JSON into the chat bubble.
+ */
+function resolveRuntimeAgentError(raw: unknown): AgentError {
+  if (raw instanceof Error) {
+    const parsed = parseAgentError(raw)
+    if (parsed) return parsed
+    // AI SDK often puts the JSON body in error.message — classify the Error.
+    return classifyError(raw)
+  }
+  if (typeof raw === 'string') {
+    const parsed = parseAgentError(new Error(raw))
+    if (parsed) return parsed
+    return classifyError(raw)
+  }
+  // Some transports put the parsed JSON body (`{ error: AgentError }`) on
+  // status.error directly rather than as a string.
+  if (raw && typeof raw === 'object') {
+    const asRecord = raw as Record<string, unknown>
+    const nested = asRecord.error
+    if (
+      nested &&
+      typeof nested === 'object' &&
+      typeof (nested as AgentError).type === 'string' &&
+      typeof (nested as AgentError).message === 'string'
+    ) {
+      const parsed = parseAgentError(
+        new Error(JSON.stringify({ error: nested }))
+      )
+      if (parsed) return parsed
+    }
+    const direct = parseAgentError(new Error(JSON.stringify(raw)))
+    if (direct) return direct
+  }
+  return classifyError(raw)
+}
+
 function MessageError() {
+  const status = useMessage((m) => m.status)
+  const rawError =
+    status &&
+    typeof status === 'object' &&
+    'error' in status &&
+    (status as { error?: unknown }).error !== undefined &&
+    (status as { error?: unknown }).error !== null
+      ? (status as { error?: unknown }).error
+      : undefined
+
+  // MessagePrimitive.Error only mounts when the runtime marked the message as
+  // failed; parse any JSON body so we never dump raw `{error:{...}}` into the UI.
+  const agentError = resolveRuntimeAgentError(
+    rawError ?? 'An unexpected error occurred'
+  )
+
   return (
     <MessagePrimitive.Error>
-      <ErrorPrimitive.Root
-        role="alert"
-        className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm"
-      >
-        <ErrorPrimitive.Message className="line-clamp-4" />
-      </ErrorPrimitive.Root>
+      <AgentErrorAlert agentError={agentError} />
     </MessagePrimitive.Error>
   )
 }
@@ -354,25 +437,7 @@ function AgentDataError() {
   const content = useMessage((m) => m.content) as readonly unknown[]
   const agentError: AgentError | null = extractAgentErrorFromParts(content)
   if (!agentError) return null
-
-  return (
-    <div
-      role="alert"
-      className="border-destructive/40 bg-destructive/10 text-destructive mt-1 rounded-lg border px-3 py-2 text-sm"
-    >
-      <div className="flex items-start gap-2">
-        <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
-        <div className="min-w-0 space-y-1">
-          <p className="font-medium break-words">{agentError.message}</p>
-          {agentError.suggestion && (
-            <p className="text-destructive/80 text-xs break-words">
-              {agentError.suggestion}
-            </p>
-          )}
-        </div>
-      </div>
-    </div>
-  )
+  return <AgentErrorAlert agentError={agentError} />
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 
 mock.module('server-only', () => ({}))
 
-const { isProviderConfigured, parseModelId, resolveProvider } = await import(
-  '../providers'
-)
+const {
+  isProviderConfigured,
+  parseModelId,
+  providerNotConfiguredMessage,
+  resolveProvider,
+} = await import('../providers')
 
 describe('parseModelId', () => {
   test('parses provider:model format', () => {
@@ -184,6 +187,44 @@ describe('resolveProvider', () => {
     })
     const resolved = resolveProvider('nvidia:nvidia/test-model')
     expect(resolved.baseURL).toBe('http://custom-nvidia.local/v1')
+  })
+})
+
+describe('providerNotConfiguredMessage', () => {
+  const originalEnv = process.env
+
+  function setEnv(vars: Record<string, string | undefined>) {
+    process.env = { ...originalEnv, ...vars }
+  }
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('lists setup env vars when no provider is configured', () => {
+    setEnv({
+      ANYROUTER_API_KEY: undefined,
+      OPENROUTER_API_KEY: undefined,
+      LLM_API_KEY: undefined,
+      NVIDIA_API_KEY: undefined,
+    })
+    const msg = providerNotConfiguredMessage('anyrouter')
+    expect(msg).toContain('No LLM provider is configured')
+    expect(msg).toContain('OPENROUTER_API_KEY')
+    expect(msg).toContain('ANYROUTER_API_KEY')
+  })
+
+  test('names the missing provider when others are configured', () => {
+    setEnv({
+      ANYROUTER_API_KEY: undefined,
+      OPENROUTER_API_KEY: 'or-key',
+      LLM_API_KEY: undefined,
+      NVIDIA_API_KEY: undefined,
+    })
+    const msg = providerNotConfiguredMessage('anyrouter')
+    expect(msg).toContain('AnyRouter')
+    expect(msg).toContain('openrouter')
+    expect(msg).toContain('ANYROUTER_API_KEY')
   })
 })
 

--- a/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/errors.test.ts
@@ -113,6 +113,37 @@ describe('agent error classification', () => {
     })
   })
 
+  test('parses provider_not_configured auth_error JSON from agent route', () => {
+    const payload = {
+      error: {
+        type: 'auth_error',
+        message:
+          'No LLM provider is configured on this deployment. Set one of OPENROUTER_API_KEY (or LLM_API_KEY), ANYROUTER_API_KEY, NVIDIA_API_KEY so the AI agent can run.',
+        suggestion:
+          'Set OPENROUTER_API_KEY (or LLM_API_KEY), ANYROUTER_API_KEY, or NVIDIA_API_KEY on the deployment — at least one is required for the agent.',
+        timestamp: 1766462558646,
+        model: 'anyrouter:@preset/chmonitor',
+        provider: 'anyrouter',
+        code: 'provider_not_configured',
+      },
+    }
+    const error = new Error(JSON.stringify(payload))
+    expect(parseAgentError(error)).toMatchObject({
+      type: 'auth_error',
+      code: 'provider_not_configured',
+      provider: 'anyrouter',
+      message: expect.stringContaining('No LLM provider is configured'),
+    })
+
+    // classifyError should also recover when the message is raw JSON
+    const classified = classifyError(JSON.stringify(payload), {
+      model: 'anyrouter:@preset/chmonitor',
+      provider: 'anyrouter',
+    })
+    expect(classified.type).toBe('auth_error')
+    expect(classified.message).toContain('No LLM provider is configured')
+  })
+
   // The agent route's outermost boundary passes any uncaught throw through
   // classifyError. Whatever escapes must still become a renderable AgentError
   // (round-trippable via parseAgentError) instead of an opaque HTML 500.

--- a/apps/dashboard/src/lib/ai/agent/errors.ts
+++ b/apps/dashboard/src/lib/ai/agent/errors.ts
@@ -62,8 +62,8 @@ export function getErrorSuggestion(
   switch (type) {
     case 'auth_error':
       return provider === 'anyrouter'
-        ? 'Check ANYROUTER_API_KEY or the selected AnyRouter key in .env.local'
-        : 'Check OPENROUTER_API_KEY, NVIDIA_API_KEY, ANYROUTER_API_KEY, or LLM_API_KEY in .env.local'
+        ? 'Set ANYROUTER_API_KEY on the deployment (or pick a model from another configured provider).'
+        : 'Set OPENROUTER_API_KEY (or LLM_API_KEY), ANYROUTER_API_KEY, or NVIDIA_API_KEY on the deployment — at least one is required for the agent.'
     case 'rate_limit':
       return 'Wait a moment and retry, or switch to a different model'
     case 'billing_error':

--- a/apps/dashboard/src/lib/ai/providers.ts
+++ b/apps/dashboard/src/lib/ai/providers.ts
@@ -168,3 +168,45 @@ export function isProviderConfigured(providerId: string): boolean {
 export function getProviderName(providerId: string): string {
   return PROVIDERS[providerId]?.name ?? providerId
 }
+
+/**
+ * Provider ids that currently have an API key on this deployment.
+ */
+export function getConfiguredProviderIds(): string[] {
+  return Object.keys(PROVIDERS).filter((id) => isProviderConfigured(id))
+}
+
+/**
+ * Env var labels an operator can set to enable at least one LLM provider.
+ * OpenRouter also accepts the legacy `LLM_API_KEY` alias.
+ */
+export function getProviderSetupEnvHints(): string[] {
+  return [
+    'OPENROUTER_API_KEY (or LLM_API_KEY)',
+    'ANYROUTER_API_KEY',
+    'NVIDIA_API_KEY',
+  ]
+}
+
+/**
+ * User-facing message when the selected provider has no key, or when no LLM
+ * providers are configured at all.
+ */
+export function providerNotConfiguredMessage(providerId: string): string {
+  const configured = getConfiguredProviderIds()
+  if (configured.length === 0) {
+    return (
+      'No LLM provider is configured on this deployment. Set one of ' +
+      `${getProviderSetupEnvHints().join(', ')} ` +
+      'so the AI agent can run.'
+    )
+  }
+  const envVar =
+    PROVIDERS[providerId]?.apiKeyEnvVar ??
+    `${providerId.toUpperCase()}_API_KEY`
+  return (
+    `Provider "${getProviderName(providerId)}" is not configured on this deployment. ` +
+    `Pick a model from a configured provider (${configured.join(', ')}) ` +
+    `or ask the operator to set ${envVar}.`
+  )
+}

--- a/apps/dashboard/src/lib/hooks/use-agent-model.ts
+++ b/apps/dashboard/src/lib/hooks/use-agent-model.ts
@@ -21,7 +21,7 @@ import {
   type ModelPricing,
   type OpenAIModel,
 } from '@/lib/ai/agent-models'
-import { ANYROUTER_AUTO_MODEL_ID } from '@/lib/ai/anyrouter-dynamic-models'
+import { FALLBACK_AGENT_MODEL } from '@/lib/ai/agent-model-registry'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export type { OpenAIModel } from '@/lib/ai/agent-models'
@@ -29,11 +29,14 @@ export type { OpenAIModel } from '@/lib/ai/agent-models'
 const MODEL_STORAGE_KEY = 'clickhouse-monitor-agent-model'
 
 /**
- * Client default when no saved selection exists.
- * Prefer the AnyRouter auto alias (resolved server-side to top-by-usage);
- * curated Gemma remains the static registry fallback for offline/static lists.
+ * Client default when no saved selection exists and the models API has not
+ * loaded yet. Prefer OpenRouter free (works with LLM_API_KEY / OPENROUTER_API_KEY)
+ * — never hardcode AnyRouter, which would 503 when ANYROUTER_API_KEY is unset.
+ * Format as `provider:model` for the agent route.
  */
-const DEFAULT_MODEL = ANYROUTER_AUTO_MODEL_ID
+const DEFAULT_MODEL: OpenAIModel = FALLBACK_AGENT_MODEL.includes(':')
+  ? (FALLBACK_AGENT_MODEL as OpenAIModel)
+  : (`openrouter:${FALLBACK_AGENT_MODEL}` as OpenAIModel)
 
 /**
  * Ensure a model identifier is in `provider:model` form.
@@ -126,6 +129,15 @@ export interface UseAgentModelResult {
   models: readonly ModelDisplayInfo[]
   setModel: (model: OpenAIModel) => void
   resetModel: () => void
+  /** True once /api/v1/agents/models has returned (possibly empty). */
+  modelsLoaded: boolean
+  /**
+   * Provider ids with a key on this deployment (from models API).
+   * Empty array means no LLM keys — agent chat cannot run.
+   */
+  configuredProviders: readonly string[]
+  /** True when models API reports zero configured providers. */
+  noProvidersConfigured: boolean
 }
 
 function getStaticModels(): ModelDisplayInfo[] {
@@ -150,7 +162,10 @@ function getStaticModels(): ModelDisplayInfo[] {
   })
 }
 
-async function fetchModelsWithCapabilities(): Promise<ModelDisplayInfo[]> {
+async function fetchModelsWithCapabilities(): Promise<{
+  models: ModelDisplayInfo[]
+  configuredProviders: string[]
+}> {
   try {
     const response = await apiFetch('/api/v1/agents/models')
     if (!response.ok) {
@@ -161,9 +176,14 @@ async function fetchModelsWithCapabilities(): Promise<ModelDisplayInfo[]> {
       models: ModelDisplayInfo[]
       configuredProviders?: string[]
     }
-    return data.models
+    return {
+      models: data.models,
+      configuredProviders: data.configuredProviders ?? [],
+    }
   } catch {
-    return getStaticModels()
+    // Offline / error: keep static list for local dev; configuredProviders
+    // unknown so leave empty (UI will not claim "no providers" incorrectly).
+    return { models: getStaticModels(), configuredProviders: [] }
   }
 }
 
@@ -189,13 +209,27 @@ export function useAgentModel(): UseAgentModelResult {
   const [model, setModelState] = useState<OpenAIModel>(() => getSavedModel())
 
   const [models, setModels] = useState<ModelDisplayInfo[]>(getStaticModels)
+  const [modelsLoaded, setModelsLoaded] = useState(false)
+  const [configuredProviders, setConfiguredProviders] = useState<string[]>([])
 
   useEffect(() => {
     let cancelled = false
 
     async function loadModels() {
-      const nextModels = await fetchModelsWithCapabilities()
-      if (cancelled || nextModels.length === 0) return
+      const { models: nextModels, configuredProviders: nextProviders } =
+        await fetchModelsWithCapabilities()
+      if (cancelled) return
+
+      setModelsLoaded(true)
+      setConfiguredProviders(nextProviders)
+
+      // Empty list = no provider keys on this deployment (or only
+      // unconfigured providers were filtered out). Clear the picker and keep
+      // the last model id only as a soft preference until keys exist.
+      if (nextModels.length === 0) {
+        setModels([])
+        return
+      }
 
       setModels(nextModels)
 
@@ -213,8 +247,8 @@ export function useAgentModel(): UseAgentModelResult {
           nextModels.some((m) => m.id === current) &&
           nextModels.find((m) => m.id === current)?.available !== false
         if (stillAvailable) return current
-        fallbackId = fallbackPool[0].id
-        return fallbackId
+        fallbackId = fallbackPool[0]?.id
+        return fallbackId ?? current
       })
 
       // Side effects outside the updater — save and broadcast fallback
@@ -259,5 +293,11 @@ export function useAgentModel(): UseAgentModelResult {
     models,
     setModel,
     resetModel,
+    modelsLoaded,
+    configuredProviders,
+    noProvidersConfigured:
+      modelsLoaded &&
+      configuredProviders.length === 0 &&
+      models.length === 0,
   }
 }

--- a/apps/dashboard/src/routes/api/v1/__tests__/agent-quota-release.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/agent-quota-release.test.ts
@@ -45,6 +45,8 @@ mock.module('@/lib/ai/providers', () => ({
   parseModelId: () => ({ provider: 'test', model: 'test-model' }),
   isProviderConfigured: () => true,
   getProviderName: () => 'Test Provider',
+  providerNotConfiguredMessage: (providerId: string) =>
+    `Provider "${providerId}" is not configured (test stub)`,
 }))
 mock.module('@/lib/ai/agent-model-registry', () => ({
   DEFAULT_AGENT_MODEL: 'test/test-model',

--- a/apps/dashboard/src/routes/api/v1/__tests__/agent.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/agent.test.ts
@@ -80,6 +80,8 @@ mock.module('@/lib/ai/providers', () => ({
   parseModelId: () => ({ provider: 'test', model: 'test-model' }),
   isProviderConfigured: () => providerConfigured,
   getProviderName: () => 'Test Provider',
+  providerNotConfiguredMessage: (providerId: string) =>
+    `Provider "${providerId}" is not configured (test stub)`,
 }))
 mock.module('@/lib/ai/agent-model-registry', () => ({
   DEFAULT_AGENT_MODEL: 'test/test-model',

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -61,9 +61,9 @@ import {
   resolveAnyRouterAutoModelId,
 } from '@/lib/ai/anyrouter-dynamic-models'
 import {
-  getProviderName,
   isProviderConfigured,
   parseModelId,
+  providerNotConfiguredMessage,
 } from '@/lib/ai/providers'
 import {
   checkRateLimitDurable,
@@ -534,10 +534,16 @@ async function handlePost(request: Request): Promise<Response> {
   // `anyrouter:auto` is a picker alias — resolve to the current top-by-usage
   // tool-capable model (cached) before provider preflight / chat setup.
   // Fail-soft: curated DEFAULT_AGENT_MODEL when the dynamic catalog is down.
+  // If AnyRouter itself is not configured, drop to resolveDefaultAgentModel()
+  // so we do not hard-fail on a stale client default of `anyrouter:auto`.
   if (isAnyRouterAutoModelId(model)) {
-    const top = await resolveAnyRouterAutoModelId()
-    // Fail-soft to curated static default (not `anyrouter:auto` again).
-    model = top ?? DEFAULT_AGENT_MODEL
+    if (!isProviderConfigured('anyrouter')) {
+      model = resolveDefaultAgentModel()
+    } else {
+      const top = await resolveAnyRouterAutoModelId()
+      // Fail-soft to curated static default (not `anyrouter:auto` again).
+      model = top ?? DEFAULT_AGENT_MODEL
+    }
   }
 
   // BYOK: the user may supply their own provider API key. When present and
@@ -559,7 +565,7 @@ async function handlePost(request: Request): Promise<Response> {
         statusCode: 503,
         error: {
           code: 'provider_not_configured',
-          message: `Provider "${getProviderName(requestedProvider)}" is not configured on this deployment. Pick a model from a configured provider or ask the operator to set ${requestedProvider.toUpperCase()}_API_KEY.`,
+          message: providerNotConfiguredMessage(requestedProvider),
         },
       },
       { model, provider: requestedProvider }

--- a/apps/dashboard/src/routes/api/v1/agent/followups.ts
+++ b/apps/dashboard/src/routes/api/v1/agent/followups.ts
@@ -30,9 +30,9 @@ import {
   resolveAnyRouterAutoModelId,
 } from '@/lib/ai/anyrouter-dynamic-models'
 import {
-  getProviderName,
   isProviderConfigured,
   parseModelId,
+  providerNotConfiguredMessage,
 } from '@/lib/ai/providers'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
@@ -315,7 +315,7 @@ async function handlePost(request: Request): Promise<Response> {
         statusCode: 503,
         error: {
           code: 'provider_not_configured',
-          message: `Provider "${getProviderName(requestedProvider)}" is not configured on this deployment.`,
+          message: providerNotConfiguredMessage(requestedProvider),
         },
       },
       { model, provider: requestedProvider }

--- a/apps/dashboard/src/routes/api/v1/agents/config-check.ts
+++ b/apps/dashboard/src/routes/api/v1/agents/config-check.ts
@@ -89,17 +89,21 @@ async function handleGet(request: Request): Promise<Response> {
     })
 
     const selectedProviderId = getSelectedProviderId(getSelectedModel())
-    const selectedProviderConfigured = isProviderConfigured(selectedProviderId)
+    // Readiness: the agent works if *any* provider key is set (the UI hides
+    // unconfigured providers and falls back to a configured model).
+    const anyProviderConfigured = providers.some((p) => p.configured)
 
     const configured: ConfigStatus['configured'] = {
-      apiKey: selectedProviderConfigured,
+      apiKey: anyProviderConfigured,
       apiBase: true,
     }
 
-    const isFullyConfigured = configured.apiKey
+    const isFullyConfigured = anyProviderConfigured
 
     const requiredKeys: ConfigStatus['requiredKeys'] = {
-      apiKey: getRequiredApiKeyLabel(selectedProviderId),
+      apiKey: anyProviderConfigured
+        ? getRequiredApiKeyLabel(selectedProviderId)
+        : 'OPENROUTER_API_KEY (or LLM_API_KEY), ANYROUTER_API_KEY, or NVIDIA_API_KEY',
       apiBase: 'Provider default base URL',
     }
 

--- a/apps/dashboard/src/routes/api/v1/agents/models.ts
+++ b/apps/dashboard/src/routes/api/v1/agents/models.ts
@@ -28,7 +28,10 @@ import {
   loadAnyRouterDynamicModelEntries,
   mergeAnyRouterDynamicModels,
 } from '@/lib/ai/anyrouter-dynamic-models'
-import { isProviderConfigured, PROVIDERS } from '@/lib/ai/providers'
+import {
+  getConfiguredProviderIds,
+  isProviderConfigured,
+} from '@/lib/ai/providers'
 import { authorizeAgentApiRequest } from '@/lib/auth/agent-api-auth'
 import { formatCompactNumber } from '@/lib/format-number'
 
@@ -135,14 +138,15 @@ function extractCapabilities(
 
 /**
  * Filter models to those whose provider has a key configured.
- * If no provider is configured at all, return the full list so the dev UI
- * is not empty.
+ * Unconfigured providers (e.g. AnyRouter without ANYROUTER_API_KEY) are always
+ * hidden — never fall back to the full registry so the picker cannot offer a
+ * model that would 503 on the first message.
+ * When no provider keys exist, returns [] (the client surfaces a setup message).
  */
 function filterByConfiguredProviders(
   models: ModelCapability[]
 ): ModelCapability[] {
-  const filtered = models.filter((m) => isProviderConfigured(m.provider))
-  return filtered.length > 0 ? filtered : models
+  return models.filter((m) => isProviderConfigured(m.provider))
 }
 
 function buildStaticModels(): ModelCapability[] {
@@ -163,11 +167,8 @@ function buildStaticModels(): ModelCapability[] {
         contextLength: entry.contextLength,
         formattedContextLength: formatCompactNumber(entry.contextLength),
         isFree,
-        // `available` reflects whether THIS provider's key is configured, even
-        // when the whole list is returned as a dev fallback because no provider
-        // is configured at all. The client uses it to avoid sending a model
-        // whose provider would 503 on the first message.
-        available: isProviderConfigured(provider),
+        // Only configured providers reach this list; mark available for clarity.
+        available: true,
         pricing: entry.pricing,
       })
     }
@@ -216,7 +217,7 @@ async function buildRegistryModels(): Promise<ModelCapability[]> {
             }
           : {}),
         isFree,
-        available: isProviderConfigured(provider),
+        available: true,
         pricing: entry.pricing,
         ...capabilities,
       })
@@ -247,7 +248,7 @@ async function buildModels(): Promise<ModelCapability[]> {
 }
 
 function getConfiguredProviders(): string[] {
-  return Object.keys(PROVIDERS).filter((id) => isProviderConfigured(id))
+  return getConfiguredProviderIds()
 }
 
 async function handleGet(request: Request): Promise<Response> {


### PR DESCRIPTION
## Summary

Fixes the AI agent chat error when AnyRouter is not configured (raw JSON `auth_error` / `provider_not_configured` blob in the thread).

- **Hide unconfigured providers** in `/api/v1/agents/models` — never fall back to the full registry. AnyRouter models disappear when `ANYROUTER_API_KEY` is unset.
- **Client defaults** use OpenRouter free instead of `anyrouter:auto`, and auto-fallback clears stale AnyRouter selections once the models list loads.
- **No keys at all**: composer banner + model picker message tell operators to set `OPENROUTER_API_KEY` / `LLM_API_KEY`, `ANYROUTER_API_KEY`, or `NVIDIA_API_KEY`. Chat submit is blocked until a key exists.
- **API preflight** message lists all setup env vars when none are configured (same for followups).
- **Chat error UI** parses `{ error: AgentError }` JSON and shows message + suggestion (no more raw JSON dump).

## Test plan

- [x] `bun test` providers + agent errors + model registry
- [ ] Local: with only `OPENROUTER_API_KEY` set, model picker has no AnyRouter group
- [ ] Local: clear all LLM keys → banner + no models; sending blocked
- [ ] Local: force unconfigured provider → chat shows title + suggestion, not JSON
- [ ] Deploy preview: open agent chat and confirm error path is readable