### PR TITLE
fix(charts): drop stale 'last year' wording from the heatmap empty state

### DIFF
--- a/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
+++ b/apps/dashboard/src/components/charts/query/query-count-heatmap.tsx
@@ -227,7 +227,7 @@ function CalendarBody({
   if (data.length === 0) {
     return (
       <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">
-        No query activity in the last year
+        No recent query activity
       </div>
     )
   }


### PR DESCRIPTION
Follow-up to #2874, which widened the Query Activity Heatmap window from a fixed year to a responsive whole-month window (up to 24 months, capped at data coverage). The empty state still said "No query activity in the last year", which no longer matches. One-line copy fix; landed a moment too late to make #2874's auto-merge.