### PR TITLE
refactor(clickhouse-client): split the fetchData funnel into testable modules

### DIFF
--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-fetch.test.ts
@@ -103,11 +103,7 @@ afterAll(() => {
 // Dynamic import ensures mocks are in place before the module loads.
 // The cache-busting query keeps this test isolated from earlier module loads
 // in Bun's shared test process.
-const {
-  __testCountJsonEachRowRows,
-  fetchData,
-  fetchJsonEachRowAsNormalizedJson,
-} = await import(
+const { fetchData, fetchJsonEachRowAsNormalizedJson } = await import(
   new URL('../clickhouse-fetch.ts?test=clickhouse-fetch', import.meta.url).href
 )
 
@@ -702,13 +698,6 @@ describe('clickhouse-fetch', () => {
       )
       expect(result.metadata.rows).toBe(2)
       expect(result.metadata.rawResponseLength).toBeGreaterThan(0)
-    })
-
-    it('counts JSONEachRow rows without allocating line arrays', () => {
-      expect(__testCountJsonEachRowRows('')).toBe(0)
-      expect(__testCountJsonEachRowRows('\n  \n\t\n')).toBe(0)
-      expect(__testCountJsonEachRowRows('{"a":1}\n{"a":2}\n')).toBe(2)
-      expect(__testCountJsonEachRowRows('{"a":1}\n\n{"a":2}')).toBe(2)
     })
 
     it('executes the version-selected sql from a versioned queryConfig.sql[], not the raw query arg', async () => {

--- a/packages/clickhouse-client/src/clickhouse/__tests__/fetch-headers.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/fetch-headers.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for clickhouse/fetch-headers.ts — pure parsers, no mocks needed.
+ */
+
+import {
+  countJsonEachRowRows,
+  parseReadBytesFromHeaders,
+  parseRowsBeforeLimitFromHeaders,
+} from '../fetch-headers'
+import { describe, expect, it } from 'bun:test'
+
+describe('parseReadBytesFromHeaders', () => {
+  it('parses read_bytes from the summary header', () => {
+    expect(
+      parseReadBytesFromHeaders({
+        'x-clickhouse-summary': '{"read_bytes":"1024","read_rows":"7"}',
+      })
+    ).toBe(1024)
+  })
+
+  it('uses the first value when the header repeats', () => {
+    expect(
+      parseReadBytesFromHeaders({
+        'x-clickhouse-summary': ['{"read_bytes":"5"}', '{"read_bytes":"9"}'],
+      })
+    ).toBe(5)
+  })
+
+  it('returns undefined when headers are missing entirely', () => {
+    expect(parseReadBytesFromHeaders(undefined)).toBeUndefined()
+    expect(parseReadBytesFromHeaders({})).toBeUndefined()
+    expect(
+      parseReadBytesFromHeaders({ 'x-clickhouse-summary': undefined })
+    ).toBeUndefined()
+    expect(parseReadBytesFromHeaders({ 'x-clickhouse-summary': '' })).toBe(
+      undefined
+    )
+  })
+
+  it('returns undefined for malformed JSON or non-numeric values', () => {
+    expect(
+      parseReadBytesFromHeaders({ 'x-clickhouse-summary': 'not-json' })
+    ).toBeUndefined()
+    expect(
+      parseReadBytesFromHeaders({ 'x-clickhouse-summary': '{"read_bytes":' })
+    ).toBeUndefined()
+    expect(
+      parseReadBytesFromHeaders({
+        'x-clickhouse-summary': '{"read_bytes":"abc"}',
+      })
+    ).toBeUndefined()
+    expect(
+      parseReadBytesFromHeaders({ 'x-clickhouse-summary': '{"read_rows":"3"}' })
+    ).toBeUndefined()
+  })
+})
+
+describe('parseRowsBeforeLimitFromHeaders', () => {
+  it('parses rows_before_limit_at_least from the summary header', () => {
+    expect(
+      parseRowsBeforeLimitFromHeaders({
+        'x-clickhouse-summary': '{"rows_before_limit_at_least":"250"}',
+      })
+    ).toBe(250)
+  })
+
+  it('returns undefined when the field or header is absent', () => {
+    expect(parseRowsBeforeLimitFromHeaders(undefined)).toBeUndefined()
+    expect(
+      parseRowsBeforeLimitFromHeaders({
+        'x-clickhouse-summary': '{"read_bytes":"10"}',
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for malformed or non-numeric values', () => {
+    expect(
+      parseRowsBeforeLimitFromHeaders({ 'x-clickhouse-summary': '{oops' })
+    ).toBeUndefined()
+    expect(
+      parseRowsBeforeLimitFromHeaders({
+        'x-clickhouse-summary': '{"rows_before_limit_at_least":"many"}',
+      })
+    ).toBeUndefined()
+  })
+})
+
+describe('countJsonEachRowRows', () => {
+  it('counts non-empty lines without allocating line arrays', () => {
+    expect(countJsonEachRowRows('')).toBe(0)
+    expect(countJsonEachRowRows('\n  \n\t\n')).toBe(0)
+    expect(countJsonEachRowRows('{"a":1}\n{"a":2}\n')).toBe(2)
+    expect(countJsonEachRowRows('{"a":1}\n\n{"a":2}')).toBe(2)
+  })
+
+  it('handles CRLF line endings and a missing trailing newline', () => {
+    expect(countJsonEachRowRows('{"a":1}\r\n{"a":2}\r\n')).toBe(2)
+    expect(countJsonEachRowRows('{"a":1}')).toBe(1)
+  })
+})

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts
@@ -1,110 +1,37 @@
 /**
  * ClickHouse Data Fetching
  * Main fetchData function for executing queries with error handling
+ *
+ * The pieces of the funnel live in sibling modules so they can be tested in
+ * isolation:
+ * - `fetch-headers.ts` — response-header / JSONEachRow parsers (pure)
+ * - `fetch-request.ts` — host resolution, optional-table check, versioned SQL
+ * - `fetch-errors.ts` — error classification, logging, error-result shape
+ * - `fetch-normalize.ts` — `fetchJsonEachRowAsNormalizedJson`
  */
 
 import type { QueryParams } from '@clickhouse/client'
 
 import type { QueryConfigLike } from '@chm/sql-builder'
-import type { FetchDataErrorType, FetchDataResult } from './types'
+import type { FetchDataResult } from './types'
 
-import { getClickHouseVersion, selectVersionedSql } from '../clickhouse-version'
-import { validateTableExistence } from '../table-validator'
-import { transformClickHouseJsonEachRowWasmJson } from '../wasm/monitor-core'
 import { getClient, releaseClient } from './clickhouse-client'
-import { getClickHouseConfigs } from './clickhouse-config'
 import { QUERY_COMMENT } from './constants'
-import { debug, error, isDebugEnabled, warn } from '@chm/logger'
+import { handleFetchError } from './fetch-errors'
+import {
+  parseReadBytesFromHeaders,
+  parseRowsBeforeLimitFromHeaders,
+} from './fetch-headers'
+import {
+  checkOptionalTables,
+  resolveEffectiveQuery,
+  resolveHostConfig,
+} from './fetch-request'
+import { debug, isDebugEnabled } from '@chm/logger'
 
-type FetchJsonEachRowTextResult = FetchDataResult<never> & {
-  dataJson: string | null
-}
+export type { FetchJsonEachRowTextResult } from './fetch-normalize'
 
-/**
- * Parse `read_bytes` out of the `X-ClickHouse-Summary` response header (always
- * sent by the ClickHouse HTTP interface, regardless of format). Returns
- * `undefined` when the header is absent/unparseable — or when the result set
- * itself doesn't carry response_headers, e.g. in unit tests that stub a
- * minimal client — so callers only ever see a genuine value, never a guess.
- */
-function parseReadBytesFromHeaders(
-  headers: Record<string, string | string[] | undefined> | undefined
-): number | undefined {
-  const raw = headers?.['x-clickhouse-summary']
-  const text = Array.isArray(raw) ? raw[0] : raw
-  if (!text) return undefined
-
-  try {
-    const summary = JSON.parse(text) as { read_bytes?: string }
-    const bytes = summary.read_bytes ? Number(summary.read_bytes) : undefined
-    return bytes !== undefined && Number.isFinite(bytes) ? bytes : undefined
-  } catch {
-    return undefined
-  }
-}
-
-/**
- * Parse `rows_before_limit_at_least` out of the `X-ClickHouse-Summary`
- * response header (#2490). ClickHouse sets this when a query hits
- * `max_result_rows` with `result_overflow_mode: 'break'` (or a plain LIMIT) —
- * it reports how many rows existed before the cap/limit truncated the result.
- * Returns `undefined` when absent/unparseable, mirroring
- * `parseReadBytesFromHeaders`.
- */
-function parseRowsBeforeLimitFromHeaders(
-  headers: Record<string, string | string[] | undefined> | undefined
-): number | undefined {
-  const raw = headers?.['x-clickhouse-summary']
-  const text = Array.isArray(raw) ? raw[0] : raw
-  if (!text) return undefined
-
-  try {
-    const summary = JSON.parse(text) as {
-      rows_before_limit_at_least?: string
-    }
-    const value = summary.rows_before_limit_at_least
-      ? Number(summary.rows_before_limit_at_least)
-      : undefined
-    return value !== undefined && Number.isFinite(value) ? value : undefined
-  } catch {
-    return undefined
-  }
-}
-
-/**
- * Extract an HTTP status code (100–599) from a fetch error message.
- *
- * Strategy:
- * 1. Try a keyword-anchored match that handles:
- *    - "status: 500", "HTTP status 403", "HTTP error 502"
- *    - Standard HTTP status lines: "HTTP/1.1 500", "HTTP/2 502"
- * 2. If (1) fails AND the message also contains a ClickHouse "Code:" clause
- *    that sits at the start of a line or is unaccompanied by HTTP keywords,
- *    skip the generic digit scan to avoid misidentifying internal error codes.
- * 3. Otherwise fall back to a generic 3-digit match.
- */
-function extractHttpStatusCode(errorMessage: string): number | undefined {
-  // Keyword-anchored: matches "status 500", "HTTP status 403", "HTTP/1.1 500", "HTTP/2 502", etc.
-  const keywordMatch = errorMessage.match(
-    /\b(?:status|HTTP(?:\/\d+(?:\.\d+)?)?(?:\s+(?:status|error))?)\s*([1-5]\d{2})\b/i
-  )
-  if (keywordMatch) {
-    return parseInt(keywordMatch[1], 10)
-  }
-
-  // Skip generic digit scan when ClickHouse internal codes are present and no
-  // HTTP keyword was found above, to avoid false positives like "Code: 210".
-  if (errorMessage.includes('Code:')) {
-    return undefined
-  }
-
-  const genericMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
-  if (genericMatch) {
-    return parseInt(genericMatch[1], 10)
-  }
-
-  return undefined
-}
+export { fetchJsonEachRowAsNormalizedJson } from './fetch-normalize'
 
 /**
  * Fetch data from ClickHouse with comprehensive error handling
@@ -138,73 +65,18 @@ export const fetchData = async <
 }): Promise<FetchDataResult<T>> => {
   const start = new Date()
 
-  // Parse and validate hostId to prevent NaN
-  const currentHostId = Number(hostId)
-  if (Number.isNaN(currentHostId)) {
-    throw new Error(`Invalid hostId: ${hostId}. Must be a valid number.`)
+  const resolved = resolveHostConfig(hostId, {
+    label: '[fetchData]',
+    extraNoConfigLogs: [
+      '[fetchData] Make sure environment variables are loaded.',
+      '[fetchData] Check .env, .env.local, or deployment environment settings.',
+    ],
+  })
+  if (!resolved.ok) {
+    return { data: null, ...resolved.failure }
   }
 
-  const configs = getClickHouseConfigs()
-
-  // Check if any configs are available
-  if (configs.length === 0) {
-    const errorMessage =
-      'No ClickHouse hosts configured. Please set CLICKHOUSE_HOST environment variable.\n' +
-      'Example: CLICKHOUSE_HOST=http://localhost:8123\n' +
-      'See console logs for more details.'
-
-    error('[fetchData] No ClickHouse configurations available!')
-    error('[fetchData] Make sure environment variables are loaded.')
-    error(
-      '[fetchData] Check .env, .env.local, or deployment environment settings.'
-    )
-
-    return {
-      data: null,
-      metadata: {
-        queryId: '',
-        duration: 0,
-        rows: 0,
-        host: 'unknown',
-      },
-      error: {
-        type: 'validation_error',
-        message: errorMessage,
-        details: {
-          originalError: new Error(errorMessage),
-          host: 'unknown',
-        },
-      },
-    }
-  }
-
-  const clientConfig = configs[currentHostId]
-
-  // Check if clientConfig exists before using it
-  if (!clientConfig) {
-    const availableHosts = configs.map((c) => c.id).join(', ')
-    const errorMessage = `Invalid hostId: ${currentHostId}. Available hosts: ${availableHosts} (total: ${configs.length})`
-
-    error('[fetchData]', errorMessage)
-
-    return {
-      data: null,
-      metadata: {
-        queryId: '',
-        duration: 0,
-        rows: 0,
-        host: 'unknown',
-      },
-      error: {
-        type: 'validation_error',
-        message: errorMessage,
-        details: {
-          originalError: new Error(errorMessage),
-          host: 'unknown',
-        },
-      },
-    }
-  }
+  const { clientConfig, currentHostId } = resolved
 
   // When a default database is requested, scope the pooled client to it so
   // unqualified table names resolve against `database`. No-op otherwise, so
@@ -216,48 +88,14 @@ export const fetchData = async <
 
   try {
     // Perform table validation if queryConfig is provided and query is optional
-    if (queryConfig?.optional) {
-      const validation = await validateTableExistence(
-        queryConfig,
-        currentHostId
-      )
-
-      if (!validation.shouldProceed) {
-        const missingTables = validation.missingTables
-        // A probe failure (network/timeout/auth) means table existence is
-        // unknown, not confirmed missing — classify it as a network error so
-        // the UI shows a connectivity/retry message instead of "table does
-        // not exist" (issue #2505).
-        const isProbeFailure = validation.reason === 'probe_failed'
-        const errorMessage =
-          validation.error ||
-          `Missing required tables: ${missingTables.join(', ')}`
-
-        warn(
-          isProbeFailure
-            ? `Skipping query "${queryConfig.name}" — could not verify table availability:`
-            : `Skipping query "${queryConfig.name}" due to missing tables:`,
-          isProbeFailure ? errorMessage : missingTables
-        )
-
-        return {
-          data: null,
-          metadata: {
-            queryId: '',
-            duration: 0,
-            rows: 0,
-            host: clientConfig.host,
-          },
-          error: {
-            type: isProbeFailure ? 'network_error' : 'table_not_found',
-            message: errorMessage,
-            details: {
-              missingTables,
-              host: clientConfig.host,
-            },
-          },
-        }
-      }
+    const skipped = await checkOptionalTables({
+      queryConfig,
+      currentHostId,
+      host: clientConfig.host,
+      classifyProbeFailure: true,
+    })
+    if (skipped) {
+      return { data: null, ...skipped }
     }
 
     // getClient() defaults to the web client (web !== false) — fetch()-based,
@@ -269,34 +107,9 @@ export const fetchData = async <
 
     try {
       // Select version-appropriate query
-      let effectiveQuery = query
-      // Only fetch version when needed (prevents infinite recursion since
-      // getClickHouseVersion itself calls fetchData without queryConfig)
-      let clickhouseVersion: Awaited<ReturnType<typeof getClickHouseVersion>> =
-        null
-
-      if (queryConfig) {
-        // Get ClickHouse version for query selection
-        clickhouseVersion = await getClickHouseVersion(currentHostId)
-
-        // New format: sql is an array of VersionedSql
-        if (Array.isArray(queryConfig.sql)) {
-          effectiveQuery = selectVersionedSql(
-            queryConfig.sql,
-            clickhouseVersion
-          )
-
-          debug(
-            `[fetchData] Version selection for ${queryConfig.name}: ` +
-              `detected=${clickhouseVersion?.raw ?? 'null'}, ` +
-              `selected=${effectiveQuery.substring(0, 60).replace(/\s+/g, ' ')}...`
-          )
-        }
-        // Simple string sql
-        else if (typeof queryConfig.sql === 'string') {
-          effectiveQuery = queryConfig.sql
-        }
-      }
+      const { effectiveQuery, clickhouseVersion } = await resolveEffectiveQuery(
+        { query, queryConfig, currentHostId }
+      )
 
       const resultSet = await client.query({
         query: QUERY_COMMENT + effectiveQuery,
@@ -411,421 +224,13 @@ export const fetchData = async <
       releaseClient({ clientConfig: effectiveConfig })
     }
   } catch (originalError) {
-    const errorMessage =
-      originalError instanceof Error
-        ? originalError.message
-        : String(originalError)
-
-    // Categorize error types based on error message patterns
-    let errorType: FetchDataErrorType = 'query_error'
-
-    // Extract HTTP status code from fetch errors
-    const httpStatusCode = extractHttpStatusCode(errorMessage)
-
-    // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
-    // digits embedded in larger numbers like "525.00 MiB" or "15251")
-    if (
-      /(?<![\d.])52[56](?!\d)(?!\.\d)/.test(errorMessage) ||
-      errorMessage.toLowerCase().includes('ssl') ||
-      errorMessage.toLowerCase().includes('tls') ||
-      errorMessage.toLowerCase().includes('certificate') ||
-      errorMessage.toLowerCase().includes('handshake')
-    ) {
-      errorType = 'ssl_error'
-    }
-    // Timeout errors
-    else if (
-      errorMessage.toLowerCase().includes('timeout') ||
-      errorMessage.includes('ETIMEDOUT') ||
-      errorMessage.includes('socket timeout')
-    ) {
-      errorType = 'timeout_error'
-    }
-    // Table not found errors
-    else if (
-      (errorMessage.toLowerCase().includes('table') &&
-        errorMessage.toLowerCase().includes('not') &&
-        errorMessage.toLowerCase().includes('exist')) ||
-      errorMessage.toLowerCase().includes('unknown table')
-    ) {
-      errorType = 'table_not_found'
-    }
-    // Permission errors
-    else if (
-      errorMessage.toLowerCase().includes('permission') ||
-      errorMessage.toLowerCase().includes('access')
-    ) {
-      errorType = 'permission_error'
-    }
-    // Network errors
-    else if (
-      errorMessage.toLowerCase().includes('network') ||
-      errorMessage.toLowerCase().includes('connection') ||
-      errorMessage.includes('fetch failed') ||
-      errorMessage.includes('ECONNREFUSED') ||
-      errorMessage.includes('ENOTFOUND') ||
-      errorMessage.includes('getaddrinfo') ||
-      errorMessage.includes('socket hang up') ||
-      errorMessage.includes('UND_ERR')
-    ) {
-      errorType = 'network_error'
-    }
-
-    const enrichedMessage = `${errorMessage} (host: ${clientConfig.host})`
-
-    // Enhanced error logging with full details
-    error(`Query failed (host: ${clientConfig.host}):`, errorMessage)
-    error(`[Error Details]`, {
-      errorType,
-      httpStatusCode,
-      host: clientConfig.host,
-      stack: originalError instanceof Error ? originalError.stack : undefined,
-      fullMessage: errorMessage,
-    })
-
-    // Log specific guidance for SSL errors
-    if (errorType === 'ssl_error') {
-      error(
-        `[SSL Error Help] SSL/TLS handshake failed with ${clientConfig.host}. ` +
-          `This usually means: ` +
-          `1) The origin uses HTTP but you configured HTTPS, ` +
-          `2) The origin has an invalid SSL certificate, ` +
-          `3) The origin is behind Cloudflare Tunnel without proper SSL configuration. ` +
-          `Try changing CLICKHOUSE_HOST to use HTTP (http://) instead of HTTPS (https://).`
-      )
-    }
-
     return {
       data: null,
-      metadata: {
-        queryId: '',
-        duration: (Date.now() - start.getTime()) / 1000,
-        rows: 0,
+      ...handleFetchError({
+        originalError,
         host: clientConfig.host,
-      },
-      error: {
-        type: errorType,
-        message: enrichedMessage,
-        details: {
-          originalError:
-            originalError instanceof Error ? originalError : undefined,
-          host: clientConfig.host,
-          httpStatusCode,
-        },
-      },
+        start,
+      }),
     }
   }
-}
-
-export const fetchJsonEachRowAsNormalizedJson = async ({
-  query,
-  query_params,
-  clickhouse_settings,
-  hostId,
-  queryConfig,
-}: QueryParams & {
-  hostId: number | string
-  clickhouse_settings?: QueryParams['clickhouse_settings'] & {
-    /** IANA timezone for ClickHouse session (mapped to session_timezone) */
-    session_timezone?: string
-  }
-  queryConfig?: QueryConfigLike
-}): Promise<FetchJsonEachRowTextResult> => {
-  const start = new Date()
-
-  const currentHostId = Number(hostId)
-  if (Number.isNaN(currentHostId)) {
-    throw new Error(`Invalid hostId: ${hostId}. Must be a valid number.`)
-  }
-
-  const configs = getClickHouseConfigs()
-  if (configs.length === 0) {
-    const errorMessage =
-      'No ClickHouse hosts configured. Please set CLICKHOUSE_HOST environment variable.\n' +
-      'Example: CLICKHOUSE_HOST=http://localhost:8123\n' +
-      'See console logs for more details.'
-
-    error(
-      '[fetchJsonEachRowAsNormalizedJson] No ClickHouse configurations available!'
-    )
-
-    return {
-      data: null,
-      dataJson: null,
-      metadata: {
-        queryId: '',
-        duration: 0,
-        rows: 0,
-        host: 'unknown',
-      },
-      error: {
-        type: 'validation_error',
-        message: errorMessage,
-        details: {
-          originalError: new Error(errorMessage),
-          host: 'unknown',
-        },
-      },
-    }
-  }
-
-  const clientConfig = configs[currentHostId]
-  if (!clientConfig) {
-    const availableHosts = configs.map((c) => c.id).join(', ')
-    const errorMessage = `Invalid hostId: ${currentHostId}. Available hosts: ${availableHosts} (total: ${configs.length})`
-
-    error('[fetchJsonEachRowAsNormalizedJson]', errorMessage)
-
-    return {
-      data: null,
-      dataJson: null,
-      metadata: {
-        queryId: '',
-        duration: 0,
-        rows: 0,
-        host: 'unknown',
-      },
-      error: {
-        type: 'validation_error',
-        message: errorMessage,
-        details: {
-          originalError: new Error(errorMessage),
-          host: 'unknown',
-        },
-      },
-    }
-  }
-
-  try {
-    if (queryConfig?.optional) {
-      const validation = await validateTableExistence(
-        queryConfig,
-        currentHostId
-      )
-
-      if (!validation.shouldProceed) {
-        const missingTables = validation.missingTables
-        const errorMessage =
-          validation.error ||
-          `Missing required tables: ${missingTables.join(', ')}`
-
-        warn(
-          `Skipping query "${queryConfig.name}" due to missing tables:`,
-          missingTables
-        )
-
-        return {
-          data: null,
-          dataJson: null,
-          metadata: {
-            queryId: '',
-            duration: 0,
-            rows: 0,
-            host: clientConfig.host,
-          },
-          error: {
-            type: 'table_not_found',
-            message: errorMessage,
-            details: {
-              missingTables,
-              host: clientConfig.host,
-            },
-          },
-        }
-      }
-    }
-
-    const client = await getClient({
-      clientConfig,
-    })
-
-    // Select the version-appropriate SQL when a versioned queryConfig is
-    // provided, mirroring fetchData. Current callers pre-resolve the SQL and
-    // pass only a minimal queryConfig (for the optional-table check), so this
-    // is a no-op for them; it makes the helper correct for any caller that
-    // hands over a queryConfig with a versioned sql[] instead.
-    let effectiveQuery = query
-    if (queryConfig && Array.isArray(queryConfig.sql)) {
-      const clickhouseVersion = await getClickHouseVersion(currentHostId)
-      effectiveQuery = selectVersionedSql(queryConfig.sql, clickhouseVersion)
-      debug(
-        `[fetchJsonEachRowAsNormalizedJson] Version selection for ${queryConfig.name}: ` +
-          `detected=${clickhouseVersion?.raw ?? 'null'}`
-      )
-    }
-
-    try {
-      const resultSet = await client.query({
-        query: QUERY_COMMENT + effectiveQuery,
-        format: 'JSONEachRow',
-        query_params,
-        clickhouse_settings,
-      })
-
-      const queryId = resultSet.query_id
-      const rawText = await resultSet.text()
-      const dataJson = await transformClickHouseJsonEachRowWasmJson(rawText)
-      const duration = (Date.now() - start.getTime()) / 1000
-      const rows = countJsonEachRowRows(rawText)
-
-      debug(
-        `--> Query (${queryId}, host: ${clientConfig.host}):`,
-        effectiveQuery.replace(/(\n|\s+)/g, ' ').replace(/\s+/g, ' ')
-      )
-      debug(`<-- Response (${queryId}):`, { rows, duration, unit: 's' })
-
-      // Only present when the X-ClickHouse-Summary header parses cleanly —
-      // callers (e.g. OTel span attributes) must treat this as optional.
-      const readBytes = parseReadBytesFromHeaders(resultSet.response_headers)
-
-      return {
-        data: null,
-        dataJson,
-        metadata: {
-          queryId,
-          duration,
-          rows,
-          host: clientConfig.host,
-          sql: effectiveQuery.replace(/\s+/g, ' ').trim(),
-          rawResponseLength: rawText.length,
-          rawResponsePreview:
-            rawText.length <= 500 ? rawText : `${rawText.substring(0, 500)}...`,
-          ...(readBytes !== undefined ? { readBytes } : {}),
-        },
-      }
-    } finally {
-      releaseClient({ clientConfig })
-    }
-  } catch (originalError) {
-    const errorMessage =
-      originalError instanceof Error
-        ? originalError.message
-        : String(originalError)
-
-    let errorType: FetchDataErrorType = 'query_error'
-
-    // Extract HTTP status code from fetch errors
-    const httpStatusCode = extractHttpStatusCode(errorMessage)
-
-    // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
-    // digits embedded in larger numbers like "525.00 MiB" or "15251")
-    if (
-      /(?<![\d.])52[56](?!\d)(?!\.\d)/.test(errorMessage) ||
-      errorMessage.toLowerCase().includes('ssl') ||
-      errorMessage.toLowerCase().includes('tls') ||
-      errorMessage.toLowerCase().includes('certificate') ||
-      errorMessage.toLowerCase().includes('handshake')
-    ) {
-      errorType = 'ssl_error'
-    }
-    // Timeout errors
-    else if (
-      errorMessage.toLowerCase().includes('timeout') ||
-      errorMessage.includes('ETIMEDOUT') ||
-      errorMessage.includes('socket timeout')
-    ) {
-      errorType = 'timeout_error'
-    }
-    // Table not found errors
-    else if (
-      (errorMessage.toLowerCase().includes('table') &&
-        errorMessage.toLowerCase().includes('not') &&
-        errorMessage.toLowerCase().includes('exist')) ||
-      errorMessage.toLowerCase().includes('unknown table')
-    ) {
-      errorType = 'table_not_found'
-    }
-    // Permission errors
-    else if (
-      errorMessage.toLowerCase().includes('permission') ||
-      errorMessage.toLowerCase().includes('access')
-    ) {
-      errorType = 'permission_error'
-    }
-    // Network errors
-    else if (
-      errorMessage.toLowerCase().includes('network') ||
-      errorMessage.toLowerCase().includes('connection') ||
-      errorMessage.includes('fetch failed') ||
-      errorMessage.includes('ECONNREFUSED') ||
-      errorMessage.includes('ENOTFOUND') ||
-      errorMessage.includes('getaddrinfo') ||
-      errorMessage.includes('socket hang up') ||
-      errorMessage.includes('UND_ERR')
-    ) {
-      errorType = 'network_error'
-    }
-
-    const enrichedMessage = `${errorMessage} (host: ${clientConfig.host})`
-
-    // Enhanced error logging with full details
-    error(`Query failed (host: ${clientConfig.host}):`, errorMessage)
-    error(`[Error Details]`, {
-      errorType,
-      httpStatusCode,
-      host: clientConfig.host,
-      stack: originalError instanceof Error ? originalError.stack : undefined,
-      fullMessage: errorMessage,
-    })
-
-    // Log specific guidance for SSL errors
-    if (errorType === 'ssl_error') {
-      error(
-        `[SSL Error Help] SSL/TLS handshake failed with ${clientConfig.host}. ` +
-          `This usually means: ` +
-          `1) The origin uses HTTP but you configured HTTPS, ` +
-          `2) The origin has an invalid SSL certificate, ` +
-          `3) The origin is behind Cloudflare Tunnel without proper SSL configuration. ` +
-          `Try changing CLICKHOUSE_HOST to use HTTP (http://) instead of HTTPS (https://).`
-      )
-    }
-
-    return {
-      data: null,
-      dataJson: null,
-      metadata: {
-        queryId: '',
-        duration: (Date.now() - start.getTime()) / 1000,
-        rows: 0,
-        host: clientConfig.host,
-      },
-      error: {
-        type: errorType,
-        message: enrichedMessage,
-        details: {
-          originalError:
-            originalError instanceof Error ? originalError : undefined,
-          host: clientConfig.host,
-          httpStatusCode,
-        },
-      },
-    }
-  }
-}
-
-function countJsonEachRowRows(input: string): number {
-  let rows = 0
-  let hasContent = false
-
-  for (let index = 0; index < input.length; index += 1) {
-    const ch = input.charCodeAt(index)
-    if (ch === 10) {
-      if (hasContent) {
-        rows += 1
-        hasContent = false
-      }
-    } else if (ch !== 13 && ch !== 32 && ch !== 9) {
-      hasContent = true
-    }
-  }
-
-  if (hasContent) {
-    rows += 1
-  }
-
-  return rows
-}
-
-export function __testCountJsonEachRowRows(input: string): number {
-  return countJsonEachRowRows(input)
 }

--- a/packages/clickhouse-client/src/clickhouse/fetch-errors.ts
+++ b/packages/clickhouse-client/src/clickhouse/fetch-errors.ts
@@ -1,0 +1,174 @@
+/**
+ * Error classification and error-result construction for the fetch funnel.
+ *
+ * Extracted from `clickhouse-fetch.ts`. `classifyFetchError` and
+ * `extractHttpStatusCode` are pure; `handleFetchError` additionally performs
+ * the (unchanged) error logging both fetch entrypoints share.
+ */
+
+import type { FetchDataErrorType, FetchDataResult } from './types'
+
+import { error } from '@chm/logger'
+
+/**
+ * Extract an HTTP status code (100–599) from a fetch error message.
+ *
+ * Strategy:
+ * 1. Try a keyword-anchored match that handles:
+ *    - "status: 500", "HTTP status 403", "HTTP error 502"
+ *    - Standard HTTP status lines: "HTTP/1.1 500", "HTTP/2 502"
+ * 2. If (1) fails AND the message also contains a ClickHouse "Code:" clause
+ *    that sits at the start of a line or is unaccompanied by HTTP keywords,
+ *    skip the generic digit scan to avoid misidentifying internal error codes.
+ * 3. Otherwise fall back to a generic 3-digit match.
+ */
+export function extractHttpStatusCode(
+  errorMessage: string
+): number | undefined {
+  // Keyword-anchored: matches "status 500", "HTTP status 403", "HTTP/1.1 500", "HTTP/2 502", etc.
+  const keywordMatch = errorMessage.match(
+    /\b(?:status|HTTP(?:\/\d+(?:\.\d+)?)?(?:\s+(?:status|error))?)\s*([1-5]\d{2})\b/i
+  )
+  if (keywordMatch) {
+    return parseInt(keywordMatch[1], 10)
+  }
+
+  // Skip generic digit scan when ClickHouse internal codes are present and no
+  // HTTP keyword was found above, to avoid false positives like "Code: 210".
+  if (errorMessage.includes('Code:')) {
+    return undefined
+  }
+
+  const genericMatch = errorMessage.match(/\b([1-5]\d{2})\b/)
+  if (genericMatch) {
+    return parseInt(genericMatch[1], 10)
+  }
+
+  return undefined
+}
+
+/**
+ * Categorize an error message into a `FetchDataErrorType`. Order matters — the
+ * first matching category wins, mirroring the original if/else chain.
+ */
+export function classifyFetchError(errorMessage: string): FetchDataErrorType {
+  // SSL/TLS errors (Cloudflare 525/526 as standalone status codes, not
+  // digits embedded in larger numbers like "525.00 MiB" or "15251")
+  if (
+    /(?<![\d.])52[56](?!\d)(?!\.\d)/.test(errorMessage) ||
+    errorMessage.toLowerCase().includes('ssl') ||
+    errorMessage.toLowerCase().includes('tls') ||
+    errorMessage.toLowerCase().includes('certificate') ||
+    errorMessage.toLowerCase().includes('handshake')
+  ) {
+    return 'ssl_error'
+  }
+  // Timeout errors
+  if (
+    errorMessage.toLowerCase().includes('timeout') ||
+    errorMessage.includes('ETIMEDOUT') ||
+    errorMessage.includes('socket timeout')
+  ) {
+    return 'timeout_error'
+  }
+  // Table not found errors
+  if (
+    (errorMessage.toLowerCase().includes('table') &&
+      errorMessage.toLowerCase().includes('not') &&
+      errorMessage.toLowerCase().includes('exist')) ||
+    errorMessage.toLowerCase().includes('unknown table')
+  ) {
+    return 'table_not_found'
+  }
+  // Permission errors
+  if (
+    errorMessage.toLowerCase().includes('permission') ||
+    errorMessage.toLowerCase().includes('access')
+  ) {
+    return 'permission_error'
+  }
+  // Network errors
+  if (
+    errorMessage.toLowerCase().includes('network') ||
+    errorMessage.toLowerCase().includes('connection') ||
+    errorMessage.includes('fetch failed') ||
+    errorMessage.includes('ECONNREFUSED') ||
+    errorMessage.includes('ENOTFOUND') ||
+    errorMessage.includes('getaddrinfo') ||
+    errorMessage.includes('socket hang up') ||
+    errorMessage.includes('UND_ERR')
+  ) {
+    return 'network_error'
+  }
+
+  return 'query_error'
+}
+
+/**
+ * Classify, log and shape a thrown query error into the `{ metadata, error }`
+ * half of a `FetchDataResult`. Both fetch entrypoints share this body; the
+ * caller adds `data: null` (and `dataJson: null` where applicable).
+ */
+export function handleFetchError({
+  originalError,
+  host,
+  start,
+}: {
+  originalError: unknown
+  host: string
+  start: Date
+}): Pick<FetchDataResult<never>, 'metadata' | 'error'> {
+  const errorMessage =
+    originalError instanceof Error
+      ? originalError.message
+      : String(originalError)
+
+  // Categorize error types based on error message patterns
+  const errorType = classifyFetchError(errorMessage)
+
+  // Extract HTTP status code from fetch errors
+  const httpStatusCode = extractHttpStatusCode(errorMessage)
+
+  const enrichedMessage = `${errorMessage} (host: ${host})`
+
+  // Enhanced error logging with full details
+  error(`Query failed (host: ${host}):`, errorMessage)
+  error(`[Error Details]`, {
+    errorType,
+    httpStatusCode,
+    host,
+    stack: originalError instanceof Error ? originalError.stack : undefined,
+    fullMessage: errorMessage,
+  })
+
+  // Log specific guidance for SSL errors
+  if (errorType === 'ssl_error') {
+    error(
+      `[SSL Error Help] SSL/TLS handshake failed with ${host}. ` +
+        `This usually means: ` +
+        `1) The origin uses HTTP but you configured HTTPS, ` +
+        `2) The origin has an invalid SSL certificate, ` +
+        `3) The origin is behind Cloudflare Tunnel without proper SSL configuration. ` +
+        `Try changing CLICKHOUSE_HOST to use HTTP (http://) instead of HTTPS (https://).`
+    )
+  }
+
+  return {
+    metadata: {
+      queryId: '',
+      duration: (Date.now() - start.getTime()) / 1000,
+      rows: 0,
+      host,
+    },
+    error: {
+      type: errorType,
+      message: enrichedMessage,
+      details: {
+        originalError:
+          originalError instanceof Error ? originalError : undefined,
+        host,
+        httpStatusCode,
+      },
+    },
+  }
+}

--- a/packages/clickhouse-client/src/clickhouse/fetch-headers.ts
+++ b/packages/clickhouse-client/src/clickhouse/fetch-headers.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure parsers for ClickHouse HTTP response headers and JSONEachRow payloads.
+ *
+ * Extracted from `clickhouse-fetch.ts` — no I/O, no config, directly unit
+ * testable.
+ */
+
+/**
+ * Parse `read_bytes` out of the `X-ClickHouse-Summary` response header (always
+ * sent by the ClickHouse HTTP interface, regardless of format). Returns
+ * `undefined` when the header is absent/unparseable — or when the result set
+ * itself doesn't carry response_headers, e.g. in unit tests that stub a
+ * minimal client — so callers only ever see a genuine value, never a guess.
+ */
+export function parseReadBytesFromHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined
+): number | undefined {
+  const raw = headers?.['x-clickhouse-summary']
+  const text = Array.isArray(raw) ? raw[0] : raw
+  if (!text) return undefined
+
+  try {
+    const summary = JSON.parse(text) as { read_bytes?: string }
+    const bytes = summary.read_bytes ? Number(summary.read_bytes) : undefined
+    return bytes !== undefined && Number.isFinite(bytes) ? bytes : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Parse `rows_before_limit_at_least` out of the `X-ClickHouse-Summary`
+ * response header (#2490). ClickHouse sets this when a query hits
+ * `max_result_rows` with `result_overflow_mode: 'break'` (or a plain LIMIT) —
+ * it reports how many rows existed before the cap/limit truncated the result.
+ * Returns `undefined` when absent/unparseable, mirroring
+ * `parseReadBytesFromHeaders`.
+ */
+export function parseRowsBeforeLimitFromHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined
+): number | undefined {
+  const raw = headers?.['x-clickhouse-summary']
+  const text = Array.isArray(raw) ? raw[0] : raw
+  if (!text) return undefined
+
+  try {
+    const summary = JSON.parse(text) as {
+      rows_before_limit_at_least?: string
+    }
+    const value = summary.rows_before_limit_at_least
+      ? Number(summary.rows_before_limit_at_least)
+      : undefined
+    return value !== undefined && Number.isFinite(value) ? value : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Count non-empty lines in a JSONEachRow payload without allocating an array
+ * of lines (these payloads can be large).
+ */
+export function countJsonEachRowRows(input: string): number {
+  let rows = 0
+  let hasContent = false
+
+  for (let index = 0; index < input.length; index += 1) {
+    const ch = input.charCodeAt(index)
+    if (ch === 10) {
+      if (hasContent) {
+        rows += 1
+        hasContent = false
+      }
+    } else if (ch !== 13 && ch !== 32 && ch !== 9) {
+      hasContent = true
+    }
+  }
+
+  if (hasContent) {
+    rows += 1
+  }
+
+  return rows
+}

--- a/packages/clickhouse-client/src/clickhouse/fetch-normalize.ts
+++ b/packages/clickhouse-client/src/clickhouse/fetch-normalize.ts
@@ -1,0 +1,138 @@
+/**
+ * JSONEachRow → normalized-JSON fetching.
+ *
+ * Extracted from `clickhouse-fetch.ts` (which re-exports
+ * `fetchJsonEachRowAsNormalizedJson` unchanged). Streams the raw JSONEachRow
+ * text through the WASM normalizer instead of parsing it in JS.
+ */
+
+import type { QueryParams } from '@clickhouse/client'
+
+import type { QueryConfigLike } from '@chm/sql-builder'
+import type { FetchDataResult } from './types'
+
+import { getClickHouseVersion, selectVersionedSql } from '../clickhouse-version'
+import { transformClickHouseJsonEachRowWasmJson } from '../wasm/monitor-core'
+import { getClient, releaseClient } from './clickhouse-client'
+import { QUERY_COMMENT } from './constants'
+import { handleFetchError } from './fetch-errors'
+import {
+  countJsonEachRowRows,
+  parseReadBytesFromHeaders,
+} from './fetch-headers'
+import { checkOptionalTables, resolveHostConfig } from './fetch-request'
+import { debug } from '@chm/logger'
+
+export type FetchJsonEachRowTextResult = FetchDataResult<never> & {
+  dataJson: string | null
+}
+
+export const fetchJsonEachRowAsNormalizedJson = async ({
+  query,
+  query_params,
+  clickhouse_settings,
+  hostId,
+  queryConfig,
+}: QueryParams & {
+  hostId: number | string
+  clickhouse_settings?: QueryParams['clickhouse_settings'] & {
+    /** IANA timezone for ClickHouse session (mapped to session_timezone) */
+    session_timezone?: string
+  }
+  queryConfig?: QueryConfigLike
+}): Promise<FetchJsonEachRowTextResult> => {
+  const start = new Date()
+
+  const resolved = resolveHostConfig(hostId, {
+    label: '[fetchJsonEachRowAsNormalizedJson]',
+  })
+  if (!resolved.ok) {
+    return { data: null, dataJson: null, ...resolved.failure }
+  }
+
+  const { clientConfig, currentHostId } = resolved
+
+  try {
+    const skipped = await checkOptionalTables({
+      queryConfig,
+      currentHostId,
+      host: clientConfig.host,
+      classifyProbeFailure: false,
+    })
+    if (skipped) {
+      return { data: null, dataJson: null, ...skipped }
+    }
+
+    const client = await getClient({
+      clientConfig,
+    })
+
+    // Select the version-appropriate SQL when a versioned queryConfig is
+    // provided, mirroring fetchData. Current callers pre-resolve the SQL and
+    // pass only a minimal queryConfig (for the optional-table check), so this
+    // is a no-op for them; it makes the helper correct for any caller that
+    // hands over a queryConfig with a versioned sql[] instead.
+    let effectiveQuery = query
+    if (queryConfig && Array.isArray(queryConfig.sql)) {
+      const clickhouseVersion = await getClickHouseVersion(currentHostId)
+      effectiveQuery = selectVersionedSql(queryConfig.sql, clickhouseVersion)
+      debug(
+        `[fetchJsonEachRowAsNormalizedJson] Version selection for ${queryConfig.name}: ` +
+          `detected=${clickhouseVersion?.raw ?? 'null'}`
+      )
+    }
+
+    try {
+      const resultSet = await client.query({
+        query: QUERY_COMMENT + effectiveQuery,
+        format: 'JSONEachRow',
+        query_params,
+        clickhouse_settings,
+      })
+
+      const queryId = resultSet.query_id
+      const rawText = await resultSet.text()
+      const dataJson = await transformClickHouseJsonEachRowWasmJson(rawText)
+      const duration = (Date.now() - start.getTime()) / 1000
+      const rows = countJsonEachRowRows(rawText)
+
+      debug(
+        `--> Query (${queryId}, host: ${clientConfig.host}):`,
+        effectiveQuery.replace(/(\n|\s+)/g, ' ').replace(/\s+/g, ' ')
+      )
+      debug(`<-- Response (${queryId}):`, { rows, duration, unit: 's' })
+
+      // Only present when the X-ClickHouse-Summary header parses cleanly —
+      // callers (e.g. OTel span attributes) must treat this as optional.
+      const readBytes = parseReadBytesFromHeaders(resultSet.response_headers)
+
+      return {
+        data: null,
+        dataJson,
+        metadata: {
+          queryId,
+          duration,
+          rows,
+          host: clientConfig.host,
+          sql: effectiveQuery.replace(/\s+/g, ' ').trim(),
+          rawResponseLength: rawText.length,
+          rawResponsePreview:
+            rawText.length <= 500 ? rawText : `${rawText.substring(0, 500)}...`,
+          ...(readBytes !== undefined ? { readBytes } : {}),
+        },
+      }
+    } finally {
+      releaseClient({ clientConfig })
+    }
+  } catch (originalError) {
+    return {
+      data: null,
+      dataJson: null,
+      ...handleFetchError({
+        originalError,
+        host: clientConfig.host,
+        start,
+      }),
+    }
+  }
+}

--- a/packages/clickhouse-client/src/clickhouse/fetch-request.ts
+++ b/packages/clickhouse-client/src/clickhouse/fetch-request.ts
@@ -1,0 +1,203 @@
+/**
+ * Request-preparation seams of the fetch funnel: host/config resolution,
+ * optional-table validation, and version-aware SQL selection.
+ *
+ * Extracted from `clickhouse-fetch.ts` — behaviour is unchanged, including the
+ * exact log calls each entrypoint made before the split.
+ */
+
+import type { QueryConfigLike } from '@chm/sql-builder'
+import type { ClickHouseConfig, FetchDataResult } from './types'
+
+import { getClickHouseVersion, selectVersionedSql } from '../clickhouse-version'
+import { validateTableExistence } from '../table-validator'
+import { getClickHouseConfigs } from './clickhouse-config'
+import { debug, error, warn } from '@chm/logger'
+
+type ErrorHalf = Pick<FetchDataResult<never>, 'metadata' | 'error'>
+
+export type HostResolution =
+  | { ok: true; clientConfig: ClickHouseConfig }
+  | { ok: false; failure: ErrorHalf }
+
+/**
+ * Validate `hostId` and resolve it to a configured ClickHouse host.
+ *
+ * Throws (rather than returning a failure) for a non-numeric `hostId`, matching
+ * the original behaviour of both entrypoints.
+ */
+export function resolveHostConfig(
+  hostId: number | string,
+  {
+    label,
+    extraNoConfigLogs = [],
+  }: { label: string; extraNoConfigLogs?: string[] }
+): HostResolution & { currentHostId: number } {
+  // Parse and validate hostId to prevent NaN
+  const currentHostId = Number(hostId)
+  if (Number.isNaN(currentHostId)) {
+    throw new Error(`Invalid hostId: ${hostId}. Must be a valid number.`)
+  }
+
+  const configs = getClickHouseConfigs()
+
+  // Check if any configs are available
+  if (configs.length === 0) {
+    const errorMessage =
+      'No ClickHouse hosts configured. Please set CLICKHOUSE_HOST environment variable.\n' +
+      'Example: CLICKHOUSE_HOST=http://localhost:8123\n' +
+      'See console logs for more details.'
+
+    error(`${label} No ClickHouse configurations available!`)
+    for (const line of extraNoConfigLogs) {
+      error(line)
+    }
+
+    return {
+      ok: false,
+      currentHostId,
+      failure: unknownHostFailure(errorMessage),
+    }
+  }
+
+  const clientConfig = configs[currentHostId]
+
+  // Check if clientConfig exists before using it
+  if (!clientConfig) {
+    const availableHosts = configs.map((c) => c.id).join(', ')
+    const errorMessage = `Invalid hostId: ${currentHostId}. Available hosts: ${availableHosts} (total: ${configs.length})`
+
+    error(label, errorMessage)
+
+    return {
+      ok: false,
+      currentHostId,
+      failure: unknownHostFailure(errorMessage),
+    }
+  }
+
+  return { ok: true, currentHostId, clientConfig }
+}
+
+function unknownHostFailure(errorMessage: string): ErrorHalf {
+  return {
+    metadata: {
+      queryId: '',
+      duration: 0,
+      rows: 0,
+      host: 'unknown',
+    },
+    error: {
+      type: 'validation_error',
+      message: errorMessage,
+      details: {
+        originalError: new Error(errorMessage),
+        host: 'unknown',
+      },
+    },
+  }
+}
+
+/**
+ * Run the optional-table existence check for a queryConfig marked `optional`.
+ * Returns the error half of the result when the query must be skipped, or
+ * `null` when it should proceed (including when no check applies).
+ *
+ * `classifyProbeFailure` reproduces `fetchData`'s #2505 behaviour: a probe
+ * failure (network/timeout/auth) means table existence is unknown, not
+ * confirmed missing, so it is reported as a network error.
+ */
+export async function checkOptionalTables({
+  queryConfig,
+  currentHostId,
+  host,
+  classifyProbeFailure,
+}: {
+  queryConfig: QueryConfigLike | undefined
+  currentHostId: number
+  host: string
+  classifyProbeFailure: boolean
+}): Promise<ErrorHalf | null> {
+  if (!queryConfig?.optional) return null
+
+  const validation = await validateTableExistence(queryConfig, currentHostId)
+  if (validation.shouldProceed) return null
+
+  const missingTables = validation.missingTables
+  const isProbeFailure =
+    classifyProbeFailure && validation.reason === 'probe_failed'
+  const errorMessage =
+    validation.error || `Missing required tables: ${missingTables.join(', ')}`
+
+  if (isProbeFailure) {
+    warn(
+      `Skipping query "${queryConfig.name}" — could not verify table availability:`,
+      errorMessage
+    )
+  } else {
+    warn(
+      `Skipping query "${queryConfig.name}" due to missing tables:`,
+      missingTables
+    )
+  }
+
+  return {
+    metadata: {
+      queryId: '',
+      duration: 0,
+      rows: 0,
+      host,
+    },
+    error: {
+      type: isProbeFailure ? 'network_error' : 'table_not_found',
+      message: errorMessage,
+      details: {
+        missingTables,
+        host,
+      },
+    },
+  }
+}
+
+/**
+ * Pick the version-appropriate SQL for a queryConfig. The ClickHouse version is
+ * only fetched when a queryConfig is supplied, preventing infinite recursion
+ * (getClickHouseVersion itself calls fetchData without a queryConfig).
+ */
+export async function resolveEffectiveQuery({
+  query,
+  queryConfig,
+  currentHostId,
+}: {
+  query: string
+  queryConfig: QueryConfigLike | undefined
+  currentHostId: number
+}): Promise<{
+  effectiveQuery: string
+  clickhouseVersion: Awaited<ReturnType<typeof getClickHouseVersion>>
+}> {
+  let effectiveQuery = query
+  let clickhouseVersion: Awaited<ReturnType<typeof getClickHouseVersion>> = null
+
+  if (queryConfig) {
+    // Get ClickHouse version for query selection
+    clickhouseVersion = await getClickHouseVersion(currentHostId)
+
+    // New format: sql is an array of VersionedSql
+    if (Array.isArray(queryConfig.sql)) {
+      effectiveQuery = selectVersionedSql(queryConfig.sql, clickhouseVersion)
+
+      debug(
+        `[fetchData] Version selection for ${queryConfig.name}: ` +
+          `detected=${clickhouseVersion?.raw ?? 'null'}, ` +
+          `selected=${effectiveQuery.substring(0, 60).replace(/\s+/g, ' ')}...`
+      )
+    }
+    // Simple string sql
+    else if (typeof queryConfig.sql === 'string') {
+      effectiveQuery = queryConfig.sql
+    }
+  }
+
+  return { effectiveQuery, clickhouseVersion }
+}


### PR DESCRIPTION
Fixes #2893

Pure refactor of `packages/clickhouse-client/src/clickhouse/clickhouse-fetch.ts` (831 lines, two ~400/~285-line functions) into siblings along the seams in the issue. Zero behavior change: identical error messages, log calls (same arity/wording), query comments, param passing, and table-validation caching semantics. `fetchData`'s signature, generics, and exports are untouched, so every `apps/dashboard` call site — including the engine-aware explorer queries (#2871) and fleet status (#2880) — compiles unmodified.

## Before → after map

| Before (`clickhouse-fetch.ts`) | After |
|---|---|
| `parseReadBytesFromHeaders:30`, `parseRowsBeforeLimitFromHeaders:54`, `countJsonEachRowRows:806`, `__testCountJsonEachRowRows:829` | `fetch-headers.ts` (84 lines, all pure; test escape hatch deleted) |
| `extractHttpStatusCode:86` + the two duplicated ~90-line catch bodies (`:413-517`, `:699-803`) | `fetch-errors.ts` (174) — `extractHttpStatusCode`, `classifyFetchError`, shared `handleFetchError` |
| hostId/config validation (`:141-207`), optional-table check (`:219-261`), versioned-SQL selection (`:271-299`) | `fetch-request.ts` (203) — `resolveHostConfig`, `checkOptionalTables`, `resolveEffectiveQuery` |
| `fetchJsonEachRowAsNormalizedJson:520-804` | `fetch-normalize.ts` (137); re-exported from `clickhouse-fetch.ts` so the entrypoint is unchanged |
| `fetchData:112-519` | `clickhouse-fetch.ts` (235) — build request → execute → map errors |

Notes on the two entrypoints' small differences, all preserved:
- `fetchData` logs 3 "no configs" lines, `fetchJsonEachRowAsNormalizedJson` logs 1 with its own prefix (`label` + `extraNoConfigLogs`).
- The #2505 probe-failure → `network_error` classification (with its distinct `warn` wording) exists only in `fetchData` (`classifyProbeFailure`).
- `metadata.sql` still excludes `QUERY_COMMENT` while `client.query` includes it; the lazy `rawResponse*` getters stay lazy.

## Acceptance criteria

- [x] No file in `src/clickhouse/` exceeds ~300 lines (max is now 235).
- [x] `__testCountJsonEachRowRows` gone; tests import `countJsonEachRowRows` from `fetch-headers.ts`.
- [x] New `__tests__/fetch-headers.test.ts` covers missing, empty, repeated (array), malformed-JSON, and non-numeric header cases for both summary parsers.
- [x] `bun test packages/clickhouse-client/src/clickhouse` — 126 pass / 0 fail. `pnpm run lint` clean (only pre-existing warnings in cluster-topology). Full `pnpm run build` left to CI (worktree has no `node_modules`); `tsc --noEmit` reports no errors in the touched files.

Co-Authored-By: duyetbot <bot@duyet.net>
