### PR TITLE
feat(explorer): engine-aware, denser Overview tab

### DIFF
--- a/apps/dashboard/src/components/explorer/tabs/overview-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/overview-tab.tsx
@@ -1,29 +1,43 @@
 'use client'
 
+import type { LucideIcon } from 'lucide-react'
 import {
   Activity,
+  AlertTriangle,
+  Boxes,
   Clock,
   Database,
-  Gauge,
+  FileCode2,
   HardDrive,
-  Layers,
-  Rows3Icon,
+  Info,
 } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
 import type { ReactNode } from 'react'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  classifyEngine,
+  engineKindLabel,
+  formatTimestamp,
+  hasPartStorage,
+  parseMaterializedViewTarget,
+} from '@/lib/explorer/engine-kind'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
+import { cn } from '@/lib/utils'
 
 interface OverviewRow {
   total_bytes?: string | number | null
   total_rows?: string | number | null
   engine?: string | null
   engine_full?: string | null
+  sorting_key?: string | null
+  partition_key?: string | null
+  primary_key?: string | null
+  as_select?: string | null
+  create_table_query?: string | null
   primary_key_bytes_in_memory?: string | number | null
   primary_key_bytes_in_memory_allocated?: string | number | null
   metadata_modification_time?: string | null
@@ -32,6 +46,23 @@ interface OverviewRow {
   active_parts?: string | number | null
   partitions?: string | number | null
   last_modified?: string | null
+}
+
+interface DictionaryRow {
+  status?: string | null
+  type?: string | null
+  element_count?: string | number | null
+  bytes_allocated?: string | number | null
+  load_factor?: string | number | null
+  loading_duration?: string | number | null
+  loading_start_time?: string | null
+  last_successful_update_time?: string | null
+  last_exception?: string | null
+  source?: string | null
+  key_names?: string[] | null
+  attribute_names?: string[] | null
+  lifetime_min?: string | number | null
+  lifetime_max?: string | number | null
 }
 
 interface UsageRow {
@@ -48,13 +79,6 @@ interface ApiResponse<T> {
   }
 }
 
-interface StatCardProps {
-  label: string
-  value: string
-  icon: ReactNode
-  subline?: ReactNode
-}
-
 const fetcher = async <T,>(url: string): Promise<ApiResponse<T>> => {
   const res = await apiFetch(url)
   if (!res.ok) {
@@ -62,6 +86,8 @@ const fetcher = async <T,>(url: string): Promise<ApiResponse<T>> => {
   }
   return res.json()
 }
+
+const EM_DASH = '—'
 
 function toFiniteNumber(value: unknown): number | null {
   if (value === null || value === undefined || value === '') return null
@@ -72,7 +98,7 @@ function toFiniteNumber(value: unknown): number | null {
 
 function formatBytes(value: unknown): string {
   const bytes = toFiniteNumber(value)
-  if (bytes === null) return '—'
+  if (bytes === null) return EM_DASH
   if (bytes === 0) return '0 B'
 
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
@@ -88,14 +114,15 @@ function formatBytes(value: unknown): string {
 
 function formatNumber(value: unknown): string {
   const n = toFiniteNumber(value)
-  return n === null ? '—' : n.toLocaleString()
+  return n === null ? EM_DASH : n.toLocaleString()
 }
 
-function formatDateTime(value: unknown): string {
-  if (typeof value !== 'string' || value.trim() === '') return '—'
-
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+function formatSeconds(value: unknown): string {
+  const seconds = toFiniteNumber(value)
+  if (seconds === null) return EM_DASH
+  if (seconds < 1) return `${Math.round(seconds * 1000)} ms`
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 2 : 0)}s`
+  return `${Math.round(seconds / 60)}m`
 }
 
 function formatCompressionRatio(
@@ -106,7 +133,7 @@ function formatCompressionRatio(
   const uncompressed = toFiniteNumber(uncompressedValue)
 
   if (compressed === null || uncompressed === null || compressed === 0) {
-    return '—'
+    return EM_DASH
   }
 
   return `${(uncompressed / compressed).toFixed(1)}x`
@@ -116,40 +143,98 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function StatCard({ label, value, icon, subline }: StatCardProps) {
+/** Compact stat tile: label, value, one optional context line. */
+function StatTile({
+  label,
+  value,
+  context,
+  title,
+  tone,
+}: {
+  label: string
+  value: string
+  context?: ReactNode
+  title?: string
+  tone?: 'default' | 'warning'
+}) {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium text-muted-foreground">
-          {label}
-        </CardTitle>
-        <div className="text-muted-foreground">{icon}</div>
-      </CardHeader>
-      <CardContent>
-        <div className="break-words text-2xl font-semibold">{value}</div>
-        {subline ? (
-          <div className="mt-1 break-words text-sm text-muted-foreground">
-            {subline}
-          </div>
-        ) : null}
-      </CardContent>
-    </Card>
+    <div className="min-w-0 rounded-lg border bg-card p-3" title={title}>
+      <div className="truncate text-xs text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          'mt-0.5 truncate text-lg font-semibold tracking-tight',
+          tone === 'warning' && 'text-chart-yellow'
+        )}
+      >
+        {value}
+      </div>
+      {context ? (
+        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+          {context}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function Section({
+  icon: Icon,
+  title,
+  children,
+}: {
+  icon: LucideIcon
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Icon className="size-4 text-muted-foreground" strokeWidth={1.5} />
+        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">{children}</div>
+    </section>
+  )
+}
+
+/** Key/value definition row for long metadata (keys, sources, SQL). */
+function MetaRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 border-b py-2 last:border-b-0 sm:flex-row sm:gap-4">
+      <div className="w-40 shrink-0 text-xs text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          'min-w-0 break-words text-[13px]',
+          mono && 'font-mono text-xs'
+        )}
+      >
+        {value}
+      </div>
+    </div>
   )
 }
 
 function OverviewSkeleton() {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {Array.from({ length: 9 }).map((_, i) => (
-        <Card key={i}>
-          <CardHeader className="pb-2">
-            <Skeleton className="h-4 w-28" />
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <Skeleton className="h-8 w-24" />
-            <Skeleton className="h-4 w-36" />
-          </CardContent>
-        </Card>
+    <div className="space-y-5">
+      <Skeleton className="h-12 w-full rounded-lg" />
+      {[0, 1].map((section) => (
+        <div key={section} className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-[74px] rounded-lg" />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   )
@@ -159,14 +244,13 @@ export function OverviewTab() {
   const hostId = useHostId()
   const { database, table } = useExplorerState()
 
-  const summaryUrl =
+  const params =
     database && table
-      ? `/api/v1/tables/explorer-table-overview?hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
+      ? `hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
       : null
-  const usageUrl =
-    database && table
-      ? `/api/v1/tables/explorer-table-usage?hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
-      : null
+  const summaryUrl = params
+    ? `/api/v1/tables/explorer-table-overview?${params}`
+    : null
 
   const {
     data: summaryResponse,
@@ -176,6 +260,29 @@ export function OverviewTab() {
     queryKey: [summaryUrl],
     queryFn: () => fetcher<OverviewRow[]>(summaryUrl!),
     enabled: Boolean(summaryUrl),
+  })
+
+  const summary = summaryResponse?.data?.[0]
+  const kind = classifyEngine(summary?.engine)
+  const isDictionary = kind === 'dictionary'
+  const isViewLike = kind === 'view' || kind === 'materialized-view'
+
+  // Engine-aware follow-up queries: only fetch what this object type has.
+  const dictionaryUrl =
+    params && isDictionary
+      ? `/api/v1/tables/explorer-dictionary-overview?${params}`
+      : null
+  const usageUrl =
+    params && !isViewLike
+      ? `/api/v1/tables/explorer-table-usage?${params}`
+      : null
+
+  const { data: dictionaryResponse, isLoading: dictionaryLoading } = useQuery<
+    ApiResponse<DictionaryRow[]>
+  >({
+    queryKey: [dictionaryUrl],
+    queryFn: () => fetcher<DictionaryRow[]>(dictionaryUrl!),
+    enabled: Boolean(dictionaryUrl),
   })
 
   const {
@@ -198,93 +305,250 @@ export function OverviewTab() {
 
   if (summaryError) {
     return (
-      <Card>
-        <CardContent className="pt-6">
-          <div className="text-sm text-destructive">
-            Failed to load overview: {getErrorMessage(summaryError)}
-          </div>
-        </CardContent>
-      </Card>
+      <div className="rounded-lg border bg-card p-4 text-sm text-destructive">
+        Failed to load overview: {getErrorMessage(summaryError)}
+      </div>
     )
   }
 
-  const summary = summaryResponse?.data?.[0]
+  const dictionary = dictionaryResponse?.data?.[0]
   const usage = usageResponse?.data?.[0]
   const usageUnavailable =
     Boolean(usageError) ||
     usageResponse?.metadata?.unavailable === true ||
     (!usageLoading && !usage)
-  const lastModified =
-    summary?.last_modified || summary?.metadata_modification_time || null
-  const usageValue =
-    usageLoading || usageUnavailable || !usage
-      ? '—'
-      : `${formatNumber(usage.queries_24h)} (24h) / ${formatNumber(usage.queries_7d)} (7d)`
+
+  const lastModified = formatTimestamp(
+    summary?.last_modified || summary?.metadata_modification_time
+  )
+  const metadataChanged = formatTimestamp(summary?.metadata_modification_time)
+  const showStorage = hasPartStorage(kind)
+  const mvTarget = parseMaterializedViewTarget(summary?.create_table_query)
+  const definition = summary?.as_select?.trim() || ''
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <StatCard
-        label="Table size"
-        value={formatBytes(summary?.total_bytes)}
-        icon={<HardDrive className="size-4" />}
-      />
-      <StatCard
-        label="Rows"
-        value={formatNumber(summary?.total_rows)}
-        icon={<Rows3Icon className="size-4" />}
-      />
-      <StatCard
-        label="Engine"
-        value={summary?.engine || '—'}
-        icon={<Database className="size-4" />}
-        subline={
-          summary?.engine_full && summary.engine_full !== summary.engine ? (
-            <code className="font-mono text-xs">{summary.engine_full}</code>
-          ) : undefined
-        }
-      />
-      <StatCard
-        label="Index size"
-        value={formatBytes(summary?.primary_key_bytes_in_memory)}
-        icon={<Gauge className="size-4" />}
-        subline={`/ ${formatBytes(summary?.primary_key_bytes_in_memory_allocated)} allocated`}
-      />
-      <StatCard
-        label="Compression"
-        value={formatCompressionRatio(
-          summary?.compressed_bytes,
-          summary?.uncompressed_bytes
+    <div className="space-y-5">
+      {/* Identity strip — what this object actually is */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border bg-card px-3 py-2.5">
+        <Database
+          className="size-4 shrink-0 text-muted-foreground"
+          strokeWidth={1.5}
+        />
+        <span className="text-sm font-medium">{engineKindLabel(kind)}</span>
+        <span className="text-muted-foreground">·</span>
+        <code className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+          {summary?.engine_full || summary?.engine || 'Unknown engine'}
+        </code>
+      </div>
+
+      {showStorage ? (
+        <Section icon={HardDrive} title="Storage">
+          <StatTile
+            label="Table size"
+            value={formatBytes(summary?.total_bytes)}
+            context={`${formatNumber(summary?.total_rows)} rows`}
+          />
+          <StatTile
+            label="Compression"
+            value={formatCompressionRatio(
+              summary?.compressed_bytes,
+              summary?.uncompressed_bytes
+            )}
+            context={`${formatBytes(summary?.compressed_bytes)} of ${formatBytes(summary?.uncompressed_bytes)}`}
+          />
+          <StatTile
+            label="Parts"
+            value={formatNumber(summary?.active_parts)}
+            context={`${formatNumber(summary?.partitions)} partitions`}
+          />
+          <StatTile
+            label="Index in memory"
+            value={formatBytes(summary?.primary_key_bytes_in_memory)}
+            context={`${formatBytes(summary?.primary_key_bytes_in_memory_allocated)} allocated`}
+          />
+        </Section>
+      ) : null}
+
+      {isDictionary ? (
+        <>
+          {dictionary?.last_exception ? (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-[13px]">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <div className="min-w-0 break-words">
+                <div className="font-medium text-destructive">Load failed</div>
+                <div className="mt-0.5 text-muted-foreground">
+                  {dictionary.last_exception}
+                </div>
+              </div>
+            </div>
+          ) : null}
+          <Section icon={Boxes} title="Dictionary">
+            <StatTile
+              label="Status"
+              value={
+                dictionaryLoading
+                  ? '…'
+                  : dictionary?.status?.replace(/_/g, ' ') || 'Unknown'
+              }
+              context={dictionary?.type || undefined}
+              tone={
+                dictionary?.status && dictionary.status !== 'LOADED'
+                  ? 'warning'
+                  : 'default'
+              }
+            />
+            <StatTile
+              label="Elements"
+              value={formatNumber(dictionary?.element_count)}
+              context={
+                toFiniteNumber(dictionary?.load_factor) === null
+                  ? undefined
+                  : `load factor ${Number(dictionary?.load_factor).toFixed(2)}`
+              }
+            />
+            <StatTile
+              label="Memory"
+              value={formatBytes(dictionary?.bytes_allocated)}
+            />
+            <StatTile
+              label="Load time"
+              value={formatSeconds(dictionary?.loading_duration)}
+              context={
+                formatTimestamp(dictionary?.last_successful_update_time)
+                  .relative === 'never'
+                  ? 'never updated'
+                  : `updated ${formatTimestamp(dictionary?.last_successful_update_time).relative}`
+              }
+              title={
+                formatTimestamp(dictionary?.last_successful_update_time)
+                  .absolute ?? undefined
+              }
+            />
+          </Section>
+        </>
+      ) : null}
+
+      <Section icon={Activity} title="Activity">
+        {showStorage ? (
+          <StatTile
+            label="Last modified"
+            value={lastModified.relative}
+            context={lastModified.absolute ?? 'no active parts'}
+            title={lastModified.absolute ?? undefined}
+          />
+        ) : (
+          <StatTile
+            label="Metadata changed"
+            value={metadataChanged.relative}
+            context={metadataChanged.absolute ?? undefined}
+            title={metadataChanged.absolute ?? undefined}
+          />
         )}
-        icon={<Activity className="size-4" />}
-        subline={`compressed ${formatBytes(summary?.compressed_bytes)} · uncompressed ${formatBytes(summary?.uncompressed_bytes)}`}
-      />
-      <StatCard
-        label="Active parts"
-        value={formatNumber(summary?.active_parts)}
-        icon={<Layers className="size-4" />}
-      />
-      <StatCard
-        label="Partitions"
-        value={formatNumber(summary?.partitions)}
-        icon={<Layers className="size-4" />}
-      />
-      <StatCard
-        label="Last modified"
-        value={formatDateTime(lastModified)}
-        icon={<Clock className="size-4" />}
-      />
-      <StatCard
-        label="Usage"
-        value={usageValue}
-        icon={<Activity className="size-4" />}
-        subline={
-          usageLoading
-            ? 'Loading usage...'
-            : usageUnavailable
-              ? 'Usage unavailable (system.query_log disabled)'
-              : undefined
-        }
-      />
+        {isViewLike ? null : (
+          <>
+            <StatTile
+              label="Queries (24h)"
+              value={
+                usageLoading
+                  ? '…'
+                  : usageUnavailable
+                    ? EM_DASH
+                    : formatNumber(usage?.queries_24h)
+              }
+              context={
+                usageUnavailable && !usageLoading
+                  ? 'system.query_log unavailable'
+                  : undefined
+              }
+            />
+            <StatTile
+              label="Queries (7d)"
+              value={
+                usageLoading
+                  ? '…'
+                  : usageUnavailable
+                    ? EM_DASH
+                    : formatNumber(usage?.queries_7d)
+              }
+            />
+          </>
+        )}
+        {isDictionary && dictionary ? (
+          <StatTile
+            label="Lifetime"
+            value={
+              toFiniteNumber(dictionary.lifetime_max) === null
+                ? EM_DASH
+                : `${formatNumber(dictionary.lifetime_min)}–${formatNumber(dictionary.lifetime_max)}s`
+            }
+            context="refresh window"
+          />
+        ) : null}
+      </Section>
+
+      <Section icon={Info} title="Metadata">
+        <div className="sm:col-span-2 lg:col-span-4 rounded-lg border bg-card px-3 py-1">
+          {showStorage ? (
+            <>
+              <MetaRow
+                label="Sorting key"
+                value={summary?.sorting_key || EM_DASH}
+                mono
+              />
+              <MetaRow
+                label="Partition key"
+                value={summary?.partition_key || 'none'}
+                mono
+              />
+              <MetaRow
+                label="Primary key"
+                value={summary?.primary_key || EM_DASH}
+                mono
+              />
+            </>
+          ) : null}
+          {isDictionary && dictionary ? (
+            <>
+              <MetaRow
+                label="Key"
+                value={dictionary.key_names?.join(', ') || EM_DASH}
+                mono
+              />
+              <MetaRow
+                label="Attributes"
+                value={dictionary.attribute_names?.join(', ') || 'none'}
+                mono
+              />
+              <MetaRow label="Source" value={dictionary.source || EM_DASH} />
+            </>
+          ) : null}
+          {kind === 'materialized-view' ? (
+            <MetaRow label="Target table" value={mvTarget || 'inner table'} />
+          ) : null}
+          {!showStorage && !isDictionary && !isViewLike ? (
+            <MetaRow
+              label="Engine"
+              value={summary?.engine_full || summary?.engine || EM_DASH}
+              mono
+            />
+          ) : null}
+        </div>
+      </Section>
+
+      {isViewLike && definition ? (
+        <Section icon={FileCode2} title="Definition">
+          <pre className="sm:col-span-2 lg:col-span-4 max-h-64 overflow-auto rounded-lg border bg-card p-3 font-mono text-xs">
+            {definition}
+          </pre>
+        </Section>
+      ) : null}
+
+      {!showStorage && !isDictionary && !isViewLike ? (
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Clock className="size-3.5" strokeWidth={1.5} />
+          This engine does not expose part-level storage statistics.
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/apps/dashboard/src/lib/explorer/engine-kind.test.ts
+++ b/apps/dashboard/src/lib/explorer/engine-kind.test.ts
@@ -1,0 +1,125 @@
+import {
+  classifyEngine,
+  engineKindLabel,
+  formatTimestamp,
+  hasPartStorage,
+  isEpochZero,
+  parseMaterializedViewTarget,
+} from './engine-kind'
+import { describe, expect, test } from 'bun:test'
+
+describe('classifyEngine', () => {
+  test('classifies the MergeTree family (incl. replicated/shared variants)', () => {
+    for (const engine of [
+      'MergeTree',
+      'ReplacingMergeTree',
+      'ReplicatedMergeTree',
+      'ReplicatedSummingMergeTree',
+      'SharedMergeTree',
+    ]) {
+      expect(classifyEngine(engine)).toBe('mergetree')
+    }
+  })
+
+  test('classifies dictionaries and views distinctly', () => {
+    expect(classifyEngine('Dictionary')).toBe('dictionary')
+    expect(classifyEngine('View')).toBe('view')
+    expect(classifyEngine('LiveView')).toBe('view')
+    expect(classifyEngine('MaterializedView')).toBe('materialized-view')
+  })
+
+  test('classifies log and integration engines', () => {
+    expect(classifyEngine('TinyLog')).toBe('log')
+    expect(classifyEngine('Distributed')).toBe('integration')
+    expect(classifyEngine('Kafka')).toBe('integration')
+  })
+
+  test('falls back to other for unknown/missing engines', () => {
+    expect(classifyEngine(undefined)).toBe('other')
+    expect(classifyEngine('')).toBe('other')
+    expect(classifyEngine('SomethingNew')).toBe('other')
+  })
+})
+
+describe('hasPartStorage', () => {
+  test('only MergeTree-family objects expose part-based storage stats', () => {
+    // This is what keeps "Partitions 0 / Active parts 0" off a Dictionary.
+    expect(hasPartStorage(classifyEngine('MergeTree'))).toBe(true)
+    expect(hasPartStorage(classifyEngine('Dictionary'))).toBe(false)
+    expect(hasPartStorage(classifyEngine('View'))).toBe(false)
+    expect(hasPartStorage(classifyEngine('MaterializedView'))).toBe(false)
+  })
+})
+
+describe('engineKindLabel', () => {
+  test('names the object type for headers', () => {
+    expect(engineKindLabel(classifyEngine('Dictionary'))).toBe('Dictionary')
+    expect(engineKindLabel(classifyEngine('MaterializedView'))).toBe(
+      'Materialized view'
+    )
+    expect(engineKindLabel(classifyEngine('MergeTree'))).toBe('Table')
+  })
+})
+
+describe('parseMaterializedViewTarget', () => {
+  test('extracts the TO target of a materialized view', () => {
+    expect(
+      parseMaterializedViewTarget(
+        'CREATE MATERIALIZED VIEW default.mv TO default.dest (`a` UInt8) AS SELECT a FROM src'
+      )
+    ).toBe('default.dest')
+  })
+
+  test('strips backticks from quoted identifiers', () => {
+    expect(
+      parseMaterializedViewTarget(
+        'CREATE MATERIALIZED VIEW `db`.`mv` TO `my db`.`my table` AS SELECT 1'
+      )
+    ).toBe('my db.my table')
+  })
+
+  test('returns null for an inner-table MV or a plain view', () => {
+    expect(
+      parseMaterializedViewTarget(
+        'CREATE MATERIALIZED VIEW default.mv ENGINE = MergeTree ORDER BY a AS SELECT a FROM src'
+      )
+    ).toBeNull()
+    expect(parseMaterializedViewTarget('')).toBeNull()
+    expect(parseMaterializedViewTarget(null)).toBeNull()
+  })
+})
+
+describe('isEpochZero', () => {
+  test('detects ClickHouse epoch-zero datetimes regardless of timezone', () => {
+    // Parsed as local time, so getTime() is non-zero in most timezones —
+    // the check must be year-based, not `getTime() === 0`.
+    expect(isEpochZero('1970-01-01 00:00:00')).toBe(true)
+    expect(isEpochZero(0)).toBe(true)
+  })
+
+  test('does not flag real timestamps', () => {
+    expect(isEpochZero('2026-08-12 10:00:00')).toBe(false)
+  })
+})
+
+describe('formatTimestamp', () => {
+  test('renders epoch-zero as the fallback, never 1/1/1970', () => {
+    const result = formatTimestamp('1970-01-01 00:00:00')
+    expect(result.relative).toBe('never')
+    expect(result.absolute).toBeNull()
+  })
+
+  test('renders missing/invalid values as the fallback', () => {
+    expect(formatTimestamp(null).relative).toBe('never')
+    expect(formatTimestamp('').relative).toBe('never')
+    expect(formatTimestamp('not-a-date').relative).toBe('never')
+    expect(formatTimestamp(undefined, '—').relative).toBe('—')
+  })
+
+  test('renders a real timestamp as relative plus absolute', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    const result = formatTimestamp(twoHoursAgo.toISOString())
+    expect(result.relative).toBe('2h ago')
+    expect(result.absolute).toBe(twoHoursAgo.toLocaleString())
+  })
+})

--- a/apps/dashboard/src/lib/explorer/engine-kind.ts
+++ b/apps/dashboard/src/lib/explorer/engine-kind.ts
@@ -1,0 +1,150 @@
+/**
+ * Engine classification + overview formatting helpers for the Data Explorer.
+ *
+ * The Overview tab is engine-aware: a Dictionary has no parts, partitions or
+ * compression, and a View has no storage at all. Rendering em-dash cards for
+ * those metrics is noise, so classify the engine first and pick the card set.
+ */
+
+import { formatRelativeTime } from '@/lib/utils/format-relative-time'
+
+export type EngineKind =
+  | 'mergetree'
+  | 'dictionary'
+  | 'view'
+  | 'materialized-view'
+  | 'log'
+  | 'integration'
+  | 'other'
+
+const INTEGRATION_ENGINES = new Set([
+  'Distributed',
+  'Kafka',
+  'RabbitMQ',
+  'NATS',
+  'S3',
+  'S3Queue',
+  'URL',
+  'HDFS',
+  'MySQL',
+  'PostgreSQL',
+  'MongoDB',
+  'SQLite',
+  'ODBC',
+  'JDBC',
+  'Redis',
+  'DeltaLake',
+  'Iceberg',
+  'Hudi',
+  'File',
+  'Merge',
+  'Buffer',
+])
+
+/** Map a `system.tables.engine` value to a coarse kind. */
+export function classifyEngine(engine: string | null | undefined): EngineKind {
+  const name = (engine ?? '').trim()
+  if (name === '') return 'other'
+
+  if (name === 'Dictionary') return 'dictionary'
+  if (name === 'MaterializedView') return 'materialized-view'
+  if (name === 'View' || name === 'LiveView' || name === 'WindowView') {
+    return 'view'
+  }
+  // Covers MergeTree, ReplicatedMergeTree, SharedReplacingMergeTree, ...
+  if (name.endsWith('MergeTree')) return 'mergetree'
+  if (name === 'Log' || name === 'TinyLog' || name === 'StripeLog') return 'log'
+  if (INTEGRATION_ENGINES.has(name)) return 'integration'
+
+  return 'other'
+}
+
+/** Engines that physically store parts (size / rows / parts / compression). */
+export function hasPartStorage(kind: EngineKind): boolean {
+  return kind === 'mergetree'
+}
+
+/** Human label for the object type, used in headers and empty states. */
+export function engineKindLabel(kind: EngineKind): string {
+  switch (kind) {
+    case 'mergetree':
+      return 'Table'
+    case 'dictionary':
+      return 'Dictionary'
+    case 'view':
+      return 'View'
+    case 'materialized-view':
+      return 'Materialized view'
+    case 'log':
+      return 'Log table'
+    case 'integration':
+      return 'Integration table'
+    default:
+      return 'Table'
+  }
+}
+
+/**
+ * Extract the target table of a materialized view from its CREATE statement
+ * (`CREATE MATERIALIZED VIEW x TO db.target (...) AS SELECT ...`). Returns
+ * null for an inner-table MV (`ENGINE = ...`), which has no explicit target.
+ */
+export function parseMaterializedViewTarget(
+  createQuery: string | null | undefined
+): string | null {
+  if (typeof createQuery !== 'string' || createQuery.trim() === '') return null
+
+  const match = createQuery.match(
+    /\bTO\s+((?:`[^`]+`|[A-Za-z_][\w$]*)(?:\.(?:`[^`]+`|[A-Za-z_][\w$]*))?)/i
+  )
+  if (!match) return null
+
+  return match[1].replace(/`/g, '')
+}
+
+/**
+ * ClickHouse returns "no value" datetimes as the epoch string
+ * `1970-01-01 00:00:00`. Parsing that yields a non-zero ms value once the
+ * local timezone offset is applied, so detect it by year, not by `getTime()`.
+ */
+export function isEpochZero(value: unknown): boolean {
+  if (typeof value === 'string') {
+    if (value.trim().startsWith('1970-01-01')) return true
+  }
+  const date = toDate(value)
+  return date !== null && date.getUTCFullYear() < 1971
+}
+
+function toDate(value: unknown): Date | null {
+  if (value === null || value === undefined || value === '') return null
+  const date =
+    typeof value === 'number' ? new Date(value) : new Date(String(value))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export interface FormattedTimestamp {
+  /** Short relative text ("3h ago") or the fallback for missing values. */
+  relative: string
+  /** Full locale timestamp for a tooltip / sub-line, or null when missing. */
+  absolute: string | null
+}
+
+/**
+ * Format a ClickHouse datetime as relative + absolute. Missing values and
+ * epoch-zero both render as `fallback` (default "never") — never as
+ * `1/1/1970, 12:00:00 AM`.
+ */
+export function formatTimestamp(
+  value: unknown,
+  fallback = 'never'
+): FormattedTimestamp {
+  if (isEpochZero(value)) return { relative: fallback, absolute: null }
+
+  const date = toDate(value)
+  if (date === null) return { relative: fallback, absolute: null }
+
+  return {
+    relative: formatRelativeTime(date.getTime()),
+    absolute: date.toLocaleString(),
+  }
+}

--- a/apps/dashboard/src/lib/query-config/explorer/index.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/index.ts
@@ -16,6 +16,7 @@ export { explorerIndexesConfig } from './indexes'
 export { explorerProjectionsConfig } from './projections'
 export { explorerSkipIndexesConfig } from './skip-indexes'
 export {
+  explorerDictionaryOverviewConfig,
   explorerTableOverviewConfig,
   explorerTableUsageConfig,
 } from './table-overview'

--- a/apps/dashboard/src/lib/query-config/explorer/table-overview.test.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/table-overview.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  explorerDictionaryOverviewConfig,
   explorerTableOverviewConfig,
   explorerTableUsageConfig,
 } from './table-overview'
@@ -39,8 +40,46 @@ describe('explorerTableOverviewConfig', () => {
       'compressed_bytes',
       'uncompressed_bytes',
       'active_parts',
+      // Engine-aware overview needs the schema keys + view definition so the
+      // Overview tab can render a summary instead of empty storage cards.
+      'sorting_key',
+      'partition_key',
+      'primary_key',
+      'as_select',
+      'create_table_query',
     ]) {
       expect(explorerTableOverviewConfig.columns).toContain(column)
+    }
+  })
+})
+
+describe('explorerDictionaryOverviewConfig', () => {
+  test('is an optional system.dictionaries query', () => {
+    expect(explorerDictionaryOverviewConfig.name).toBe(
+      'explorer-dictionary-overview'
+    )
+    expect(explorerDictionaryOverviewConfig.optional).toBe(true)
+    expect(explorerDictionaryOverviewConfig.tableCheck).toBe(
+      'system.dictionaries'
+    )
+  })
+
+  test('scopes to one dictionary and exposes dictionary-only metrics', () => {
+    const sql = explorerDictionaryOverviewConfig.sql as string
+    expect(isNonEmptyString(sql)).toBe(true)
+    expect(sql).toContain('system.dictionaries')
+    expect(sql).toContain('{database:String}')
+    expect(sql).toContain('{table:String}')
+
+    // These replace the meaningless size/parts/partitions cards for a Dictionary.
+    for (const column of [
+      'status',
+      'element_count',
+      'bytes_allocated',
+      'last_successful_update_time',
+      'source',
+    ]) {
+      expect(explorerDictionaryOverviewConfig.columns).toContain(column)
     }
   })
 })

--- a/apps/dashboard/src/lib/query-config/explorer/table-overview.ts
+++ b/apps/dashboard/src/lib/query-config/explorer/table-overview.ts
@@ -10,6 +10,11 @@ export const explorerTableOverviewConfig: QueryConfig = {
       total_rows,
       engine,
       engine_full,
+      sorting_key,
+      partition_key,
+      primary_key,
+      as_select,
+      create_table_query,
       metadata_modification_time,
       (SELECT sum(primary_key_bytes_in_memory)           FROM system.parts WHERE database = {database:String} AND table = {table:String} AND active) AS primary_key_bytes_in_memory,
       (SELECT sum(primary_key_bytes_in_memory_allocated) FROM system.parts WHERE database = {database:String} AND table = {table:String} AND active) AS primary_key_bytes_in_memory_allocated,
@@ -26,6 +31,11 @@ export const explorerTableOverviewConfig: QueryConfig = {
     'total_rows',
     'engine',
     'engine_full',
+    'sorting_key',
+    'partition_key',
+    'primary_key',
+    'as_select',
+    'create_table_query',
     'primary_key_bytes_in_memory',
     'primary_key_bytes_in_memory_allocated',
     'metadata_modification_time',
@@ -34,6 +44,55 @@ export const explorerTableOverviewConfig: QueryConfig = {
     'active_parts',
     'partitions',
     'last_modified',
+  ],
+  defaultParams: { database: 'default', table: '' },
+}
+
+/**
+ * Dictionary-specific overview. Dictionaries have no parts, partitions or
+ * compression, so the Overview tab swaps the storage cards for the metrics
+ * that actually exist: load status, element count, memory and refresh times.
+ */
+export const explorerDictionaryOverviewConfig: QueryConfig = {
+  name: 'explorer-dictionary-overview',
+  description:
+    'Per-dictionary summary: status, element count, memory, load timing and source',
+  optional: true,
+  tableCheck: 'system.dictionaries',
+  sql: `
+    SELECT
+      status,
+      type,
+      element_count,
+      bytes_allocated,
+      load_factor,
+      loading_duration,
+      loading_start_time,
+      last_successful_update_time,
+      last_exception,
+      source,
+      key.names AS key_names,
+      attribute.names AS attribute_names,
+      lifetime_min,
+      lifetime_max
+    FROM system.dictionaries
+    WHERE database = {database:String} AND name = {table:String}
+  `,
+  columns: [
+    'status',
+    'type',
+    'element_count',
+    'bytes_allocated',
+    'load_factor',
+    'loading_duration',
+    'loading_start_time',
+    'last_successful_update_time',
+    'last_exception',
+    'source',
+    'key_names',
+    'attribute_names',
+    'lifetime_min',
+    'lifetime_max',
   ],
   defaultParams: { database: 'default', table: '' },
 }

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -21,6 +21,7 @@ import {
   explorerDdlConfig,
   explorerDependenciesDownstreamConfig,
   explorerDependenciesUpstreamConfig,
+  explorerDictionaryOverviewConfig,
   explorerDictionarySourceConfig,
   explorerIndexesConfig,
   explorerProjectionsConfig,
@@ -152,6 +153,7 @@ export const queries: Array<QueryConfig> = [
   explorerDependenciesDownstreamConfig,
   explorerDependenciesUpstreamConfig,
   explorerDictionarySourceConfig,
+  explorerDictionaryOverviewConfig,
   explorerTableDependenciesConfig,
 
   // Tables


### PR DESCRIPTION
## Problem

The Data Explorer's Overview tab rendered the same nine tall stat cards for every object. Selecting a **Dictionary** produced a page of em-dashes and zeros — "Table size —", "Compression — compressed 0 B · uncompressed 0 B", "Partitions 0", "Active parts 0" — plus a `1/1/1970, 12:00:00 AM` timestamp, with one number lost in each card's whitespace.

## Changes

**Engine-aware cards.** `classifyEngine()` (`lib/explorer/engine-kind.ts`) maps `system.tables.engine` onto a coarse kind and the tab renders only the applicable sections:

| Engine kind | Sections rendered |
|---|---|
| MergeTree family (incl. `Replicated*` / `Shared*`) | Storage (size+rows, compression, parts+partitions, index in memory) · Activity (last modified, queries 24h/7d) · Metadata (sorting / partition / primary key) |
| Dictionary | Dictionary (status, elements, memory, load time) · Activity (metadata changed, queries, lifetime) · Metadata (key, attributes, source) · load-failure banner on `last_exception` |
| View / MaterializedView | Activity (metadata changed) · Metadata (MV target table) · Definition (`as_select`) — no storage or query_log fetch |
| Log / integration / unknown | Activity + engine metadata, with a note that the engine exposes no part-level stats |

Follow-up queries are gated on the classified kind, so `system.dictionaries` is only queried for a Dictionary and `system.query_log` is skipped for views.

**No more `1/1/1970`.** `formatTimestamp()` treats epoch-zero and missing values as `never`. The check is year-based, because ClickHouse's `1970-01-01 00:00:00` string parses to a non-zero ms value in most timezones. Real dates render relative ("3h ago") with the absolute timestamp as the context line / tooltip.

**Denser layout.** Compact stat tiles (`rounded-lg border bg-card p-3`, label / value / context line) in a 4-up grid, grouped under section headers using the paired-section idiom (`icon size-4 + h2 text-sm font-medium`), behind an identity strip naming the object type and full engine. Metadata moves to key/value rows rather than tiles, so long sorting keys and dictionary sources are readable. The skeleton matches the new layout.

**Data.** `explorer-table-overview` additionally returns `sorting_key`, `partition_key`, `primary_key`, `as_select`, `create_table_query`; new optional `explorer-dictionary-overview` config reads `system.dictionaries` (columns already proven by the existing `dictionaries` config).

## Verification

- `bun test src/lib/explorer src/lib/query-config/explorer/table-overview.test.ts` — 22 pass (engine classification incl. replicated/shared variants, epoch-zero handling, MV `TO` target parsing, new config shape).
- `pnpm run lint` clean for the touched files; build run in CI.

Left the explorer tree panel alone: vertical scroll panels in this app keep native scrollbars (`scrollbar-hide` is only used on horizontal strips), so there was no trivial convention-matching polish to apply.

Co-Authored-By: duyetbot <bot@duyet.net>