### PR TITLE
fix(dashboard): finite clampLimit fallback and LRU memory cache

### DIFF
--- a/apps/dashboard/src/lib/cache/adapters/memory-cache.test.ts
+++ b/apps/dashboard/src/lib/cache/adapters/memory-cache.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression coverage for #2954: `MemoryCacheAdapter` evicted strictly
+ * FIFO — reads never re-inserted a hit, so eviction (which walks `keys()`
+ * from the front) removed the oldest-written entry even if it was the
+ * hottest one just read a moment ago. Fixed by delete+set on hit to move the
+ * entry to the tail of the Map's insertion order, making eviction LRU.
+ */
+
+import type { CacheOptions } from '../types'
+
+import { MemoryCacheAdapter } from './memory-cache'
+import { afterEach, describe, expect, test } from 'bun:test'
+
+const keyed = (name: string): CacheOptions => ({ key: [name] })
+
+describe('MemoryCacheAdapter', () => {
+  let adapter: MemoryCacheAdapter | undefined
+
+  afterEach(() => {
+    adapter?.dispose()
+    adapter = undefined
+  })
+
+  test('caches the fn result for a repeated key (no recompute on hit)', async () => {
+    adapter = new MemoryCacheAdapter()
+    let calls = 0
+    const fn = async () => {
+      calls++
+      return 'value'
+    }
+
+    expect(await adapter.wrap(fn, keyed('a'))).toBe('value')
+    expect(await adapter.wrap(fn, keyed('a'))).toBe('value')
+    expect(calls).toBe(1)
+  })
+
+  test('a hot key survives eviction after being touched (LRU, not FIFO)', async () => {
+    adapter = new MemoryCacheAdapter(3)
+    const makeFn = (v: string) => async () => v
+
+    // Fill the cache to its max size: insertion order [a, b, c].
+    await adapter.wrap(makeFn('a'), keyed('a'))
+    await adapter.wrap(makeFn('b'), keyed('b'))
+    await adapter.wrap(makeFn('c'), keyed('c'))
+
+    // Touch "a" again — a plain FIFO cache leaves insertion order untouched;
+    // an LRU cache moves "a" to the tail: [b, c, a].
+    let aRecomputed = 0
+    await adapter.wrap(async () => {
+      aRecomputed++
+      return 'a-recomputed'
+    }, keyed('a'))
+    expect(aRecomputed).toBe(0) // still a hit, not recomputed
+
+    // Writing a 4th distinct key pushes the cache over maxSize by one,
+    // evicting exactly one entry from the front.
+    await adapter.wrap(makeFn('d'), keyed('d'))
+
+    // "b" was never touched after being written first among the survivors —
+    // it is the least-recently-used entry and gets evicted.
+    let bRecomputed = 0
+    await adapter.wrap(async () => {
+      bRecomputed++
+      return 'b-recomputed'
+    }, keyed('b'))
+    expect(bRecomputed).toBe(1) // recomputed: "b" was evicted
+
+    // "a" was touched most recently before the eviction, so it must survive.
+    let aRecomputedAfterEvict = 0
+    await adapter.wrap(async () => {
+      aRecomputedAfterEvict++
+      return 'a-recomputed-again'
+    }, keyed('a'))
+    expect(aRecomputedAfterEvict).toBe(0) // still cached, not recomputed
+  })
+})

