### PR TITLE
fix(ci): unbreak deploy jobs (pnpm cache, CF 10215 secret order, topology cycles)

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -99,7 +99,11 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
+          # Only cache when this job actually installs (build/lint). A `docker`
+          # job skips "Install dependencies", so the pnpm store never exists and
+          # setup-node's post step fails the job with "Path Validation Error:
+          # Path(s) specified in the action for caching do(es) not exist".
+          cache: ${{ (inputs.job-type == 'build' || inputs.job-type == 'lint') && 'pnpm' || '' }}
           cache-dependency-path: |
             pnpm-lock.yaml
             apps/*/pnpm-lock.yaml

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -88,8 +88,14 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/dashboard/pnpm-lock.yaml
+          # NO `cache: pnpm` in this workflow. Every deploy job installs
+          # CONDITIONALLY (dorny/paths-filter), so on a run where the app did not
+          # change the install is skipped and the pnpm store directory is never
+          # created — setup-node's post step then fails the whole job with
+          # "Path Validation Error: Path(s) specified in the action for caching
+          # do(es) not exist" (the cloud-hooks regression from #2910). Caching
+          # stays enabled in the workflows whose install is unconditional
+          # (ci.yml, test.yml, a11y.yml, bundle-size.yml, …).
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -215,7 +221,62 @@ jobs:
             bun scripts/patch-wrangler-env.ts
           fi
 
+      - name: Deploy preview
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.actor != 'dependabot[bot]' &&
+          (steps.filter.outputs.dashboard == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler deploy --minify
+
+      - name: Apply D1 migrations (production)
+        # Bring the chm-cloud D1 schema up to date BEFORE the new worker goes
+        # live, so a cold/behind database can't 500 the billing webhook or block
+        # per-user connections (the incident behind migrations 0001–0004).
+        # Idempotent: wrangler records applied migrations in the d1_migrations
+        # ledger, so re-running every deploy is a no-op once applied. The
+        # migrations here are additive (CREATE TABLE), safe to apply pre-deploy.
+        # Production only — never from a PR, which could push an unmerged
+        # migration to the shared preview/prod D1.
+        if: >-
+          github.event_name != 'pull_request' &&
+          (steps.filter.outputs.dashboard == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler d1 migrations apply chm-cloud --remote
+
+      - name: Deploy production
+        if: >-
+          github.event_name != 'pull_request' &&
+          (steps.filter.outputs.dashboard == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm exec wrangler deploy --minify
+
       - name: Set secrets
+        # DEPLOY FIRST, THEN SET SECRETS. `wrangler secret put` fails with CF
+        # error 10215 ("the latest version of your Worker isn't currently
+        # deployed") whenever a previous run uploaded a Worker version without
+        # deploying it — exactly what a concurrency-cancelled deploy leaves
+        # behind. With secrets running before the deploy that wedged production
+        # permanently: every run died at this step and never reached the deploy.
+        # Secret VALUES persist across versions, so deploying with the secrets
+        # already on the Worker and then re-applying them here is safe and is
+        # Cloudflare's recommended way out of 10215.
+        #
         # Dependabot PRs run with GitHub's isolated dependabot secret store, so
         # the deployment secrets resolve empty and `set-secrets.ts --strict`
         # exits 1 — structurally failing the required `dashboard` check on every
@@ -271,51 +332,6 @@ jobs:
           else
             bun ../../scripts/set-secrets.ts --from-env --strict --target dashboard
           fi
-
-      - name: Deploy preview
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.actor != 'dependabot[bot]' &&
-          (steps.filter.outputs.dashboard == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'release' ||
-          github.ref_type == 'tag')
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm exec wrangler deploy --minify
-
-      - name: Apply D1 migrations (production)
-        # Bring the chm-cloud D1 schema up to date BEFORE the new worker goes
-        # live, so a cold/behind database can't 500 the billing webhook or block
-        # per-user connections (the incident behind migrations 0001–0004).
-        # Idempotent: wrangler records applied migrations in the d1_migrations
-        # ledger, so re-running every deploy is a no-op once applied. The
-        # migrations here are additive (CREATE TABLE), safe to apply pre-deploy.
-        # Production only — never from a PR, which could push an unmerged
-        # migration to the shared preview/prod D1.
-        if: >-
-          github.event_name != 'pull_request' &&
-          (steps.filter.outputs.dashboard == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'release' ||
-          github.ref_type == 'tag')
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm exec wrangler d1 migrations apply chm-cloud --remote
-
-      - name: Deploy production
-        if: >-
-          github.event_name != 'pull_request' &&
-          (steps.filter.outputs.dashboard == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'release' ||
-          github.ref_type == 'tag')
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm exec wrangler deploy --minify
 
       - name: Verify deployment
         # Skip for dependabot PRs — no preview was deployed (see Set secrets).
@@ -373,35 +389,6 @@ jobs:
         working-directory: .
         run: pnpm install --frozen-lockfile
 
-      - name: Set MCP worker secrets
-        # Skip for dependabot — its isolated secret store resolves the deploy
-        # secrets empty and set-secrets.ts --strict exits 1 (see Set secrets).
-        if: >-
-          github.actor != 'dependabot[bot]' &&
-          (steps.filter.outputs.mcp == 'true' ||
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'release' ||
-          github.ref_type == 'tag')
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
-          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
-          # Enables Clerk OAuth verification on the MCP worker. set-secrets.ts reads
-          # CLERK_SECRET_KEY_TEST first for --env preview (resolveValue), and
-          # CLERK_SECRET_KEY for production. Without the verifier the worker has the
-          # issuer (pubkey in wrangler.toml) but rejects every Clerk OAuth token.
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
-        working-directory: apps/mcp
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bun ../../scripts/set-secrets.ts --from-env --strict --target mcp --env preview
-          else
-            bun ../../scripts/set-secrets.ts --from-env --strict --target mcp
-          fi
-
       # The committed wrangler.toml [vars] are GENERIC placeholders (OSS-clean).
       # The real PRIVATE host topology + Clerk publishable key are injected here
       # at deploy with --var, from the same repo secrets the dashboard uses plus
@@ -450,6 +437,39 @@ jobs:
             --var CLICKHOUSE_USER:"$CH_USER" \
             --var CLICKHOUSE_NAME:"$CH_NAME" \
             --var NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:"$CLERK_PK"
+
+      - name: Set MCP worker secrets
+        # Runs AFTER the MCP deploys, same reason as the dashboard "Set secrets"
+        # step: `wrangler secret put` errors 10215 when the Worker's latest
+        # version was uploaded but never deployed.
+        #
+        # Skip for dependabot — its isolated secret store resolves the deploy
+        # secrets empty and set-secrets.ts --strict exits 1 (see Set secrets).
+        if: >-
+          github.actor != 'dependabot[bot]' &&
+          (steps.filter.outputs.mcp == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag')
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+          CHM_API_KEY_SECRET: ${{ secrets.CHM_API_KEY_SECRET }}
+          # Enables Clerk OAuth verification on the MCP worker. set-secrets.ts reads
+          # CLERK_SECRET_KEY_TEST first for --env preview (resolveValue), and
+          # CLERK_SECRET_KEY for production. Without the verifier the worker has the
+          # issuer (pubkey in wrangler.toml) but rejects every Clerk OAuth token.
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
+        working-directory: apps/mcp
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            bun ../../scripts/set-secrets.ts --from-env --strict --target mcp --env preview
+          else
+            bun ../../scripts/set-secrets.ts --from-env --strict --target mcp
+          fi
 
       # Telemetry collector (apps/telemetry) — standalone, no deps, no secrets.
       # Public write-only ingest → Analytics Engine (+ optional D1). The
@@ -562,8 +582,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/landing/pnpm-lock.yaml
+          # No pnpm cache — conditional install, see the dashboard job above.
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -669,8 +688,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/docs/pnpm-lock.yaml
+          # No pnpm cache — conditional install, see the dashboard job above.
 
       - name: Detect changes
         id: filter
@@ -756,8 +774,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/blog/pnpm-lock.yaml
+          # No pnpm cache — conditional install, see the dashboard job above.
 
       - name: Detect changes
         id: filter
@@ -841,8 +858,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/bug-handler/pnpm-lock.yaml
+          # No pnpm cache — conditional install, see the dashboard job above.
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -986,8 +1002,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: apps/cloud-hooks/pnpm-lock.yaml
+          # No pnpm cache — conditional install, see the dashboard job above.
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/apps/dashboard/src/components/cluster-topology/model-assemble.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-assemble.ts
@@ -24,7 +24,7 @@ import type {
   NodeLiveMetrics,
   TopologyData,
   TopologyMeta,
-} from './model'
+} from './model-types'
 
 import { CLUSTER_PALETTE } from './model-constants'
 import {

--- a/apps/dashboard/src/components/cluster-topology/model-constants.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-constants.ts
@@ -7,7 +7,7 @@
  * isolation; check the contract in the knowledge doc first.
  */
 
