### PR TITLE
fix(sql-builder): stop scanning string literals in validator; fix '/*/' comment parsing

### DIFF
--- a/docs/knowledge/sql-validator-threat-model.md
+++ b/docs/knowledge/sql-validator-threat-model.md
@@ -3,7 +3,7 @@ id: sql-validator-threat-model
 title: SQL Validator Threat Model & False-Positive Class
 type: decision
 status: active
-updated: 2026-07-10
+updated: 2026-08-12
 tags:
   - security
   - sql
@@ -77,6 +77,28 @@ string literals (`'…'`), double-quoted and backtick identifiers untouched
 (honoring `\` escapes and doubled quotes), so a benign literal like
 `'-- text'` or `'/* text */'` is never mistaken for a comment. Regression cases
 live in `sql-validator.test.ts` ("dangerous functions via comment bypass").
+
+## String literals are data, not SQL (2026-08-12, issue #2949)
+
+The blocklists are raw-text regexes, so they also matched *inside* string
+literals: `SELECT query FROM system.query_log WHERE query LIKE '%DROP TABLE%'`
+was rejected as a DROP statement. Auditing DDL history or hunting `s3()`/`url()`
+usage in `system.query_log` is routine read-only monitoring, and it was
+impossible on every free-form surface.
+
+Fix: `stripSqlComments(sql, { blankLiterals: true })` produces a second copy in
+which the **contents** of single-quoted literals are replaced by spaces
+(newlines preserved) while the delimiting quotes stay put — the query keeps its
+structure, so `STRING_INJECTION_OR_SINGLE` still sees `OR ' '=' '` and rejects
+the tautology. All `SQL_INJECTION_PATTERNS` scan that copy; the statement-type
+prefix check still runs on the comment-only-normalized copy. Double-quoted and
+backtick identifiers are **never** blanked (they are names, and
+`STRING_INJECTION_DOUBLE` needs them). Escapes (`''` and `\'`) are blanked as
+content, so a literal can never be split in half. Regression cases live in
+`sql-validator.test.ts` ("blocked keywords inside string literals").
+
+Anything outside a literal is still blocked, unchanged — chained DDL, table
+functions, comment-obfuscated calls (the two passes compose).
 
 ## Rule: keep shipped SQL and the validator in sync
 

--- a/packages/sql-builder/src/__tests__/split-statements.test.ts
+++ b/packages/sql-builder/src/__tests__/split-statements.test.ts
@@ -88,6 +88,36 @@ describe('splitSqlStatements', () => {
     ])
   })
 
