### PR TITLE
fix(charts): polish Top Tables by Size toggle and scrollbar

### DIFF
--- a/apps/dashboard/src/components/cards/chart-card.tsx
+++ b/apps/dashboard/src/components/cards/chart-card.tsx
@@ -89,6 +89,8 @@ interface ChartCardProps
   enableScaleToggle?: boolean
   /** Optional zoom button to render in header */
   zoomButton?: React.ReactNode
+  /** Optional extra controls (e.g. a segmented toggle) rendered in the header */
+  headerControls?: React.ReactNode
   /** Optional icon rendered before the title */
   icon?: React.ReactNode
   /** Optional className override for the header */
@@ -118,6 +120,7 @@ function ChartCardContent({
   staleError,
   onRetry,
   zoomButton,
+  headerControls,
   href,
   ...cardProps
 }: ChartCardProps) {
@@ -175,6 +178,7 @@ function ChartCardContent({
               )}
               <ScaleToggle />
               {zoomButton}
+              {headerControls}
               {dateRangeConfig && onRangeChange && (
                 <DateRangeSelector
                   config={dateRangeConfig}

--- a/apps/dashboard/src/components/charts/top-table-size.tsx
+++ b/apps/dashboard/src/components/charts/top-table-size.tsx
@@ -5,6 +5,7 @@ import { ChartCard } from '@/components/cards/chart-card'
 import { ChartContainer } from '@/components/charts/chart-container'
 import { RankBars } from '@/components/charts/primitives/rank-bars'
 import { SegmentedControl } from '@/components/filters/segmented-control'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { REFRESH_INTERVAL, useChartData } from '@/lib/swr'
 
 type DataRow = {
@@ -76,19 +77,17 @@ export const ChartTopTableSize = function ChartTopTableSize({
             metadata={metadata}
             data-testid="top-table-size-chart"
             contentClassName={chartCardContentClassName}
+            headerControls={
+              <SegmentedControl
+                options={MODE_OPTIONS}
+                value={mode}
+                onChange={(v) => setMode(v as 'size' | 'rows')}
+              />
+            }
           >
-            <div className="flex h-full min-h-0 flex-col gap-3">
-              <div className="flex items-center justify-end">
-                <SegmentedControl
-                  options={MODE_OPTIONS}
-                  value={mode}
-                  onChange={(v) => setMode(v as 'size' | 'rows')}
-                />
-              </div>
-              <div className="min-h-0 flex-1 overflow-auto">
-                <RankBars items={items} />
-              </div>
-            </div>
+            <ScrollArea className="h-full min-h-0">
+              <RankBars items={items} />
+            </ScrollArea>
           </ChartCard>
         )
       }}

--- a/apps/dashboard/src/components/filters/segmented-control.tsx
+++ b/apps/dashboard/src/components/filters/segmented-control.tsx
@@ -1,5 +1,3 @@
-import { CheckIcon } from 'lucide-react'
-
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -61,7 +59,6 @@ export function SegmentedControl({
             aria-pressed={isActive}
             onClick={() => onChange(option.value)}
           >
-            {isActive && <CheckIcon className="size-3" aria-hidden="true" />}
             <span>{option.label}</span>
           </Button>
         )


### PR DESCRIPTION
## Summary
- Move the Size/Rows segmented toggle into the card header (new `ChartCard` `headerControls` slot) instead of floating below it
- Drop the checkmark from `SegmentedControl` for a compact style consistent with `FleetViewToggle`
- Swap the list's native `overflow-auto` for the shared `ScrollArea` so the scrollbar auto-hides

## Test plan
- [x] `pnpm run lint` (apps/dashboard) — pre-existing unrelated warnings only
- [x] `pnpm run build` (apps/dashboard) — succeeds
- [ ] CI `dashboard` + `unit-tests` checks