### PR TITLE
fix(agents): collapse conversation rail by default on small screens

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/agent-thread-page.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-thread-page.tsx
@@ -35,7 +35,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer'
-import { useIsMobile } from '@/hooks/use-mobile'
+import { useIsLgDown, useIsMobile } from '@/hooks/use-mobile'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
 import { useHostId } from '@/lib/swr/use-host'
 import { useHosts } from '@/lib/swr/use-hosts'
@@ -68,13 +68,19 @@ function AgentThreadPageError() {
 export function AgentThreadPage() {
   const isMobile = useIsMobile()
   // Conversation rail: persistent inline column on desktop (open by default so
-  // its width is reserved on first paint, no CLS); a Drawer on mobile.
+  // its width is reserved on first paint, no CLS); a Drawer on mobile. It also
+  // starts collapsed on tablet-sized (`lg`-down) viewports, where the inline
+  // rail is still used but 280px eats too much of the chat column — the user
+  // can still open it via the toggle button.
+  const isLgDown = useIsLgDown()
   const [railOpen, setRailOpen] = useState(true)
   const [mobileConvOpen, setMobileConvOpen] = useState(false)
   // Settings sidebar (open by default on desktop; Drawer on mobile).
   const [rightSidebarOpen, setRightSidebarOpen] = useState(true)
   useEffect(() => {
-    setRailOpen(!isMobile)
+    setRailOpen(!isLgDown)
+  }, [isLgDown])
+  useEffect(() => {
     setRightSidebarOpen(!isMobile)
   }, [isMobile])
   const firstName = useClerkFirstName()

--- a/apps/dashboard/src/components/assistant-ui/conversation-rail.tsx
+++ b/apps/dashboard/src/components/assistant-ui/conversation-rail.tsx
@@ -235,7 +235,7 @@ export function ConversationRailBody({
         </div>
       </div>
 
-      <ScrollArea className="min-h-0 flex-1">
+      <ScrollArea className="min-h-0 flex-1 scroll-area-autohide">
         <div className="px-2 pb-3">
           {groups.length === 0 ? (
             <p className="text-muted-foreground px-2 py-8 text-center text-[12px]">

--- a/apps/dashboard/src/hooks/use-mobile.tsx
+++ b/apps/dashboard/src/hooks/use-mobile.tsx
@@ -1,19 +1,32 @@
 import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
+// Tailwind `lg` breakpoint — used to default collapsible panels (e.g. the
+// agents page conversation rail) closed on tablet-sized viewports too, not
+// just phones.
+const LG_BREAKPOINT = 1024
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+function useBreakpointDown(breakpoint: number) {
+  const [isBelow, setIsBelow] = React.useState<boolean | undefined>(undefined)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`)
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+      setIsBelow(window.innerWidth < breakpoint)
     }
     mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    setIsBelow(window.innerWidth < breakpoint)
     return () => mql.removeEventListener('change', onChange)
-  }, [])
+  }, [breakpoint])
 
-  return !!isMobile
+  return !!isBelow
+}
+
+export function useIsMobile() {
+  return useBreakpointDown(MOBILE_BREAKPOINT)
+}
+
+/** True below the `lg` breakpoint (covers phones and tablets). */
+export function useIsLgDown() {
+  return useBreakpointDown(LG_BREAKPOINT)
 }

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -200,6 +200,17 @@
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
   }
+  /* Auto-hide the base-ui ScrollArea scrollbar — visible only while
+     hovering/scrolling, hidden otherwise (e.g. the /agents conversation
+     rail list). Scoped via this wrapper class, not global. */
+  .scroll-area-autohide [data-slot='scroll-area-scrollbar'] {
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+  .scroll-area-autohide [data-slot='scroll-area-scrollbar'][data-hovering],
+  .scroll-area-autohide [data-slot='scroll-area-scrollbar'][data-scrolling] {
+    opacity: 1;
+  }
 }
 
 /* Markdown content styling for agent responses */


### PR DESCRIPTION
## Summary
- The /agents conversation rail (sidebar of saved chats) defaulted **open** at every desktop width, including tablet-sized viewports (`md`–`lg`, 768px–1024px) where the inline 280px column crowds the chat. Below `md` it already switched to a mobile Drawer that starts closed.
- Added a `useIsLgDown()` breakpoint hook (Tailwind `lg` = 1024px, alongside the existing `useIsMobile()` at `md` = 768px) and default the rail **collapsed** below `lg`. The existing collapse/expand toggle (`ConversationRailOpenButton` / the header's collapse button) still opens it — no new UI needed. Desktop (`lg`+) keeps opening by default, unchanged. There's no persisted open-state (localStorage) today, so there's nothing to conflict with.
- Auto-hide the conversation list's scrollbar: added a scoped `.scroll-area-autohide` utility (in `styles.css`, targeting `[data-slot="scroll-area-scrollbar"][data-hovering]`/`[data-scrolling]`) and applied it to the rail's `ScrollArea`, since base-ui's `ScrollArea` scrollbar is visible by default and needs explicit opacity styling to fade in/out. The chat thread already uses a thin (`scrollbar-thin`) scrollbar, not a chunky one, so it was left untouched.

## Test plan
- [x] `pnpm run lint` — clean (pre-existing unrelated warnings only)
- [x] `vite build` — succeeds
- [x] `tsc --noEmit` — no errors
- [ ] Manual check in a real browser: rail starts collapsed under 1024px, opens via toggle, stays open at desktop widths, scrollbar fades in on hover/scroll in the conversation list

https://claude.ai/code/session_019MzLkNcZYT5J8fCAUYnF1E