### PR TITLE
feat(fleet): add fleet summary strip, richer host metrics and sparklines

### DIFF
--- a/apps/dashboard/src/components/fleet/fleet-helpers.test.ts
+++ b/apps/dashboard/src/components/fleet/fleet-helpers.test.ts
@@ -5,11 +5,15 @@
  */
 
 import {
+  computeFleetSummary,
   DEFAULT_FLEET_VIEW,
   FLEET_VIEW_STORAGE_KEY,
   formatCount,
+  formatPercent,
   parseFleetView,
   readFleetView,
+  safeRatio,
+  sparklinePoints,
   writeFleetView,
 } from './fleet-helpers'
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
@@ -129,5 +133,112 @@ describe('formatCount', () => {
 
   test('truncates fractional values', () => {
     expect(formatCount(12.9)).toBe('12')
+  })
+})
+
+describe('formatPercent', () => {
+  test('renders an en-dash for absent / non-finite values', () => {
+    expect(formatPercent(undefined)).toBe('—')
+    expect(formatPercent(null)).toBe('—')
+    expect(formatPercent(Number.NaN)).toBe('—')
+  })
+
+  test('rounds a ratio to whole percent', () => {
+    expect(formatPercent(0)).toBe('0%')
+    expect(formatPercent(0.4212)).toBe('42%')
+    expect(formatPercent(1)).toBe('100%')
+  })
+})
+
+describe('safeRatio', () => {
+  test('divides used by total', () => {
+    expect(safeRatio(50, 200)).toBe(0.25)
+  })
+
+  test('guards a zero / negative / missing total', () => {
+    // A host reporting no disk capacity must degrade to an en-dash, never
+    // render Infinity%.
+    expect(safeRatio(50, 0)).toBeUndefined()
+    expect(safeRatio(50, -1)).toBeUndefined()
+    expect(safeRatio(50, undefined)).toBeUndefined()
+    expect(safeRatio(undefined, 200)).toBeUndefined()
+  })
+})
+
+describe('computeFleetSummary', () => {
+  test('counts online / offline and leaves browser hosts unknown', () => {
+    // A browser-stored connection has no status probe, so it must not be
+    // reported as offline (which would look like an outage).
+    const summary = computeFleetSummary([
+      { state: 'online', version: '24.3' },
+      { state: 'offline' },
+      { state: 'unknown' },
+      { state: 'loading' },
+    ])
+    expect(summary.total).toBe(4)
+    expect(summary.online).toBe(1)
+    expect(summary.offline).toBe(1)
+  })
+
+  test('flags version drift only when hosts disagree', () => {
+    expect(
+      computeFleetSummary([
+        { state: 'online', version: '24.3' },
+        { state: 'online', version: '24.3' },
+      ]).versionDrift
+    ).toBe(false)
+    const drift = computeFleetSummary([
+      { state: 'online', version: '25.1' },
+      { state: 'online', version: '24.3' },
+    ])
+    expect(drift.versionDrift).toBe(true)
+    expect(drift.versions).toEqual(['24.3', '25.1'])
+  })
+
+  test('sums reported metrics and stays undefined when none reported', () => {
+    // Undefined (nothing reported) must stay distinguishable from a real 0,
+    // so the tile shows an en-dash rather than a misleading zero.
+    const none = computeFleetSummary([{ state: 'unknown' }])
+    expect(none.runningQueries).toBeUndefined()
+    const some = computeFleetSummary([
+      { state: 'online', runningQueries: 3, databases: 2, tables: 10 },
+      { state: 'online', runningQueries: 4 },
+      { state: 'offline' },
+    ])
+    expect(some.runningQueries).toBe(7)
+    expect(some.databases).toBe(2)
+    expect(some.tables).toBe(10)
+  })
+
+  test('handles an empty fleet', () => {
+    const summary = computeFleetSummary([])
+    expect(summary).toMatchObject({
+      total: 0,
+      online: 0,
+      offline: 0,
+      versions: [],
+      versionDrift: false,
+    })
+  })
+})
+
+describe('sparklinePoints', () => {
+  test('needs at least two finite points', () => {
+    expect(sparklinePoints([], 100, 20)).toBe('')
+    expect(sparklinePoints([5], 100, 20)).toBe('')
+    expect(sparklinePoints([5, Number.NaN], 100, 20)).toBe('')
+  })
+
+  test('scales values across the box with y inverted', () => {
+    // Lowest value sits on the baseline (y = height), highest at the top.
+    expect(sparklinePoints([0, 10], 100, 20)).toBe('0.00,20.00 100.00,0.00')
+  })
+
+  test('draws a flat series as a centred line', () => {
+    // A constant series has no span; collapsing it to the baseline would read
+    // as "zero activity" rather than "steady activity".
+    expect(sparklinePoints([7, 7, 7], 100, 20)).toBe(
+      '0.00,10.00 50.00,10.00 100.00,10.00'
+    )
   })
 })

--- a/apps/dashboard/src/components/fleet/fleet-helpers.ts
+++ b/apps/dashboard/src/components/fleet/fleet-helpers.ts
@@ -50,3 +50,120 @@ export function formatCount(value: number | null | undefined): string {
   }
   return Math.trunc(value).toLocaleString()
 }
