### PR TITLE
fix: cluster-topology stale counter, sub-1 unit formatting, insights wording

### DIFF
--- a/apps/dashboard/src/components/cluster-topology/topology-view.tsx
+++ b/apps/dashboard/src/components/cluster-topology/topology-view.tsx
@@ -195,9 +195,10 @@ export function TopologyView({
       ? activeCluster
       : null
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset the "updated Ns ago" counter whenever fresh data arrives, not on every render
   useEffect(() => {
     setSecsAgo(0)
-  }, [])
+  }, [topology, liveRow])
   useEffect(() => {
     const t = setInterval(() => setSecsAgo((s) => s + 1), 1000)
     return () => clearInterval(t)

--- a/apps/dashboard/src/lib/insights/operational-checks.test.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.test.ts
@@ -99,14 +99,22 @@ describe('checkLongRunningQuery', () => {
     ).toBe('critical')
   })
 
-  test('a second concurrent long query is mentioned in the detail', () => {
-    expect(checkLongRunningQuery(LONG_QUERY_WARN_SECONDS, 3)?.detail).toContain(
-      '3 queries over a minute'
+  test('other concurrent long queries are mentioned in the detail, excluding the headline query', () => {
+    expect(checkLongRunningQuery(720, 3)?.detail).toContain(
+      '2 other queries over 5m'
     )
-    // A single long query does not tack on the "(N queries...)" clause.
+  })
+
+  test('a single other long query uses the singular noun', () => {
+    expect(checkLongRunningQuery(720, 2)?.detail).toContain(
+      '1 other query over 5m'
+    )
+  })
+
+  test('a lone long query does not tack on the "(N other...)" clause', () => {
     expect(
       checkLongRunningQuery(LONG_QUERY_WARN_SECONDS, 1)?.detail
-    ).not.toContain('queries over a minute')
+    ).not.toContain('other quer')
   })
 })
 

--- a/apps/dashboard/src/lib/insights/operational-checks.ts
+++ b/apps/dashboard/src/lib/insights/operational-checks.ts
@@ -86,14 +86,14 @@ export function checkLongRunningQuery(
     maxElapsedSeconds < LONG_QUERY_WARN_SECONDS
   )
     return null
-  const others = Number.isFinite(count) && count > 1 ? count : 0
+  const additional = Number.isFinite(count) && count > 1 ? count - 1 : 0
   return {
     severity:
       maxElapsedSeconds >= LONG_QUERY_CRITICAL_SECONDS ? 'critical' : 'warning',
     category: 'performance',
     metric: 'longest_running_query',
     title: `A query has been running for ${formatDuration(maxElapsedSeconds)}`,
-    detail: `The longest live query has been running for ${formatDuration(maxElapsedSeconds)}${others ? ` (${others} queries over a minute)` : ''}. Long-running queries hold locks and memory — check for a runaway scan or a missing filter, and cancel it if it is stuck.`,
+    detail: `The longest live query has been running for ${formatDuration(maxElapsedSeconds)}${additional ? ` (${additional} other quer${additional > 1 ? 'ies' : 'y'} over ${formatDuration(LONG_QUERY_WARN_SECONDS)})` : ''}. Long-running queries hold locks and memory — check for a runaway scan or a missing filter, and cancel it if it is stuck.`,
     value: Math.round(maxElapsedSeconds),
     action: { label: 'Open running queries', href: '/running-queries' },
   }

--- a/apps/dashboard/src/lib/utils.test.ts
+++ b/apps/dashboard/src/lib/utils.test.ts
@@ -76,6 +76,11 @@ describe('formatBytes', () => {
   test('caps at the largest unit', () => {
     expect(formatBytes(1024 ** 6)).toContain('PB')
   })
+
+  test('clamps the low end for values between 0 and 1', () => {
+    expect(formatBytes(0.5)).toBe('0.5 B')
+    expect(formatBytes(0.001)).toBe('0.0 B')
+  })
 })
 
 describe('formatPercentage', () => {
@@ -100,6 +105,10 @@ describe('formatCount', () => {
     expect(formatCount(1500)).toBe('1.5K')
     expect(formatCount(2_000_000)).toBe('2.0M')
     expect(formatCount(3_000_000_000)).toBe('3.0B')
+  })
+
+  test('clamps the low end for values between 0 and 1', () => {
+    expect(formatCount(0.5)).toBe('0.5')
   })
 })
 

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -31,7 +31,7 @@ export function formatBytes(bytes: number): string {
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
   const i = Math.floor(Math.log(bytes) / Math.log(k))
-  const safeIndex = Math.min(i, sizes.length - 1)
+  const safeIndex = Math.min(Math.max(i, 0), sizes.length - 1)
   return `${(bytes / k ** safeIndex).toFixed(1)} ${sizes[safeIndex]}`
 }
 
@@ -45,7 +45,7 @@ export function formatCount(count: number): string {
   if (count < 1000) return count.toString()
   const units = ['', 'K', 'M', 'B', 'T']
   const unitIndex = Math.floor(Math.log(count) / Math.log(1000))
-  const safeUnitIndex = Math.min(unitIndex, units.length - 1)
+  const safeUnitIndex = Math.min(Math.max(unitIndex, 0), units.length - 1)
   return `${(count / 1000 ** safeUnitIndex).toFixed(1)}${units[safeUnitIndex]}`
 }
 


### PR DESCRIPTION
## Summary
- `topology-view.tsx`: the "updated Ns ago" label reset effect had an empty dependency array, so it only ran once on mount — the ticker climbed forever regardless of real refreshes. Now resets on `[topology, liveRow]`, which cover both the ~60s server-refreshed topology and the fast-tick live snapshot (and the manual Refresh button, since it updates the same data).
- `lib/utils.ts`: `formatBytes`/`formatCount` clamped their unit index only at the top (`Math.min`), not the bottom. For `0 < bytes < 1`, `Math.log(bytes)` is negative, producing `sizes[-1]` → `undefined`. Now clamps both ends (`Math.min(Math.max(i, 0), ...)`).
- `lib/insights/operational-checks.ts`: `checkLongRunningQuery`'s detail text said "queries over a minute" but the actual threshold is `LONG_QUERY_WARN_SECONDS` (5 minutes), and it counted the headline query itself in the parenthetical. Now derives the wording from the threshold constant and reports queries *additional* to the one already named.

## Test plan
- [x] `bun test src/lib/utils.test.ts src/lib/insights/operational-checks.test.ts` — 48 pass
- [x] `pnpm run lint` — clean (2 pre-existing unrelated warnings)
- [ ] CI `dashboard` check covers build/typecheck

Fixes #2911
Fixes #2915
Fixes #2916