### PR TITLE
feat(alerts): redesign alert-settings channels as a configured-first card grid

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -73,6 +73,19 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `from-background`→`transparent` edge fade per scrollable side, paging via
   `scrollBy`. Re-measure on scroll / `ResizeObserver` / content-count change.
   Copy `components/insights/insights-strip.tsx`.
+- **Settings channel grid (configured-first):** a settings surface with many
+  optional integrations renders a responsive `grid gap-3 sm:grid-cols-2` of
+  collapsible `ChannelCard`s (summary row = icon + name + status + badges +
+  enable switch; expanded = the config form) for the channels that are ALREADY
+  configured, and compact dashed `AddChannelTile`s (icon + one-line description
+  + an example target value) for the rest, which expand into the same card on
+  click. Nothing configured → `EmptyState`, never a wall of blank forms. Pin a
+  card open once the user edits it so clearing its value can't unmount the input
+  mid-keystroke. See `components/health/channel-card.tsx` +
+  `alert-channels-panel.tsx` (`/alert-settings`).
+- **Tab strips:** define the tabs as one array and map it — an icon per tab with
+  ONE size (`size-3.5`) and NO margin utility; `TabsTrigger` already supplies
+  `items-center gap-1.5`. Adding `mr-*` on top of that reads as misalignment.
 - **Paired page sections** (e.g. AI-generated vs. plain-statistics content):
   identical-weight header on both — `icon (size-4, muted-foreground) + <h2
   className="text-sm font-medium text-foreground">`. A *genuinely* empty section