+
+/**
+ * Format a ratio (0..1) as a whole percentage for a Fleet cell. En-dash when
+ * the value is absent/non-finite, so a host that couldn't report it degrades
+ * like every other metric.
+ */
+export function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return '—'
+  }
+  return `${Math.round(value * 100)}%`
+}
+
+/**
+ * Ratio of `used` to `total`, or undefined when either side is missing or the
+ * total is not positive (avoids a divide-by-zero rendering as `Infinity%`).
+ */
+export function safeRatio(
+  used: number | null | undefined,
+  total: number | null | undefined
+): number | undefined {
+  if (!Number.isFinite(used as number) || !Number.isFinite(total as number)) {
+    return undefined
+  }
+  if ((total as number) <= 0) return undefined
+  return (used as number) / (total as number)
+}
+
+/** One host's contribution to the fleet summary. */
+export interface FleetSummaryEntry {
+  /** `unknown` covers browser-stored connections, which have no status probe. */
+  state: 'online' | 'offline' | 'unknown' | 'loading'
+  version?: string
+  runningQueries?: number
+  databases?: number
+  tables?: number
+}
+
+/** Aggregate fleet-wide figures rendered by the summary strip. */
+export interface FleetSummary {
+  total: number
+  online: number
+  offline: number
+  /** Distinct ClickHouse versions among hosts that reported one, sorted. */
+  versions: string[]
+  /** True when hosts disagree on version — surfaced as a subtle warning. */
+  versionDrift: boolean
+  /** Sums stay undefined when NO host reported the metric (vs. a genuine 0). */
+  runningQueries?: number
+  databases?: number
+  tables?: number
+}
+
+/**
+ * Reduce per-host status into the fleet summary. Pure: the caller collects the
+ * entries from each host's own `useHostStatus` (hooks at the deepest consumer).
+ */
+export function computeFleetSummary(
+  entries: readonly FleetSummaryEntry[]
+): FleetSummary {
+  const versions = new Set<string>()
+  let online = 0
+  let offline = 0
+  let runningQueries: number | undefined
+  let databases: number | undefined
+  let tables: number | undefined
+
+  const add = (acc: number | undefined, v: number | undefined) =>
+    Number.isFinite(v as number) ? (acc ?? 0) + (v as number) : acc
+
+  for (const entry of entries) {
+    if (entry.state === 'online') online += 1
+    else if (entry.state === 'offline') offline += 1
+    if (entry.version) versions.add(entry.version)
+    runningQueries = add(runningQueries, entry.runningQueries)
+    databases = add(databases, entry.databases)
+    tables = add(tables, entry.tables)
+  }
+
+  const sorted = [...versions].sort()
+  return {
+    total: entries.length,
+    online,
+    offline,
+    versions: sorted,
+    versionDrift: sorted.length > 1,
+    runningQueries,
+    databases,
+    tables,
+  }
+}
+
+/**
+ * Build an SVG polyline `points` string for a sparkline over `values`, scaled
+ * into a `width` x `height` box (y inverted so higher values sit higher).
+ * Returns an empty string for fewer than two finite points; a flat series is
+ * drawn as a centred horizontal line rather than collapsing onto the baseline.
+ */
+export function sparklinePoints(
+  values: readonly number[],
+  width: number,
+  height: number
+): string {
+  const finite = values.filter((v) => Number.isFinite(v))
+  if (finite.length < 2) return ''
+  const min = Math.min(...finite)
+  const max = Math.max(...finite)
+  const span = max - min
+  const step = width / (finite.length - 1)
+  return finite
+    .map((v, i) => {
+      const ratio = span === 0 ? 0.5 : (v - min) / span
+      const y = height - ratio * height
+      return `${(i * step).toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+}

--- a/apps/dashboard/src/components/fleet/fleet-host-card.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-host-card.tsx
@@ -2,6 +2,8 @@ import { useNavigate } from '@tanstack/react-router'
 
 import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
 
+import { formatCount, formatPercent, safeRatio } from './fleet-helpers'
+import { FleetSparkline } from './fleet-sparkline'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -12,7 +14,9 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { formatReadableSize } from '@/lib/format-readable'
 import { useHostStatus } from '@/lib/swr/use-host-status'
+import { cn } from '@/lib/utils'
 
 interface FleetHostCardProps {
   host: MergedHostInfo
@@ -27,7 +31,10 @@ export function FleetHostCard({ host }: FleetHostCardProps) {
     data: status,
     isLoading,
     isOnline,
-  } = useHostStatus(isBrowser ? null : host.id)
+  } = useHostStatus(isBrowser ? null : host.id, { fleet: true })
+
+  const diskRatio = safeRatio(status?.diskUsedBytes, status?.diskTotalBytes)
+  const memRatio = safeRatio(status?.memoryBytes, status?.memoryTotalBytes)
 
   const handleView = () => {
     navigate({
@@ -75,20 +82,80 @@ export function FleetHostCard({ host }: FleetHostCardProps) {
           </p>
         ) : isLoading ? (
           <div className="space-y-1.5">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-4 w-20" />
+            {/* Matches the metric list height below to avoid layout shift. */}
+            {Array.from({ length: 7 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+            <Skeleton className="h-5 w-full" />
           </div>
         ) : status ? (
-          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs">
-            <dt className="text-muted-foreground">Version</dt>
-            <dd className="truncate font-mono">{status.version}</dd>
-            <dt className="text-muted-foreground">Uptime</dt>
-            <dd className="truncate">{status.uptime}</dd>
-            <dt className="text-muted-foreground">Hostname</dt>
-            <dd className="truncate text-muted-foreground">
-              {status.hostname}
-            </dd>
-          </dl>
+          <div className="space-y-2">
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs">
+              <dt className="text-muted-foreground">Version</dt>
+              <dd className="truncate font-mono">{status.version}</dd>
+              <dt className="text-muted-foreground">Uptime</dt>
+              <dd className="truncate">{status.uptime}</dd>
+              <dt className="text-muted-foreground">Hostname</dt>
+              <dd className="truncate text-muted-foreground">
+                {status.hostname}
+              </dd>
+              <dt className="text-muted-foreground">Running</dt>
+              <dd className="truncate tabular-nums">
+                {formatCount(status.runningQueries)}
+              </dd>
+              <dt className="text-muted-foreground">Memory</dt>
+              <dd className="truncate tabular-nums">
+                {status.memoryBytes === undefined
+                  ? '—'
+                  : formatReadableSize(status.memoryBytes)}
+                {memRatio === undefined ? null : (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    ({formatPercent(memRatio)})
+                  </span>
+                )}
+              </dd>
+              <dt className="text-muted-foreground">Disk used</dt>
+              <dd className="truncate tabular-nums">
+                {formatPercent(diskRatio)}
+                {status.diskTotalBytes === undefined ? null : (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    of {formatReadableSize(status.diskTotalBytes)}
+                  </span>
+                )}
+              </dd>
+              {status.replicationDelay === undefined ? null : (
+                <>
+                  <dt className="text-muted-foreground">Replica lag</dt>
+                  <dd className="truncate tabular-nums">
+                    {formatCount(status.replicationDelay)}s
+                    {status.readonlyReplicas ? (
+                      <span className="text-amber-600 dark:text-amber-500">
+                        {' '}
+                        · {formatCount(status.readonlyReplicas)} read-only
+                      </span>
+                    ) : null}
+                  </dd>
+                </>
+              )}
+              <dt className="text-muted-foreground">Errors (1h)</dt>
+              <dd
+                className={cn(
+                  'truncate tabular-nums',
+                  status.recentErrors
+                    ? 'text-amber-600 dark:text-amber-500'
+                    : undefined
+                )}
+              >
+                {formatCount(status.recentErrors)}
+              </dd>
+            </dl>
+            <FleetSparkline
+              values={status.series}
+              label="Running queries over the last hour"
+            />
+          </div>
         ) : (
           <p className="text-xs text-muted-foreground">Unable to reach host.</p>
         )}

--- a/apps/dashboard/src/components/fleet/fleet-overview.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-overview.tsx
@@ -1,4 +1,5 @@
 import { FleetHostCard } from './fleet-host-card'
+import { FleetSummaryStrip } from './fleet-summary'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 
@@ -6,7 +7,7 @@ function FleetSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        <Skeleton key={i} className="h-44 w-full rounded-xl" />
+        <Skeleton key={i} className="h-72 w-full rounded-xl" />
       ))}
     </div>
   )
@@ -34,10 +35,13 @@ export function FleetOverview() {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {hosts.map((host) => (
-        <FleetHostCard key={`${host.source}-${host.id}`} host={host} />
-      ))}
+    <div className="flex flex-col gap-4">
+      <FleetSummaryStrip hosts={hosts} />
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {hosts.map((host) => (
+          <FleetHostCard key={`${host.source}-${host.id}`} host={host} />
+        ))}
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/components/fleet/fleet-sparkline.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-sparkline.tsx
@@ -1,0 +1,51 @@
+import { sparklinePoints } from './fleet-helpers'
+import { cn } from '@/lib/utils'
+
+const WIDTH = 100
+const HEIGHT = 20
+
+interface FleetSparklineProps {
+  /** Samples, oldest first. Fewer than two finite points renders nothing. */
+  values: readonly number[] | undefined
+  /** Accessible label describing what the series measures. */
+  label: string
+  className?: string
+}
+
+/**
+ * Minimal inline-SVG sparkline for a Fleet host card. Deliberately not a
+ * Recharts chart: it renders once per host card with no axes, tooltip or
+ * responsive container, so it stays cheap in a grid of many hosts.
+ *
+ * Fail-soft by design — `system.metric_log` is opt-in in ClickHouse, so the
+ * caller passes `undefined` when the series is unavailable and nothing renders.
+ */
+export function FleetSparkline({
+  values,
+  label,
+  className,
+}: FleetSparklineProps) {
+  const points = sparklinePoints(values ?? [], WIDTH, HEIGHT)
+  if (!points) return null
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      preserveAspectRatio="none"
+      className={cn('h-5 w-full text-chart-1', className)}
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}

--- a/apps/dashboard/src/components/fleet/fleet-summary.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-summary.tsx
@@ -1,0 +1,172 @@
+import { AlertTriangle } from 'lucide-react'
+
+import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
+import type { FleetSummaryEntry } from './fleet-helpers'
+
+import { computeFleetSummary, formatCount } from './fleet-helpers'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useHostStatus } from '@/lib/swr/use-host-status'
+import { cn } from '@/lib/utils'
+
+/**
+ * Invisible per-host probe. It calls the SAME `useHostStatus(id, { fleet: true })`
+ * query as the host card / table row, so TanStack Query serves all three from
+ * one request per host — this adds no extra polling. Keeping the hook here
+ * (rather than lifting host fetching into the summary) preserves the
+ * hooks-at-deepest-consumer rule: one slow host never blocks the others.
+ */
+function HostStatusProbe({
+  host,
+  onReport,
+}: {
+  host: MergedHostInfo
+  onReport: (key: string, entry: FleetSummaryEntry) => void
+}) {
+  const isBrowser = host.id < 0
+  const {
+    data: status,
+    isLoading,
+    isOnline,
+  } = useHostStatus(isBrowser ? null : host.id, { fleet: true })
+
+  const key = `${host.source}-${host.id}`
+  const state: FleetSummaryEntry['state'] = isBrowser
+    ? 'unknown'
+    : isLoading
+      ? 'loading'
+      : isOnline
+        ? 'online'
+        : 'offline'
+
+  const version = status?.version || undefined
+  const runningQueries = status?.runningQueries
+  const databases = status?.databases
+  const tables = status?.tables
+
+  // Report after commit (never during render — that would update the parent
+  // while this child renders). The parent stores by key and ignores an
+  // unchanged report, so this settles immediately.
+  useEffect(() => {
+    onReport(key, { state, version, runningQueries, databases, tables })
+  }, [onReport, key, state, version, runningQueries, databases, tables])
+
+  return null
+}
+
+/** Single compact stat tile. Deliberately lighter than a ChartCard. */
+function StatTile({
+  label,
+  value,
+  hint,
+  warn,
+}: {
+  label: string
+  value: string
+  hint?: string
+  warn?: boolean
+}) {
+  return (
+    <div className="rounded-lg border bg-card px-3 py-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p
+        className={cn(
+          'text-lg font-semibold tabular-nums leading-tight tracking-tight',
+          warn && 'text-amber-600 dark:text-amber-500'
+        )}
+      >
+        {value}
+      </p>
+      {hint ? (
+        <p
+          className={cn(
+            'flex items-center gap-1 truncate text-xs text-muted-foreground',
+            warn && 'text-amber-600 dark:text-amber-500'
+          )}
+        >
+          {warn ? (
+            <AlertTriangle className="size-3 shrink-0" strokeWidth={1.5} />
+          ) : null}
+          {hint}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+interface FleetSummaryStripProps {
+  hosts: readonly MergedHostInfo[]
+}
+
+/**
+ * Fleet-wide stat tiles shown above both the card grid and the table: host
+ * counts, ClickHouse version spread (flagging drift), and summed running
+ * queries / databases / tables across every reachable host.
+ */
+export function FleetSummaryStrip({ hosts }: FleetSummaryStripProps) {
+  const [entries, setEntries] = useState<Record<string, FleetSummaryEntry>>({})
+
+  const handleReport = useCallback((key: string, entry: FleetSummaryEntry) => {
+    setEntries((prev) => {
+      const current = prev[key]
+      if (
+        current &&
+        current.state === entry.state &&
+        current.version === entry.version &&
+        current.runningQueries === entry.runningQueries &&
+        current.databases === entry.databases &&
+        current.tables === entry.tables
+      ) {
+        return prev
+      }
+      return { ...prev, [key]: entry }
+    })
+  }, [])
+
+  const summary = useMemo(() => {
+    const keys = hosts.map((h) => `${h.source}-${h.id}`)
+    return computeFleetSummary(
+      keys.map((key) => entries[key] ?? { state: 'loading' })
+    )
+  }, [hosts, entries])
+
+  if (hosts.length === 0) return null
+
+  const versionHint = summary.versionDrift
+    ? `${summary.versions.length} versions in use`
+    : (summary.versions[0] ?? 'not reported')
+
+  return (
+    <>
+      {hosts.map((host) => (
+        <HostStatusProbe
+          key={`probe-${host.source}-${host.id}`}
+          host={host}
+          onReport={handleReport}
+        />
+      ))}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+        <StatTile label="Hosts" value={formatCount(summary.total)} />
+        <StatTile
+          label="Online"
+          value={`${summary.online} / ${summary.total}`}
+          hint={summary.offline > 0 ? `${summary.offline} offline` : undefined}
+          warn={summary.offline > 0}
+        />
+        <StatTile
+          label="Versions"
+          value={formatCount(summary.versions.length)}
+          hint={versionHint}
+          warn={summary.versionDrift}
+        />
+        <StatTile
+          label="Running queries"
+          value={formatCount(summary.runningQueries)}
+        />
+        <StatTile
+          label="Databases / tables"
+          value={`${formatCount(summary.databases)} / ${formatCount(summary.tables)}`}
+        />
+      </div>
+    </>
+  )
+}

--- a/apps/dashboard/src/components/fleet/fleet-table.tsx
+++ b/apps/dashboard/src/components/fleet/fleet-table.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from '@tanstack/react-router'
 import type { PgConnectionInfo } from '@/lib/hooks/use-pg-connections'
 import type { MergedHostInfo } from '@/lib/swr/use-merged-hosts'
 
-import { formatCount } from './fleet-helpers'
+import { formatCount, formatPercent, safeRatio } from './fleet-helpers'
+import { FleetSummaryStrip } from './fleet-summary'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -15,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { formatReadableSize } from '@/lib/format-readable'
 import { usePgConnections } from '@/lib/hooks/use-pg-connections'
 import { useRouter } from '@/lib/next-compat'
 import { useHostStatus } from '@/lib/swr/use-host-status'
@@ -22,7 +24,7 @@ import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { cn, getHost } from '@/lib/utils'
 
 /** Number of metric columns between "Host" and the trailing action column. */
-const METRIC_COLSPAN = 6
+const METRIC_COLSPAN = 11
 
 /** Small status dot — green (online), red (offline), muted (unknown). */
 function StatusDot({
@@ -69,7 +71,9 @@ function FleetTableRow({ host }: { host: MergedHostInfo }) {
     data: status,
     isLoading,
     isOnline,
-  } = useHostStatus(isBrowser ? null : host.id, { includeCounts: true })
+  } = useHostStatus(isBrowser ? null : host.id, { fleet: true })
+
+  const diskRatio = safeRatio(status?.diskUsedBytes, status?.diskTotalBytes)
 
   const handleView = () => {
     navigate({
@@ -122,9 +126,9 @@ function FleetTableRow({ host }: { host: MergedHostInfo }) {
           <MetricSkeletonCell />
           <MetricSkeletonCell />
           <MetricSkeletonCell />
-          <MetricSkeletonCell className="text-right" />
-          <MetricSkeletonCell className="text-right" />
-          <MetricSkeletonCell className="text-right" />
+          {Array.from({ length: 8 }).map((_, i) => (
+            <MetricSkeletonCell key={i} className="text-right" />
+          ))}
         </>
       ) : status ? (
         <>
@@ -144,15 +148,47 @@ function FleetTableRow({ host }: { host: MergedHostInfo }) {
           <TableCell className="text-right tabular-nums">
             {formatCount(status.clusterNodes)}
           </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatCount(status.runningQueries)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {status.memoryBytes === undefined
+              ? '—'
+              : formatReadableSize(status.memoryBytes)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {formatPercent(diskRatio)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {status.replicationDelay === undefined
+              ? '—'
+              : `${formatCount(status.replicationDelay)}s`}
+            {status.readonlyReplicas ? (
+              <span className="text-amber-600 dark:text-amber-500">
+                {' '}
+                · {formatCount(status.readonlyReplicas)} ro
+              </span>
+            ) : null}
+          </TableCell>
+          <TableCell
+            className={cn(
+              'text-right tabular-nums',
+              status.recentErrors && 'text-amber-600 dark:text-amber-500'
+            )}
+          >
+            {formatCount(status.recentErrors)}
+          </TableCell>
         </>
       ) : (
         <>
           <TableCell className="text-muted-foreground">—</TableCell>
           <TableCell className="text-muted-foreground">—</TableCell>
           <TableCell className="text-muted-foreground">—</TableCell>
-          <TableCell className="text-right text-muted-foreground">—</TableCell>
-          <TableCell className="text-right text-muted-foreground">—</TableCell>
-          <TableCell className="text-right text-muted-foreground">—</TableCell>
+          {Array.from({ length: 8 }).map((_, i) => (
+            <TableCell key={i} className="text-right text-muted-foreground">
+              —
+            </TableCell>
+          ))}
         </>
       )}
 
@@ -275,29 +311,39 @@ export function FleetTable() {
   }
 
   return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Host</TableHead>
-            <TableHead>Version</TableHead>
-            <TableHead>Uptime</TableHead>
-            <TableHead>Hostname</TableHead>
-            <TableHead className="text-right">Databases</TableHead>
-            <TableHead className="text-right">Tables</TableHead>
-            <TableHead className="text-right">Cluster</TableHead>
-            <TableHead className="w-0" />
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {hosts.map((host) => (
-            <FleetTableRow key={`${host.source}-${host.id}`} host={host} />
-          ))}
-          {pgConnections.map((pg) => (
-            <FleetPgRow key={`pg-${pg.connectionId}`} pg={pg} />
-          ))}
-        </TableBody>
-      </Table>
+    <div className="flex flex-col gap-4">
+      <FleetSummaryStrip hosts={hosts} />
+      {/* The metric matrix is intentionally wide — scroll it rather than
+          dropping columns. */}
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Host</TableHead>
+              <TableHead>Version</TableHead>
+              <TableHead>Uptime</TableHead>
+              <TableHead>Hostname</TableHead>
+              <TableHead className="text-right">Databases</TableHead>
+              <TableHead className="text-right">Tables</TableHead>
+              <TableHead className="text-right">Cluster</TableHead>
+              <TableHead className="text-right">Running</TableHead>
+              <TableHead className="text-right">Memory</TableHead>
+              <TableHead className="text-right">Disk used</TableHead>
+              <TableHead className="text-right">Replica lag</TableHead>
+              <TableHead className="text-right">Errors (1h)</TableHead>
+              <TableHead className="w-0" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {hosts.map((host) => (
+              <FleetTableRow key={`${host.source}-${host.id}`} host={host} />
+            ))}
+            {pgConnections.map((pg) => (
+              <FleetPgRow key={`pg-${pg.connectionId}`} pg={pg} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   )
 }

--- a/apps/dashboard/src/lib/swr/use-host-status.ts
+++ b/apps/dashboard/src/lib/swr/use-host-status.ts
@@ -14,6 +14,15 @@ type HostStatusApiResponse = {
     databases?: number
     tables?: number
     clusterNodes?: number
+    runningQueries?: number
+    memoryBytes?: number
+    memoryTotalBytes?: number
+    diskUsedBytes?: number
+    diskTotalBytes?: number
+    recentErrors?: number
+    readonlyReplicas?: number
+    replicationDelay?: number
+    series?: number[]
   }
   error?: string
 }
@@ -23,12 +32,30 @@ export type HostStatus = {
   version: string
   uptime: string
   hostname: string
-  /** Number of databases (only when `includeCounts` is requested). */
+  /** Number of databases (only when `fleet` is requested). */
   databases?: number
-  /** Number of tables (only when `includeCounts` is requested). */
+  /** Number of tables (only when `fleet` is requested). */
   tables?: number
-  /** Distinct cluster nodes (only when `includeCounts` is requested). */
+  /** Distinct cluster nodes (only when `fleet` is requested). */
   clusterNodes?: number
+  /** Currently running queries (`system.metrics`). */
+  runningQueries?: number
+  /** Resident memory in bytes (`asynchronous_metrics.MemoryResident`). */
+  memoryBytes?: number
+  /** Total OS memory in bytes (`asynchronous_metrics.OSMemoryTotal`). */
+  memoryTotalBytes?: number
+  /** Used disk space in bytes across `system.disks`. */
+  diskUsedBytes?: number
+  /** Total disk space in bytes across `system.disks`. */
+  diskTotalBytes?: number
+  /** Distinct error kinds last seen within the past hour (`system.errors`). */
+  recentErrors?: number
+  /** Replicas currently in read-only mode (`system.replicas`). */
+  readonlyReplicas?: number
+  /** Max replica absolute delay in seconds (`system.replicas`). */
+  replicationDelay?: number
+  /** Running-query samples over the last hour (`system.metric_log`), oldest first. */
+  series?: number[]
 }
 
 interface UseHostStatusOptions {
@@ -43,12 +70,15 @@ interface UseHostStatusOptions {
    */
   revalidateOnFocus?: boolean
   /**
-   * Also fetch cross-host comparison counts (databases/tables/cluster nodes)
-   * for the Fleet table. Off by default so the widely-polled status probe stays
-   * a single round-trip. Uses a distinct query key from the countless variant.
+   * Also fetch the Fleet metric bundle (databases/tables/cluster nodes, running
+   * queries, memory, disk, replication, recent errors and the metric_log
+   * sparkline series). Off by default so the widely-polled status probe (host
+   * switcher, logo indicator) stays a single cheap round-trip. Every Fleet
+   * surface passes `fleet: true`, so they share ONE query key per host and
+   * TanStack Query dedupes them into a single request.
    * @default false
    */
-  includeCounts?: boolean
+  fleet?: boolean
 }
 
 /**
@@ -72,15 +102,15 @@ export function useHostStatus(
   const {
     refreshInterval = 60000,
     revalidateOnFocus = false,
-    includeCounts = false,
+    fleet = false,
   } = options
 
   // Skip status check for browser connections (negative hostId) — they have
   // no server-side host entry and the proxy endpoint handles connectivity.
   const isBrowserConnection = hostId !== null && hostId < 0
 
-  const url = includeCounts
-    ? `/api/v1/host-status?hostId=${hostId}&counts=1`
+  const url = fleet
+    ? `/api/v1/host-status?hostId=${hostId}&fleet=1`
     : `/api/v1/host-status?hostId=${hostId}`
   const queryKey = [url]
 
@@ -106,6 +136,15 @@ export function useHostStatus(
         databases: json.data.databases,
         tables: json.data.tables,
         clusterNodes: json.data.clusterNodes,
+        runningQueries: json.data.runningQueries,
+        memoryBytes: json.data.memoryBytes,
+        memoryTotalBytes: json.data.memoryTotalBytes,
+        diskUsedBytes: json.data.diskUsedBytes,
+        diskTotalBytes: json.data.diskTotalBytes,
+        recentErrors: json.data.recentErrors,
+        readonlyReplicas: json.data.readonlyReplicas,
+        replicationDelay: json.data.replicationDelay,
+        series: json.data.series,
       }
     },
     enabled: hostId !== null && !isBrowserConnection,

--- a/apps/dashboard/src/routes/(dashboard)/fleet.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/fleet.tsx
@@ -14,7 +14,7 @@ function FleetSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        <Skeleton key={i} className="h-44 w-full rounded-xl" />
+        <Skeleton key={i} className="h-72 w-full rounded-xl" />
       ))}
     </div>
   )

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -28,11 +28,16 @@ export const Route = createFileRoute('/api/v1/host-status')({
       GET: async ({ request }) => {
         const searchParams = new URL(request.url).searchParams
         const hostIdRaw = searchParams.get('hostId')
-        // Opt-in: the Fleet table asks for extra cross-host comparison counts
-        // (databases/tables/cluster nodes). Off by default so the widely-polled
-        // status probe (host switcher, logo indicator, cards) stays a single
-        // round-trip for every other consumer.
-        const wantCounts = searchParams.get('counts') === '1'
+        // Opt-in Fleet metric bundle (counts + live resource metrics +
+        // replication + metric_log sparkline). Off by default so the
+        // widely-polled status probe (host switcher, logo indicator) stays a
+        // single cheap round-trip for every other consumer. ONE param, so the
+        // Fleet summary tiles, cards and table share a single query key per
+        // host and TanStack Query dedupes them into one request per poll.
+        // `counts=1` is accepted as the original name of this same bundle.
+        const wantCounts =
+          searchParams.get('fleet') === '1' ||
+          searchParams.get('counts') === '1'
 
         if (hostIdRaw === null || hostIdRaw === '') {
           return Response.json(
@@ -128,7 +133,20 @@ export const Route = createFileRoute('/api/v1/host-status')({
             databases?: number
             tables?: number
             clusterNodes?: number
+            runningQueries?: number
+            memoryBytes?: number
+            memoryTotalBytes?: number
+            diskUsedBytes?: number
+            diskTotalBytes?: number
+            recentErrors?: number
+            readonlyReplicas?: number
+            replicationDelay?: number
+            series?: number[]
           } = {}
+          const toNum = (v: unknown) => {
+            const n = Number(v)
+            return Number.isFinite(n) ? n : undefined
+          }
           if (wantCounts) {
             try {
               const countsSet = await runWithQueryCache(cacheOpts, (cache) =>
@@ -147,10 +165,6 @@ export const Route = createFileRoute('/api/v1/host-status')({
                 clusterNodes: string | number
               }>()
               const row = countRows[0]
-              const toNum = (v: string | number | undefined) => {
-                const n = Number(v)
-                return Number.isFinite(n) ? n : undefined
-              }
               counts = {
                 databases: toNum(row?.databases),
                 tables: toNum(row?.tables),
@@ -158,6 +172,100 @@ export const Route = createFileRoute('/api/v1/host-status')({
               }
             } catch (countsErr) {
               error('[GET /api/v1/host-status] counts query failed:', countsErr)
+            }
+
+            // Live resource metrics. Separate guarded block: a restricted
+            // grant on one of these system tables must not drop the counts
+            // above (each missing metric renders as an en-dash).
+            try {
+              const metricsSet = await runWithQueryCache(cacheOpts, (cache) =>
+                client.query({
+                  query: `${QUERY_COMMENT}SELECT
+  (SELECT value FROM system.metrics WHERE metric = 'Query') AS runningQueries,
+  (SELECT value FROM system.asynchronous_metrics WHERE metric = 'MemoryResident') AS memoryBytes,
+  (SELECT value FROM system.asynchronous_metrics WHERE metric = 'OSMemoryTotal') AS memoryTotalBytes,
+  (SELECT sum(total_space - free_space) FROM system.disks) AS diskUsedBytes,
+  (SELECT sum(total_space) FROM system.disks) AS diskTotalBytes,
+  (SELECT count() FROM system.errors WHERE last_error_time > now() - 3600) AS recentErrors`,
+                  format: 'JSONEachRow',
+                  clickhouse_settings: cache,
+                })
+              )
+              const metricRows =
+                await metricsSet.json<Record<string, unknown>>()
+              const row = metricRows[0]
+              counts = {
+                ...counts,
+                runningQueries: toNum(row?.runningQueries),
+                memoryBytes: toNum(row?.memoryBytes),
+                memoryTotalBytes: toNum(row?.memoryTotalBytes),
+                diskUsedBytes: toNum(row?.diskUsedBytes),
+                diskTotalBytes: toNum(row?.diskTotalBytes),
+                recentErrors: toNum(row?.recentErrors),
+              }
+            } catch (metricsErr) {
+              error(
+                '[GET /api/v1/host-status] metrics query failed:',
+                metricsErr
+              )
+            }
+
+            // Replication summary. Own block because `system.replicas` may be
+            // restricted; only cheap local columns are read (never the
+            // ZooKeeper-backed ones, which cost a ZK round-trip per table).
+            try {
+              const replicaSet = await runWithQueryCache(cacheOpts, (cache) =>
+                client.query({
+                  query: `${QUERY_COMMENT}SELECT
+  countIf(is_readonly) AS readonlyReplicas,
+  max(absolute_delay) AS replicationDelay
+FROM system.replicas`,
+                  format: 'JSONEachRow',
+                  clickhouse_settings: cache,
+                })
+              )
+              const replicaRows =
+                await replicaSet.json<Record<string, unknown>>()
+              const row = replicaRows[0]
+              counts = {
+                ...counts,
+                readonlyReplicas: toNum(row?.readonlyReplicas),
+                replicationDelay: toNum(row?.replicationDelay),
+              }
+            } catch (replicaErr) {
+              error(
+                '[GET /api/v1/host-status] replicas query failed:',
+                replicaErr
+              )
+            }
+
+            // Sparkline series (running queries, last hour). `system.metric_log`
+            // is opt-in in ClickHouse — absent on many installs, so this is
+            // fully guarded and simply yields no sparkline when missing.
+            try {
+              const seriesSet = await runWithQueryCache(cacheOpts, (cache) =>
+                client.query({
+                  query: `${QUERY_COMMENT}SELECT avg(CurrentMetric_Query) AS value
+FROM system.metric_log
+WHERE event_time > now() - INTERVAL 1 HOUR
+GROUP BY toStartOfInterval(event_time, INTERVAL 5 MINUTE) AS t
+ORDER BY t`,
+                  format: 'JSONEachRow',
+                  clickhouse_settings: cache,
+                })
+              )
+              const seriesRows = await seriesSet.json<{
+                value: string | number
+              }>()
+              const series = seriesRows
+                .map((r) => toNum(r?.value))
+                .filter((n): n is number => n !== undefined)
+              if (series.length > 0) counts = { ...counts, series }
+            } catch (seriesErr) {
+              error(
+                '[GET /api/v1/host-status] metric_log query failed:',
+                seriesErr
+              )
             }
           }
 

--- a/apps/dashboard/src/routes/api/v1/host-status.ts
+++ b/apps/dashboard/src/routes/api/v1/host-status.ts
@@ -217,6 +217,7 @@ export const Route = createFileRoute('/api/v1/host-status')({
               const replicaSet = await runWithQueryCache(cacheOpts, (cache) =>
                 client.query({
                   query: `${QUERY_COMMENT}SELECT
+  count() AS replicaCount,
   countIf(is_readonly) AS readonlyReplicas,
   max(absolute_delay) AS replicationDelay
 FROM system.replicas`,
@@ -227,10 +228,18 @@ FROM system.replicas`,
               const replicaRows =
                 await replicaSet.json<Record<string, unknown>>()
               const row = replicaRows[0]
-              counts = {
-                ...counts,
-                readonlyReplicas: toNum(row?.readonlyReplicas),
-                replicationDelay: toNum(row?.replicationDelay),
+              // These aggregates return 0 (not NULL) over an empty
+              // system.replicas, so a host with no replicated tables would
+              // otherwise report a meaningless "0s replica lag". Emit the
+              // fields only when the host actually has replicas — the UI then
+              // omits the row entirely rather than showing a fake zero.
+              const replicaCount = toNum(row?.replicaCount) ?? 0
+              if (replicaCount > 0) {
+                counts = {
+                  ...counts,
+                  readonlyReplicas: toNum(row?.readonlyReplicas),
+                  replicationDelay: toNum(row?.replicationDelay),
+                }
               }
             } catch (replicaErr) {
               error(


### PR DESCRIPTION
Improves `/fleet` with fleet-wide signal and deeper per-host metrics. Core OSS functionality — nothing gated behind cloud mode, no new dependencies.

## What's added

**1. Fleet summary strip** (`fleet-summary.tsx`), shown above both the card grid and the table:

| Tile | Detail |
|---|---|
| Hosts | total configured |
| Online | `online / total`, amber hint when any host is offline |
| Versions | distinct ClickHouse versions; **amber version-drift warning when >1** |
| Running queries | summed across the fleet |
| Databases / tables | summed across the fleet |

**2. Richer per-host metrics** in both the card and the table: running queries, memory (readable size + % of OS memory), disk used %, replica lag + read-only replica count, and recent error kinds (1h).

**3. Tiny sparkline per host card** — minimal inline SVG (`fleet-sparkline.tsx`), running queries over the last hour from `system.metric_log`. No Recharts: no axes/tooltip/responsive container, so it stays cheap across a grid of many hosts.

## API / data

The status endpoint gains **one** opt-in bundle param, `fleet=1` (the original `counts=1` is kept as an alias). Using a single variant matters: the summary probes, the cards and the table rows all call `useHostStatus(id, { fleet: true })`, so they share one query key per host and TanStack Query dedupes all three surfaces into **a single request per host per poll**. The plain no-param probe (host switcher, logo indicator) is untouched and stays a single cheap round-trip.

New queries are cheap and each sits in its **own guarded block**, so one restricted grant never degrades the rest:

- `system.metrics` / `system.asynchronous_metrics` / `system.disks` / `system.errors` — resource metrics
- `system.replicas` — **cheap local columns only** (`is_readonly`, `absolute_delay`); no ZooKeeper-backed columns, which would cost a ZK round-trip per table
- `system.metric_log` — opt-in in ClickHouse, so an absent table simply yields no sparkline

Any failure resolves that metric to `undefined`, rendering an en-dash via `formatCount` — never a failed status response.

## Behaviour preserved

- Browser-source hosts (negative ids) stay degraded exactly as before, and count as **unknown** (never offline) in the summary, so a browser connection can't look like an outage.
- Demo / saved / Postgres badges unchanged; no existing column removed — the wider table scrolls horizontally instead.
- Hooks stay at the deepest consumer, so one slow host never blocks the others.

## Verification

- `bun test src/components/fleet/fleet-helpers.test.ts` — **23 pass / 0 fail**. New coverage for `computeFleetSummary` (online/offline vs. unknown, version drift, sums staying `undefined` when nothing reported vs. a real `0`, empty fleet), `sparklinePoints` (empty / 1-point / non-finite / flat-series centring / y-inversion), `formatPercent` and `safeRatio` (zero and negative totals must not render `Infinity%`).
- `pnpm run lint` — clean (2 pre-existing warnings in unrelated cluster-topology code).
- `pnpm run type-check` — clean. The full `vite build` client stage succeeded; its SSR stage was killed by SIGTERM from local machine contention (several agents share this host), not a code error — leaving the full build to CI.

No screenshots: rendering requires live ClickHouse hosts, which this environment has none of.