### PR TITLE
chore: fix docs/config drift (Next.js remnants, cron trigger, LLM_MODEL format)

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -133,7 +133,7 @@ CHM_FEATURE_AGENT_ACCESS=public
 
 # ── AI agent / LLM ──────────────────────────────────────────────────────────
 # Default AI model (provider:model or anyrouter:@preset/...).
-LLM_MODEL=anyrouter/free
+LLM_MODEL=anyrouter:anyrouter/free
 # Extra agent models to expose, comma-separated provider:model ids.
 # LLM_EXTRA_MODELS=
 # OpenRouter free-tier fallback model (used when the free model is rate-limited).

--- a/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/providers.test.ts
@@ -70,6 +70,23 @@ describe('parseModelId', () => {
       model: 'qwen/qwen3-coder:free',
     })
   })
+
+  // Pin the exact LLM_MODEL values shipped in the committed env files so
+  // .env.example can't silently drift back to a format that resolves
+  // through a different provider branch than .env.production/.env.preview.
+  test('parses the LLM_MODEL shipped in .env.production / .env.example', () => {
+    expect(parseModelId('anyrouter:anyrouter/free')).toEqual({
+      provider: 'anyrouter',
+      model: 'anyrouter/free',
+    })
+  })
+
+  test('parses the LLM_MODEL shipped in .env.preview', () => {
+    expect(parseModelId('anyrouter:z-ai/glm-4.7-flash')).toEqual({
+      provider: 'anyrouter',
+      model: 'z-ai/glm-4.7-flash',
+    })
+  })
 })
 
 describe('resolveProvider', () => {

--- a/docs/knowledge/cloud-hooks-worker.md
+++ b/docs/knowledge/cloud-hooks-worker.md
@@ -18,7 +18,7 @@ tags:
     telemetry,
     issues,
   ]
-updated: 2026-08-11
+updated: 2026-08-12
 ---
 
 # Cloud-hooks worker (Polar webhooks + ops notifications)
@@ -45,8 +45,14 @@ Clerk ──► POST hooks.chmonitor.dev/webhooks/clerk
        Telegram notify:  🆕 user.created · 🔑 session.created (KV-throttled
        1/user/6h) · 🏢 organization.created.  Unknown events → 202, ignored.
 
-cron ("*/15 * * * *" — the ONLY trigger; Workers Free caps crons at 5/account
-and the dashboard uses 4. Reports dispatch off the tick's scheduledTime.)
+cron ("*/15 * * * *" — the intended cadence, currently NOT attached: the
+account is over the Workers Free 5-crons-per-account budget, so
+`wrangler.toml` deliberately declares no `[triggers]` block — see
+apps/cloud-hooks/wrangler.toml:78-89 and src/cron.test.ts, which pins this
+so a future edit does not re-add it. Worker is driven by its HTTP endpoints
+only until the account regains cron budget. The tick-dispatch logic below
+still describes what runs once the trigger is re-attached; reports dispatch
+off the tick's scheduledTime.)
   ├─ 00:00 UTC tick   → + daily digest → Telegram
   │                      (users + DAU/WAU/MAU + subs + surfaces)
   ├─ Mon 01:00 tick   → + weekly report → Telegram
@@ -259,7 +265,13 @@ The same `chm-cloud` D1 is bound into both Workers; the monotonic
 ## Config (`wrangler.toml`)
 
 - `name = chmonitor-hooks`, custom domain `hooks.chmonitor.dev` (auto-provisions
-  DNS on the managed zone), cron `["*/15 * * * *"]` (single trigger — free-plan account cron budget).
+  DNS on the managed zone). **No `[triggers]` block** — the intended
+  `*/15 * * * *` cadence is not attached because the account is over the
+  Workers Free 5-crons-per-account budget (any schedules PUT fails after a
+  successful script upload otherwise). Guarded by `src/cron.test.ts`
+  (`wrangler.toml` must not declare `crons =`); re-attach
+  `[triggers] crons = ["*/15 * * * *"]` if the account ever regains cron
+  budget.
 - D1 binding `CHM_CLOUD_D1` → `chm-cloud` (`database_id`
   `cca247b6-9b25-41bd-b9ca-727b35bc6039`, same as the dashboard).
 - D1 binding `CHM_TELEMETRY_DB` → `chm_telemetry` (`database_id`
@@ -339,6 +351,11 @@ steps (operator, out of v1 scope): add `https://hooks.chmonitor.dev/webhooks/pol
 as a second Polar endpoint and verify deliveries + Telegram in sandbox then prod;
 then remove the old endpoint and delete the dashboard webhook route (keep
 `/api/v1/billing/*` — those are user-facing APIs, not webhooks).
+
+Separately, the cron-driven ops sweep (digests, health probes, exception scan,
+issue watch) is dormant for a different reason: no cron trigger is currently
+attached (account cron budget, see "Config" above), independent of the Polar
+cutover above. It stays dormant until the account regains cron budget.
 
 ## Operator step — Clerk lifecycle endpoint
 

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -3,7 +3,7 @@ id: deployment
 title: Deployment Guide
 type: reference
 status: active
-updated: 2026-06-29
+updated: 2026-08-12
 tags:
   - deployment
   - docker
@@ -86,7 +86,7 @@ The TanStack Start app builds to **two targets** from one codebase, selected by
 | Target | Build | Runtime | `cloudflare:workers` resolves to |
 |--------|-------|---------|-----------------------------------|
 | `node` (Docker / k8s) | `pnpm run build:node:ci` → `.output/server/index.mjs` | Nitro `node-server` on `node:24-alpine` | `src/lib/cloudflare-workers-shim.ts` (`env` = `process.env`) |
-| `cloudflare` (default `pnpm run build` / `cf:build`) | `@cloudflare/vite-plugin` → workerd bundle | Cloudflare Workers | workerd built-in binding |
+| `cloudflare` (default `pnpm run build`) | `@cloudflare/vite-plugin` → workerd bundle | Cloudflare Workers | workerd built-in binding |
 
 ### The contract (enforced by test)
 
@@ -129,24 +129,28 @@ from the shim first.
 
 | Platform | Build Command | Entry Point |
 |----------|--------------|-------------|
-| **Docker** | `docker build` | `.next/standalone/server.js` |
-| **Cloudflare** | `pnpm run cf:build` | `.open-next/worker.js` |
+| **Docker** | `pnpm run build:node:ci` | `.output/server/index.mjs` (Nitro `node-server`) |
+| **Cloudflare** | `pnpm run build:production` (or `build:preview`) | workerd bundle via `@cloudflare/vite-plugin` |
 
-Both use `next build` with `output: 'standalone'` in `next.config.ts`.
+Both build from the same TanStack Start + Vite pipeline; there is no Next.js
+build step and no `output: 'standalone'` config.
 
 ## Unified Cloudflare Deploy (CI + Local)
 
-The same script deploys from both CI and local:
+The same script deploys from both CI and local (run inside `apps/dashboard`):
 
 ```bash
 pnpm run cf:deploy
 ```
 
-This runs `scripts/cloudflare-deploy.ts` which executes:
+This is `pnpm run build:production && bun scripts/patch-wrangler-env.ts && wrangler deploy --minify`, i.e.:
 
-1. `pnpm run cf:build` — Next.js build + OpenNext transform
-2. `wrangler deploy --minify` — Deploy to Workers
-3. `opennextjs-cloudflare populateCache remote` — Populate KV cache
+1. `pnpm run build:production` — vite build (Cloudflare target) + `tsc --noEmit`
+2. `bun scripts/patch-wrangler-env.ts` — injects Worker runtime `[vars]` from `.env.production` (+ `.env.preview` overlay)
+3. `wrangler deploy --minify` — deploy to Workers
+
+No OpenNext transform, no KV/R2/D1 cache population step — the TanStack Start
+build produces a native Workers bundle directly.
 
 **Auth priority**:
 1. `CLOUDFLARE_API_TOKEN` env var (set in `.env.production.local` or CI secrets)
@@ -156,16 +160,14 @@ This runs `scripts/cloudflare-deploy.ts` which executes:
 
 ```bash
 pnpm run cf:config    # Set secrets from .env.production.local
-pnpm run cf:build     # Build + OpenNext transform
-wrangler deploy --minify
-opennextjs-cloudflare populateCache remote
+pnpm run cf:deploy    # build:production -> patch-wrangler-env.ts -> wrangler deploy --minify
 ```
 
 ### CI
 
-Production deploys on push to `main` via `.github/workflows/cloudflare.yml`. It uses
-the same `pnpm run cf:build` command and the same env var names — secrets come
-from GitHub Secrets instead of local files.
+Production deploys on push to `main` via `.github/workflows/cloudflare.yml`. It
+runs `build:production` (main) / `build:preview` (PRs) and the same env var
+names — secrets come from GitHub Secrets instead of local files.
 
 ## Unified per-Worker deploy (`scripts/deploy-worker.ts`)
 
@@ -222,7 +224,7 @@ docker run -d -p 3000:3000 \
 ### Multi-stage Build
 
 1. **deps**: `pnpm install --frozen-lockfile`
-2. **builder**: `pnpm run build` → `.next/standalone/`
+2. **builder**: `pnpm run build:node:ci` → `.output/`
 3. **runner**: Production image with only necessary files
 
 ### Environment Variables
@@ -242,13 +244,11 @@ pnpm run docker:health
 
 ## Cloudflare Environment Configuration
 
-**Non-sensitive** (`wrangler.toml` `[vars]`):
-```toml
-CLICKHOUSE_HOST = "https://your-host.com"
-CLICKHOUSE_USER = "default"
-CLICKHOUSE_MAX_EXECUTION_TIME = "60"
-CLOUDFLARE_WORKERS = "1"
-```
+`wrangler.toml` declares **no** `[vars]` block (see "Never re-add a `[vars]`
+block to `wrangler.toml`" above). Non-secret config for the hosted product
+lives only in the committed `apps/dashboard/.env.production` (+ `.env.preview`
+overlay); `scripts/patch-wrangler-env.ts` injects it as Worker runtime vars at
+deploy time. To change a value, edit `.env.production`, not `wrangler.toml`.
 
 **Secrets** (set via `pnpm run cf:config` or manually):
 ```bash
@@ -259,10 +259,10 @@ wrangler secret put CLICKHOUSE_PASSWORD
 
 | Resource | Binding | Purpose |
 |----------|---------|---------|
-| R2 Bucket | `NEXT_INC_CACHE_R2_BUCKET` | Incremental static cache |
-| D1 Database | `NEXT_TAG_CACHE_D1` | Tag cache |
-| KV Namespace | `NEXT_INC_CACHE_KV` | Incremental cache |
-| Durable Objects | `NEXT_CACHE_DO_QUEUE` | Cache queue handler |
+| D1 Database | `CHM_CLOUD_D1` | AI agent conversations + per-user connections + billing |
+| KV Namespace | `CHM_DASHBOARD_QUERY_KV` | `/api/v1/data` dashboard-query allowlist cache |
+| KV Namespace | `CHM_VERSION_CACHE_KV` | Version + table-existence L2 cache |
+| Durable Objects | `AgentConversationDurableObject` | AI agent conversation state |
 
 ### Health Check
 
@@ -324,9 +324,9 @@ then `preview-chmonitor-landing` claims it. The two new subdomains
 (`preview.dash`, `preview.docs`) have no prior holder, so they provision cleanly.
 
 **`cloud.chmonitor.dev` → `dash.chmonitor.dev` 301** is a Cloudflare edge
-**Redirect Rule**, NOT Next.js middleware. `middleware.ts` cannot redirect the
-prerendered static root: OpenNext serves `/` as an asset without invoking the
-worker, so the host-redirect code never runs. A zone Redirect Rule fires at the
+**Redirect Rule**, not app-level routing code. TanStack Start prerenders `/` as
+a static asset, so it is served without invoking the worker — any host-redirect
+logic in a route handler would never run. A zone Redirect Rule fires at the
 edge *before* the worker, covering every path uniformly. Provision/refresh it
 (idempotent) with a `CLOUDFLARE_API_TOKEN` scoped to **Zone › Single Redirect ›
 Edit** (manages the rule) **and Zone › Zone › Read** (the script resolves the
@@ -343,7 +343,6 @@ pnpm run cf:redirect-rule --dry-run  # preview the ruleset payload
 |-------|----------|
 | Docker connection errors | Check ClickHouse accessibility and docker-compose depends_on |
 | `__name is not defined` (CF) | `wrangler.toml` has `keep_names = false` |
-| Build lock error | Remove `.next/lock` and retry |
 | Secrets not updating | See [secret-rotation.md](secret-rotation.md) — redeploy after updating |
 | `/api/mcp` → 503 "MCP API key auth is not configured" | `CHM_API_KEY_SECRET` empty on `chmonitor-mcp`. Worker secrets don't survive a rename. Set the GitHub secret (`pnpm run gh:sync-secrets`) and redeploy; CI pushes it to both workers. |
-| `cloud.chmonitor.dev` returns 200 instead of 301 | Edge Redirect Rule missing — run `pnpm run cf:redirect-rule`. Middleware can't fix this (prerendered root skips the worker). |
+| `cloud.chmonitor.dev` returns 200 instead of 301 | Edge Redirect Rule missing — run `pnpm run cf:redirect-rule`. App-level routing can't fix this (prerendered root skips the worker). |

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!**/*.test.ts", "!**/__tests__/**"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**", ".open-next/**"]
+      "outputs": ["dist/**"]
     },
     "type-check": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Summary
- `docs/knowledge/deployment.md`: purge stale Next.js/OpenNext build steps and the `wrangler.toml [vars]` example; describe the actual `cf:deploy` pipeline (vite build → `patch-wrangler-env.ts` → `wrangler deploy`) and the current D1/KV/DO bindings
- `docs/knowledge/cloud-hooks-worker.md`: the `*/15 * * * *` cron is the intended cadence but is currently NOT attached (account is over the Workers Free cron budget); points at `wrangler.toml` + `src/cron.test.ts` as the enforcing sources so a future reader doesn't "fix" the missing trigger
- `turbo.json`: drop dead `.next/**` / `.open-next/**` build outputs
- `apps/dashboard/.env.example`: fix `LLM_MODEL` to `anyrouter:anyrouter/free` (matching `.env.production`'s `provider:model` format) instead of the bare `anyrouter/free` form that fell through `parseModelId` into the `legacy` branch; added tests pinning both the `.env.production` and `.env.preview` values

Fixes #2892
Fixes #2895
Fixes #2908
Fixes #2909

## Test plan
- [x] `rg -n "open-next|OpenNext|\.next/|cf:build" docs/knowledge/deployment.md` — only the explicitly-labelled historical note and the "No OpenNext…" negation line remain
- [x] No section instructs adding a `wrangler.toml [vars]` block
- [x] Every command referenced exists in the relevant `package.json`
- [x] `cd apps/cloud-hooks && bun test src/cron.test.ts` passes
- [x] `turbo.json` validated as JSON
- [x] `cd apps/dashboard && bun test src/lib/ai/__tests__/providers.test.ts` passes (28/28), including new tests for `.env.production`/`.env.preview` `LLM_MODEL` values