+  // Regression for issue #2949's sibling #2950: `/*/` opened a block comment
+  // whose very same `*` was then read as the start of the closing `*/`, so the
+  // comment ended immediately and a `;` inside it split one statement into two
+  // invalid fragments. The closing `*/` must begin at least 2 chars after the
+  // opening `/*`.
+  it("does not close a block comment early on '/*/' (#2950)", () => {
+    expect(splitSqlStatements('SELECT 1 /*/ ; */ , 2')).toEqual([
+      'SELECT 1 /*/ ; */ , 2',
+    ])
+  })
+
+  it("splits on a real ';' after a '/*/'-opened comment (#2950)", () => {
+    expect(splitSqlStatements('SELECT 1 /*/ ; */; SELECT 2')).toEqual([
+      'SELECT 1 /*/ ; */',
+      'SELECT 2',
+    ])
+  })
+
+  it('still closes ordinary block comments at the first valid */', () => {
+    expect(splitSqlStatements('SELECT 1 /**/; SELECT 2')).toEqual([
+      'SELECT 1 /**/',
+      'SELECT 2',
+    ])
+    // Block comments do not nest: `/*/*/` closes at its trailing `*/`.
+    expect(splitSqlStatements('SELECT 1 /*/*/; SELECT 2')).toEqual([
+      'SELECT 1 /*/*/',
+      'SELECT 2',
+    ])
+  })
+
   it('drops comment-only trailing fragments', () => {
     expect(splitSqlStatements('SELECT 1; -- trailing note')).toEqual([
       'SELECT 1',

--- a/packages/sql-builder/src/__tests__/sql-validator.test.ts
+++ b/packages/sql-builder/src/__tests__/sql-validator.test.ts
@@ -2,7 +2,11 @@
  * SQL Validator Tests
  */
 
-import { SQL_PATTERNS, validateSqlQuery } from '../sql-validator'
+import {
+  SQL_PATTERNS,
+  stripSqlComments,
+  validateSqlQuery,
+} from '../sql-validator'
 import { describe, expect, test } from 'bun:test'
 
 // Detect if validateSqlQuery has been globally mocked (e.g., by MCP tool tests)
@@ -403,6 +407,47 @@ describe('SQL_PATTERNS', () => {
       expect(SQL_PATTERNS.DANGEROUS_FUNCTIONS.test('count()')).toBe(false)
       expect(SQL_PATTERNS.DANGEROUS_FUNCTIONS.test('sum(bytes)')).toBe(false)
     })
+  })
+})
+
+// The blocklists scan a copy whose single-quoted literal CONTENTS are blanked
+// (issue #2949). The quotes themselves — and every identifier — must survive so
+// the query keeps its structure and the OR-tautology patterns still match.
+describe('stripSqlComments (blankLiterals)', () => {
+  test('leaves literals intact by default', () => {
+    expect(stripSqlComments("SELECT 'DROP' AS x")).toBe("SELECT 'DROP' AS x")
+  })
+
+  test('blanks single-quoted literal contents, keeping the quotes', () => {
+    expect(
+      stripSqlComments("SELECT 'DROP' AS x", { blankLiterals: true })
+    ).toBe("SELECT '    ' AS x")
+  })
+
+  test('blanks doubled-quote and backslash escapes as literal content', () => {
+    // 'a''b' is one literal (a'b): 1 + 2 + 1 content chars -> 4 spaces.
+    expect(
+      stripSqlComments("SELECT 'a''b' AS x", { blankLiterals: true })
+    ).toBe("SELECT '    ' AS x")
+    // 'a\'b' is one literal too: 1 + 2 + 1 content chars -> 4 spaces.
+    expect(
+      stripSqlComments("SELECT 'a\\'b' AS x", { blankLiterals: true })
+    ).toBe("SELECT '    ' AS x")
+  })
+
+  test('preserves newlines inside a blanked literal', () => {
+    expect(
+      stripSqlComments("SELECT 'a\nb' AS x", { blankLiterals: true })
+    ).toBe("SELECT ' \n ' AS x")
+  })
+
+  test('never blanks quoted or backtick identifiers', () => {
+    expect(
+      stripSqlComments('SELECT "DROP" AS x', { blankLiterals: true })
+    ).toBe('SELECT "DROP" AS x')
+    expect(
+      stripSqlComments('SELECT `DROP` AS x', { blankLiterals: true })
+    ).toBe('SELECT `DROP` AS x')
   })
 })
 
