### PR TITLE
chore(deploy): guard the inert dashboard wrangler cron triggers

### DIFF
--- a/apps/dashboard/scripts/cron-triggers.test.ts
+++ b/apps/dashboard/scripts/cron-triggers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Cron triggers — guards a coupling that fails silently (issue #2900).
+ *
+ * `wrangler.toml` declares four `[triggers] crons`, but the deploy DROPS the
+ * key: `scripts/patch-wrangler-env.ts` runs `delete generated.triggers` because
+ * the account is over the Workers Free 5-crons-per-account budget, and ANY
+ * schedules PUT (even `crons: []`) fails after a successful script upload and
+ * exits the deploy 1 (see PRs #2866 / #2868). So the array is documentation of
+ * the already-attached state, not a live setting.
+ *
+ * Two ways that goes wrong silently, both pinned here:
+ *  1. Someone edits a cadence (say the 10-minute health sweep). The diff looks
+ *     applied, review passes, the deploy is green — and production is
+ *     unchanged. The array is pinned to the documented four cadences so such
+ *     an edit has to be deliberate and has to update this test + the docs.
+ *  2. Someone "cleans up" the strip in patch-wrangler-env.ts. The deploy then
+ *     attempts a schedules PUT again and turns red the way #2868 did. The
+ *     strip guard is pinned so removing it fails here first.
+ *
+ * Mirrors apps/cloud-hooks/src/cron.test.ts, which pins the same constraint
+ * from the other side (that worker declares no crons at all).
+ *
+ * Re-enable path: the account must have cron budget again, THEN remove the
+ * `delete generated.triggers` line (restoring the preview-only guard) and
+ * update this test. See docs/knowledge/deployment.md § Cron triggers.
+ */
+
+import wranglerToml from '../wrangler.toml' with { type: 'toml' }
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * The cadences currently ATTACHED to the deployed `chmonitor-dash` worker.
+ * Meanings (kept in wrangler.toml and docs/knowledge/deployment.md):
+ *   "0 3 * * *"    → retention-prune, daily 03:00 UTC
+ *   "0 8 * * 1"    → weekly-report, Mondays 08:00 UTC
+ *   "0 8 1 * *"    → monthly-report, 1st of month 08:00 UTC
+ *   "*\/10 * * * *" → health-sweep, every 10 minutes
+ */
+const DOCUMENTED_CRONS = [
+  '0 3 * * *',
+  '0 8 * * 1',
+  '0 8 1 * *',
+  '*/10 * * * *',
+] as const
+
+const toml = wranglerToml as {
+  triggers?: { crons?: string[] }
+  env?: { preview?: { triggers?: unknown } }
+}
+
+describe('dashboard cron triggers (INERT — see #2900)', () => {
+  test('wrangler.toml crons match the documented attached cadences', () => {
+    expect(toml.triggers?.crons).toEqual([...DOCUMENTED_CRONS])
+  })
+
+  test('preview env declares no triggers', () => {
+    // Preview never had schedules; the cron HTTP routes work with CRON_SECRET.
+    expect(toml.env?.preview?.triggers).toBeUndefined()
+  })
+
+  test('the deploy strips the triggers key — no schedules PUT', async () => {
+    // Pinned on the source of scripts/patch-wrangler-env.ts rather than its
+    // output: producing the output requires a full vite build and would
+    // overwrite dist/server/wrangler.json. Both fail on the same event —
+    // the strip guard being removed.
+    const script = await Bun.file(
+      new URL('./patch-wrangler-env.ts', import.meta.url)
+    ).text()
+    expect(script).toMatch(/^\s*delete generated\.triggers\s*$/m)
+  })
+})

--- a/apps/dashboard/wrangler.toml
+++ b/apps/dashboard/wrangler.toml
@@ -231,6 +231,14 @@ simple = { limit = 30, period = 60 }
 # exit 1 after a successful upload). The crons below stay attached from earlier
 # deploys. Changing this array therefore has NO effect until the account has
 # cron budget again and the patch-script guard is removed.
+#
+# ⚠️  INERT — EDITING THE ARRAY BELOW CHANGES NOTHING IN PRODUCTION.
+#     The deploy drops this key (`delete generated.triggers` in
+#     scripts/patch-wrangler-env.ts). Pinned by scripts/cron-triggers.test.ts;
+#     re-enable path + cadence meanings: docs/knowledge/deployment.md
+#     § Cron triggers (issue #2900, PRs #2866 / #2868).
+#     Self-hosters copying this file: these four crons count against the
+#     Workers Free 5-crons-per-account budget.
 # ─────────────────────────────────────────────────────────────────────────────
 [triggers]
 crons = ["0 3 * * *", "0 8 * * 1", "0 8 1 * *", "*/10 * * * *"]

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -3,7 +3,7 @@ id: deployment
 title: Deployment Guide
 type: reference
 status: active
-updated: 2026-06-29
+updated: 2026-08-12
 tags:
   - deployment
   - docker
@@ -336,6 +336,42 @@ zone id first, so a token missing read still fails):
 pnpm run cf:redirect-rule            # apply
 pnpm run cf:redirect-rule --dry-run  # preview the ruleset payload
 ```
+
+## Cron triggers (dashboard) — declared but INERT
+
+`apps/dashboard/wrangler.toml` declares four `[triggers] crons`, but **the
+deploy strips the key**, so editing that array has no effect on production.
+Single record of what is attached and why (issue #2900):
+
+| Cron | Job | Notes |
+|------|-----|-------|
+| `0 3 * * *` | retention-prune | daily 03:00 UTC |
+| `0 8 * * 1` | weekly-report | Mondays 08:00 UTC; per-host `CHM_WEEKLY_REPORT_HOSTS` + per-owner `report_subscriptions` fan-out, no-op when both empty |
+| `0 8 1 * *` | monthly-report | 1st of month 08:00 UTC (#2785); `report_subscriptions` cadence `monthly`, no-op when none |
+| `*/10 * * * *` | health-sweep | every 10 min (#2666); gated by `CHM_HEALTH_SWEEP_ENABLED`, defaults enabled iff `CRON_SECRET` set |
+
+**Why it is inert.** The Cloudflare account is over the Workers Free
+5-crons-per-account budget, so any schedules PUT — even `crons: []` — fails
+*after* a successful script upload and exits the deploy 1 (PRs #2866, #2868).
+`scripts/patch-wrangler-env.ts` therefore runs `delete generated.triggers`;
+wrangler skips the schedules API entirely when the key is absent, and the crons
+attached by earlier deploys stay in place. The cron HTTP routes
+(`src/routes/api/cron/*`) still work with `CRON_SECRET` from any scheduler.
+`apps/cloud-hooks` handles the same constraint by declaring no crons at all
+(one `*/15` trigger via its own worker) — see
+[cloud-hooks-worker.md](cloud-hooks-worker.md).
+
+**Guard.** `apps/dashboard/scripts/cron-triggers.test.ts` pins the crons array
+to the table above, asserts preview declares no triggers, and asserts the
+`delete generated.triggers` strip is still present — so removing the strip (and
+reintroducing the #2868 red deploy) fails in CI first.
+
+**Re-enable path.** 1) The account regains cron budget (free plan → 5 total, or
+upgrade; count all workers). 2) Remove `delete generated.triggers` from
+`scripts/patch-wrangler-env.ts`, restoring the earlier preview-only guard.
+3) Update `cron-triggers.test.ts` and this table. 4) Verify with
+`pnpm exec wrangler deploy --minify --dry-run`, then deploy and confirm the
+schedules PUT succeeds.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #2900

Option A from the issue: keep the `[triggers]` block (it is the only record of the attached cadences), make its inertness explicit, and pin it with a test. **Docs/comments/test only — no deploy behaviour, runtime code, money or auth path is touched.**

## Why
`apps/dashboard/wrangler.toml` declares 4 crons, but `scripts/patch-wrangler-env.ts` does `delete generated.triggers` at deploy — the account is over the Workers Free 5-crons-per-account budget, so any schedules PUT (even `crons: []`) fails *after* a successful upload and exits the deploy 1 (PRs #2866 / #2868). Two silent-failure modes result:
1. Editing a cadence (e.g. the 10-min health sweep) looks applied in the diff, reviews fine, deploys green — and prod is unchanged.
2. Someone "cleans up" the strip in `patch-wrangler-env.ts` → the red deploy of #2868 comes back.

## Changes
- **`apps/dashboard/scripts/cron-triggers.test.ts`** (new, mirrors `apps/cloud-hooks/src/cron.test.ts`) pins:
  - `[triggers] crons` deep-equals the four documented cadences (so a cadence edit must be deliberate and update the test + docs);
  - `[env.preview]` declares no triggers;
  - `patch-wrangler-env.ts` still contains `delete generated.triggers`.
- **`apps/dashboard/wrangler.toml`** — a short loud `⚠️ INERT` banner directly above `[triggers]` pointing at the guard test, the knowledge doc and #2900, plus a note for self-hosters that these 4 crons eat their account budget. The `crons = [...]` line itself is **unchanged**.
- **`docs/knowledge/deployment.md`** — new "Cron triggers (dashboard) — declared but INERT" section: cadence→job table with meanings, why it is stripped, the guard, and the re-enable path. `updated:` bumped.

## Deviation from the acceptance criteria, flagged for review
- The issue asks to assert the *output* of `patch-wrangler-env.ts` has no `triggers` key. That script writes to `dist/server/wrangler.json` and needs a full vite build first; running it in a unit test would require a build and would clobber a real build artifact. So the test pins the **source** guard (`delete generated.triggers`) instead. It fails on exactly the same event — the strip being removed — which is what criterion 1 is protecting.
- `wrangler deploy --minify --dry-run` was **not** run: the only `wrangler.toml` change is comment lines, and no runtime code changed. TOML validity is covered by the new test, which parses the file via bun's TOML import.

## Verification
- `bun test scripts/cron-triggers.test.ts` → 3 pass.
- `pnpm run lint` → clean (only pre-existing warnings in an unrelated file).
- No change to the schedules actually attached in production.
