### PR TITLE
fix(lint): resolve biome errors on main

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/composer.tsx
@@ -81,8 +81,8 @@ export function WelcomeComposer() {
             <code className="font-mono text-[11px]">OPENROUTER_API_KEY</code>{' '}
             (or <code className="font-mono text-[11px]">LLM_API_KEY</code>),{' '}
             <code className="font-mono text-[11px]">ANYROUTER_API_KEY</code>, or{' '}
-            <code className="font-mono text-[11px]">NVIDIA_API_KEY</code> on this
-            deployment so the agent can answer.
+            <code className="font-mono text-[11px]">NVIDIA_API_KEY</code> on
+            this deployment so the agent can answer.
           </p>
         </div>
       ) : null}

--- a/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/indexes-tab.tsx
@@ -224,7 +224,9 @@ export function IndexesTab() {
               <div className="text-sm font-medium">{indexData.engine}</div>
               {indexData.engine_full &&
                 indexData.engine_full !== indexData.engine && (
-                  <SqlExprBlock code={formatEngineFull(indexData.engine_full)} />
+                  <SqlExprBlock
+                    code={formatEngineFull(indexData.engine_full)}
+                  />
                 )}
             </div>
           </CardContent>

--- a/apps/dashboard/src/lib/ai/providers.ts
+++ b/apps/dashboard/src/lib/ai/providers.ts
@@ -202,8 +202,7 @@ export function providerNotConfiguredMessage(providerId: string): string {
     )
   }
   const envVar =
-    PROVIDERS[providerId]?.apiKeyEnvVar ??
-    `${providerId.toUpperCase()}_API_KEY`
+    PROVIDERS[providerId]?.apiKeyEnvVar ?? `${providerId.toUpperCase()}_API_KEY`
   return (
     `Provider "${getProviderName(providerId)}" is not configured on this deployment. ` +
     `Pick a model from a configured provider (${configured.join(', ')}) ` +

--- a/apps/dashboard/src/lib/hooks/use-agent-model.ts
+++ b/apps/dashboard/src/lib/hooks/use-agent-model.ts
@@ -12,6 +12,7 @@
 
 import { useEffect, useState } from 'react'
 import {
+  FALLBACK_AGENT_MODEL,
   getAllModelOptions,
   MODEL_REGISTRY,
 } from '@/lib/ai/agent-model-registry'
@@ -21,7 +22,6 @@ import {
   type ModelPricing,
   type OpenAIModel,
 } from '@/lib/ai/agent-models'
-import { FALLBACK_AGENT_MODEL } from '@/lib/ai/agent-model-registry'
 import { apiFetch } from '@/lib/swr/api-fetch'
 
 export type { OpenAIModel } from '@/lib/ai/agent-models'
@@ -296,8 +296,6 @@ export function useAgentModel(): UseAgentModelResult {
     modelsLoaded,
     configuredProviders,
     noProvidersConfigured:
-      modelsLoaded &&
-      configuredProviders.length === 0 &&
-      models.length === 0,
+      modelsLoaded && configuredProviders.length === 0 && models.length === 0,
   }
 }


### PR DESCRIPTION
## Summary
- Fixes ~5 Biome check errors on `main` (format + import-order) that were breaking every contributor's pre-push hook.
- Files: `composer.tsx`, `indexes-tab.tsx`, `providers.ts`, `use-agent-model.ts`.

## Test plan
- [x] `pnpm run check` passes locally (0 errors; 2 pre-existing warnings + 1 info unrelated to this change, in `topo-canvas.tsx`)