### PR TITLE
feat(explorer): sql syntax highlight for ddl

### DIFF
--- a/apps/dashboard/src/components/explorer/tabs/ddl-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/ddl-tab.tsx
@@ -2,7 +2,9 @@ import { Check, Copy, SparklesIcon } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { highlightCode } from '@/components/ai-elements/code-block'
+import { HLJS_TOKEN_CLASSES } from '@/components/ai-elements/hljs-token-classes'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -10,7 +12,7 @@ import { Switch } from '@/components/ui/switch'
 import { formatSql } from '@/lib/sql-format'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
-import { dedent } from '@/lib/utils'
+import { cn, dedent } from '@/lib/utils'
 import { copyToClipboard } from '@/lib/utils/clipboard'
 
 interface DdlRow {
@@ -74,6 +76,11 @@ export function DdlTab() {
   }, [isBeautified, ddl])
 
   const displaySql = isBeautified ? (formatted ?? raw) : raw
+
+  const highlightedHtml = useMemo(() => {
+    if (!displaySql) return ''
+    return highlightCode(displaySql, 'sql')
+  }, [displaySql])
 
   const handleCopy = async () => {
     if (displaySql) {
@@ -148,9 +155,13 @@ export function DdlTab() {
         </div>
       </CardHeader>
       <CardContent>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted p-4 font-mono text-xs leading-relaxed">
-          <code>{displaySql}</code>
-        </pre>
+        <div
+          className={cn(
+            'overflow-x-auto rounded-md bg-muted [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:bg-transparent! [&_pre]:p-4 [&_pre]:text-xs [&_pre]:leading-relaxed',
+            HLJS_TOKEN_CLASSES
+          )}
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
       </CardContent>
     </Card>
   )

--- a/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
@@ -2,6 +2,9 @@ import { Database, Filter, Key, Layers, Settings } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 
 import { useExplorerState } from '../hooks/use-explorer-state'
+import { useMemo } from 'react'
+import { highlightCode } from '@/components/ai-elements/code-block'
+import { HLJS_TOKEN_CLASSES } from '@/components/ai-elements/hljs-token-classes'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -14,6 +17,21 @@ import {
 } from '@/components/ui/table'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useHostId } from '@/lib/swr/use-host'
+import { cn } from '@/lib/utils'
+
+/** Small syntax-highlighted SQL expression block (e.g. engine, key expr). */
+function SqlExprBlock({ code }: { code: string }) {
+  const html = useMemo(() => highlightCode(code, 'sql'), [code])
+  return (
+    <div
+      className={cn(
+        'overflow-auto rounded-md bg-muted [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:bg-transparent! [&_pre]:p-2.5 [&_pre]:text-xs',
+        HLJS_TOKEN_CLASSES
+      )}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
 
 interface IndexesData {
   partition_key: string
@@ -206,9 +224,7 @@ export function IndexesTab() {
               <div className="text-sm font-medium">{indexData.engine}</div>
               {indexData.engine_full &&
                 indexData.engine_full !== indexData.engine && (
-                  <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2.5 font-mono text-xs">
-                    <code>{formatEngineFull(indexData.engine_full)}</code>
-                  </pre>
+                  <SqlExprBlock code={formatEngineFull(indexData.engine_full)} />
                 )}
             </div>
           </CardContent>
@@ -227,9 +243,7 @@ export function IndexesTab() {
             </CardHeader>
             <CardContent className="px-4">
               {value ? (
-                <pre className="overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2.5 font-mono text-xs">
-                  <code>{value}</code>
-                </pre>
+                <SqlExprBlock code={value} />
               ) : (
                 <p className="text-xs text-muted-foreground">Not set</p>
               )}


### PR DESCRIPTION
## Summary
- Data Explorer DDL tab now renders the CREATE statement with syntax highlighting instead of plain monospace text.
- Structure/Indexes tab's engine (`engine_full`) and key-expression (partition/sorting/primary/sampling key) blocks get the same treatment for consistency.
- Reuses the existing `highlightCode` (highlight.js) + `HLJS_TOKEN_CLASSES` pattern already used by the Request Info SQL dialog (`components/dialogs/dialog-sql.tsx`) — no new dependency, theme-aware via existing token classes, copy-to-clipboard and Beautify toggle in the DDL tab preserved.
- Did not touch the Overview tab (owned by a parallel branch) or Query tab (already CodeMirror-highlighted).

## Test plan
- [x] `pnpm run lint` — clean (no new findings)
- [x] `pnpm run build` (vite build + tsc --noEmit) — passes, prerender succeeds
- [ ] CI: dashboard, unit-tests