@@ -845,6 +890,97 @@ describe.skipIf(actuallyMocked)('validateSqlQuery', () => {
       ).not.toThrow()
       // A stray */ inside a literal must not desync comment tracking.
       expect(() => validateSqlQuery("SELECT 'x */ y' AS s")).not.toThrow()
+    })
+  })
+
+  // Regression for issue #2949: the blocklists used to scan raw text including
+  // string-literal contents, so auditing DDL history or hunting s3()/url() usage
+  // in system.query_log — routine read-only monitoring — was rejected outright.
+  // Literal contents are data, never executable SQL, so they are blanked before
+  // the blocklists run. Everything OUTSIDE a literal is still blocked.
+  describe('blocked keywords inside string literals (issue #2949)', () => {
+    test('accepts the exact issue query', () => {
+      expect(() =>
+        validateSqlQuery(
+          "SELECT query FROM system.query_log WHERE query LIKE '%DROP TABLE%'"
+        )
+      ).not.toThrow()
+    })
+
+    test('accepts auditing every DDL/DML keyword through a literal', () => {
+      const ok = [
+        "SELECT query FROM system.query_log WHERE query LIKE '%DROP TABLE%'",
+        "SELECT query FROM system.query_log WHERE query LIKE '%INSERT INTO%'",
+        "SELECT count() FROM system.query_log WHERE query ILIKE '%ALTER TABLE%'",
+        "SELECT query FROM system.query_log WHERE query LIKE '%TRUNCATE%' OR query LIKE '%RENAME%'",
+        "SELECT query FROM system.query_log WHERE query LIKE '%GRANT%' OR query LIKE '%KILL%'",
+        "SELECT 'DROP TABLE users' AS example",
+      ]
+      for (const sql of ok) {
+        expect(() => validateSqlQuery(sql)).not.toThrow()
+      }
+    })
+
+    test('accepts hunting dangerous table-function usage in query history', () => {
+      const ok = [
+        "SELECT query FROM system.query_log WHERE query ILIKE '%s3(%'",
+        "SELECT query FROM system.query_log WHERE query ILIKE '%url(%' OR query ILIKE '%remote(%'",
+        "SELECT count() FROM system.query_log WHERE query LIKE '%file(%'",
+      ]
+      for (const sql of ok) {
+        expect(() => validateSqlQuery(sql)).not.toThrow()
+      }
+    })
+
+    test('accepts escaped quotes inside an audited literal', () => {
+      // Doubled-quote and backslash escapes keep the whole span one literal, so
+      // the blocked keyword stays data.
+      expect(() =>
+        validateSqlQuery("SELECT 'it''s a DROP TABLE note' AS s")
+      ).not.toThrow()
+      expect(() =>
+        validateSqlQuery("SELECT 'don\\'t DROP TABLE' AS s")
+      ).not.toThrow()
+    })
+
+    test('still rejects DDL outside a literal', () => {
+      const bad = [
+        'DROP TABLE users',
+        "SELECT 'audit' AS tag; DROP TABLE users",
+        "SELECT query FROM system.query_log WHERE query LIKE '%DROP%'; DROP TABLE t",
+        "SELECT 'x' AS a, 'y' AS b FROM t; TRUNCATE TABLE t",
+      ]
+      for (const sql of bad) {
+        expect(() => validateSqlQuery(sql)).toThrow()
+      }
+    })
+
+    test('still rejects dangerous table functions outside a literal', () => {
+      const bad = [
+        "SELECT * FROM s3('bucket/key')",
+        "SELECT * FROM url('http://evil.com/x', 'CSV')",
+        "SELECT * FROM remote('h','d','t') WHERE query LIKE '%DROP TABLE%'",
+        // Comment-bypass (#2465) and literal blanking must compose.
+        "SELECT * FROM s3/*x*/('b/k') WHERE query LIKE '%s3(%'",
+      ]
+      for (const sql of bad) {
+        expect(() => validateSqlQuery(sql)).toThrow(
+          'Potentially dangerous SQL detected'
+        )
+      }
+    })
+
+    test('still rejects OR-tautologies (blanking keeps quote structure)', () => {
+      const bad = [
+        "SELECT * FROM t WHERE name = '' OR '1'='1",
+        "SELECT * FROM t WHERE name = '' OR '1'='1'",
+        "SELECT * FROM t WHERE name = '' OR 1=1",
+      ]
+      for (const sql of bad) {
+        expect(() => validateSqlQuery(sql)).toThrow(
+          'Potentially dangerous SQL detected'
+        )
+      }
     })
   })
 

