### PR TITLE
feat(charts): responsive month window for the query activity heatmap

### DIFF
--- a/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.test.ts
@@ -3,6 +3,7 @@ import type { HeatmapDayRow } from './query-count-calendar'
 import {
   buildCalendarModel,
   buildMonthBlocks,
+  buildMonthWindowModel,
   buildStatCards,
   formatCalendarDate,
   formatDurationMs,
@@ -10,6 +11,8 @@ import {
   isoDate,
   METRIC_CONFIGS,
   pickVisibleMonthBlocks,
+  resolveWindowStart,
+  summarizeVisibleBlocks,
 } from './query-count-calendar'
 import { describe, expect, it } from 'bun:test'
 
@@ -322,5 +325,100 @@ describe('buildStatCards', () => {
     // Peak memory = max daily reading = 600 bytes, formatted as a size.
     expect(cards[0].value).toBe('600 Bytes')
     expect(cards[1].label).toBe('Average')
+  })
+})
+
+describe('resolveWindowStart', () => {
+  const today = new Date(2026, 5, 17) // Jun 17 2026
+
+  it('caps at MAX_WINDOW_MONTHS back when data spans further', () => {
+    const start = resolveWindowStart([row('2020-01-05')], today)
+    // 24 months inclusive of the current one → Jul 1 2024.
+    expect(start.getFullYear()).toBe(2024)
+    expect(start.getMonth()).toBe(6)
+    expect(start.getDate()).toBe(1)
+  })
+
+  it('starts at the oldest data month when coverage is shorter', () => {
+    const start = resolveWindowStart(
+      [row('2026-04-20'), row('2026-05-02')],
+      today
+    )
+    expect(start.getFullYear()).toBe(2026)
+    expect(start.getMonth()).toBe(3) // April
+    expect(start.getDate()).toBe(1)
+  })
+
+  it('falls back to the full cap with no rows', () => {
+    const start = resolveWindowStart([], today)
+    expect(start.getFullYear()).toBe(2024)
+    expect(start.getMonth()).toBe(6)
+  })
+})
+
+describe('buildMonthWindowModel', () => {
+  const today = new Date(2026, 5, 17)
+
+  it('starts at a month boundary — the oldest block has no foreign days', () => {
+    const model = buildMonthWindowModel([row('2026-04-10')], today, QUERIES)
+    const blocks = buildMonthBlocks(model)
+    expect(blocks[0]?.key).toBe('2026-3') // April, not a March remnant
+    const days = blocks[0]?.weeks.flat().filter(Boolean) ?? []
+    expect(days.every((d) => d?.date.getMonth() === 3)).toBe(true)
+    expect(days.some((d) => d?.iso === '2026-04-01')).toBe(true)
+  })
+
+  it('runs through the end of the current month (future days dimmed)', () => {
+    const model = buildMonthWindowModel([row('2026-06-01')], today, QUERIES)
+    const june = buildMonthBlocks(model).find((b) => b.key === '2026-5')
+    const days = june?.weeks.flat().filter(Boolean) ?? []
+    expect(days.map((d) => d?.iso)).toContain('2026-06-30')
+    expect(days.find((d) => d?.iso === '2026-06-30')?.isFuture).toBe(true)
+  })
+
+  it('reaches further back than a year when data allows', () => {
+    const model = buildMonthWindowModel([row('2024-08-01')], today, QUERIES)
+    expect(buildMonthBlocks(model).length).toBeGreaterThan(13)
+  })
+})
+
+describe('summarizeVisibleBlocks', () => {
+  const today = new Date(2026, 5, 17)
+  const rows = [
+    row('2026-04-10', { query_count: 500 }),
+    row('2026-06-10', { query_count: 100 }),
+    row('2026-06-11', { query_count: 40 }),
+  ]
+  const blocks = buildMonthBlocks(buildMonthWindowModel(rows, today, QUERIES))
+
+  it('counts only the visible months, not the whole model', () => {
+    const all = summarizeVisibleBlocks(blocks)
+    const juneOnly = summarizeVisibleBlocks(blocks.slice(-1))
+    expect(all.total).toBe(640)
+    expect(juneOnly.total).toBe(140)
+    expect(juneOnly.max).toBe(100)
+    expect(juneOnly.activeDays).toBe(2)
+    expect(juneOnly.totalDays).toBeLessThan(all.totalDays)
+    expect(juneOnly.rangeLabel).toBe('Jun 2026 – Jun 2026')
+  })
+
+  it('excludes future days of the current month from the stats', () => {
+    // Jun 1..17 inclusive — the dimmed Jun 18-30 cells never count.
+    expect(summarizeVisibleBlocks(blocks.slice(-1)).totalDays).toBe(17)
+  })
+
+  it('feeds stat cards that describe the visible window', () => {
+    const cards = buildStatCards(
+      QUERIES,
+      summarizeVisibleBlocks(blocks.slice(-1))
+    )
+    expect(cards[0].sub).toBe('over 17 days')
+  })
+
+  it('is empty-safe', () => {
+    const empty = summarizeVisibleBlocks([])
+    expect(empty.total).toBe(0)
+    expect(empty.peak).toBeNull()
+    expect(empty.rangeLabel).toBe('')
   })
 })

