### PR TITLE
fix(ci): harden workflows — pipefail, pnpm caching, frozen-lockfile

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -45,6 +45,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -99,6 +99,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            apps/*/pnpm-lock.yaml
 
       - name: Setup Rust
         if: ${{ inputs.job-type == 'build' }}
@@ -118,7 +122,7 @@ jobs:
 
       - name: Install dependencies
         if: ${{ inputs.job-type == 'build' || inputs.job-type == 'lint' }}
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       # === Linting ===
       - name: Lint

--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/blog/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,13 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            apps/*/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Validate dependency boundaries
         run: pnpm run depcruise
@@ -203,17 +207,22 @@ jobs:
             type=sha,prefix=sha-,format=long
 
       - name: Create and push multi-arch manifests
+        shell: bash
         env:
           TAGS_JSON: ${{ steps.meta.outputs.json }}
         run: |
+          set -euo pipefail
           AMD64=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64
           ARM64=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-arm64
 
-          echo "$TAGS_JSON" | jq -r '.tags[]' | while IFS= read -r TAG; do
+          TAGS=$(jq -r '.tags[]' <<<"$TAGS_JSON")
+          [ -n "$TAGS" ] || { echo "::error::metadata-action produced no tags"; exit 1; }
+
+          while IFS= read -r TAG; do
             [ -z "$TAG" ] && continue
             echo "Creating manifest: $TAG"
             docker buildx imagetools create -t "$TAG" "$AMD64" "$ARM64"
-          done
+          done <<<"$TAGS"
 
   # Validate only on main/release.
   # Reuse the image build-docker-amd64 already built & pushed instead of

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -88,6 +88,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -560,6 +562,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/landing/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -665,6 +669,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/docs/pnpm-lock.yaml
 
       - name: Detect changes
         id: filter
@@ -750,6 +756,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/blog/pnpm-lock.yaml
 
       - name: Detect changes
         id: filter
@@ -833,6 +841,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/bug-handler/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -976,6 +986,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/cloud-hooks/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/docs/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/landing/pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       # Install so commitlint resolves from the repo's pinned devDependencies
       # (incl. the conventional-changelog-conventionalcommits transitive dep),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,17 +211,22 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Create and push multi-arch manifests
+        shell: bash
         env:
           TAGS_JSON: ${{ steps.meta.outputs.json }}
         run: |
+          set -euo pipefail
           AMD64=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-amd64
           ARM64=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-arm64
 
-          echo "$TAGS_JSON" | jq -r '.tags[]' | while IFS= read -r TAG; do
+          TAGS=$(jq -r '.tags[]' <<<"$TAGS_JSON")
+          [ -n "$TAGS" ] || { echo "::error::metadata-action produced no tags"; exit 1; }
+
+          while IFS= read -r TAG; do
             [ -z "$TAG" ] && continue
             echo "Creating manifest: $TAG"
             docker buildx imagetools create -t "$TAG" "$AMD64" "$ARM64"
-          done
+          done <<<"$TAGS"
 
   assets:
     name: assets
@@ -244,6 +249,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -52,7 +56,7 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Install dashboard dependencies
         working-directory: apps/dashboard
@@ -102,6 +106,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -192,6 +198,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -199,7 +209,7 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Install dashboard dependencies
         working-directory: apps/dashboard
@@ -241,6 +251,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            apps/dashboard/pnpm-lock.yaml
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -248,7 +262,7 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Install dashboard dependencies
         working-directory: apps/dashboard


### PR DESCRIPTION
## Summary
- Multi-arch manifest step (`ci.yml` + `release.yml`) now uses `shell: bash` + `set -euo pipefail`, materializes the jq tag list into a variable, and asserts it's non-empty before the loop — a jq failure or empty tag list now fails the job loudly with an `::error::` annotation instead of silently passing.
- All 19 `actions/setup-node` steps across every workflow now set `cache: pnpm` with a scoped `cache-dependency-path` (root + relevant app lockfile(s)).
- The five bare `pnpm install` steps (`base.yml`, `ci.yml` depcruise job, `test.yml` unit-tests/test-queries-config/test-postgres-integration) now use `--frozen-lockfile`, matching every other install step in the repo.

## Test plan
- [x] Validated every changed workflow file parses as YAML (`python3 -c "import yaml; yaml.safe_load(open(f))"` per file)
- [ ] CI run on this PR is green (`dashboard`, `unit-tests` required checks)
- [ ] Cache hit visible on a second CI run for the setup-node steps

Fixes #2901
Fixes #2890
Fixes #2891