--- a/packages/sql-builder/src/split-statements.ts
+++ b/packages/sql-builder/src/split-statements.ts
@@ -48,6 +48,10 @@ export function splitSqlStatements(sql: string): string[] {
   let buf = ''
   type State = 'normal' | 'single' | 'double' | 'backtick' | 'line' | 'block'
   let state: State = 'normal'
+  // Index of the `/` that opened the current block comment. The closing `*/`
+  // must begin at least 2 chars later, otherwise `/*/` would be read as an
+  // opened-and-closed comment (the same `*` cannot both open and close it).
+  let blockStart = -1
 
   for (let i = 0; i < sql.length; i++) {
     const ch = sql[i]
@@ -65,7 +69,10 @@ export function splitSqlStatements(sql: string): string[] {
         else if (ch === '"') state = 'double'
         else if (ch === '`') state = 'backtick'
         else if (ch === '-' && next === '-') state = 'line'
-        else if (ch === '/' && next === '*') state = 'block'
+        else if (ch === '/' && next === '*') {
+          state = 'block'
+          blockStart = i
+        }
         break
       }
       case 'line': {
@@ -75,7 +82,7 @@ export function splitSqlStatements(sql: string): string[] {
       }
       case 'block': {
         buf += ch
-        if (ch === '*' && next === '/') {
+        if (ch === '*' && next === '/' && i >= blockStart + 2) {
           buf += next
           i++
           state = 'normal'

--- a/packages/sql-builder/src/sql-validator.ts
+++ b/packages/sql-builder/src/sql-validator.ts
@@ -138,14 +138,30 @@ const SQL_INJECTION_PATTERNS = [
  *
  * Comment markers are only honored outside string literals (`'...'`), quoted
  * identifiers (`"..."`), and backtick identifiers (`` `...` ``), so a benign
- * literal like `'a -- b'` or `'/* not a comment *\/'` is preserved verbatim and
- * never produces a false positive.
+ * literal like `'a -- b'` or `'/* not a comment *\/'` is never mistaken for a
+ * comment.
+ *
+ * With `blankLiterals`, the CONTENTS of single-quoted string literals are
+ * additionally replaced by spaces (newlines preserved) while their delimiting
+ * quotes stay in place, so the result is still structurally valid SQL. This is
+ * what the keyword/function blocklists scan: a literal is *data*, and
+ * `WHERE query LIKE '%DROP TABLE%'` must not read as a DROP statement.
+ * Double-quoted and backtick identifiers are NEVER blanked — they are names,
+ * not data, and {@link SQL_PATTERNS.STRING_INJECTION_DOUBLE} needs them intact.
  *
  * @param sql - The raw SQL string
+ * @param options.blankLiterals - Also blank single-quoted literal contents
  * @returns The SQL with all comments replaced by single spaces
  * @internal
  */
-export function stripSqlComments(sql: string): string {
+export function stripSqlComments(
+  sql: string,
+  options: { blankLiterals?: boolean } = {}
+): string {
+  const blankLiterals = options.blankLiterals === true
+  // Blank a literal's content char, keeping newlines so line structure (and any
+  // non-dotall pattern that relies on it) is unchanged.
+  const mask = (c: string) => (c === '\n' ? '\n' : ' ')
   let out = ''
   let i = 0
   const n = sql.length
@@ -156,23 +172,30 @@ export function stripSqlComments(sql: string): string {
     const ch = sql[i]
 
     if (quote !== null) {
-      // Inside a string literal or quoted identifier: copy verbatim, honoring
-      // both backslash escapes (\' \" \`) and SQL-standard doubled quotes ('').
+      // Inside a string literal or quoted identifier: copy verbatim (or blank
+      // the contents of a `'...'` literal when asked), honoring both backslash
+      // escapes (\' \" \`) and SQL-standard doubled quotes ('').
+      const blank = blankLiterals && quote === "'"
       if (ch === '\\' && i + 1 < n) {
-        out += ch + sql[i + 1]
+        const esc = sql[i + 1]
+        out += blank ? mask(ch) + mask(esc) : ch + esc
         i += 2
         continue
       }
       if (ch === quote) {
         if (sql[i + 1] === quote) {
           // Doubled quote is an escaped quote, still inside the literal.
-          out += ch + sql[i + 1]
+          out += blank ? mask(ch) + mask(ch) : ch + sql[i + 1]
           i += 2
           continue
         }
+        // Closing delimiter: always kept so the quote structure survives.
         quote = null
+        out += ch
+        i += 1
+        continue
       }
-      out += ch
+      out += blank ? mask(ch) : ch
       i += 1
       continue
     }
@@ -238,14 +261,20 @@ export function validateSqlQuery(sql: string): void {
 
   // Normalize comments away BEFORE running keyword/function detection. A block or
   // line comment placed between a blocked token and its `(` (e.g. `remote/*x*/(`)
-  // otherwise slips past `\s*\(` while parsing identically for ClickHouse. String
-  // literals are left intact so benign `'-- text'` / `'/* text */'` don't trip the
-  // patterns. See {@link stripSqlComments}.
+  // otherwise slips past `\s*\(` while parsing identically for ClickHouse.
+  // See {@link stripSqlComments}.
   const normalized = stripSqlComments(sql)
+
+  // The blocklists scan a second copy whose string-literal CONTENTS are blanked
+  // (quotes kept, so the query's structure — and the OR-tautology patterns that
+  // rely on it — is unchanged). Text inside a literal is data, never executable
+  // SQL: `WHERE query LIKE '%DROP TABLE%'` and `LIKE '%s3(%'` are routine
+  // monitoring queries and must not read as DDL or a table-function call.
+  const scannable = stripSqlComments(sql, { blankLiterals: true })
 
   // Check for SQL injection patterns
   for (const pattern of SQL_INJECTION_PATTERNS) {
-    if (pattern.test(normalized)) {
+    if (pattern.test(scannable)) {
       throw new Error(
         'Potentially dangerous SQL detected. Only SELECT, WITH, DESCRIBE, and EXPLAIN queries are allowed.'
       )


### PR DESCRIPTION
## What

Two bugs in `packages/sql-builder`, both found by the automated bug audit.

### #2949 — validator rejected SELECTs whose string literals contain blocked keywords

The keyword/function blocklists ran over raw text, so text *inside* a string
literal was read as SQL. `SELECT query FROM system.query_log WHERE query LIKE
'%DROP TABLE%'` threw "Potentially dangerous SQL detected" on every free-form SQL
surface (explorer, `/api/v1/data`, agent `query` tool, Slack commands, browser
connection proxy). Auditing DDL history or hunting `s3()`/`url()` usage is routine
read-only monitoring and was impossible.

`stripSqlComments` gained a `blankLiterals` mode: it blanks the **contents** of
single-quoted literals (newlines preserved) while keeping the delimiting quotes,
so the query keeps its structure. The blocklists scan that copy; the
statement-type prefix check still runs on the comment-only-normalized copy.

- Escapes (`''` and `\'`) are blanked as content, so a literal can never be split in half.
- Double-quoted / backtick identifiers are **never** blanked — they are names, and `STRING_INJECTION_DOUBLE` needs them.
- Quote structure survives, so `OR '1'='1` still becomes `OR ' '=' ` and is still rejected.
- Everything outside a literal is blocked exactly as before, including the #2465 comment-bypass (the two passes compose).

### #2950 — `splitSqlStatements` closed a block comment early on `/*/`

Entering the block state consumed only `/`, so in `/*/` the same `*` that opened
the comment also closed it and `SELECT 1 /*/ ; */ , 2` (one statement to
ClickHouse) split into two invalid fragments. The opener index is now recorded
and the closing `*/` must begin at least 2 chars later, mirroring
`sql-validator.ts`.

## Tests

- `sql-validator.test.ts`: new `stripSqlComments (blankLiterals)` unit block + `blocked keywords inside string literals (issue #2949)` — accepts the exact issue query, DDL/table-function audits, escaped-quote literals; still rejects DDL and `s3()`/`url()`/`remote()` outside a literal, comment-obfuscated calls, and OR-tautologies.
- `split-statements.test.ts`: `/*/ ; */` stays one statement; a real trailing `;` after it still splits; ordinary `/**/` and non-nesting `/*/*/` unchanged.

## Docs

`docs/knowledge/sql-validator-threat-model.md` gets a dated section for the
literal-blanking pass (the previous section explicitly documented literals being
left untouched).

Fixes #2949
Fixes #2950
