### PR TITLE
fix(insights): redesign the AI Insights card, copy and popover dialog

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -68,6 +68,16 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `<button>`); inner links `e.stopPropagation()` (not `preventDefault`) so they
   still navigate. Drive drill-down from a per-item field, rendered via
   `ResultTable`. See `components/health/{health-card-shell,health-detail-rows}.tsx`.
+- **One severity signal per card:** severity reads from a single tinted icon —
+  never icon tile + colored border + severity pill + header count badge on the
+  same finding. `components/insights/severity-meta.ts` is the source of truth
+  (label / icon / `iconColor` / neutral `badge`); card surface, border and count
+  badges stay neutral. Body `line-clamp-2` + `title` tooltip; the breakdown goes
+  in a detail dialog.
+- **A dialog opened from a popover lives OUTSIDE the popover subtree.** Rendered
+  inside `PopoverContent`, closing the popover unmounts the dialog and nothing
+  appears. Keep the selected item + dialog in the parent, as a sibling of
+  `<Popover>` — see `components/insights/insights-popover.tsx`.
 - **Overflow strip (one row, no wrap):** `scrollbar-hide overflow-x-auto` + `py-*`
   (so shadows/accents/focus rings aren't clipped) with a chevron button + a
   `from-background`→`transparent` edge fade per scrollable side, paging via

--- a/apps/dashboard/src/components/insights/insight-card.tsx
+++ b/apps/dashboard/src/components/insights/insight-card.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react'
 import { InsightDetailDialog } from '@/components/insights/insight-detail-dialog'
 import { SEVERITY_META } from '@/components/insights/severity-meta'
 import { AppLink as Link } from '@/components/ui/app-link'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { buildUrl } from '@/lib/url/url-builder'
@@ -64,18 +63,30 @@ export function InsightCard({
       }}
       className={cn(
         'h-full cursor-pointer gap-0 p-4 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        style.accent,
         className
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <div
-          className={cn(
-            'flex size-7 shrink-0 items-center justify-center rounded-md',
-            style.iconBg
-          )}
-        >
-          <Icon className={cn('size-3.5', style.iconColor)} />
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon
+            className={cn('size-4 shrink-0', style.iconColor)}
+            strokeWidth={1.5}
+            aria-hidden="true"
+          />
+          <span className="truncate text-xs text-muted-foreground">
+            {style.label}
+            {hasGeneratedAt ? (
+              <>
+                {' · '}
+                <time
+                  dateTime={insight.generatedAt}
+                  title={new Date(generatedMs).toLocaleString()}
+                >
+                  {formatRelativeTime(generatedMs)}
+                </time>
+              </>
+            ) : null}
+          </span>
         </div>
         <Button
           type="button"
@@ -95,28 +106,14 @@ export function InsightCard({
       <h3 className="mt-3 text-sm font-medium leading-snug text-foreground">
         {insight.title}
       </h3>
-      <p className="mt-1 line-clamp-3 text-xs leading-relaxed text-muted-foreground">
+      <p
+        className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground"
+        title={insight.detail}
+      >
         {insight.detail}
       </p>
 
-      <div className="mt-3 flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <Badge
-            variant="outline"
-            className={cn('text-[10px] font-medium', style.badge)}
-          >
-            {style.label}
-          </Badge>
-          {hasGeneratedAt ? (
-            <time
-              dateTime={insight.generatedAt}
-              title={new Date(generatedMs).toLocaleString()}
-              className="truncate text-[10px] text-muted-foreground/70"
-            >
-              {formatRelativeTime(generatedMs)}
-            </time>
-          ) : null}
-        </div>
+      <div className="mt-3 flex items-center justify-end gap-2">
         {action && actionHref ? (
           <Button
             variant="ghost"

--- a/apps/dashboard/src/components/insights/insight-detail-dialog.tsx
+++ b/apps/dashboard/src/components/insights/insight-detail-dialog.tsx
@@ -91,14 +91,11 @@ export function InsightDetailDialog({
       <DialogContent className="flex max-h-[85vh] w-[calc(100%-1.5rem)] flex-col gap-4 overflow-hidden sm:max-w-4xl lg:max-w-5xl">
         <DialogHeader>
           <div className="flex items-start gap-3">
-            <div
-              className={cn(
-                'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
-                style.iconBg
-              )}
-            >
-              <Icon className={cn('size-4', style.iconColor)} />
-            </div>
+            <Icon
+              className={cn('mt-1 size-4 shrink-0', style.iconColor)}
+              strokeWidth={1.5}
+              aria-hidden="true"
+            />
             <div className="min-w-0 flex-1">
               <DialogTitle className="text-base leading-snug">
                 {insight.title}

--- a/apps/dashboard/src/components/insights/insights-popover.tsx
+++ b/apps/dashboard/src/components/insights/insights-popover.tsx
@@ -168,7 +168,6 @@ export function InsightsPopover() {
                 <InsightsPopoverItem
                   key={insight.key}
                   insight={insight}
-                  hostId={hostId}
                   onOpenDetail={() => {
                     setSelected(insight)
                     setIsOpen(false)

--- a/apps/dashboard/src/components/insights/insights-popover.tsx
+++ b/apps/dashboard/src/components/insights/insights-popover.tsx
@@ -8,21 +8,13 @@
  * overview panel, so counts and dismissals stay in sync everywhere.
  */
 
-import {
-  AlertTriangle,
-  ArrowRight,
-  Lightbulb,
-  RefreshCw,
-  Settings2,
-  Sparkles,
-  TriangleAlert,
-  X,
-} from 'lucide-react'
+import { ArrowRight, RefreshCw, Settings2, Sparkles, X } from 'lucide-react'
 
-import type { InsightCard, InsightSeverity } from '@/lib/insights/types'
+import type { InsightCard } from '@/lib/insights/types'
 
 import { useState } from 'react'
 import { InsightDetailDialog } from '@/components/insights/insight-detail-dialog'
+import { SEVERITY_META } from '@/components/insights/severity-meta'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -37,28 +29,17 @@ import { useHostId } from '@/lib/swr/use-host'
 import { buildUrl } from '@/lib/url/url-builder'
 import { cn } from '@/lib/utils'
 
-const SEVERITY_ICON: Record<InsightSeverity, typeof AlertTriangle> = {
-  critical: AlertTriangle,
-  warning: TriangleAlert,
-  info: Lightbulb,
-}
-
-const SEVERITY_COLOR: Record<InsightSeverity, string> = {
-  critical: 'text-rose-600 dark:text-rose-400',
-  warning: 'text-amber-600 dark:text-amber-400',
-  info: 'text-sky-600 dark:text-sky-400',
-}
-
-const SEVERITY_BG: Record<InsightSeverity, string> = {
-  critical: 'bg-rose-500/10',
-  warning: 'bg-amber-500/10',
-  info: 'bg-sky-500/10',
-}
-
 const VISIBLE = 5
 
 export function InsightsPopover() {
   const [isOpen, setIsOpen] = useState(false)
+  /**
+   * The insight whose detail dialog is open. Kept HERE, outside the popover
+   * subtree: the dialog used to be rendered inside `PopoverContent`, so opening
+   * it closed the popover, which unmounted the dialog with it and the detail
+   * never appeared. The dialog is now a sibling of `<Popover>` and survives.
+   */
+  const [selected, setSelected] = useState<InsightCard | null>(null)
   const hostId = useHostId()
   const {
     insights,
@@ -121,172 +102,166 @@ export function InsightsPopover() {
   const visible = insights.slice(0, VISIBLE)
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger render={<div className="relative hidden sm:flex" />}>
-        <IconButton
-          tooltip={`${total} AI insight${total === 1 ? '' : 's'}`}
-          icon={<Sparkles className="size-4" />}
-          className="hidden sm:flex"
-        />
-        {total > 0 && (
-          <Badge
-            className={cn(
-              'absolute -top-0.5 -right-0.5 size-3.5 flex items-center justify-center border-transparent p-0 text-[10px] font-medium tabular-nums',
-              badgeTone
-            )}
-          >
-            {total > 99 ? '99+' : total}
-          </Badge>
-        )}
-      </PopoverTrigger>
+    <>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger render={<div className="relative hidden sm:flex" />}>
+          <IconButton
+            tooltip={`${total} AI insight${total === 1 ? '' : 's'}`}
+            icon={<Sparkles className="size-4" />}
+            className="hidden sm:flex"
+          />
+          {total > 0 && (
+            <Badge
+              className={cn(
+                'absolute -top-0.5 -right-0.5 size-3.5 flex items-center justify-center border-transparent p-0 text-[10px] font-medium tabular-nums',
+                badgeTone
+              )}
+            >
+              {total > 99 ? '99+' : total}
+            </Badge>
+          )}
+        </PopoverTrigger>
 
-      <PopoverContent align="end" className="w-80 p-0">
-        <div className="flex items-center justify-between border-b px-3 py-2">
-          <div className="flex items-center gap-2">
-            <Sparkles className="size-3.5 text-sky-500" />
-            <h3 className="text-sm font-semibold">AI Insights</h3>
-            {total > 0 && (
-              <Badge
-                variant="secondary"
-                className="h-4 px-1 text-[10px] tabular-nums"
+        <PopoverContent align="end" className="w-80 p-0">
+          <div className="flex items-center justify-between border-b px-3 py-2">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-3.5 text-sky-500" />
+              <h3 className="text-sm font-semibold">AI Insights</h3>
+              {total > 0 && (
+                <Badge
+                  variant="secondary"
+                  className="h-4 px-1 text-[10px] tabular-nums"
+                >
+                  {total}
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-0.5">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 text-muted-foreground"
+                aria-label="AI Insights settings"
+                render={<Link href={settingsHref} />}
               >
-                {total}
-              </Badge>
-            )}
+                <Settings2 className="size-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                onClick={() => setIsOpen(false)}
+              >
+                <X className="size-3.5" />
+              </Button>
+            </div>
           </div>
-          <div className="flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 text-muted-foreground"
-              aria-label="AI Insights settings"
-              render={<Link href={settingsHref} />}
-            >
-              <Settings2 className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7"
-              onClick={() => setIsOpen(false)}
-            >
-              <X className="size-3.5" />
-            </Button>
-          </div>
-        </div>
 
-        {visible.length === 0 ? (
-          <div className="flex flex-col items-center justify-center px-4 py-6 text-center">
-            <Sparkles className="mb-2 size-6 text-muted-foreground/50" />
-            <p className="text-xs text-muted-foreground">No insights</p>
-          </div>
-        ) : (
-          <div className="max-h-[320px] overflow-y-auto py-1">
-            {visible.map((insight) => (
-              <InsightsPopoverItem
-                key={insight.key}
-                insight={insight}
-                hostId={hostId}
-                onDismiss={dismiss}
-                onOpenDetail={() => setIsOpen(false)}
+          {visible.length === 0 ? (
+            <div className="flex flex-col items-center justify-center px-4 py-6 text-center">
+              <Sparkles className="mb-2 size-6 text-muted-foreground/50" />
+              <p className="text-xs text-muted-foreground">No insights</p>
+            </div>
+          ) : (
+            <div className="max-h-[320px] overflow-y-auto py-1">
+              {visible.map((insight) => (
+                <InsightsPopoverItem
+                  key={insight.key}
+                  insight={insight}
+                  hostId={hostId}
+                  onOpenDetail={() => {
+                    setSelected(insight)
+                    setIsOpen(false)
+                  }}
+                />
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between border-t bg-muted/30 px-2.5 py-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              onClick={() => {
+                generate()
+                refresh()
+              }}
+              disabled={isGenerating}
+            >
+              <RefreshCw
+                className={cn('size-3', isGenerating && 'animate-spin')}
               />
-            ))}
+              {isGenerating ? 'Refreshing…' : 'Refresh'}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+              render={
+                <Link href={overviewHref} onClick={() => setIsOpen(false)} />
+              }
+            >
+              View all
+              <ArrowRight className="size-3" />
+            </Button>
           </div>
-        )}
+        </PopoverContent>
+      </Popover>
 
-        <div className="flex items-center justify-between border-t bg-muted/30 px-2.5 py-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 px-2 text-xs"
-            onClick={() => {
-              generate()
-              refresh()
-            }}
-            disabled={isGenerating}
-          >
-            <RefreshCw
-              className={cn('size-3', isGenerating && 'animate-spin')}
-            />
-            {isGenerating ? 'Refreshing…' : 'Refresh'}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 px-2 text-xs"
-            render={
-              <Link href={overviewHref} onClick={() => setIsOpen(false)} />
-            }
-          >
-            View all
-            <ArrowRight className="size-3" />
-          </Button>
-        </div>
-      </PopoverContent>
-    </Popover>
+      {selected ? (
+        <InsightDetailDialog
+          insight={selected}
+          hostId={hostId}
+          open
+          onOpenChange={(open) => {
+            if (!open) setSelected(null)
+          }}
+          onDismiss={dismiss}
+        />
+      ) : null}
+    </>
   )
 }
 
 function InsightsPopoverItem({
   insight,
-  hostId,
-  onDismiss,
   onOpenDetail,
 }: {
   insight: InsightCard
-  hostId: number
-  onDismiss: (insight: InsightCard) => void
-  /** Called when the detail dialog opens, so the popover can close behind it. */
+  /** Selects this insight in the parent and closes the popover behind the dialog. */
   onOpenDetail: () => void
 }) {
-  const [detailOpen, setDetailOpen] = useState(false)
-  const Icon = SEVERITY_ICON[insight.severity]
-
-  const open = () => {
-    setDetailOpen(true)
-    onOpenDetail()
-  }
+  const style = SEVERITY_META[insight.severity]
+  const Icon = style.icon
 
   return (
-    <>
-      <div
-        role="button"
-        tabIndex={0}
-        aria-label={`View insight: ${insight.title}`}
-        onClick={open}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            open()
-          }
-        }}
-        className="group relative block cursor-pointer rounded-md transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        <div className="flex items-start gap-3 px-3 py-2.5">
-          <div
-            className={cn(
-              'mt-0.5 shrink-0 rounded-md p-1.5',
-              SEVERITY_BG[insight.severity]
-            )}
-          >
-            <Icon className={cn('size-4', SEVERITY_COLOR[insight.severity])} />
-          </div>
-          <div className="min-w-0 flex-1 space-y-0.5">
-            <p className="truncate text-sm font-medium">{insight.title}</p>
-            <p className="line-clamp-2 text-xs text-muted-foreground">
-              {insight.detail}
-            </p>
-          </div>
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`View insight: ${insight.title}`}
+      onClick={onOpenDetail}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onOpenDetail()
+        }
+      }}
+      className="group relative block cursor-pointer rounded-md transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-start gap-3 px-3 py-2.5">
+        <Icon
+          className={cn('mt-0.5 size-4 shrink-0', style.iconColor)}
+          strokeWidth={1.5}
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1 space-y-0.5">
+          <p className="truncate text-sm font-medium">{insight.title}</p>
+          <p className="line-clamp-2 text-xs text-muted-foreground">
+            {insight.detail}
+          </p>
         </div>
       </div>
-
-      <InsightDetailDialog
-        insight={insight}
-        hostId={hostId}
-        open={detailOpen}
-        onOpenChange={setDetailOpen}
-        onDismiss={onDismiss}
-      />
-    </>
+    </div>
   )
 }

--- a/apps/dashboard/src/components/insights/severity-meta.ts
+++ b/apps/dashboard/src/components/insights/severity-meta.ts
@@ -16,43 +16,34 @@ export interface SeverityMeta {
   /** Human label shown on badges. Note: `info` reads as "Notice". */
   readonly label: string
   readonly icon: LucideIcon
-  /** Background token for the icon chip. */
-  readonly iconBg: string
-  /** Foreground token for the icon. */
+  /**
+   * Foreground token for the icon — the SINGLE severity signal on a card.
+   * Everything else (surface, border, badge) stays neutral so one finding is
+   * not shouted four times (see the product-design skill, non-negotiable #6).
+   */
   readonly iconColor: string
-  /** Tinted outline-badge classes (also used for header count badges). */
+  /** Neutral outline-badge classes (also used for header count badges). */
   readonly badge: string
-  /** Full-border accent color for the card (all four sides), by severity. */
-  readonly accent: string
 }
 
 export const SEVERITY_META: Record<InsightSeverity, SeverityMeta> = {
   critical: {
     label: 'Critical',
     icon: AlertTriangle,
-    iconBg: 'bg-rose-100 dark:bg-rose-950/50',
     iconColor: 'text-rose-600 dark:text-rose-400',
-    badge:
-      'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-800/60 dark:bg-rose-950/40 dark:text-rose-400',
-    accent: 'border-rose-300 dark:border-rose-700/60',
+    badge: 'border-border bg-transparent text-muted-foreground',
   },
   warning: {
     label: 'Warning',
     icon: TriangleAlert,
-    iconBg: 'bg-amber-100 dark:bg-amber-950/50',
     iconColor: 'text-amber-600 dark:text-amber-400',
-    badge:
-      'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-400',
-    accent: 'border-amber-300 dark:border-amber-700/60',
+    badge: 'border-border bg-transparent text-muted-foreground',
   },
   info: {
     label: 'Notice',
     icon: Info,
-    iconBg: 'bg-muted',
     iconColor: 'text-muted-foreground',
-    badge:
-      'border-border bg-muted/50 text-muted-foreground dark:bg-muted/30 dark:text-muted-foreground',
-    accent: 'border-border',
+    badge: 'border-border bg-transparent text-muted-foreground',
   },
 }
 

--- a/apps/dashboard/src/lib/insights/collectors.test.ts
+++ b/apps/dashboard/src/lib/insights/collectors.test.ts
@@ -39,7 +39,13 @@ mock.module('@chm/platform', () => ({
   getPlatformBindings: () => ({ getD1Database: () => null }),
 }))
 
-const { collectInsights, decideSeverity } = await import('./collectors')
+const {
+  alertsOn,
+  collectInsights,
+  decideSeverity,
+  formatBaselineDetail,
+  formatMetricValue,
+} = await import('./collectors')
 const { fitBaseline } = await import('./statistical-baseline')
 
 beforeEach(() => {
@@ -140,6 +146,90 @@ describe('decideSeverity — genuine anomalies still fire with a baseline presen
     const decision = decideSeverity(recent, 1500, baseline, classify)
     expect(decision.usedBaseline).toBe(true)
     expect(decision.severity).toBe('critical')
+  })
+})
+
+// ── Direction gating: a metric that only matters when it RISES. ───────────
+
+describe('decideSeverity — direction gating (alertOn)', () => {
+  const baseline: Baseline = fitBaseline(
+    '0',
+    'memory_usage',
+    [
+      2.0, 2.1, 2.05, 2.2, 2.15, 2.0, 2.1, 2.05, 2.2, 2.15, 2.0, 2.1, 2.05, 2.2,
+      2.1,
+    ]
+  )
+
+  test('an "above"-only check suppresses a below-baseline reading (no "spiked" over a drop)', () => {
+    const recent = baseline.mean - 3 * baseline.stddev
+    const decision = decideSeverity(recent, -60, baseline, classify, 'above')
+    expect(decision.usedBaseline).toBe(true)
+    expect(decision.z).toBeLessThan(0)
+    expect(decision.severity).toBeNull()
+  })
+
+  test('the same below-baseline reading still fires for a "both" check', () => {
+    const recent = baseline.mean - 3 * baseline.stddev
+    expect(
+      decideSeverity(recent, -60, baseline, classify, 'both').severity
+    ).toBe('warning')
+  })
+
+  test('an above-baseline reading is unaffected by the gate', () => {
+    const recent = baseline.mean + 3 * baseline.stddev
+    expect(
+      decideSeverity(recent, 60, baseline, classify, 'above').severity
+    ).toBe('warning')
+  })
+
+  test('the static fallback path is gated too — a drop never fires an "above" check', () => {
+    expect(decideSeverity(1, -80, null, classify, 'above').severity).toBeNull()
+    expect(decideSeverity(9, 80, null, classify, 'above').severity).toBe(
+      'warning'
+    )
+  })
+
+  test('alertsOn treats a zero deviation as no alert', () => {
+    expect(alertsOn('both', 0)).toBe(false)
+    expect(alertsOn('below', -1)).toBe(true)
+    expect(alertsOn('below', 1)).toBe(false)
+  })
+})
+
+// ── Human-readable copy: never a raw byte count in a card body. ───────────
+
+describe('insight copy formatting', () => {
+  test('bytes are humanized, not printed raw', () => {
+    expect(formatMetricValue(2190847074.84, 'bytes')).toBe('2.04 GiB')
+    expect(formatMetricValue(2190847074.84, 'bytes')).not.toContain(
+      '2190847074'
+    )
+  })
+
+  test('durations, percentages and counts are readable', () => {
+    expect(formatMetricValue(840.4, 'ms')).toBe('840ms')
+    expect(formatMetricValue(4200, 'ms')).toBe('4.2s')
+    expect(formatMetricValue(3.4567, 'percent')).toBe('3.46%')
+    expect(formatMetricValue(1234567, 'count')).toBe('1,234,567')
+  })
+
+  test('the baseline detail is one short sentence with humanized values', () => {
+    const baseline: Baseline = fitBaseline(
+      '0',
+      'memory_usage',
+      Array.from({ length: 15 }, () => 2_222_222_222)
+    )
+    const detail = formatBaselineDetail(
+      { metric: 'memory_usage', unit: 'bytes' },
+      2_390_847_074,
+      baseline,
+      2.24
+    )
+    expect(detail).toBe(
+      'Now 2.23 GiB — 2.24σ above its 7-day baseline (typical ~2.07 GiB).'
+    )
+    expect(detail).not.toContain('stddev')
   })
 })
 

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -12,6 +12,7 @@ import type { Baseline } from './statistical-baseline'
 import type { InsightCandidate, InsightSeverity } from './types'
 
 import { readOnlyQuery } from '../ai/agent/tools/helpers'
+import { formatReadableQuantity, formatReadableSize } from '../format-readable'
 import {
   buildPartsPressureCurrentSql,
   buildPartsPressureProjectionSql,
@@ -71,9 +72,30 @@ async function firstRow(
 // Anomaly collector — recent (1h) vs baseline (24h), ported from anomaly-tools.
 // ---------------------------------------------------------------------------
 
+/** How a metric's raw value is rendered in user-facing copy. */
+export type AnomalyUnit = 'bytes' | 'ms' | 'percent' | 'count'
+
+/** Which direction of deviation a check alerts on. */
+export type AnomalyCheckDirection = 'above' | 'below' | 'both'
+
 interface AnomalyCheck {
   metric: string
+  /** Title used when the current value is ABOVE the baseline. */
   title: string
+  /**
+   * Title used when the current value is BELOW the baseline. Only reachable for
+   * checks whose `alertOn` includes 'below' — present so a direction-agnostic
+   * check can never render "spiked" over a drop.
+   */
+  titleBelow?: string
+  /**
+   * Which direction of deviation is worth alerting on. Memory/latency/error
+   * rate falling below baseline is not a problem, so those are 'above' only and
+   * a below-baseline reading is suppressed rather than reported as a warning.
+   */
+  alertOn: AnomalyCheckDirection
+  /** Unit used to humanize the value in the detail copy. */
+  unit: AnomalyUnit
   recentQuery: string
   baselineQuery: string
   /**
@@ -95,27 +117,34 @@ const ANOMALY_CHECKS: AnomalyCheck[] = [
   {
     metric: 'error_rate',
     title: 'Query error rate is climbing',
+    alertOn: 'above',
+    unit: 'percent',
     recentQuery: `SELECT countIf(type = 'ExceptionWhileProcessing') * 100.0 / nullIf(count(), 0) as value FROM system.query_log WHERE event_time > now() - INTERVAL 1 HOUR`,
     baselineQuery: `SELECT countIf(type = 'ExceptionWhileProcessing') * 100.0 / nullIf(count(), 0) as value FROM system.query_log WHERE event_time BETWEEN now() - INTERVAL 25 HOUR AND now() - INTERVAL 1 HOUR`,
     sampleQuery: `SELECT toStartOfHour(event_time) AS bucket, countIf(type = 'ExceptionWhileProcessing') * 100.0 / nullIf(count(), 0) AS value FROM system.query_log WHERE event_time > now() - INTERVAL 7 DAY GROUP BY bucket HAVING isNotNull(value) ORDER BY bucket`,
     format: (recent, baseline) =>
-      `Error rate in the last hour is ${round(recent)}% vs a 24h baseline of ${round(baseline)}%. Investigate failing queries before they spread.`,
+      `Error rate in the last hour is ${formatMetricValue(recent, 'percent')} vs a ${formatMetricValue(baseline, 'percent')} 24h baseline.`,
     classify: (pct) => (pct > 100 ? 'critical' : pct > 50 ? 'warning' : 'info'),
   },
   {
     metric: 'query_duration_p95',
     title: 'Queries are slowing down (p95)',
+    alertOn: 'above',
+    unit: 'ms',
     recentQuery: `SELECT quantile(0.95)(query_duration_ms) as value FROM system.query_log WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 1 HOUR`,
     baselineQuery: `SELECT quantile(0.95)(query_duration_ms) as value FROM system.query_log WHERE type = 'QueryFinish' AND event_time BETWEEN now() - INTERVAL 25 HOUR AND now() - INTERVAL 1 HOUR`,
     sampleQuery: `SELECT toStartOfHour(event_time) AS bucket, quantile(0.95)(query_duration_ms) AS value FROM system.query_log WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 7 DAY GROUP BY bucket ORDER BY bucket`,
     format: (recent, baseline, pct) =>
-      `p95 query duration rose ${round(pct)}% (now ${round(recent)}ms vs ${round(baseline)}ms baseline). Check for heavy scans or contention.`,
+      `p95 query duration rose ${round(pct)}% — now ${formatMetricValue(recent, 'ms')} vs ${formatMetricValue(baseline, 'ms')} baseline.`,
     classify: (pct) =>
       pct > 200 ? 'critical' : pct > 100 ? 'warning' : 'info',
   },
   {
     metric: 'memory_usage',
     title: 'Memory usage spiked',
+    titleBelow: 'Memory usage dropped',
+    alertOn: 'above',
+    unit: 'bytes',
     // Reads MemoryResident from asynchronous_metric_log (same metric as
     // baselineQuery/sampleQuery below) — a live system.metrics MemoryTracking
     // snapshot would score against a different metric's baseline and produce
@@ -124,10 +153,43 @@ const ANOMALY_CHECKS: AnomalyCheck[] = [
     baselineQuery: `SELECT avg(value) as value FROM system.asynchronous_metric_log WHERE metric = 'MemoryResident' AND event_time BETWEEN now() - INTERVAL 25 HOUR AND now() - INTERVAL 1 HOUR`,
     sampleQuery: `SELECT toStartOfHour(event_time) AS bucket, avg(value) AS value FROM system.asynchronous_metric_log WHERE metric = 'MemoryResident' AND event_time > now() - INTERVAL 7 DAY GROUP BY bucket ORDER BY bucket`,
     format: (_recent, _baseline, pct) =>
-      `Tracked memory is ${round(pct)}% above the 24h average. Watch for OOM risk on memory-heavy queries.`,
+      `Tracked memory is ${round(pct)}% above the 24h average — watch for OOM risk on memory-heavy queries.`,
     classify: (pct) => (pct > 80 ? 'critical' : pct > 40 ? 'warning' : 'info'),
   },
 ]
+
+/**
+ * True when a deviation of the given sign is worth alerting on for a check.
+ * A zero deviation is never an alert.
+ */
+export function alertsOn(
+  alertOn: AnomalyCheckDirection,
+  deviation: number
+): boolean {
+  if (deviation === 0) return false
+  if (alertOn === 'both') return true
+  return alertOn === 'above' ? deviation > 0 : deviation < 0
+}
+
+/**
+ * Humanize a metric value for user-facing copy — bytes as `2.04 GiB`, durations
+ * as `1.2s`/`840ms`, percentages as `3.4%`, counts locale-formatted. Never a raw
+ * `2190847074.84`.
+ */
+export function formatMetricValue(value: number, unit: AnomalyUnit): string {
+  switch (unit) {
+    case 'bytes':
+      return formatReadableSize(value, 2)
+    case 'ms':
+      return value >= 1000
+        ? `${round(value / 1000)}s`
+        : `${Math.round(value)}ms`
+    case 'percent':
+      return `${round(value)}%`
+    default:
+      return formatReadableQuantity(value, 'long')
+  }
+}
 
 /** Above this |z|, a baseline-flagged anomaly is 'critical' rather than 'warning'. */
 const CRITICAL_Z_THRESHOLD = 4
@@ -160,12 +222,15 @@ export function decideSeverity(
   recent: number,
   changePct: number,
   baseline: Baseline | null,
-  staticClassify: (changePct: number) => InsightSeverity
+  staticClassify: (changePct: number) => InsightSeverity,
+  alertOn: AnomalyCheckDirection = 'both'
 ): AnomalySeverityDecision {
   const score = scoreAnomaly(recent, baseline)
 
   if (score.usedBaseline) {
     if (!score.isAnomaly)
+      return { severity: null, usedBaseline: true, z: score.z }
+    if (!alertsOn(alertOn, score.z))
       return { severity: null, usedBaseline: true, z: score.z }
     return {
       severity:
@@ -175,6 +240,9 @@ export function decideSeverity(
     }
   }
 
+  if (!alertsOn(alertOn, changePct))
+    return { severity: null, usedBaseline: false, z: null }
+
   const severity = staticClassify(changePct)
   return {
     severity: severity === 'info' ? null : severity,
@@ -183,15 +251,28 @@ export function decideSeverity(
   }
 }
 
-/** Detail string for the baseline-backed path — labels the signal as statistical, not a fixed default. */
-function formatBaselineDetail(
-  check: AnomalyCheck,
+/**
+ * One-sentence detail for the baseline-backed path.
+ *
+ * Values are humanized by unit (bytes → `2.04 GiB`) and the σ phrasing is kept
+ * to a single readable clause — the full fit (mean / stddev / sample count) is
+ * available in the insight detail dialog, not crammed into the card body.
+ */
+export function formatBaselineDetail(
+  check: Pick<AnomalyCheck, 'metric' | 'unit'>,
   recent: number,
   baseline: Baseline,
   z: number
 ): string {
   const direction = z >= 0 ? 'above' : 'below'
-  return `${check.title}: the current value (${round(recent)}) is ${round(Math.abs(z))}σ ${direction} this cluster's own 7-day baseline (mean ${round(baseline.mean)}, stddev ${round(baseline.stddev)}, n=${baseline.sampleCount}). This threshold is statistically fitted per cluster, not a fixed default.`
+  const current = formatMetricValue(recent, check.unit)
+  const typical = formatMetricValue(baseline.mean, check.unit)
+  return `Now ${current} — ${round(Math.abs(z))}σ ${direction} its 7-day baseline (typical ~${typical}).`
+}
+
+/** Title matching the direction of the deviation, so copy never contradicts the data. */
+export function directionalTitle(check: AnomalyCheck, z: number): string {
+  return z < 0 && check.titleBelow ? check.titleBelow : check.title
 }
 
 async function collectAnomalies(hostId: number): Promise<InsightCandidate[]> {
@@ -228,7 +309,8 @@ async function collectAnomalies(hostId: number): Promise<InsightCandidate[]> {
           recent,
           changePct,
           fittedBaseline,
-          check.classify
+          check.classify,
+          check.alertOn
         )
         if (decision.severity === null) return
 
@@ -241,7 +323,10 @@ async function collectAnomalies(hostId: number): Promise<InsightCandidate[]> {
           severity: decision.severity,
           category: 'anomaly',
           metric: check.metric,
-          title: check.title,
+          title: directionalTitle(
+            check,
+            usedBaseline ? (decision.z as number) : changePct
+          ),
           detail: usedBaseline
             ? formatBaselineDetail(
                 check,

--- a/docs/knowledge/ai-insights.md
+++ b/docs/knowledge/ai-insights.md
@@ -3,7 +3,7 @@ id: ai-insights
 title: AI Insights Engine
 type: spec
 status: active
-updated: 2026-07-11
+updated: 2026-08-12
 tags:
   - insights
   - findings
@@ -65,6 +65,22 @@ is fragmented", "replication is lagging" — generated and **cached server-side*
   suggestions into one. `deriveAction` returns a generic "Ask the agent"
   deep-link for `category === 'optimization'` (the full DDL only survives the
   immediate `generate()` response, not the scalar findings store).
+- **Anomaly checks are direction-aware.** Each `AnomalyCheck` declares
+  `alertOn: 'above' | 'below' | 'both'` and a `unit`
+  (`bytes | ms | percent | count`). `decideSeverity` suppresses a deviation whose
+  sign the check does not alert on — in BOTH the baseline and static-threshold
+  paths — so memory / p95 / error rate falling below baseline never fires a
+  warning, and `directionalTitle` picks `titleBelow` when a `'both'` check does
+  fire on a drop. Titles must therefore never hardcode a direction the check can
+  contradict ("Memory usage spiked" over a below-baseline value was the bug this
+  fixed, 2026-08-12).
+- **Card copy is humanized at generation time.** Findings are persisted as text,
+  so raw numbers baked into `detail` live on in the store: format with
+  `formatMetricValue` (bytes → `formatReadableSize`, ms → `840ms` / `4.2s`,
+  percent rounded, counts locale-formatted) before writing. `formatBaselineDetail`
+  emits ONE sentence — `Now 2.23 GiB — 2.24σ above its 7-day baseline (typical
+  ~2.07 GiB).` — the mean/stddev/n fit belongs in the detail dialog, not the card
+  body. Older raw-number findings age out on the next regeneration sweep.
 - **Operational collectors** (`collectOperational` in `collectors.ts`) add cheap
   point-in-time checks across categories — detached parts (`storage`), stuck /
   failing mutations + FAILED dictionaries (`reliability`), and the longest

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-24
+updated: 2026-08-12
 tags:
   - design-system
   - ui
@@ -286,6 +286,19 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   hover/focus "Details" hint. Drive drill-down generically from a per-item field
   (e.g. each health check's `detailChartName`) rendered via `ResultTable`, not
   per-card code — see `components/health/{health-card-shell,health-detail-rows}.tsx`.
+- **Insight cards carry ONE severity signal.** `components/insights/severity-meta.ts`
+  is the single source of truth (label / icon / `iconColor` / neutral `badge`).
+  The severity reads from the **tinted icon only** — no tinted icon tile, no
+  colored card border, no colored severity pill, and header count badges stay
+  neutral (`border-border bg-transparent text-muted-foreground`). Repeating the
+  same signal four times was the "AI slop" the card was redesigned away from
+  (2026-08-12). Card body is `line-clamp-2` with the full text as a `title`
+  tooltip; the breakdown lives in `InsightDetailDialog`.
+- **A dialog opened from a popover must live OUTSIDE the popover subtree.**
+  Rendering a `Dialog` inside `PopoverContent` means closing the popover
+  unmounts the dialog with it and nothing appears. Keep the selected item +
+  dialog in the parent, as a sibling of `<Popover>` (see
+  `components/insights/insights-popover.tsx`).
 - **Severity-tiered "many checks at a glance":** don't give every item equal
   visual weight. Items that need attention expand to full cards; healthy/normal
   items collapse into ONE dense, quiet bordered list (`divide-y … rounded-xl


### PR DESCRIPTION
## Why

The AI Insights card on `/overview` read like AI slop. From the reported screenshot of a single warning card:

- **Contradictory copy** — title "Memory usage spiked" over a body saying the value was `2.24σ` **below** the 7-day baseline. A memory *drop* was being reported as a warning.
- **Raw numbers** — `2190847074.84` printed verbatim, with decimals.
- **Four copies of one signal** — amber card border + amber icon tile + amber "Warning" pill + amber "1 warning" header count badge.
- Body text truncated mid-number because the sentence carried the whole statistical fit.

Note: the finding copy is **not** in `lib/insights/templates.ts` (that file is settings presets). The real source is `lib/insights/collectors.ts` — `ANOMALY_CHECKS` + `formatBaselineDetail`.

## What changed

### Direction logic (`lib/insights/collectors.ts`)
- `AnomalyCheck` gains `alertOn: 'above' | 'below' | 'both'` and `unit`. All three current checks (error rate, p95, memory) are `'above'` — falling below baseline is not a problem.
- `decideSeverity(..., alertOn)` suppresses a wrong-direction deviation in **both** the baseline path and the static-threshold fallback. A below-baseline memory reading now produces no finding at all.
- `directionalTitle()` picks `titleBelow` when a (future) `'both'` check fires on a drop, so a title can never contradict the body.

### Copy
- `formatMetricValue(value, unit)`: bytes → `formatReadableSize` (`2.04 GiB`), ms → `840ms` / `4.2s`, percent → rounded `3.46%`, counts → locale-formatted. Applied to the baseline detail and the static fallback strings too.
- Before: `Memory usage spiked: the current value (2190847074.84) is 2.24σ below this cluster's own 7-day baseline (mean 2074000000, stddev 61000000, n=168). This threshold is statistically fitted per cluster, not a fixed default.`
- After: `Now 2.23 GiB — 2.24σ above its 7-day baseline (typical ~2.07 GiB).` (and the below-baseline case no longer fires). The mean/stddev/n fit stays available in the detail dialog.

### Card design
- `severity-meta.ts` is still the single source of truth, minus `iconBg` and the full-border `accent`; `badge` classes are neutral.
- **Before:** colored 4-sided card border, colored icon tile, colored "Warning" pill, colored header count badges (panel + strip + Postgres panel).
- **After:** neutral `bg-card` surface and border; severity reads from **one** tinted lucide icon; the meta line is plain muted text `Warning · 2h ago`; header counts are neutral outline badges. Body is `line-clamp-2` with the full detail as a `title` tooltip, so it no longer truncates mid-number.
- Dismiss (×), timestamp and the `Open running queries →` action are all kept; the action stays the existing ghost-link + arrow used elsewhere in the panel.

### Popover detail dialog (reported separately, same components)
Clicking an item in the top-right AI Insights popover did nothing. Root cause: `InsightDetailDialog` was rendered **inside** `PopoverContent`, so the click closed the popover, which unmounted the dialog along with its `open` state. Fixed by lifting the selected insight + the dialog into `InsightsPopover`, rendered as a **sibling** of `<Popover>`: item click sets the selection and closes the popover, the dialog opens and survives.

## Dismissal keys — no impact
Keys are `host:category:metric:title` (`insightKey`). Because below-baseline readings are **suppressed** rather than retitled, `"Memory usage spiked"` remains the only memory title that ever fires → every existing key is byte-identical, no migration needed. `titleBelow` is only reachable for a `'both'` check, which would be a brand-new key that never had dismissals.

Already-stored findings that contain raw numbers are not rewritten: findings regenerate on the cron sweep / throttled auto-generate, so old copy ages out on its own. No defensive regex in the renderer.

## Verification
- `bun test src/lib/insights/collectors.test.ts` — 15 pass (new: direction gating for baseline + static paths, `alertsOn` zero-deviation, byte/ms/percent/count formatting, exact baseline sentence).
- `pnpm run lint` (biome) clean; `pnpm run build` (vite + `tsc --noEmit`).
- Knowledge docs updated in the same change: `docs/knowledge/ai-insights.md` (direction-aware checks, humanize-at-generation-time) and `docs/knowledge/product-design.md` (one severity signal per insight card; a popover-launched dialog must live outside the popover subtree).
