### PR TITLE
fix(billing): count org seats from Clerk totalCount; document AnyRouter pricing units

### DIFF
--- a/apps/dashboard/src/lib/ai/__tests__/anyrouter-dynamic-models.test.ts
+++ b/apps/dashboard/src/lib/ai/__tests__/anyrouter-dynamic-models.test.ts
@@ -506,3 +506,69 @@ describe('models endpoint merge simulation', () => {
     expect(merged).toEqual(staticModels)
   })
 })
+
+/**
+ * Pricing-unit regression pins (issue #2914).
+ *
+ * AnyRouter reports EVERY `pricing` field in USD per MILLION tokens — the
+ * OpenRouter-style `prompt`/`completion` strings are a same-unit mirror of
+ * `input_per_1m`/`output_per_1m`, NOT per-token values. Verified 2026-08-12
+ * against `GET https://anyrouter.dev/api/v1/models`: all 188 catalog entries
+ * carry `input_per_1m`, and `Number(prompt) === input_per_1m` for every one
+ * (e.g. `alibaba/qwen3-max` → `prompt: "0.78"`, `input_per_1m: 0.78`).
+ *
+ * These tests exist to stop a future "fix" from multiplying the string branch
+ * by 1e6, which would over-report every price by a million.
+ */
+describe('anyrouter pricing units', () => {
+  function pricingOf(pricing: AnyRouterModelListItem['pricing']) {
+    const ranked = rankModelsByUsage(
+      [{ model: model({ id: 'vendor/priced', pricing }), requestCount: 1 }],
+      1
+    )
+    return ranked[0]
+  }
+
+  test('string prompt/completion are read as per-million, not per-token', () => {
+    // Real shape from the live catalog (alibaba/qwen3-max).
+    const entry = pricingOf({ prompt: '0.78', completion: '3.9' })
+    expect(entry?.pricing).toEqual({
+      inputPerMillion: 0.78,
+      outputPerMillion: 3.9,
+    })
+  })
+
+  test('numeric input_per_1m/output_per_1m are unchanged', () => {
+    const entry = pricingOf({ input_per_1m: 2.5, output_per_1m: 10 })
+    expect(entry?.pricing).toEqual({
+      inputPerMillion: 2.5,
+      outputPerMillion: 10,
+    })
+  })
+
+  test('both shapes agree when the catalog sends both (same unit)', () => {
+    const stringOnly = pricingOf({ prompt: '0.78', completion: '3.9' })
+    const both = pricingOf({
+      prompt: '0.78',
+      completion: '3.9',
+      input_per_1m: 0.78,
+      output_per_1m: 3.9,
+    })
+    expect(both?.pricing).toEqual(stringOnly?.pricing as never)
+  })
+
+  test('zero/zero omits pricing and marks the model free, in either shape', () => {
+    const asStrings = pricingOf({ prompt: '0', completion: '0' })
+    expect(asStrings?.pricing).toBeUndefined()
+    expect(asStrings?.isFree).toBe(true)
+
+    const asNumbers = pricingOf({ input_per_1m: 0, output_per_1m: 0 })
+    expect(asNumbers?.pricing).toBeUndefined()
+    expect(asNumbers?.isFree).toBe(true)
+  })
+
+  test('unparseable pricing yields no pricing rather than NaN', () => {
+    const entry = pricingOf({ prompt: 'n/a', completion: 'n/a' })
+    expect(entry?.pricing).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
+++ b/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
@@ -6,6 +6,15 @@
  * - `GET {base}/models` returns `{ data: AnyRouterModelListItem[] }`. Query
  *   params like `sort=usage` / `order=usage` are **not** supported — the list
  *   order is the same catalog order regardless.
+ * - **Pricing units (re-verified 2026-08-12):** every `pricing` field is USD
+ *   **per million tokens** — the OpenRouter-style `prompt`/`completion`
+ *   strings are NOT per-token here. Across all 188 catalog entries,
+ *   `Number(prompt) === input_per_1m` and `Number(completion) === output_per_1m`
+ *   exactly (e.g. `alibaba/qwen3-max` → `prompt: "0.78"`, `input_per_1m: 0.78`),
+ *   and every entry carries `input_per_1m`, so the string fields are a
+ *   same-unit mirror rather than a differently-scaled fallback. Do NOT add a
+ *   `* 1_000_000` conversion to the fallback branch of `readPricePair` — that
+ *   would over-report prices by 1e6.
  * - Per-model usage lives at `GET {base}/models/{id}/metrics` → field
  *   `request_count` (and success/error/latency stats). Router aliases
  *   (`anyrouter/agent`, `anyrouter/free`, …) often 404 metrics; rank real
@@ -42,10 +51,19 @@ export interface AnyRouterModelListItem {
   capabilities?: string[]
   supported_parameters?: string[]
   category?: string
+  /**
+   * All four fields are USD **per million tokens** (see the pricing-units note
+   * in the module header). `prompt`/`completion` are the OpenRouter-shaped
+   * string mirrors of `input_per_1m`/`output_per_1m`, in the same unit.
+   */
   pricing?: {
+    /** USD per 1M input tokens, as a string (mirrors `input_per_1m`). */
     prompt?: string | number
+    /** USD per 1M output tokens, as a string (mirrors `output_per_1m`). */
     completion?: string | number
+    /** USD per 1M input tokens. */
     input_per_1m?: number
+    /** USD per 1M output tokens. */
     output_per_1m?: number
   }
   architecture?: {

--- a/apps/dashboard/src/lib/billing/owner-usage.test.ts
+++ b/apps/dashboard/src/lib/billing/owner-usage.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Seat-count resolution tests (issue #2912).
+ *
+ * `resolveSeatsUsed` is internal, so these drive it through the public
+ * `resolveOwnerUsage`. Clerk's membership list is PAGINATED: counting the
+ * returned page pinned every org at the page size (100). We must read the
+ * server-provided `totalCount` instead, while keeping the fail-safe that a
+ * Clerk error degrades to 1 seat (under-count, never a wrong over-limit).
+ */
+
+import type { BillingOwner } from './billing-owner'
+
+import { describe, expect, mock, test } from 'bun:test'
+
+interface MembershipPage {
+  data: unknown[]
+  totalCount?: number
+}
+
+/** Swapped per test; defaults to a healthy 1-member org. */
+let membershipListImpl: (args: {
+  organizationId: string
+  limit: number
+}) => Promise<MembershipPage> = async () => ({ data: [{}], totalCount: 1 })
+
+/** Records every call so we can assert the common path stays a single request. */
+const membershipCalls: Array<{ organizationId: string; limit: number }> = []
+
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  clerkClient: () => ({
+    organizations: {
+      getOrganizationMembershipList: (args: {
+        organizationId: string
+        limit: number
+      }) => {
+        membershipCalls.push(args)
+        return membershipListImpl(args)
+      },
+    },
+  }),
+}))
+
+// The other metered dimensions are irrelevant here — stub them so the test is
+// deterministic and never touches D1 / ClickHouse.
+mock.module('./user-subscription', () => ({
+  getPlanForOwner: async () => ({ id: 'team', name: 'Team' }),
+}))
+mock.module('./ai-usage-store', () => ({
+  getAiUsageToday: async () => 0,
+  getAiSpendThisMonth: async () => 0,
+}))
+mock.module('./host-usage-store', () => ({
+  getHostOverageThisMonth: async () => 0,
+}))
+mock.module('./org-host-count', () => ({
+  countOwnerHosts: async () => ({ count: 0 }),
+}))
+mock.module('@/lib/connection-store/resolve-store', () => ({
+  resolveConnectionStore: async () => ({ list: async () => [] }),
+}))
+
+const { resolveOwnerUsage } = await import('./owner-usage')
+
+const ORG: BillingOwner = { type: 'org', id: 'org_big' }
+
+/** A page of `n` placeholder memberships (Clerk caps this at `limit`). */
+function page(n: number): unknown[] {
+  return Array.from({ length: n }, () => ({}))
+}
+
+async function seatsFor(owner: BillingOwner): Promise<number> {
+  membershipCalls.length = 0
+  const usage = await resolveOwnerUsage(owner, 'user_actor')
+  return usage.seatsUsed
+}
+
+describe('resolveOwnerUsage — seats', () => {
+  test('a 250-member org reports 250, not the 100-row page length', async () => {
+    // Clerk returns at most `limit` rows but always the true remote total.
+    membershipListImpl = async ({ limit }) => ({
+      data: page(Math.min(250, limit)),
+      totalCount: 250,
+    })
+    expect(await seatsFor(ORG)).toBe(250)
+  })
+
+  test('counts seats with a single Clerk call (no per-page fan-out)', async () => {
+    membershipListImpl = async ({ limit }) => ({
+      data: page(Math.min(250, limit)),
+      totalCount: 250,
+    })
+    await seatsFor(ORG)
+    expect(membershipCalls).toHaveLength(1)
+  })
+
+  test('a small org is unaffected', async () => {
+    membershipListImpl = async () => ({ data: page(7), totalCount: 7 })
+    expect(await seatsFor(ORG)).toBe(7)
+  })
+
+  test('a Clerk failure degrades to 1 seat rather than throwing', async () => {
+    membershipListImpl = async () => {
+      throw new Error('clerk 503')
+    }
+    expect(await seatsFor(ORG)).toBe(1)
+  })
+
+  test('a missing totalCount falls back to the page length, not to 1', async () => {
+    // Guards the older-SDK path: degrade to previous behaviour, not to the
+    // 1-seat fail-safe.
+    membershipListImpl = async () => ({ data: page(42) })
+    expect(await seatsFor(ORG)).toBe(42)
+  })
+
+  test('a zero/absent membership count still fail-safes to 1 seat', async () => {
+    membershipListImpl = async () => ({ data: [], totalCount: 0 })
+    expect(await seatsFor(ORG)).toBe(1)
+  })
+
+  test('a user-scoped owner is always 1 seat and never calls Clerk', async () => {
+    membershipListImpl = async () => ({ data: page(99), totalCount: 99 })
+    expect(await seatsFor({ type: 'user', id: 'user_actor' })).toBe(1)
+    expect(membershipCalls).toHaveLength(0)
+  })
+})

--- a/apps/dashboard/src/lib/billing/owner-usage.ts
+++ b/apps/dashboard/src/lib/billing/owner-usage.ts
@@ -50,6 +50,14 @@ async function resolveHostsUsed(
  * Seats consumed. A user-scoped (free) owner is always a single seat; an org
  * owner counts its current Clerk members. Fail-safe to 1 so a Clerk hiccup can
  * only under-count (never wrongly show an over-limit meter).
+ *
+ * Reads Clerk's server-provided `totalCount` rather than the length of the
+ * returned page: the membership list is paginated, so counting `data` capped
+ * the meter at the page size (100) for every larger org. `totalCount` is the
+ * remote total, so this stays ONE API call regardless of org size. The page
+ * length remains as a fallback for the (typed-impossible, but cheap to guard)
+ * case of a missing `totalCount`, which degrades to today's behaviour instead
+ * of to the 1-seat fail-safe.
  */
 async function resolveSeatsUsed(owner: BillingOwner): Promise<number> {
   if (owner.type !== 'org') return 1
@@ -60,6 +68,10 @@ async function resolveSeatsUsed(owner: BillingOwner): Promise<number> {
         organizationId: owner.id,
         limit: 100,
       })
+    const total = memberships.totalCount
+    if (typeof total === 'number' && Number.isFinite(total) && total > 0) {
+      return total
+    }
     return memberships.data.length || 1
   } catch {
     return 1


### PR DESCRIPTION
Fixes #2912
Fixes #2914

Two money-adjacent reports, investigated end-to-end. One was a real defect and is fixed; the other's premise was disproven against the live API, so it is resolved by documentation + regression tests instead of a behaviour change.

---

## #2912 — org seat count capped at 100 (real defect, fixed)

**Reproduced by reading the data flow.** `resolveSeatsUsed` (`lib/billing/owner-usage.ts`) called Clerk's `getOrganizationMembershipList({ organizationId, limit: 100 })` and returned `memberships.data.length || 1`. That list is paginated, so `data` is capped at `limit`. Any org with more than 100 members returned exactly 100, with no pagination loop and no read of the total.

**Fix.** Read Clerk's server-provided `totalCount` instead of the page length. Verified against the installed SDK rather than assumed — `@clerk/backend@3.10`, `dist/api/resources/Deserializer.d.ts`:

```ts
export type PaginatedResourceResponse<T> = ResourceResponse<T> & {
    /** The total count of data that exist remotely. */
    totalCount: number;
}
```

`getOrganizationMembershipList` returns `Promise<PaginatedResourceResponse<OrganizationMembership[]>>`, so `totalCount` is present and typed — no cast needed. This keeps the common path at **one** API call regardless of org size (no unbounded pagination on every usage read).

Two deliberate choices on the degradation paths:

- **`limit: 100` is kept**, not dropped to `limit: 1`. `totalCount` is the value actually read, so the limit no longer affects correctness — but if `totalCount` were ever absent, the page-length fallback then degrades to *today's* behaviour (correct up to 100) rather than to the 1-seat fail-safe. With `limit: 1` that fallback would be strictly worse than the status quo.
- **The `catch → 1` fail-safe is unchanged**, preserving the module's documented invariant that a Clerk hiccup can only *under*-count and never wrongly show an over-limit meter.

**Blast radius — narrower than the issue states, and worth correcting.** The issue says seat overage is "under-billed". It is not: `seatsUsed` reaches only two consumers (`grep`-verified) —

- `routes/api/v1/billing/usage.ts` → `checkSeatLimit(plan, seatsUsed)` for the usage meter, and
- `routes/api/v1/billing/can-downgrade.ts` → the same check against a target plan.

Seats are a **flat plan-included cap**, not a metered quantity: `packages/pricing/src/plans.ts` sets Free 1, Pro 3, Team/Max 10, Enterprise `null` (unlimited). Nothing multiplies a seat count into an invoice, and no Polar path reads it. So the accurate impact is:

- **Customer-facing meter is wrong** for >100-member orgs (shows "100 seats used" for a 250-member org) — the real, user-visible bug.
- **Entitlement gating is unchanged in practice.** Because every finite cap is ≤10, a >100-member org already fails the check at 100 just as it does at 250; and Enterprise's `null` cap passes either way. There is no plan where 100 passes and 250 fails.
- **No billing impact.** No under-billing, no revenue leak.

Nothing in the webhook signature verification, the monotonic guard, or plan resolution was touched.

**Tests** (`lib/billing/owner-usage.test.ts`, new) drive the internal resolver through the public `resolveOwnerUsage`, following the `mock.module` pattern already used in `org-host-count.test.ts`. The 250-member mock honours `limit` when building its page, so it returns a 100-row page with `totalCount: 250` — meaning these tests genuinely fail against the old `data.length` code. Cases: 250-member org → 250; single Clerk call; small org unaffected; Clerk throws → 1; missing `totalCount` → page length (not 1); zero members → 1; user owner → 1 with no Clerk call.

---

## #2914 — AnyRouter per-token pricing (premise disproven, no behaviour change)

The issue's own step 1 asks to confirm the unit against the live API before converting. I did, and **the per-token premise does not hold.** `GET https://anyrouter.dev/api/v1/models`, 2026-08-12:

```
alibaba/qwen3-max        {"prompt": "0.78", "completion": "3.9", "input_per_1m": 0.78, "output_per_1m": 3.9}
google/gemini-3-flash    {"prompt": "0.5",  "completion": "3",   "input_per_1m": 0.5,  "output_per_1m": 3}
```

Whole-catalog check: `models total 188 | missing input_per_1m: 0 | prompt != input_per_1m: 0`.

So `Number(prompt) === input_per_1m` for all 188 entries — the OpenRouter-style strings are a **same-unit mirror**, per-million, not per-token. `$0.78/M` for qwen3-max is a plausible price; read as per-token it would be $780,000/M, which is the tell. Additionally *every* entry carries `input_per_1m`, so `readPricePair`'s string branch is a defensive path that never runs against the live catalog. Applying the proposed `* 1_000_000` would have **over**-reported every price by a million — i.e. the "fix" was the more dangerous change.

Per the issue's final acceptance criterion ("If step 1 shows AnyRouter returns per-million in `prompt`/`completion`, close this issue with that evidence and add the unit to the field docs instead"), this PR takes the docs route:

- Module header gains a dated pricing-units note recording the verification and an explicit "do NOT add a `* 1_000_000` conversion" warning.
- Every `pricing` field in `AnyRouterModelListItem` is annotated with its unit, so the two branches can't be re-mixed.
- Regression tests pin both shapes at the same-unit interpretation, so a future reader of #2914 cannot silently reintroduce the multiply. (The live-API check is a point-in-time snapshot; the tests + docs are what make the interpretation durable.)

**Blast radius, had it been real: display only.** `inputPerMillion` flows to the agent model-picker label (`agent-model-picker.tsx`) and to `isListedAsFree` (unaffected either way — 0 is 0 in any unit). `MODEL_PRICING` in `lib/ai/agent/analytics.ts` is a **separate** hardcoded per-million table, already correctly documented and not fed by the AnyRouter catalog. **Nothing bills from either** — verified there is no AI-spend or cost path reading these values; `estimateCost` output is presentational.

Evidence also posted on the issue: https://github.com/chmonitor/chmonitor/issues/2914#issuecomment-5257812819

---

## Verification

- `bun test src/lib/billing/owner-usage.test.ts src/lib/ai/__tests__/anyrouter-dynamic-models.test.ts` → **35 pass, 0 fail**
- `pnpm run lint` → no errors (2 pre-existing warnings in unrelated cluster-topology components)
- Build left to CI.

Co-Authored-By: duyetbot <bot@duyet.net>