-import type { ChNode, KeeperNode } from './model'
+import type { ChNode, KeeperNode } from './model-types'
 
 // Canvas viewBox. WIDE aspect so it fills the xl two-column container instead of
 // letterboxing horizontally — the "relax the space" ask. The extra height leaves

--- a/apps/dashboard/src/components/cluster-topology/model-hulls.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-hulls.ts
@@ -7,7 +7,7 @@
  * for the envelope/boundary contracts these functions rely on.
  */
 
-import type { ChNode, ClusterHull, ClusterInfo, KeeperNode } from './model'
+import type { ChNode, ClusterHull, ClusterInfo, KeeperNode } from './model-types'
 
 import { roundedRectPath } from './geometry'
 import {

--- a/apps/dashboard/src/components/cluster-topology/model-layout.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-layout.ts
@@ -20,7 +20,7 @@ import type {
   TopologyData,
   TopologyMeta,
   TopologyModel,
-} from './model'
+} from './model-types'
 import type {
   ClusterLiveRow,
   KeeperInfoRow,

--- a/apps/dashboard/src/components/cluster-topology/model-parse.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-parse.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ClusterTopologyRow } from '@/lib/query-config/system/clusters-topology'
-import type { ChNode, KeeperNode, KeeperRole } from './model'
+import type { ChNode, KeeperNode, KeeperRole } from './model-types'
 
 /** Type guard: is this node a Keeper (vs a ClickHouse node)? */
 export function isKeeperNode(n: KeeperNode | ChNode): n is KeeperNode {

--- a/apps/dashboard/src/components/cluster-topology/model-types.ts
+++ b/apps/dashboard/src/components/cluster-topology/model-types.ts
@@ -1,0 +1,196 @@
+/**
+ * Cluster topology data model — shared TYPES only.
+ *
+ * Split out of `model.ts` so the implementation siblings (`model-parse`,
+ * `model-assemble`, `model-layout`, `model-hulls`, `model-constants`) can import
+ * the shapes they need WITHOUT importing the `model.ts` barrel — the barrel
+ * re-exports those siblings, so importing it from inside made every sibling
+ * part of an import cycle (dependency-cruiser `no-circular`).
+ *
+ * `model.ts` re-exports this file, so `import type { ... } from './model'`
+ * keeps working unchanged for consumers outside this folder.
+ */
+
+export interface NodeLiveMetrics {
+  cpuPct: number | null
+  memUsed: number | null
+  memTotal: number | null
+  memAvailable: number | null
+  diskUsed: number | null
+  diskTotal: number | null
+  activeQueries: number | null
+  uptimeSeconds: number | null
+  version: string | null
+}
+
+export type KeeperRole =
+  | 'leader'
+  | 'follower'
+  | 'observer'
+  | 'standalone'
+  | 'unknown'
+
+export interface KeeperNode {
+  id: string
+  host: string
+  port: number
+  role: KeeperRole
+  isLeader: boolean
+  version: string
+  avgLatency: number
+  znodeCount: number
+  watchCount: number
+  outstanding: number
+  isConnected: boolean
+  clusterName: string
+  x: number
+  y: number
+}
+
+export type ChStatus = 'healthy' | 'warn' | 'down' | 'unreachable'
+
+export interface ChNode {
+  id: string
+  host: string
+  address: string
+  port: number
+  isLocal: boolean
+  /** healthy | warn | down | unreachable — derived from errors/active/live, never random */
+  status: ChStatus
+  errors: number
+  slowdowns: number
+  recoveryTime: number
+  isActive: number | null
+  /** Replicated-DB replica lag (24.10+), null otherwise */
+  replicationLag: number | null
+  /** ClickHouse version, from the live fan-out (null when not reachable) */
+  version: string | null
+  /** live metrics for this node (null fields when not reachable / not permitted) */
+  live: NodeLiveMetrics | null
+  /** default-cluster shard/replica role, if present */
+  defaultRole?: { s: number; r: number }
+  x: number
+  y: number
+}
+
+export interface ClusterInfo {
+  id: string
+  name: string
+  kind: 'physical' | 'logical'
+  color: string
+  topo: string
+  /** members keyed by node id → shard/replica role */
+  members: Record<string, { s: number; r: number }>
+  /** rendered as a dotted outline (physical default cluster) instead of a filled hull */
+  outline: boolean
+  nodeCount: number
+  /** true when any shard has >1 replica → draw replication edges between replicas. */
+  replicated: boolean
+}
+
+/**
+ * Precomputed cluster overlay: an offset-convex-hull path plus the metadata the
+ * canvas needs to draw it (color, border style, area for z-ordering, label
+ * anchor). Pure function of structure + layout → stable across live ticks.
+ */
+export interface ClusterHull {
+  id: string
+  name: string
+  color: string
+  /** physical cluster → dotted outline (no fill); logical/virtual → dashed border + fill. */
+  outline: boolean
+  /** the single closed SVG path (circle / stadium / rounded polygon). */
+  d: string
+  /** Minkowski-sum area, used to z-order: largest drawn first (behind). */
+  area: number
+  /** Axis-aligned box of the territory (same as path bounds). Used to clamp
+   * drag so nodes stay inside their cluster box, and to decide which nested
+   * ring gets the single outer stroke (no overlapping borders). */
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+  /** Stable signature of the rendered member set — coincident clusters share one. */
+  memberSig: string
+  /** Nest rank within a coincident group (0 = outermost / largest). */
+  nestRank: number
+  /** resolved label position (may be nudged off the rect to de-overlap). */
+  labelX: number
+  labelY: number
+  /** the rect's true top-center, where a leader line points back to. */
+  anchorX: number
+  anchorY: number
+  /** draw a thin connector from the label to the anchor (label was moved away). */
+  leader: boolean
+}
+
+export type KeeperSource = 'keeper' | 'zookeeper' | 'none'
+
+export interface KeeperSummary {
+  present: boolean
+  source: KeeperSource
+  leaderId: string | null
+  quorumHealthy: boolean
+}
+
+export interface TopologyMeta {
+  counts: {
+    nodes: number
+    keepers: number
+    chNodes: number
+    clusters: number
+    physical: number
+    logical: number
+  }
+  /** true when the node list was capped for rendering (large clusters) */
+  truncated: boolean
+  /** number of CH nodes hidden by the render cap */
+  hiddenChNodes: number
+  /** how the live snapshot was obtained: full fan-out, local-only fallback, or none */
+  liveSource: 'fanout' | 'local' | 'none'
+}
+
+/** Layout-free structural model — the server-route wire shape. */
+export interface TopologyData {
+  keepers: KeeperNode[]
+  chNodes: ChNode[]
+  clusters: ClusterInfo[]
+  raftEdges: [string, string][]
+  replEdges: [string, string][]
+  coordEdges: [string, string][]
+  keeper: KeeperSummary
+  meta: TopologyMeta
+}
+
+export interface TopologyModel extends TopologyData {
+  nodeById: Record<string, KeeperNode | ChNode>
+  clusterById: Record<string, ClusterInfo>
+  /** cluster overlays, sorted by area DESCENDING (largest first / behind). */
+  clusterHulls: ClusterHull[]
+  keeperHull: string
+  /** mirror of keeper.leaderId for existing consumers */
+  leaderId: string | null
+  /** mirror of keeper.quorumHealthy for existing consumers */
+  quorumHealthy: boolean
+  counts: TopologyMeta['counts']
+  /** viewBox height the canvas should use — DATA-DRIVEN: grows to fit the keeper
+   * region, the CH band, and the deepest cluster-ring nesting + bottom pills for
+   * THIS model, never below `VB_H`. A simple graph stays compact (big glyphs); a
+   * deeply-nested one grows taller and letterboxes. Width is always `VB_W`. */
+  vbHeight: number
+}
+
+/**
+ * For very large clusters the rendered CH-node set is capped (the local node is
+ * always kept) so the fixed viewBox stays readable; meta.truncated /
+ * meta.hiddenChNodes report what was hidden. Edges referencing hidden nodes are
+ * dropped by the canvas (it skips edges whose endpoints are missing).
+ */
+export interface LayoutOptions {
+  /** Whether physical/implicit (outline) clusters are drawn. Default true. When
+   * false they are dropped from the hulls AND the height reserve — they are the
+   * OUTERMOST concentric rings, so hiding them lets the viewBox shrink. CH node
+   * positions are driven only by LOGICAL clusters, so toggling never moves a
+   * node — only the outer rings appear/disappear and the height adjusts. */
+  showPhysical?: boolean
+}

--- a/apps/dashboard/src/components/cluster-topology/model.ts
+++ b/apps/dashboard/src/components/cluster-topology/model.ts
@@ -1,205 +1,25 @@
 /**
  * Cluster topology data model — types + public surface.
  *
- * The actual implementation is split across three siblings so this file stays
- * a readable table of contents (see docs/knowledge/cluster-topology.md):
+ * The actual implementation is split across siblings so this file stays a
+ * readable table of contents (see docs/knowledge/cluster-topology.md):
  *
+ *  - `model-types.ts` — the shared type/interface surface.
  *  - `model-constants.ts` — layout constants / geometry envelopes / palettes.
  *  - `model-parse.ts` — row coercion + node-identity heuristics.
  *  - `model-assemble.ts` — `assembleTopology`: raw rows → layout-free `TopologyData`.
  *  - `model-layout.ts` — `layoutTopology` / `buildTopologyModel` + node placement.
  *  - `model-hulls.ts` — cluster territory + keeper-region overlay geometry.
  *
- * This module re-exports everything from the three so no import site needs to
+ * This module re-exports everything from them so no import site needs to
  * change: `import { ... } from './model'` keeps working exactly as before.
+ * Siblings must NOT import this barrel back (it would be an import cycle) —
+ * they import `./model-types` for shapes and each other directly.
  */
-
-export interface NodeLiveMetrics {
-  cpuPct: number | null
-  memUsed: number | null
-  memTotal: number | null
-  memAvailable: number | null
-  diskUsed: number | null
-  diskTotal: number | null
-  activeQueries: number | null
-  uptimeSeconds: number | null
-  version: string | null
-}
-
-export type KeeperRole =
-  | 'leader'
-  | 'follower'
-  | 'observer'
-  | 'standalone'
-  | 'unknown'
-
-export interface KeeperNode {
-  id: string
-  host: string
-  port: number
-  role: KeeperRole
-  isLeader: boolean
-  version: string
-  avgLatency: number
-  znodeCount: number
-  watchCount: number
-  outstanding: number
-  isConnected: boolean
-  clusterName: string
-  x: number
-  y: number
-}
-
-export type ChStatus = 'healthy' | 'warn' | 'down' | 'unreachable'
-
-export interface ChNode {
-  id: string
-  host: string
-  address: string
-  port: number
-  isLocal: boolean
-  /** healthy | warn | down | unreachable — derived from errors/active/live, never random */
-  status: ChStatus
-  errors: number
-  slowdowns: number
-  recoveryTime: number
-  isActive: number | null
-  /** Replicated-DB replica lag (24.10+), null otherwise */
-  replicationLag: number | null
-  /** ClickHouse version, from the live fan-out (null when not reachable) */
-  version: string | null
-  /** live metrics for this node (null fields when not reachable / not permitted) */
-  live: NodeLiveMetrics | null
-  /** default-cluster shard/replica role, if present */
-  defaultRole?: { s: number; r: number }
-  x: number
-  y: number
-}
-
-export interface ClusterInfo {
-  id: string
-  name: string
-  kind: 'physical' | 'logical'
-  color: string
-  topo: string
-  /** members keyed by node id → shard/replica role */
-  members: Record<string, { s: number; r: number }>
-  /** rendered as a dotted outline (physical default cluster) instead of a filled hull */
-  outline: boolean
-  nodeCount: number
-  /** true when any shard has >1 replica → draw replication edges between replicas. */
-  replicated: boolean
-}
-
-/**
- * Precomputed cluster overlay: an offset-convex-hull path plus the metadata the
- * canvas needs to draw it (color, border style, area for z-ordering, label
- * anchor). Pure function of structure + layout → stable across live ticks.
- */
-export interface ClusterHull {
-  id: string
-  name: string
-  color: string
-  /** physical cluster → dotted outline (no fill); logical/virtual → dashed border + fill. */
-  outline: boolean
-  /** the single closed SVG path (circle / stadium / rounded polygon). */
-  d: string
-  /** Minkowski-sum area, used to z-order: largest drawn first (behind). */
-  area: number
-  /** Axis-aligned box of the territory (same as path bounds). Used to clamp
-   * drag so nodes stay inside their cluster box, and to decide which nested
-   * ring gets the single outer stroke (no overlapping borders). */
-  minX: number
-  minY: number
-  maxX: number
-  maxY: number
-  /** Stable signature of the rendered member set — coincident clusters share one. */
-  memberSig: string
-  /** Nest rank within a coincident group (0 = outermost / largest). */
-  nestRank: number
-  /** resolved label position (may be nudged off the rect to de-overlap). */
-  labelX: number
-  labelY: number
-  /** the rect's true top-center, where a leader line points back to. */
-  anchorX: number
-  anchorY: number
-  /** draw a thin connector from the label to the anchor (label was moved away). */
-  leader: boolean
-}
-
-export type KeeperSource = 'keeper' | 'zookeeper' | 'none'
-
-export interface KeeperSummary {
-  present: boolean
-  source: KeeperSource
-  leaderId: string | null
-  quorumHealthy: boolean
-}
-
-export interface TopologyMeta {
-  counts: {
-    nodes: number
-    keepers: number
-    chNodes: number
-    clusters: number
-    physical: number
-    logical: number
-  }
-  /** true when the node list was capped for rendering (large clusters) */
-  truncated: boolean
-  /** number of CH nodes hidden by the render cap */
-  hiddenChNodes: number
-  /** how the live snapshot was obtained: full fan-out, local-only fallback, or none */
-  liveSource: 'fanout' | 'local' | 'none'
-}
-
-/** Layout-free structural model — the server-route wire shape. */
-export interface TopologyData {
-  keepers: KeeperNode[]
-  chNodes: ChNode[]
-  clusters: ClusterInfo[]
-  raftEdges: [string, string][]
-  replEdges: [string, string][]
-  coordEdges: [string, string][]
-  keeper: KeeperSummary
-  meta: TopologyMeta
-}
-
-export interface TopologyModel extends TopologyData {
-  nodeById: Record<string, KeeperNode | ChNode>
-  clusterById: Record<string, ClusterInfo>
-  /** cluster overlays, sorted by area DESCENDING (largest first / behind). */
-  clusterHulls: ClusterHull[]
-  keeperHull: string
-  /** mirror of keeper.leaderId for existing consumers */
-  leaderId: string | null
-  /** mirror of keeper.quorumHealthy for existing consumers */
-  quorumHealthy: boolean
-  counts: TopologyMeta['counts']
-  /** viewBox height the canvas should use — DATA-DRIVEN: grows to fit the keeper
-   * region, the CH band, and the deepest cluster-ring nesting + bottom pills for
-   * THIS model, never below `VB_H`. A simple graph stays compact (big glyphs); a
-   * deeply-nested one grows taller and letterboxes. Width is always `VB_W`. */
-  vbHeight: number
-}
-
-/**
- * For very large clusters the rendered CH-node set is capped (the local node is
- * always kept) so the fixed viewBox stays readable; meta.truncated /
- * meta.hiddenChNodes report what was hidden. Edges referencing hidden nodes are
- * dropped by the canvas (it skips edges whose endpoints are missing).
- */
-export interface LayoutOptions {
-  /** Whether physical/implicit (outline) clusters are drawn. Default true. When
-   * false they are dropped from the hulls AND the height reserve — they are the
-   * OUTERMOST concentric rings, so hiding them lets the viewBox shrink. CH node
-   * positions are driven only by LOGICAL clusters, so toggling never moves a
-   * node — only the outer rings appear/disappear and the height adjusts. */
-  showPhysical?: boolean
-}
 
 export * from './model-assemble'
 export * from './model-constants'
 export * from './model-hulls'
 export * from './model-layout'
 export * from './model-parse'
+export * from './model-types'


### PR DESCRIPTION
Three CI/CD regressions, all currently red on `main`.

## 1. `cloud-hooks` deploy job: "Path Validation Error" (pnpm cache from #2910)

Root cause is **not** a wrong lockfile path — `apps/cloud-hooks/pnpm-lock.yaml` exists and is committed. Every job in `cloudflare.yml` installs **conditionally** (`dorny/paths-filter`): on a run where that app didn't change, `pnpm install` is skipped, so the pnpm **store directory is never created**, and `actions/setup-node`'s post step fails the whole job with:

```
Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

`cloud-hooks` hit it first simply because it had no previously saved cache to restore (a restore would have created the directory).

Fix: drop `cache: pnpm` from the six conditional-install deploy jobs (dashboard, landing, docs, blog, bug-handler, cloud-hooks). Caching is untouched in the workflows whose install is unconditional (`ci.yml`, `test.yml`, `a11y.yml`, `bundle-size.yml`, `docs.yml`/`landing.yml`/`blog.yml` build jobs elsewhere).

Also fixed the same latent break in `base.yml`, the only other place with a conditional install: its `docker` jobs skip `Install dependencies`, so `cache` is now gated on `job-type` (build/lint keep the cache, docker doesn't).

Rejected alternative: `mkdir -p $(pnpm store path)` keeps jobs green but saves an **empty** store under the lockfile key, which then exact-key hits forever — dead caching.

## 2. Production deploys wedged on Cloudflare error 10215

`Set secrets` ran **before** `Deploy preview` / `Deploy production`. `wrangler secret put` fails with 10215 ("the latest version of your Worker isn't currently deployed") when a previous run uploaded a Worker version without deploying it — exactly what a concurrency-cancelled deploy leaves behind. Once that happened, every subsequent run died at the secrets step and **never reached the deploy**; production hasn't shipped for the last 3 merges.

Fix: deploy first, then set secrets. Secret values persist across Worker versions, so deploying with the secrets already on the Worker and re-applying them afterwards is safe, and is Cloudflare's recommended way out of 10215. Ordering inside the deploy group is preserved (`Deploy preview` → `Apply D1 migrations (production)` → `Deploy production`), and every `if:` is unchanged. The MCP worker had the identical hazard — `Set MCP worker secrets` now runs after the MCP deploys.

## 3. `depcruise` no-circular (12 errors) from the cluster-topology model split (#2928)

The split left every implementation sibling importing its types back from the `model.ts` **barrel**, which re-exports those same siblings → 12 cycles. No dependency-cruiser rule was loosened; the rule is right. The shared types are extracted into `model-types.ts`, siblings import that, and `model.ts` re-exports it — so `import type { … } from './model'` still works unchanged for every outside consumer.

Verification note: `depcruise`/`lint` could not be run in this worktree (no `node_modules`); the cycle break is structural — no file under `cluster-topology/` imports `./model` any more except through the barrel's own re-exports.

Co-Authored-By: duyetbot <bot@duyet.net>