--- a/apps/dashboard/src/components/charts/query/query-count-calendar.ts
+++ b/apps/dashboard/src/components/charts/query/query-count-calendar.ts
@@ -265,11 +265,13 @@ export interface CalendarDay {
  *  slot outside the rendered range (e.g. future days in the final column). */
 export type CalendarWeek = (CalendarDay | null)[]
 
-export interface CalendarModel {
-  /** Week columns, oldest → newest (left → right). */
-  weeks: CalendarWeek[]
-  /** Month label per week column, or `null` when the month is unchanged. */
-  monthLabels: (string | null)[]
+/**
+ * Aggregates over a set of day cells. Produced either for the whole model
+ * ({@link buildCalendarModel}) or for just the months currently on screen
+ * ({@link summarizeVisibleBlocks}), so the KPI strip always describes exactly
+ * what the user can see.
+ */
+export interface CalendarStats {
   max: number
   total: number
   activeDays: number
@@ -278,6 +280,13 @@ export interface CalendarModel {
   peak: CalendarDay | null
   /** Caption like "Jun 2025 – Jun 2026", or '' when there are no days. */
   rangeLabel: string
+}
+
+export interface CalendarModel extends CalendarStats {
+  /** Week columns, oldest → newest (left → right). */
+  weeks: CalendarWeek[]
+  /** Month label per week column, or `null` when the month is unchanged. */
+  monthLabels: (string | null)[]
 }
 
 /**
@@ -291,7 +300,13 @@ export function buildCalendarModel(
   today: Date,
   metric: MetricConfig,
   weeksBack = 53,
-  includeFuture = false
+  includeFuture = false,
+  /**
+   * Explicit first day of the window (overrides `weeksBack`). The grid is still
+   * snapped back to the enclosing Sunday, but days before this date are left
+   * empty so the oldest month block is never a partial month.
+   */
+  startOverride?: Date
 ): CalendarModel {
   const byDate = new Map<string, HeatmapDayRow>()
   for (const r of rows) byDate.set(r.date, r)
@@ -309,8 +324,21 @@ export function buildCalendarModel(
   const end = includeFuture
     ? new Date(today.getFullYear(), today.getMonth() + 1, 0, 12)
     : todayNoon
-  const start = new Date(todayNoon)
-  start.setDate(start.getDate() - (weeksBack * 7 - 1))
+  // First day that may render. With `startOverride` this is a month boundary;
+  // otherwise the day `weeksBack` weeks before today.
+  const firstRenderable = startOverride
+    ? new Date(
+        startOverride.getFullYear(),
+        startOverride.getMonth(),
+        startOverride.getDate(),
+        12
+      )
+    : (() => {
+        const d = new Date(todayNoon)
+        d.setDate(d.getDate() - (weeksBack * 7 - 1))
+        return d
+      })()
+  const start = new Date(firstRenderable)
   // Snap to the Sunday on/before the start so columns are whole weeks.
   start.setDate(start.getDate() - start.getDay())
 
@@ -334,6 +362,12 @@ export function buildCalendarModel(
       // Future days (beyond today) stay null so the trailing column matches
       // GitHub: the current week is partially filled.
       if (cursor > end) {
+        cursor.setDate(cursor.getDate() + 1)
+        continue
+      }
+      // Leading days of the Sunday-snap that fall before the window start stay
+      // null, so the oldest month block only ever shows its own days.
+      if (startOverride && cursor < firstRenderable) {
         cursor.setDate(cursor.getDate() + 1)
         continue
       }
@@ -394,6 +428,58 @@ export function buildCalendarModel(
     peak,
     rangeLabel,
   }
+}
+
+/**
+ * Widest window the model ever builds, in calendar months (including the
+ * current one). Wide screens can show more than a year of history; this caps
+ * how far back the grid is built so ultrawide viewports stay bounded.
+ */
+export const MAX_WINDOW_MONTHS = 24
+
+/**
+ * First day of the model window: the start of the month `maxMonths - 1` months
+ * before `today`, but never earlier than the month of the oldest row we have.
+ * Capping at data coverage keeps a wide screen from rendering a year of empty
+ * cells for a deployment with a short `query_log` TTL.
+ */
+export function resolveWindowStart(
+  rows: HeatmapDayRow[],
+  today: Date,
+  maxMonths = MAX_WINDOW_MONTHS
+): Date {
+  const capStart = new Date(
+    today.getFullYear(),
+    today.getMonth() - (Math.max(1, maxMonths) - 1),
+    1,
+    12
+  )
+  let earliest: string | null = null
+  for (const r of rows) {
+    if (r.date && (earliest === null || r.date < earliest)) earliest = r.date
+  }
+  if (!earliest) return capStart
+  const [y, m] = earliest.split('-').map(Number)
+  if (!Number.isFinite(y) || !Number.isFinite(m)) return capStart
+  const dataStart = new Date(y, m - 1, 1, 12)
+  return dataStart > capStart ? dataStart : capStart
+}
+
+/**
+ * Build a calendar model spanning whole months, from {@link resolveWindowStart}
+ * through the end of the current month. The renderer then trims the oldest
+ * months that don't fit the measured container width
+ * ({@link pickVisibleMonthBlocks}), so the number of months on screen follows
+ * the available width instead of a fixed year.
+ */
+export function buildMonthWindowModel(
+  rows: HeatmapDayRow[],
+  today: Date,
+  metric: MetricConfig,
+  maxMonths = MAX_WINDOW_MONTHS
+): CalendarModel {
+  const start = resolveWindowStart(rows, today, maxMonths)
+  return buildCalendarModel(rows, today, metric, 53, true, start)
 }
 
 /**
@@ -502,6 +588,51 @@ export function pickVisibleMonthBlocks(
   return visibleReversed.reverse()
 }
 
+/**
+ * Recompute the aggregates over just the month blocks currently rendered, so
+ * "over N days" / "of N (x%)" / the range caption / the colour scale all
+ * describe the window the user actually sees. Future cells of the current month
+ * render but never count. Every day appears in exactly one block (boundary
+ * weeks are masked per month), so no de-duplication is needed.
+ */
+export function summarizeVisibleBlocks(blocks: MonthBlock[]): CalendarStats {
+  let max = 0
+  let total = 0
+  let activeDays = 0
+  let totalDays = 0
+  let peak: CalendarDay | null = null
+  let firstDay: Date | null = null
+  let lastDay: Date | null = null
+
+  for (const block of blocks) {
+    for (const week of block.weeks) {
+      for (const day of week) {
+        if (!day || day.isFuture) continue
+        if (!firstDay || day.date < firstDay) firstDay = day.date
+        if (!lastDay || day.date > lastDay) lastDay = day.date
+        totalDays += 1
+        total += day.value
+        if (day.value > 0) activeDays += 1
+        if (day.value > max) max = day.value
+        if (!peak || day.value > peak.value) peak = day
+      }
+    }
+  }
+
+  return {
+    max,
+    total,
+    activeDays,
+    totalDays,
+    avgActive: activeDays > 0 ? total / activeDays : 0,
+    peak,
+    rangeLabel:
+      firstDay && lastDay
+        ? `${formatMonthYear(firstDay)} – ${formatMonthYear(lastDay)}`
+        : '',
+  }
+}
+
 /** A single KPI/stat card shown above the calendar. */
 export interface StatCard {
   label: string
@@ -518,7 +649,7 @@ export interface StatCard {
  */
 export function buildStatCards(
   metric: MetricConfig,
-  model: CalendarModel
+  model: CalendarStats
 ): StatCard[] {
   const { total, max, activeDays, totalDays, avgActive, peak } = model
   const hasTraffic = max > 0

--- a/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
+++ b/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
@@ -18,8 +18,8 @@ import type {
 } from './query-count-calendar'
 
 import {
-  buildCalendarModel,
   buildMonthBlocks,
+  buildMonthWindowModel,
   buildStatCards,
   CALENDAR_DAY_LABELS,
   formatCalendarDate,
@@ -28,6 +28,7 @@ import {
   METRIC_CONFIGS,
   METRIC_ORDER,
   pickVisibleMonthBlocks,
+  summarizeVisibleBlocks,
 } from './query-count-calendar'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createCustomChart } from '@/components/charts/factory'
@@ -170,21 +171,29 @@ function CalendarBody({
   const [gridWidth, setGridWidth] = useState(0)
 
   // `today` is read once per render from the local clock; memoize so the
-  // ~371-cell build is off every hover re-render and only reruns on mode change.
-  // `includeFuture` renders the rest of the current month as dimmed cells.
+  // cell build is off every hover re-render and only reruns on mode change.
+  // The window spans whole months up to MAX_WINDOW_MONTHS back (capped at the
+  // oldest day we actually have data for) and always through the END of the
+  // current month — its remaining days render as dimmed, non-counting cells.
   const model = useMemo(
-    () => buildCalendarModel(data, new Date(), metric, 53, true),
+    () => buildMonthWindowModel(data, new Date(), metric),
     [data, metric]
   )
-  const statCards = useMemo(
-    () => buildStatCards(metric, model),
-    [metric, model]
-  )
   const monthBlocks = useMemo(() => buildMonthBlocks(model), [model])
-  // Trim to the most recent months that fit; always keeps the current month.
+  // Trim to the most recent months that fit the measured width; always keeps
+  // the current month. Wide screens therefore reach further back in time.
   const visibleBlocks = useMemo(
     () => pickVisibleMonthBlocks(monthBlocks, gridWidth),
     [monthBlocks, gridWidth]
+  )
+  // KPIs, colour scale and range caption describe the visible window only.
+  const summary = useMemo(
+    () => summarizeVisibleBlocks(visibleBlocks),
+    [visibleBlocks]
+  )
+  const statCards = useMemo(
+    () => buildStatCards(metric, summary),
+    [metric, summary]
   )
   const todayIso = isoDate(new Date())
 
@@ -223,7 +232,7 @@ function CalendarBody({
     )
   }
 
-  const { max, rangeLabel } = model
+  const { max, rangeLabel } = summary
   const hasTraffic = max > 0
 
   // Render one day cell (or an empty spacer for masked/out-of-range slots).
@@ -486,7 +495,10 @@ function CalendarBody({
 export const ChartQueryCountHeatmap = createCustomChart({
   chartName: 'query-count-heatmap',
   defaultTitle: 'Query Activity Heatmap',
-  defaultLastHours: 24 * 365,
+  // Two years of daily aggregates so wide screens have history to fill with;
+  // the client trims to what fits. Deployments with a short query_log TTL just
+  // return fewer rows (the window is then capped at data coverage).
+  defaultLastHours: 24 * 365 * 2,
   dataTestId: 'query-count-heatmap-chart',
   contentClassName: 'overflow-hidden',
   render: (dataArray, _sql, hostId) => (

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -379,13 +379,15 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
   // One row per calendar day carrying every switchable metric (query volume,
   // failures, peak memory, avg duration, bytes written) so the client can flip
   // modes without a refetch. Conditional aggregation keeps it a single daily
-  // scan. Default window is one year (24 * 365 hours) → ~53 calendar columns.
+  // scan. Default window is two years (24 * 365 * 2 hours) so wide viewports
+  // can render more than a year of months; the client trims to what fits and
+  // caps the window at the oldest row actually returned.
   //
   // SETTINGS max_execution_time=25: keeps execution under the Cloudflare Worker
   // response timeout (~30s). Without it, a slow full-year scan on a busy server
   // drops the connection mid-stream, returning an empty body (error 1016 —
   // RECEIVED_EMPTY_DATA) instead of a clean ClickHouse timeout error (159).
-  'query-count-heatmap': ({ lastHours = 24 * 365 }) => {
+  'query-count-heatmap': ({ lastHours = 24 * 365 * 2 }) => {
     const timeFilter = buildTimeFilter(lastHours)
     return {
       query: `


### PR DESCRIPTION
## What

The Query Activity Heatmap on `/overview` was pinned to a fixed 53-week model, so the window could only ever *shrink* to fit — a wide screen never gained months, and the KPI strip described the whole model rather than the months actually rendered.

- **Responsive months.** The model is now built over whole calendar months and the renderer trims the oldest blocks that don't fit the measured container width (existing `ResizeObserver` + `pickVisibleMonthBlocks`). Wide screens reach further back (up to 24 months); mobile drops old months so nothing squishes or overflows.
- **Window capped at data coverage.** `resolveWindowStart` starts at `max(month of oldest row, today − 24 months)`, so a deployment with a short `query_log` TTL never renders months of empty cells.
- **Complete months.** The oldest block is always a full month — leading Sunday-snap days before the window start stay empty instead of forming a partial phantom block. The window still runs through the **end of the current month**, with the remaining days dimmed and excluded from every stat.
- **Stats follow the visible window.** `summarizeVisibleBlocks` recomputes total / peak / active days / `over N days` / `of N (x%)`, the colour scale and the range caption from the blocks on screen.
- **Fetch widened** to two years of daily aggregates (chart `defaultLastHours` + the server default) so wide viewports have history to fill. Still one daily `GROUP BY` with `max_execution_time = 25`.

Metric pills, tooltips, click-for-details and the Less/More legend are unchanged.

## Verification

- `bun test query-count-calendar.test.ts` — 37 pass, incl. new cases for month-boundary snapping, the data-coverage cap, extending past 13 months, full-current-month future cells, and visible-window vs full-model stat divergence
- `pnpm run lint` clean (no new findings)
- `pnpm run type-check` clean