--- a/apps/dashboard/src/lib/cache/adapters/memory-cache.ts
+++ b/apps/dashboard/src/lib/cache/adapters/memory-cache.ts
@@ -43,6 +43,11 @@ export class MemoryCacheAdapter implements QueryCacheAdapter {
     const entry = this.cache.get(key)
     if (entry && Date.now() < entry.expires) {
       debug('[query-cache] Memory cache hit', { key, ttl })
+      // Move the entry to the tail of insertion order so eviction (which
+      // walks from the front) is LRU rather than FIFO — a hot key that keeps
+      // getting read survives even after 1000 distinct keys have been set.
+      this.cache.delete(key)
+      this.cache.set(key, entry)
       return entry.value as T
     }
 

--- a/apps/dashboard/src/lib/insights/store/types.test.ts
+++ b/apps/dashboard/src/lib/insights/store/types.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the shared `clampLimit` helper used by every insights backend
+ * (ClickHouse, D1, Postgres, AgentState, memory) and the `/api/v1/findings`
+ * route to bound a caller-supplied row limit into `[1, 1000]`.
+ *
+ * Regression coverage for #2952: a non-numeric `?limit=` (parsed to `NaN`
+ * upstream) must fall back to the default page size, not silently collapse
+ * to a single row.
+ */
+
+import { clampLimit } from './types'
+import { describe, expect, test } from 'bun:test'
+
+describe('clampLimit', () => {
+  test('defaults to the fallback when limit is undefined', () => {
+    expect(clampLimit(undefined)).toBe(100)
+    expect(clampLimit(undefined, 50)).toBe(50)
+  })
+
+  test('NaN limit falls back to the default instead of clamping to 1', () => {
+    expect(clampLimit(Number.NaN)).toBe(100)
+    expect(clampLimit(Number.NaN, 25)).toBe(25)
+  })
+
+  test('NaN produced by parsing an invalid ?limit= string falls back cleanly', () => {
+    const limit = Number.parseInt('abc', 10)
+    expect(Number.isNaN(limit)).toBe(true)
+    expect(clampLimit(limit)).toBe(100)
+  })
+
+  test('non-finite (Infinity) limit falls back to the default', () => {
+    expect(clampLimit(Number.POSITIVE_INFINITY)).toBe(100)
+    expect(clampLimit(Number.NEGATIVE_INFINITY)).toBe(100)
+  })
+
+  test('clamps in-range limits to themselves', () => {
+    expect(clampLimit(1)).toBe(1)
+    expect(clampLimit(250)).toBe(250)
+    expect(clampLimit(1000)).toBe(1000)
+  })
+
+  test('clamps below the floor up to 1', () => {
+    expect(clampLimit(0)).toBe(1)
+    expect(clampLimit(-5)).toBe(1)
+  })
+
+  test('clamps above the ceiling down to 1000', () => {
+    expect(clampLimit(5000)).toBe(1000)
+  })
+
+  test('truncates fractional limits', () => {
+    expect(clampLimit(2.9)).toBe(2)
+  })
+})

--- a/apps/dashboard/src/lib/insights/store/types.ts
+++ b/apps/dashboard/src/lib/insights/store/types.ts
@@ -107,7 +107,8 @@ export function toFindingRow(
  * in one place rather than being copy-pasted per adapter.
  */
 export function clampLimit(limit: number | undefined, fallback = 100): number {
-  return Math.min(Math.max(Math.trunc(limit ?? fallback) || 0, 1), 1000)
+  const n = Math.trunc(limit ?? fallback)
+  return Number.isFinite(n) ? Math.min(Math.max(n, 1), 1000) : fallback
 }
 
 /** Loose shape of a row read back from a DB-backed store before normalization. */

--- a/apps/dashboard/src/routes/api/v1/findings.ts
+++ b/apps/dashboard/src/routes/api/v1/findings.ts
@@ -21,6 +21,7 @@ import { debug, error, generateRequestId } from '@chm/logger'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { FINDINGS_TABLE } from '@/lib/app-tables'
 import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
+import { clampLimit } from '@/lib/insights/store/types'
 
 type FindingSeverity = 'info' | 'warning' | 'critical'
 
@@ -83,7 +84,7 @@ async function listRecentFindings(
     }
   }
 
-  const safeLimit = Math.min(Math.max(Math.trunc(limit) || 0, 1), 1000)
+  const safeLimit = clampLimit(limit)
 
   // Filter and order on the real DateTime `event_time` column inside a
   // subquery, then format it to a string in the outer SELECT. Formatting in


### PR DESCRIPTION
## Summary
- `clampLimit` (`lib/insights/store/types.ts`) treated a non-finite `limit` (e.g. `?limit=abc` parsed to `NaN`) as `0`, which then clamped to `1` instead of falling back to the default page size (100). Fixed so `Number.isFinite` gates the clamp and non-finite input returns the fallback.
- `routes/api/v1/findings.ts` had its own copy of the same buggy clamp logic inline; rewired it to call the fixed shared `clampLimit` instead of duplicating the calculation.
- `MemoryCacheAdapter` (`lib/cache/adapters/memory-cache.ts`) evicted strictly FIFO — cache hits never re-inserted the entry, so eviction (which walks `Map.keys()` from the front) could evict the hottest key (e.g. an overview chart refreshed every 60s) ahead of one-shot keys. Fixed by delete+set on hit to move the entry to the tail of the Map's insertion order, making eviction LRU.

## Test plan
- [x] Added `apps/dashboard/src/lib/insights/store/types.test.ts` covering `clampLimit`: undefined/NaN/Infinity → fallback, in-range passthrough, floor/ceiling clamping, truncation.
- [x] Added `apps/dashboard/src/lib/cache/adapters/memory-cache.test.ts` covering cache-hit dedup and the LRU-survives-eviction scenario (touched key survives eviction; never-touched key gets evicted).
- [ ] CI (unit-tests, dashboard) — not run locally per task instructions.

Fixes #2952
Fixes #2954