--- a/apps/dashboard/src/components/health/alert-channels-panel.tsx
+++ b/apps/dashboard/src/components/health/alert-channels-panel.tsx
@@ -104,6 +104,12 @@ export function AlertChannelsPanel({
   const meta = (id: LocalChannelId) =>
     LOCAL_CHANNELS.find((c) => c.id === id) as LocalChannelMeta
 
+  // Pin a card open once the operator interacts with it, so clearing its URL
+  // (or switching it off) does not collapse the card back into an "Add a
+  // channel" tile mid-edit — which would unmount the input and drop focus.
+  const pin = (id: LocalChannelId) =>
+    setOpened((prev) => (prev.includes(id) ? prev : [...prev, id]))
+
   const renderCard = (id: LocalChannelId) => {
     const m = meta(id)
     const channelSeverity = alerts.channels?.[id]?.minSeverity
@@ -125,7 +131,10 @@ export function AlertChannelsPanel({
           title={m.label}
           status={`${alerts.browserNotificationsEnabled ? 'Enabled' : 'Disabled'} · ${severityLabel(channelSeverity)}`}
           enabled={alerts.browserNotificationsEnabled}
-          onEnabledChange={onEnableBrowser}
+          onEnabledChange={(checked) => {
+            pin(id)
+            onEnableBrowser(checked)
+          }}
           defaultOpen={opened.includes(id)}
         >
           <p className="text-xs text-muted-foreground">
@@ -172,12 +181,13 @@ export function AlertChannelsPanel({
               id="healthchecks-url"
               placeholder="https://hc-ping.com/your-uuid"
               value={alerts.healthchecksUrl}
-              onChange={(e) =>
+              onChange={(e) => {
+                pin(id)
                 setAlerts((prev) => ({
                   ...prev,
                   healthchecksUrl: e.target.value.trim(),
                 }))
-              }
+              }}
             />
           </div>
           {severityRow}
@@ -221,9 +231,10 @@ export function AlertChannelsPanel({
             id="webhook-url"
             placeholder="https://hooks.slack.com/services/..."
             value={alerts.webhookUrl}
-            onChange={(e) =>
+            onChange={(e) => {
+              pin(id)
               setAlerts((prev) => ({ ...prev, webhookUrl: e.target.value }))
-            }
+            }}
           />
         </div>
         {severityRow}

--- a/apps/dashboard/src/components/health/alert-channels-panel.tsx
+++ b/apps/dashboard/src/components/health/alert-channels-panel.tsx
@@ -1,0 +1,292 @@
+import { BellRing, HeartPulse, Laptop, Webhook } from 'lucide-react'
+
+import type { ReactNode } from 'react'
+import type { AlertSettings } from '@/lib/health/alert-settings-storage'
+import type { LocalChannelId } from '@/lib/health/channel-classification'
+
+import {
+  AddChannelTile,
+  ChannelCard,
+  ChannelSectionHeader,
+} from './channel-card'
+import { ChannelSeverityToggle } from './channel-severity-toggle'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  isLocalChannelConfigured,
+  LOCAL_CHANNEL_IDS,
+  partitionChannels,
+} from '@/lib/health/channel-classification'
+
+interface LocalChannelMeta {
+  id: LocalChannelId
+  label: string
+  icon: ReactNode
+  /** One-line pitch for the compact "Add a channel" tile. */
+  description: string
+  example?: string
+}
+
+const LOCAL_CHANNELS: LocalChannelMeta[] = [
+  {
+    id: 'browser',
+    label: 'Browser notifications',
+    icon: <Laptop strokeWidth={1.5} />,
+    description: 'Desktop notifications while this browser is open',
+  },
+  {
+    id: 'healthchecks',
+    label: 'healthchecks.io pings',
+    icon: <HeartPulse strokeWidth={1.5} />,
+    description: 'Ping a healthchecks.io check on each alert and recovery',
+    example: 'https://hc-ping.com/your-uuid',
+  },
+  {
+    id: 'webhook',
+    label: 'Webhook alerts',
+    icon: <Webhook strokeWidth={1.5} />,
+    description: 'POST JSON to a Slack- or Discord-compatible URL',
+    example: 'https://hooks.slack.com/services/T000/B000/XXXX',
+  },
+]
+
+function severityLabel(value: 'warning' | 'critical' | undefined): string {
+  if (value === 'warning') return 'Warning+'
+  if (value === 'critical') return 'Critical only'
+  return 'Inherits default'
+}
+
+export interface AlertChannelsPanelProps {
+  alerts: AlertSettings
+  setAlerts: (updater: (prev: AlertSettings) => AlertSettings) => void
+  setChannelMinSeverity: (
+    id: 'browser' | 'webhook' | 'healthchecks',
+    minSeverity: 'warning' | 'critical' | undefined
+  ) => void
+  onEnableBrowser: (checked: boolean) => void
+  onTestBrowser: () => void
+  onTestHealthchecks: () => void
+  onTestWebhook: () => void
+}
+
+/**
+ * Browser-local delivery channels as a responsive card grid (issue: alert
+ * settings redesign).
+ *
+ * Configured channels get a full collapsible card (icon, status, enable
+ * switch, target field, severity floor, "Send test"); the rest are compact
+ * "Add a channel" tiles that expand into the same card on click, so a fresh
+ * install sees a short menu instead of a wall of blank forms. These settings
+ * live in this browser's localStorage and persist with the page's Save button
+ * — unlike the server channels, which save per card.
+ */
+export function AlertChannelsPanel({
+  alerts,
+  setAlerts,
+  setChannelMinSeverity,
+  onEnableBrowser,
+  onTestBrowser,
+  onTestHealthchecks,
+  onTestWebhook,
+}: AlertChannelsPanelProps) {
+  // Ids the operator opened from an "Add a channel" tile this session; they
+  // render as full (open) cards even before they hold a value.
+  const [opened, setOpened] = useState<LocalChannelId[]>([])
+
+  const { configured, available } = partitionChannels(
+    LOCAL_CHANNEL_IDS,
+    (id) => isLocalChannelConfigured(id, alerts) || opened.includes(id)
+  )
+
+  const meta = (id: LocalChannelId) =>
+    LOCAL_CHANNELS.find((c) => c.id === id) as LocalChannelMeta
+
+  const renderCard = (id: LocalChannelId) => {
+    const m = meta(id)
+    const channelSeverity = alerts.channels?.[id]?.minSeverity
+    const severityRow = (
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-muted-foreground">Minimum severity</span>
+        <ChannelSeverityToggle
+          value={channelSeverity}
+          onChange={(v) => setChannelMinSeverity(id, v)}
+        />
+      </div>
+    )
+
+    if (id === 'browser') {
+      return (
+        <ChannelCard
+          key={id}
+          icon={m.icon}
+          title={m.label}
+          status={`${alerts.browserNotificationsEnabled ? 'Enabled' : 'Disabled'} · ${severityLabel(channelSeverity)}`}
+          enabled={alerts.browserNotificationsEnabled}
+          onEnabledChange={onEnableBrowser}
+          defaultOpen={opened.includes(id)}
+        >
+          <p className="text-xs text-muted-foreground">
+            Show desktop notifications for new health alerts. Requires the
+            browser notification permission.
+          </p>
+          {severityRow}
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onTestBrowser}
+              disabled={!alerts.browserNotificationsEnabled}
+            >
+              Send test
+            </Button>
+          </div>
+        </ChannelCard>
+      )
+    }
+
+    if (id === 'healthchecks') {
+      return (
+        <ChannelCard
+          key={id}
+          icon={m.icon}
+          title={m.label}
+          status={`${alerts.healthchecksUrl ? 'Ping URL set' : 'No ping URL'} · ${severityLabel(channelSeverity)}`}
+          defaultOpen={opened.includes(id)}
+        >
+          <p className="text-xs text-muted-foreground">
+            Send a GET ping to a healthchecks.io check URL on each alert
+            (appends <code className="text-xs">/fail</code> automatically on
+            recovery).
+          </p>
+          <div className="flex flex-col gap-1">
+            <Label
+              htmlFor="healthchecks-url"
+              className="text-xs text-muted-foreground"
+            >
+              Ping URL
+            </Label>
+            <Input
+              id="healthchecks-url"
+              placeholder="https://hc-ping.com/your-uuid"
+              value={alerts.healthchecksUrl}
+              onChange={(e) =>
+                setAlerts((prev) => ({
+                  ...prev,
+                  healthchecksUrl: e.target.value.trim(),
+                }))
+              }
+            />
+          </div>
+          {severityRow}
+          <div className="flex justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onTestHealthchecks}
+              disabled={!alerts.healthchecksUrl}
+            >
+              Send test
+            </Button>
+          </div>
+        </ChannelCard>
+      )
+    }
+
+    return (
+      <ChannelCard
+        key={id}
+        icon={m.icon}
+        title={m.label}
+        status={`${alerts.webhookEnabled ? 'Enabled' : 'Disabled'} · ${severityLabel(channelSeverity)}`}
+        enabled={alerts.webhookEnabled}
+        onEnabledChange={(checked) =>
+          setAlerts((prev) => ({ ...prev, webhookEnabled: checked }))
+        }
+        defaultOpen={opened.includes(id)}
+      >
+        <p className="text-xs text-muted-foreground">
+          POST a JSON payload to a Slack- or Discord-compatible URL.
+        </p>
+        <div className="flex flex-col gap-1">
+          <Label
+            htmlFor="webhook-url"
+            className="text-xs text-muted-foreground"
+          >
+            Webhook URL
+          </Label>
+          <Input
+            id="webhook-url"
+            placeholder="https://hooks.slack.com/services/..."
+            value={alerts.webhookUrl}
+            onChange={(e) =>
+              setAlerts((prev) => ({ ...prev, webhookUrl: e.target.value }))
+            }
+          />
+        </div>
+        {severityRow}
+        <div className="flex justify-end">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onTestWebhook}
+            disabled={!alerts.webhookUrl}
+          >
+            Send test
+          </Button>
+        </div>
+      </ChannelCard>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ChannelSectionHeader
+        icon={<BellRing className="size-4" strokeWidth={1.5} />}
+        title="Browser channels"
+        description="Delivered by this browser while the dashboard is open, and stored locally on this device — press Save below to persist them."
+        count={configured.length}
+      />
+
+      {configured.length > 0 ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {configured.map(renderCard)}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed bg-card/50 p-4">
+          <EmptyState
+            variant="no-data"
+            icon={<BellRing className="size-5" strokeWidth={1.5} />}
+            title="No browser channel configured"
+            description="Pick a channel below to get alerted — desktop notifications, a healthchecks.io ping URL, or a Slack/Discord webhook."
+          />
+        </div>
+      )}
+
+      {available.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Add a channel
+          </span>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {available.map((id) => {
+              const m = meta(id)
+              return (
+                <AddChannelTile
+                  key={id}
+                  icon={m.icon}
+                  title={m.label}
+                  description={m.description}
+                  example={m.example}
+                  onClick={() => setOpened((prev) => [...prev, id])}
+                />
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/alert-settings-hero.tsx
+++ b/apps/dashboard/src/components/health/alert-settings-hero.tsx
@@ -1,6 +1,9 @@
 import {
+  Activity,
+  ArrowRight,
   BellRing,
   CircleAlert,
+  Filter,
   Radio,
   SlidersHorizontal,
   TriangleAlert,
@@ -84,6 +87,50 @@ function ThresholdDemo() {
   )
 }
 
+/**
+ * The alert pipeline in one line: health check → threshold crossing → routing,
+ * quiet hours and maintenance → the enabled channels. Plain tokens + lucide
+ * arrows, so it reads correctly in both themes.
+ */
+function AlertFlowStrip() {
+  const steps = [
+    {
+      icon: <Activity className="size-3.5" strokeWidth={1.5} />,
+      label: 'Check',
+    },
+    {
+      icon: <SlidersHorizontal className="size-3.5" strokeWidth={1.5} />,
+      label: 'Threshold',
+    },
+    {
+      icon: <Filter className="size-3.5" strokeWidth={1.5} />,
+      label: 'Routing · quiet hours',
+    },
+    {
+      icon: <Radio className="size-3.5" strokeWidth={1.5} />,
+      label: 'Channels',
+    },
+  ]
+  return (
+    <div className="scrollbar-hide flex items-center gap-1.5 overflow-x-auto py-0.5">
+      {steps.map((step, i) => (
+        <div key={step.label} className="flex items-center gap-1.5">
+          <span className="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs whitespace-nowrap text-muted-foreground">
+            {step.icon}
+            {step.label}
+          </span>
+          {i < steps.length - 1 && (
+            <ArrowRight
+              className="size-3.5 shrink-0 text-muted-foreground/60"
+              strokeWidth={1.5}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function StatTile({
   icon,
   label,
@@ -159,6 +206,7 @@ export function AlertSettingsHero() {
             Critical ≥ {SAMPLE_CRITICAL}
           </span>
         </div>
+        <AlertFlowStrip />
         <p className="text-xs text-muted-foreground">
           Each health check compares its metric against your warning and
           critical thresholds; crossings fire alerts to every enabled channel,

--- a/apps/dashboard/src/components/health/channel-card.tsx
+++ b/apps/dashboard/src/components/health/channel-card.tsx
@@ -1,0 +1,162 @@
+import { ChevronDown, Plus } from 'lucide-react'
+
+import type { ReactNode } from 'react'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
+
+/**
+ * Shared presentation for one alert delivery channel on the alert-settings
+ * grid: a compact summary row (icon, name, status badge, optional enable
+ * switch, chevron) that expands into the channel's configuration form.
+ *
+ * Deliberately dumb — it owns no channel state. The browser-local channels
+ * (localStorage, saved by the page footer) and the server channels (per-card
+ * save to D1) both render through it while keeping their own save semantics.
+ */
+export function ChannelCard({
+  icon,
+  title,
+  badges,
+  status,
+  enabled,
+  onEnabledChange,
+  switchDisabled,
+  defaultOpen,
+  children,
+}: {
+  icon: ReactNode
+  title: string
+  /** Extra badges rendered next to the status pill (e.g. "env", "secret set"). */
+  badges?: ReactNode
+  /** Short state line, e.g. "Enabled · Critical only". */
+  status: string
+  /** Omit to render a card with no enable switch. */
+  enabled?: boolean
+  onEnabledChange?: (checked: boolean) => void
+  switchDisabled?: boolean
+  defaultOpen?: boolean
+  children: ReactNode
+}) {
+  return (
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className="group/channel flex flex-col rounded-xl border bg-card shadow-sm"
+    >
+      <div className="flex items-center gap-2 p-3">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md text-left focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground [&_svg]:size-4">
+            {icon}
+          </span>
+          <span className="flex min-w-0 flex-col">
+            <span className="flex items-center gap-1.5">
+              <span className="truncate text-sm font-medium">{title}</span>
+              {badges}
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              {status}
+            </span>
+          </span>
+          <ChevronDown
+            className="ml-auto size-4 shrink-0 text-muted-foreground transition-transform group-data-open/channel:rotate-180"
+            strokeWidth={1.5}
+          />
+        </CollapsibleTrigger>
+        {onEnabledChange && (
+          <Switch
+            checked={enabled ?? false}
+            onCheckedChange={onEnabledChange}
+            disabled={switchDisabled}
+            aria-label={`Enable ${title}`}
+          />
+        )}
+      </div>
+      <CollapsibleContent className="overflow-hidden">
+        <div className="flex flex-col gap-2 border-t p-3">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+/**
+ * Compact offer tile for a channel that is not configured yet. Clicking it
+ * opens the channel's full card (the caller moves the id into its "opened"
+ * set), so an unconfigured deployment shows a short menu instead of a wall of
+ * blank forms.
+ */
+export function AddChannelTile({
+  icon,
+  title,
+  description,
+  example,
+  onClick,
+}: {
+  icon: ReactNode
+  title: string
+  description: string
+  /** Example target value, e.g. a sample Slack webhook URL. */
+  example?: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex items-start gap-2.5 rounded-xl border border-dashed bg-card/50 p-3 text-left',
+        'transition-colors hover:border-solid hover:bg-muted/50',
+        'focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none'
+      )}
+    >
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground [&_svg]:size-4">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+          {title}
+          <Plus className="size-3.5 text-muted-foreground" strokeWidth={1.5} />
+        </span>
+        <span className="text-xs text-muted-foreground">{description}</span>
+        {example && (
+          <code className="truncate text-[11px] text-muted-foreground/80">
+            {example}
+          </code>
+        )}
+      </span>
+    </button>
+  )
+}
+
+/** Section header shared by the channel groups (matches the paired-section idiom). */
+export function ChannelSectionHeader({
+  icon,
+  title,
+  description,
+  count,
+}: {
+  icon: ReactNode
+  title: string
+  description: ReactNode
+  count?: number
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-1.5 text-muted-foreground">
+        {icon}
+        <h2 className="text-sm font-medium text-foreground">{title}</h2>
+        {count !== undefined && (
+          <Badge variant="outline" className="text-xs">
+            {count}
+          </Badge>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/health/health-settings-panel.tsx
+++ b/apps/dashboard/src/components/health/health-settings-panel.tsx
@@ -1,3 +1,4 @@
+import type { LucideIcon } from 'lucide-react'
 import {
   Bell,
   Braces,
@@ -15,10 +16,10 @@ import { toast } from 'sonner'
 import type { AlertChannelId } from '@/lib/health/alert-channel-settings'
 
 import { ActiveAlertsPanel } from './active-alerts-panel'
+import { AlertChannelsPanel } from './alert-channels-panel'
 import { AlertRoutingPanel } from './alert-routing-dialog'
 import { AlertStateCard } from './alert-state-card'
 import { AlertSuggestionsPanel } from './alert-suggestions-panel'
-import { ChannelSeverityToggle } from './channel-severity-toggle'
 import { DigestSettingsPanel } from './digest-settings-panel'
 import { HEALTH_CHECKS } from './health-checks'
 import { MaintenanceWindowsPanel } from './maintenance-windows-panel'
@@ -28,11 +29,9 @@ import { RuleBuilderPanel } from './rule-builder'
 import { ServerChannelConfigPanel } from './server-channel-config-panel'
 import { WebhookSubscriptionsPanel } from './webhook-subscriptions-panel'
 import { type ReactNode, useEffect, useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   fireBrowserNotification,
@@ -66,6 +65,28 @@ export const HEALTH_SETTINGS_TABS = [
 ] as const
 
 export type HealthSettingsTab = (typeof HEALTH_SETTINGS_TABS)[number]
+
+/**
+ * Tab strip definition — one place so every tab gets the same icon size and
+ * spacing (the icons used to be hand-written with an extra `mr-1.5` on top of
+ * the trigger's built-in gap, which read as misaligned).
+ */
+const TAB_DEFS: {
+  value: HealthSettingsTab
+  label: string
+  icon: LucideIcon
+}[] = [
+  { value: 'thresholds', label: 'Thresholds', icon: SlidersHorizontal },
+  { value: 'alerts', label: 'Alerts', icon: Bell },
+  { value: 'active', label: 'Active', icon: CircleAlert },
+  { value: 'history', label: 'History', icon: History },
+  { value: 'routing', label: 'Routing', icon: Route },
+  { value: 'webhooks', label: 'Webhooks', icon: Webhook },
+  { value: 'maintenance', label: 'Maintenance', icon: Wrench },
+  { value: 'quiet-hours', label: 'Quiet Hours', icon: MoonStar },
+  { value: 'suggested', label: 'Suggested', icon: Sparkles },
+  { value: 'custom-rules', label: 'Custom Rules', icon: Braces },
+]
 
 export function isHealthSettingsTab(
   value: string | undefined
@@ -255,48 +276,17 @@ export function HealthSettingsPanel({
   return (
     <>
       <Tabs defaultValue={defaultTab}>
+        {/* One scrollable, non-wrapping strip. Icons carry no margin — the
+            trigger's own `items-center gap-1.5` aligns them with the label, and
+            a single `size-3.5` keeps every tab's glyph the same weight. */}
         <div className="scrollbar-hide -mx-1 shrink-0 overflow-x-auto px-1 py-0.5">
           <TabsList className="w-max flex-nowrap">
-            <TabsTrigger value="thresholds">
-              <SlidersHorizontal className="mr-1.5 size-3.5" />
-              Thresholds
-            </TabsTrigger>
-            <TabsTrigger value="alerts">
-              <Bell className="mr-1.5 size-3.5" />
-              Alerts
-            </TabsTrigger>
-            <TabsTrigger value="active">
-              <CircleAlert className="mr-1.5 size-3.5" />
-              Active
-            </TabsTrigger>
-            <TabsTrigger value="history">
-              <History className="mr-1.5 size-3.5" />
-              History
-            </TabsTrigger>
-            <TabsTrigger value="routing">
-              <Route className="mr-1.5 size-3.5" />
-              Routing
-            </TabsTrigger>
-            <TabsTrigger value="webhooks">
-              <Webhook className="mr-1.5 size-3.5" />
-              Webhooks
-            </TabsTrigger>
-            <TabsTrigger value="maintenance">
-              <Wrench className="mr-1.5 size-3.5" />
-              Maintenance
-            </TabsTrigger>
-            <TabsTrigger value="quiet-hours">
-              <MoonStar className="mr-1.5 size-3.5" />
-              Quiet Hours
-            </TabsTrigger>
-            <TabsTrigger value="suggested">
-              <Sparkles className="mr-1.5 size-3.5" />
-              Suggested
-            </TabsTrigger>
-            <TabsTrigger value="custom-rules">
-              <Braces className="mr-1.5 size-3.5" />
-              Custom Rules
-            </TabsTrigger>
+            {TAB_DEFS.map(({ value, label, icon: Icon }) => (
+              <TabsTrigger key={value} value={value}>
+                <Icon className="size-3.5" strokeWidth={1.5} />
+                {label}
+              </TabsTrigger>
+            ))}
           </TabsList>
         </div>
 
@@ -376,138 +366,15 @@ export function HealthSettingsPanel({
         {pane(
           'alerts',
           <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2 rounded-md border p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                  <Label className="text-sm font-medium">
-                    Browser notifications
-                  </Label>
-                  <span className="text-xs text-muted-foreground">
-                    Show desktop notifications for new health alerts
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleTestBrowser}
-                    disabled={!alerts.browserNotificationsEnabled}
-                  >
-                    Test
-                  </Button>
-                  <Switch
-                    checked={alerts.browserNotificationsEnabled}
-                    onCheckedChange={handleEnableBrowser}
-                  />
-                </div>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-muted-foreground">
-                  Minimum severity
-                </span>
-                <ChannelSeverityToggle
-                  value={alerts.channels?.browser?.minSeverity}
-                  onChange={(v) => setChannelMinSeverity('browser', v)}
-                />
-              </div>
-            </div>
-
-            <Separator />
-
-            <div className="flex flex-col gap-2 rounded-md border p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                  <Label className="text-sm font-medium">
-                    healthchecks.io pings
-                  </Label>
-                  <span className="text-xs text-muted-foreground">
-                    Send a GET ping to a healthchecks.io check URL on each alert
-                    (append <code className="text-xs">/fail</code> automatically
-                    on recovery)
-                  </span>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <Input
-                  placeholder="https://hc-ping.com/your-uuid"
-                  value={alerts.healthchecksUrl}
-                  onChange={(e) =>
-                    setAlerts((prev) => ({
-                      ...prev,
-                      healthchecksUrl: e.target.value.trim(),
-                    }))
-                  }
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => void handleTestHealthchecks()}
-                  disabled={!alerts.healthchecksUrl}
-                >
-                  Send test
-                </Button>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-muted-foreground">
-                  Minimum severity
-                </span>
-                <ChannelSeverityToggle
-                  value={alerts.channels?.healthchecks?.minSeverity}
-                  onChange={(v) => setChannelMinSeverity('healthchecks', v)}
-                />
-              </div>
-            </div>
-
-            <Separator />
-
-            <div className="flex flex-col gap-2 rounded-md border p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex flex-col">
-                  <Label className="text-sm font-medium">Webhook alerts</Label>
-                  <span className="text-xs text-muted-foreground">
-                    POST a JSON payload to a Slack- or Discord-compatible URL
-                  </span>
-                </div>
-                <Switch
-                  checked={alerts.webhookEnabled}
-                  onCheckedChange={(checked) =>
-                    setAlerts((prev) => ({
-                      ...prev,
-                      webhookEnabled: checked,
-                    }))
-                  }
-                />
-              </div>
-              <div className="flex items-center gap-2">
-                <Input
-                  placeholder="https://hooks.slack.com/services/..."
-                  value={alerts.webhookUrl}
-                  onChange={(e) =>
-                    setAlerts((prev) => ({
-                      ...prev,
-                      webhookUrl: e.target.value,
-                    }))
-                  }
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleTestWebhook}
-                  disabled={!alerts.webhookUrl}
-                >
-                  Send test
-                </Button>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-muted-foreground">
-                  Minimum severity
-                </span>
-                <ChannelSeverityToggle
-                  value={alerts.channels?.webhook?.minSeverity}
-                  onChange={(v) => setChannelMinSeverity('webhook', v)}
-                />
-              </div>
-            </div>
+            <AlertChannelsPanel
+              alerts={alerts}
+              setAlerts={setAlerts}
+              setChannelMinSeverity={setChannelMinSeverity}
+              onEnableBrowser={(checked) => void handleEnableBrowser(checked)}
+              onTestBrowser={handleTestBrowser}
+              onTestHealthchecks={() => void handleTestHealthchecks()}
+              onTestWebhook={() => void handleTestWebhook()}
+            />
 
             <Separator />
 

--- a/apps/dashboard/src/components/health/server-channel-config-panel.tsx
+++ b/apps/dashboard/src/components/health/server-channel-config-panel.tsx
@@ -14,18 +14,37 @@
  * form shows an "env" badge so the operator knows a channel is already live.
  */
 
+import {
+  HeartPulse,
+  Mail,
+  MessageCircle,
+  Radio,
+  Send,
+  Siren,
+  Smartphone,
+  Webhook,
+} from 'lucide-react'
 import { toast } from 'sonner'
 
+import type { ReactNode } from 'react'
 import type { AlertConfigChannel } from '@/lib/hooks/use-alert-channel-config'
 
+import {
+  AddChannelTile,
+  ChannelCard,
+  ChannelSectionHeader,
+} from './channel-card'
 import { ChannelSeverityToggle } from './channel-severity-toggle'
 import { useEffect, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
+import {
+  isServerChannelConfigured,
+  partitionChannels,
+} from '@/lib/health/channel-classification'
 import {
   useAlertChannelConfig,
   useAlertChannelConfigMutations,
@@ -42,6 +61,9 @@ interface ChannelSpec {
   channel: AlertConfigChannel
   label: string
   description: string
+  icon: ReactNode
+  /** Example target value shown on the compact "add a channel" tile. */
+  example?: string
   /** Non-secret target fields, in display order. */
   fields: ChannelField[]
   /** The channel's single secret, or `undefined` when it has none. */
@@ -68,6 +90,8 @@ const TEST_ENDPOINTS: Partial<Record<AlertConfigChannel, string>> = {
 const CHANNEL_SPECS: ChannelSpec[] = [
   {
     channel: 'webhook',
+    icon: <Webhook strokeWidth={1.5} />,
+    example: 'https://hooks.slack.com/services/T000/B000/XXXX',
     label: 'Webhook',
     description:
       'POST a JSON payload to a Slack- or Discord-compatible URL on each alert.',
@@ -81,6 +105,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'healthchecks',
+    icon: <HeartPulse strokeWidth={1.5} />,
+    example: 'https://hc-ping.com/your-uuid',
     label: 'healthchecks.io',
     description:
       'GET a healthchecks.io ping URL on each alert (append /fail on recovery).',
@@ -94,6 +120,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'email',
+    icon: <Mail strokeWidth={1.5} />,
+    example: 'mailgun://KEY@domain → ops@example.com',
     label: 'Email',
     description: 'Send an email via Mailgun, SendGrid, or SMTP.',
     fields: [
@@ -112,6 +140,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'opsgenie',
+    icon: <Siren strokeWidth={1.5} />,
+    example: 'Alert API key · region us | eu',
     label: 'Opsgenie',
     description: 'Create an Opsgenie alert via the Alert API.',
     fields: [{ key: 'region', label: 'Region (us | eu)', placeholder: 'us' }],
@@ -123,6 +153,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'telegram',
+    icon: <Send strokeWidth={1.5} />,
+    example: 'bot token · chat id -1001234567890',
     label: 'Telegram',
     description: 'Message a Telegram chat via a bot.',
     fields: [
@@ -136,6 +168,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'ntfy',
+    icon: <Radio strokeWidth={1.5} />,
+    example: 'https://ntfy.sh/your-topic',
     label: 'ntfy',
     description: 'Publish to an ntfy topic (self-hostable).',
     fields: [
@@ -153,6 +187,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'pushover',
+    icon: <Smartphone strokeWidth={1.5} />,
+    example: 'user key u… · app token a…',
     label: 'Pushover',
     description: 'Notify a Pushover user/group via the Messages API.',
     fields: [{ key: 'user', label: 'User/group key', placeholder: 'u…' }],
@@ -164,6 +200,8 @@ const CHANNEL_SPECS: ChannelSpec[] = [
   },
   {
     channel: 'twilio',
+    icon: <MessageCircle strokeWidth={1.5} />,
+    example: '+15557654321 → +15551234567',
     label: 'Twilio SMS',
     description:
       'Send an SMS via Twilio. Critical-only by default; each SMS costs money.',
@@ -209,6 +247,9 @@ export function ServerChannelConfigPanel() {
 
   const [drafts, setDrafts] = useState<Record<string, DraftState>>({})
   const [savingChannel, setSavingChannel] = useState<string | null>(null)
+  // Channels opened from an "Add a channel" tile this session — they render as
+  // full (expanded) cards before they hold any saved config.
+  const [opened, setOpened] = useState<string[]>([])
 
   // Hydrate drafts from the server config whenever it (re)loads.
   useEffect(() => {
@@ -304,132 +345,180 @@ export function ServerChannelConfigPanel() {
     }
   }
 
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-1">
-        <Label className="text-sm font-medium">Server delivery channels</Label>
-        <span className="text-xs text-muted-foreground">
-          Persisted on the server and used by the automated health sweep. A
-          saved channel overrides its{' '}
-          <code className="text-xs">HEALTH_ALERT_*</code> environment variable;
-          leave a secret blank to keep the stored one.
-        </span>
-      </div>
+  const isConfigured = (spec: ChannelSpec) =>
+    isServerChannelConfigured({
+      hasRow: configs.some((c) => c.channel === spec.channel),
+      envConfigured: Boolean(env[spec.channel]),
+    }) || opened.includes(spec.channel)
 
-      {CHANNEL_SPECS.map((spec, idx) => {
-        const draft = drafts[spec.channel] ?? emptyDraft()
-        const hasRow = configs.some((c) => c.channel === spec.channel)
-        const envConfigured = Boolean(env[spec.channel])
-        return (
-          <div key={spec.channel}>
-            {idx > 0 && <Separator className="mb-4" />}
-            <div className="flex flex-col gap-2 rounded-md border p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="flex flex-col">
-                  <div className="flex items-center gap-2">
-                    <Label className="text-sm font-medium">{spec.label}</Label>
-                    {!hasRow && envConfigured && (
-                      <Badge variant="secondary">
-                        Configured via server env
-                      </Badge>
-                    )}
-                    {draft.hasSecret && (
-                      <Badge variant="outline">Secret set</Badge>
-                    )}
-                  </div>
-                  <span className="text-xs text-muted-foreground">
-                    {spec.description}
-                  </span>
-                </div>
-                <Switch
-                  checked={draft.enabled}
-                  onCheckedChange={(checked) =>
-                    setDraft(spec.channel, { enabled: checked })
-                  }
-                  disabled={isLoading}
-                />
-              </div>
+  const { configured, available } = partitionChannels(
+    CHANNEL_SPECS,
+    isConfigured
+  )
 
-              {spec.fields.map((field) => (
-                <div key={field.key} className="flex flex-col gap-1">
-                  <Label className="text-xs text-muted-foreground">
-                    {field.label}
-                  </Label>
-                  <Input
-                    placeholder={field.placeholder}
-                    value={draft.target[field.key] ?? ''}
-                    onChange={(e) =>
-                      setTargetField(spec.channel, field.key, e.target.value)
-                    }
-                  />
-                </div>
-              ))}
+  const renderCard = (spec: ChannelSpec) => {
+    const draft = drafts[spec.channel] ?? emptyDraft()
+    const hasRow = configs.some((c) => c.channel === spec.channel)
+    const envConfigured = Boolean(env[spec.channel])
+    return (
+      <ChannelCard
+        key={spec.channel}
+        icon={spec.icon}
+        title={spec.label}
+        status={`${draft.enabled ? 'Enabled' : 'Disabled'} · ${
+          draft.minSeverity === 'warning'
+            ? 'Warning+'
+            : draft.minSeverity === 'critical'
+              ? 'Critical only'
+              : 'Inherits default'
+        }`}
+        badges={
+          <>
+            {!hasRow && envConfigured && <Badge variant="secondary">env</Badge>}
+            {draft.hasSecret && <Badge variant="outline">Secret set</Badge>}
+          </>
+        }
+        enabled={draft.enabled}
+        onEnabledChange={(checked) =>
+          setDraft(spec.channel, { enabled: checked })
+        }
+        switchDisabled={isLoading}
+        defaultOpen={opened.includes(spec.channel)}
+      >
+        <p className="text-xs text-muted-foreground">{spec.description}</p>
 
-              {spec.secret && (
-                <div className="flex flex-col gap-1">
-                  <Label className="text-xs text-muted-foreground">
-                    {spec.secret.label}
-                  </Label>
-                  <Input
-                    type="password"
-                    autoComplete="new-password"
-                    placeholder={
-                      draft.hasSecret
-                        ? '•••• leave blank to keep the stored secret'
-                        : spec.secret.placeholder
-                    }
-                    value={draft.secret}
-                    onChange={(e) =>
-                      setDraft(spec.channel, { secret: e.target.value })
-                    }
-                  />
-                </div>
-              )}
-
-              <div className="flex items-center justify-between pt-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-muted-foreground">
-                    Minimum severity
-                  </span>
-                  <ChannelSeverityToggle
-                    value={draft.minSeverity}
-                    onChange={(v) => setDraft(spec.channel, { minSeverity: v })}
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  {TEST_ENDPOINTS[spec.channel] && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => void handleTest(spec)}
-                      disabled={savingChannel === spec.channel}
-                    >
-                      Send test
-                    </Button>
-                  )}
-                  {hasRow && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => void handleReset(spec)}
-                      disabled={savingChannel === spec.channel}
-                    >
-                      Reset
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    onClick={() => void handleSave(spec)}
-                    disabled={savingChannel === spec.channel}
-                  >
-                    Save
-                  </Button>
-                </div>
-              </div>
-            </div>
+        {spec.fields.map((field) => (
+          <div key={field.key} className="flex flex-col gap-1">
+            <Label className="text-xs text-muted-foreground">
+              {field.label}
+            </Label>
+            <Input
+              placeholder={field.placeholder}
+              value={draft.target[field.key] ?? ''}
+              onChange={(e) =>
+                setTargetField(spec.channel, field.key, e.target.value)
+              }
+            />
           </div>
-        )
-      })}
+        ))}
+
+        {spec.secret && (
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs text-muted-foreground">
+              {spec.secret.label}
+            </Label>
+            <Input
+              type="password"
+              autoComplete="new-password"
+              placeholder={
+                draft.hasSecret
+                  ? '•••• leave blank to keep the stored secret'
+                  : spec.secret.placeholder
+              }
+              value={draft.secret}
+              onChange={(e) =>
+                setDraft(spec.channel, { secret: e.target.value })
+              }
+            />
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs text-muted-foreground">
+            Minimum severity
+          </span>
+          <ChannelSeverityToggle
+            value={draft.minSeverity}
+            onChange={(v) => setDraft(spec.channel, { minSeverity: v })}
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+          {TEST_ENDPOINTS[spec.channel] && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleTest(spec)}
+              disabled={savingChannel === spec.channel}
+            >
+              Send test
+            </Button>
+          )}
+          {hasRow && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleReset(spec)}
+              disabled={savingChannel === spec.channel}
+            >
+              Reset
+            </Button>
+          )}
+          <Button
+            size="sm"
+            onClick={() => void handleSave(spec)}
+            disabled={savingChannel === spec.channel}
+          >
+            Save
+          </Button>
+        </div>
+      </ChannelCard>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ChannelSectionHeader
+        icon={<Siren className="size-4" strokeWidth={1.5} />}
+        title="Server delivery channels"
+        description={
+          <>
+            Persisted on the server and used by the automated health sweep. A
+            saved channel overrides its{' '}
+            <code className="text-xs">HEALTH_ALERT_*</code> environment
+            variable; leave a secret blank to keep the stored one. Each card
+            saves on its own.
+          </>
+        }
+        count={configured.length}
+      />
+
+      {configured.length > 0 ? (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {configured.map(renderCard)}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-dashed bg-card/50 p-4">
+          <EmptyState
+            variant="no-data"
+            icon={<Siren className="size-5" strokeWidth={1.5} />}
+            title="No server channel configured"
+            description="The automated health sweep has nowhere to deliver yet. Add one below, or set the matching HEALTH_ALERT_* environment variables on the server."
+          />
+        </div>
+      )}
+
+      {available.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Add a channel
+          </span>
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {available.map((spec) => (
+              <AddChannelTile
+                key={spec.channel}
+                icon={spec.icon}
+                title={spec.label}
+                description={spec.description}
+                example={spec.example}
+                onClick={() =>
+                  setOpened((prev) => [...prev, spec.channel as string])
+                }
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/lib/health/__tests__/channel-classification.test.ts
+++ b/apps/dashboard/src/lib/health/__tests__/channel-classification.test.ts
@@ -1,0 +1,114 @@
+import {
+  type AlertSettings,
+  DEFAULT_ALERT_SETTINGS,
+} from '../alert-settings-storage'
+import {
+  isLocalChannelConfigured,
+  isServerChannelConfigured,
+  LOCAL_CHANNEL_IDS,
+  partitionChannels,
+} from '../channel-classification'
+import { describe, expect, it } from 'bun:test'
+
+const settings = (patch: Partial<AlertSettings> = {}): AlertSettings => ({
+  ...DEFAULT_ALERT_SETTINGS,
+  ...patch,
+})
+
+describe('isLocalChannelConfigured', () => {
+  it('treats the browser channel as configured only while enabled', () => {
+    expect(
+      isLocalChannelConfigured(
+        'browser',
+        settings({ browserNotificationsEnabled: true })
+      )
+    ).toBe(true)
+    expect(
+      isLocalChannelConfigured(
+        'browser',
+        settings({ browserNotificationsEnabled: false })
+      )
+    ).toBe(false)
+  })
+
+  it('requires a non-blank URL for the URL-based channels', () => {
+    expect(isLocalChannelConfigured('healthchecks', settings())).toBe(false)
+    expect(
+      isLocalChannelConfigured(
+        'healthchecks',
+        settings({ healthchecksUrl: '  ' })
+      )
+    ).toBe(false)
+    expect(
+      isLocalChannelConfigured(
+        'healthchecks',
+        settings({ healthchecksUrl: 'https://hc-ping.com/uuid' })
+      )
+    ).toBe(true)
+    expect(
+      isLocalChannelConfigured(
+        'webhook',
+        settings({ webhookUrl: 'https://hooks.slack.com/services/x' })
+      )
+    ).toBe(true)
+  })
+
+  it('ignores the enabled flag for the webhook URL (a saved URL stays a card)', () => {
+    // The card owns the enable switch, so a configured-but-paused webhook must
+    // keep its full card instead of dropping back to an "add" tile.
+    expect(
+      isLocalChannelConfigured(
+        'webhook',
+        settings({
+          webhookUrl: 'https://example.com/hook',
+          webhookEnabled: false,
+        })
+      )
+    ).toBe(true)
+  })
+})
+
+describe('isServerChannelConfigured', () => {
+  it('counts a saved D1 row or a server env fallback', () => {
+    expect(
+      isServerChannelConfigured({ hasRow: false, envConfigured: false })
+    ).toBe(false)
+    expect(
+      isServerChannelConfigured({ hasRow: true, envConfigured: false })
+    ).toBe(true)
+    expect(
+      isServerChannelConfigured({ hasRow: false, envConfigured: true })
+    ).toBe(true)
+  })
+})
+
+describe('partitionChannels', () => {
+  it('splits while preserving order', () => {
+    const { configured, available } = partitionChannels(
+      LOCAL_CHANNEL_IDS,
+      (id) =>
+        isLocalChannelConfigured(
+          id,
+          settings({
+            browserNotificationsEnabled: false,
+            webhookUrl: 'https://example.com/hook',
+          })
+        )
+    )
+    expect(configured).toEqual(['webhook'])
+    expect(available).toEqual(['browser', 'healthchecks'])
+  })
+
+  it('returns everything as available when nothing is configured', () => {
+    const { configured, available } = partitionChannels(
+      LOCAL_CHANNEL_IDS,
+      (id) =>
+        isLocalChannelConfigured(
+          id,
+          settings({ browserNotificationsEnabled: false })
+        )
+    )
+    expect(configured).toEqual([])
+    expect(available).toEqual([...LOCAL_CHANNEL_IDS])
+  })
+})

--- a/apps/dashboard/src/lib/health/channel-classification.ts
+++ b/apps/dashboard/src/lib/health/channel-classification.ts
@@ -1,0 +1,68 @@
+/**
+ * "Configured first" classification for the alert-settings channel grid.
+ *
+ * The Alerts tab used to render every channel as a full-width form, so a fresh
+ * install was a wall of blank inputs. These pure helpers decide which channels
+ * are already set up (full card) and which are still offers (compact
+ * "Add a channel" tile), for both delivery surfaces:
+ *
+ * - **browser-local** channels live in localStorage (`AlertSettings`): the
+ *   browser channel counts as configured once it is enabled (it needs no
+ *   target), the URL-based ones once their URL is non-empty.
+ * - **server** channels live in D1 (`hasRow`) or, on a deployment without D1,
+ *   in `HEALTH_ALERT_*` env vars (`envConfigured`) — either one means the
+ *   operator has already set that channel up.
+ *
+ * Pure — no `window`, no I/O — so both the panel and its unit test can use it.
+ */
+
+import type { AlertSettings } from './alert-settings-storage'
+
+/** The three channels the browser itself delivers (client dispatcher). */
+export type LocalChannelId = 'browser' | 'healthchecks' | 'webhook'
+
+export const LOCAL_CHANNEL_IDS: readonly LocalChannelId[] = [
+  'browser',
+  'healthchecks',
+  'webhook',
+]
+
+/** True when the operator has already set this browser-local channel up. */
+export function isLocalChannelConfigured(
+  id: LocalChannelId,
+  settings: AlertSettings
+): boolean {
+  switch (id) {
+    case 'browser':
+      return settings.browserNotificationsEnabled
+    case 'healthchecks':
+      return settings.healthchecksUrl.trim().length > 0
+    case 'webhook':
+      return settings.webhookUrl.trim().length > 0
+  }
+}
+
+/** True when a server channel has a saved D1 row or a server env fallback. */
+export function isServerChannelConfigured(input: {
+  hasRow: boolean
+  envConfigured: boolean
+}): boolean {
+  return input.hasRow || input.envConfigured
+}
+
+/**
+ * Split an ordered id list into `configured` (full cards) and `available`
+ * (compact add-tiles), preserving the input order within each bucket.
+ */
+export function partitionChannels<T>(
+  ids: readonly T[],
+  isConfigured: (id: T) => boolean
+): { configured: T[]; available: T[] } {
+  const configured: T[] = []
+  const available: T[] = []
+  for (const id of ids) {
+    if (isConfigured(id)) configured.push(id)
+    else available.push(id)
+  }
+  return { configured, available }
+}

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-07-24
+updated: 2026-08-12
 tags:
   - design-system
   - ui
@@ -273,6 +273,38 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   the agent can see; its shared state (`page-context-control.tsx`, floating-only
   provider) also gates whether `pageContext` rides along with the request — see
   `docs/content/guide/ai-agent.mdx`.
+
+### Settings channel grid (configured-first)
+
+Settings surfaces that expose many optional integrations (today:
+`/alert-settings`, shared with `/health-settings` via `HealthSettingsPanel`)
+must not render every integration as a full-width blank form. The convention,
+implemented by `components/health/channel-card.tsx`:
+
+- `ChannelCard` — a collapsible card (`ui/collapsible`, Base UI: style off
+  `data-open`) whose summary row is `icon + name + status line + badges +
+  optional enable Switch + chevron`, expanding to the channel's config form.
+  It owns no state, so the browser-local channels (localStorage, saved by the
+  page footer) and the server channels (per-card save to D1) can share it while
+  keeping different save semantics.
+- `AddChannelTile` — compact dashed tile (icon + one-line description + an
+  example target value, e.g. a sample Slack webhook URL) for an unconfigured
+  channel; clicking it expands the full card.
+- `ChannelSectionHeader` — section icon + `h2` + count badge + description.
+- Cards render in a `grid gap-3 sm:grid-cols-2`; only CONFIGURED channels get
+  cards (`lib/health/channel-classification.ts` — pure + unit-tested:
+  browser = enabled, URL channels = non-blank URL, server = D1 row OR
+  `HEALTH_ALERT_*` env). Zero configured → `EmptyState`, not blank forms.
+- Once the user edits a card, pin it open (`opened` id set) so clearing its URL
+  can't collapse the card and unmount the focused input mid-keystroke.
+
+### Tab strips
+
+Define tabs as one array and map it. One icon size (`size-3.5`), no margin
+utility — `TabsTrigger` already provides `items-center gap-1.5`; a stacked
+`mr-*` is what makes icons look off-baseline. Keep the strip in the
+`scrollbar-hide overflow-x-auto` + `TabsList w-max flex-nowrap` wrapper so many
+tabs scroll instead of wrapping.
 
 ## UX conventions
 


### PR DESCRIPTION
Redesign of `/alert-settings` from user feedback.

## What changed
- **Tab strip alignment** — the 10 tabs are now generated from one `TAB_DEFS` list with a uniform `size-3.5` icon and no extra `mr-1.5` (the trigger's own `items-center gap-1.5` does the alignment). The strip keeps its `overflow-x-auto` no-wrap scrolling on narrow screens.
- **Channel grid** — the full-width stacked channel forms are gone. Browser-local channels (browser notifications / healthchecks.io / webhook) and server delivery channels both render as a responsive `sm:grid-cols-2` grid of collapsible cards: icon, name, status line, badges, enable switch, expand for URL/secret/severity config + Send test.
- **Configured first** — only configured channels get a full card. The rest appear as compact "Add a channel" tiles (icon + one-line description + example target, e.g. a sample Slack webhook URL) that expand into the full card on click. When nothing is configured, an `EmptyState` is shown instead of blank forms.
- **Explainer** — kept the threshold sample viz + stat tiles, and added a small check → threshold → routing/quiet-hours → channels flow strip.

## Preserved
Severity floors (Inherit / Warning+ / Critical) per channel and the global floor, send-test for every channel that has one, the server-channel semantics (per-card Save/Reset, `env` badge, "leave the secret blank to keep the stored one", `HEALTH_ALERT_*` override note), the browser-local vs server-persisted distinction, digests, routing, quiet hours, maintenance, suggestions and custom rules.

## Verification
- New pure helpers `lib/health/channel-classification.ts` + unit tests (`bun test`, 6 pass).
- `biome check` clean; `tsc --noEmit` reports no errors in the touched files.
- `HealthSettingsPanel` is shared with `/health-settings`, which picks up the same redesign.

https://claude.ai/code/session_019MzLkNcZYT5J8fCAUYnF1E