### PR TITLE
fix(charts): remove default black axis line from bar charts

### DIFF
--- a/apps/dashboard/src/components/charts/primitives/bar/bar.tsx
+++ b/apps/dashboard/src/components/charts/primitives/bar/bar.tsx
@@ -121,7 +121,7 @@ export const BarChart = function BarChart({
             dataKey={index}
             tickLine={false}
             tickMargin={10}
-            axisLine={true}
+            axisLine={false}
             tickFormatter={tickFormatter}
           />
         )}


### PR DESCRIPTION
## Summary
- Bar charts rendered a solid black horizontal line along the bottom (X axis) because Recharts v3's `<XAxis />` default `axisLine` was explicitly set to `true` in the shared `BarChart` primitive.
- Set `axisLine={false}` in `apps/dashboard/src/components/charts/primitives/bar/bar.tsx` to match the `AreaChart` primitive, which already hides its axis line — this fixes every bar chart in the dashboard at once since they all route through this single shared component (including the declarative bar-chart factory).
- `tickLine` was already `false` on the bar XAxis, so no change needed there.
- No chart relies on the axis line as a visual baseline (CartesianGrid still provides the horizontal gridlines), so removal is purely cosmetic and matches the user's request.

## Test plan
- [x] `pnpm run lint` (Biome) — passes, pre-existing unrelated warnings only
- [x] `pnpm run build` (Vite build + tsc --noEmit) — verified locally after resolving concurrent-agent OOM/timeout noise
- [ ] CI: `dashboard`, `unit-tests` (required checks)

Co-Authored-By: duyetbot <bot@duyet.net>