### PR TITLE
fix(clickhouse-client): pool key, release leaks, credential list alignment, probe dedup

### DIFF
--- a/apps/dashboard/src/lib/findings/findings-store.test.ts
+++ b/apps/dashboard/src/lib/findings/findings-store.test.ts
@@ -19,15 +19,25 @@ let fetchDataImpl: (arg: {
 let lastQuery = ''
 let lastParams: Record<string, unknown> = {}
 
+// Every getClient() lease must be handed back — see issue #2946.
+let getClientCalls = 0
+let releaseClientCalls = 0
+
 // NB: do NOT mock '@chm/logger' — replacing the whole module drops named
 // exports other modules import (e.g. clerk-client's `error`), and bun's
 // mock.module is global + persists across files. The real logger is harmless
 // in tests. Only the data client is mocked.
 mock.module('@chm/clickhouse-client', () => ({
-  getClient: async () => ({
-    command: (...a: unknown[]) => commandImpl.apply(null, a as []),
-    insert: (arg: unknown) => insertImpl(arg),
-  }),
+  getClient: async () => {
+    getClientCalls++
+    return {
+      command: (...a: unknown[]) => commandImpl.apply(null, a as []),
+      insert: (arg: unknown) => insertImpl(arg),
+    }
+  },
+  releaseClient: () => {
+    releaseClientCalls++
+  },
   fetchData: (arg: {
     query: string
     query_params?: Record<string, unknown>
@@ -46,6 +56,8 @@ beforeEach(() => {
   fetchDataImpl = async () => ({ data: [] })
   lastQuery = ''
   lastParams = {}
+  getClientCalls = 0
+  releaseClientCalls = 0
 })
 
 // Use a unique hostId per recordFinding test — ensureTable() memoizes success
@@ -99,6 +111,49 @@ describe('recordFinding', () => {
       title: 'z',
     })
     expect(ok).toBe(false)
+  })
+
+  // Regression coverage for issue #2946: getClient() leases a pooled client,
+  // so ensureTable/recordFinding must hand every lease back — otherwise the
+  // pool entry can never be reclaimed by cleanupStaleClients.
+  test('releases every leased client on the happy path', async () => {
+    await recordFinding(hostSeq++, {
+      severity: 'info',
+      category: 'x',
+      source: 'y',
+      title: 'z',
+    })
+    // One lease for ensureTable (CREATE TABLE), one for the insert.
+    expect(getClientCalls).toBe(2)
+    expect(releaseClientCalls).toBe(getClientCalls)
+  })
+
+  test('releases the leased client when CREATE TABLE fails', async () => {
+    commandImpl = async () => {
+      throw new Error('READONLY')
+    }
+    await recordFinding(hostSeq++, {
+      severity: 'info',
+      category: 'x',
+      source: 'y',
+      title: 'z',
+    })
+    expect(getClientCalls).toBe(1)
+    expect(releaseClientCalls).toBe(getClientCalls)
+  })
+
+  test('releases the leased client when the insert fails', async () => {
+    insertImpl = async () => {
+      throw new Error('insert blew up')
+    }
+    await recordFinding(hostSeq++, {
+      severity: 'info',
+      category: 'x',
+      source: 'y',
+      title: 'z',
+    })
+    expect(getClientCalls).toBe(2)
+    expect(releaseClientCalls).toBe(getClientCalls)
   })
 })
 

--- a/apps/dashboard/src/lib/findings/findings-store.ts
+++ b/apps/dashboard/src/lib/findings/findings-store.ts
@@ -15,7 +15,7 @@
  * This module must only be imported by server route handlers (src/routes/api/**).
  */
 
-import { fetchData, getClient } from '@chm/clickhouse-client'
+import { fetchData, getClient, releaseClient } from '@chm/clickhouse-client'
 import { ErrorLogger } from '@chm/logger'
 import { FINDINGS_TABLE } from '@/lib/app-tables'
 
@@ -91,10 +91,16 @@ async function ensureTable(hostId: number): Promise<boolean> {
 
   try {
     const client = await getClient({ hostId })
-    await client.command({ query: CREATE_FINDINGS_TABLE })
-    ensuredHosts.add(hostId)
-    log(`ensured ${FINDINGS_TABLE} on host ${hostId}`)
-    return true
+    // getClient leases the pooled client (inUse++) — release it or the pool
+    // entry is never reclaimed by cleanupStaleClients (issue #2946).
+    try {
+      await client.command({ query: CREATE_FINDINGS_TABLE })
+      ensuredHosts.add(hostId)
+      log(`ensured ${FINDINGS_TABLE} on host ${hostId}`)
+      return true
+    } finally {
+      releaseClient({ hostId })
+    }
   } catch (err) {
     warn(
       `could not ensure ${FINDINGS_TABLE} on host ${hostId} (read-only?): ${err}`
@@ -130,24 +136,28 @@ export async function recordFinding(
 
   try {
     const client = await getClient({ hostId })
-    await client.insert({
-      table: FINDINGS_TABLE,
-      format: 'JSONEachRow',
-      values: [
-        {
-          host_id: String(hostId),
-          severity: finding.severity,
-          category: finding.category,
-          source: finding.source,
-          title: finding.title,
-          detail: finding.detail ?? '',
-          metric: finding.metric ?? '',
-          value: finding.value ?? 0,
-        },
-      ],
-    })
-    log(`recorded finding "${finding.title}" on host ${hostId}`)
-    return true
+    try {
+      await client.insert({
+        table: FINDINGS_TABLE,
+        format: 'JSONEachRow',
+        values: [
+          {
+            host_id: String(hostId),
+            severity: finding.severity,
+            category: finding.category,
+            source: finding.source,
+            title: finding.title,
+            detail: finding.detail ?? '',
+            metric: finding.metric ?? '',
+            value: finding.value ?? 0,
+          },
+        ],
+      })
+      log(`recorded finding "${finding.title}" on host ${hostId}`)
+      return true
+    } finally {
+      releaseClient({ hostId })
+    }
   } catch (err) {
     warn(`failed to record finding on host ${hostId}: ${err}`)
     return false

--- a/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
+++ b/packages/clickhouse-client/src/__tests__/clickhouse-version.test.ts
@@ -44,6 +44,11 @@ const { _resetEnvCache: resetEnvCache } = await import(
   '../clickhouse/env-schema'
 )
 const { clientPool } = await import('../clickhouse/connection-pool')
+// Same `?test=version` buster as the module under test, so this is the SAME
+// pool instance its probes lease from.
+const { clientPool: versionPool } = await import(
+  new URL('../clickhouse/connection-pool.ts?test=version', import.meta.url).href
+)
 
 describe('parseVersion', () => {
   it('parses a standard 3-part version', () => {
@@ -690,5 +695,105 @@ describe('getClickHouseVersion — L2 (KV) cache wiring (issue #2183)', () => {
     const result = await getClickHouseVersion(0)
     expect(result).toEqual(parseVersion('24.3.1.1'))
     expect(mockClientQuery).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('probe lifecycle (issues #2946, #2953)', () => {
+  const originalEnv = { ...process.env }
+  // The module under test is loaded through a `?test=version` cache-buster, so
+  // read both pool instances and assert on whichever one actually got leased.
+  const leasedEntries = () => [
+    ...Array.from(versionPool.values()),
+    ...Array.from(clientPool.values()),
+  ]
+  const expectEveryClientReleased = () => {
+    const entries = leasedEntries() as { inUse: number }[]
+    expect(entries.length).toBeGreaterThan(0)
+    expect(entries.map((entry) => entry.inUse)).toEqual(entries.map(() => 0))
+  }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
+    process.env.CLICKHOUSE_USER = 'default'
+    process.env.CLICKHOUSE_PASSWORD = ''
+    resetEnvCache()
+    versionPool.clear()
+    clientPool.clear()
+    clearVersionCache()
+    setVersionCacheL2Provider(null)
+    mockCreateClient.mockReset()
+    mockClientQuery.mockReset()
+    mockCreateClient.mockReturnValue(mockClient)
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ version: '24.3.1.1' }]),
+    })
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  // getClient() leases the pooled client (inUse++); without a matching
+  // releaseClient the entry never drops back to 0, so cleanupStaleClients can
+  // never reclaim it (issue #2946).
+  it('releases the pooled client after a successful version probe', async () => {
+    await getClickHouseVersion(0)
+
+    expectEveryClientReleased()
+  })
+
+  it('releases the pooled client when the version probe throws', async () => {
+    mockClientQuery.mockRejectedValue(new Error('connection refused'))
+
+    expect(await getClickHouseVersion(0)).toBeNull()
+    expectEveryClientReleased()
+  })
+
+  it('releases the pooled client after checkTableExists', async () => {
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ exists: 1 }]),
+    })
+
+    await checkTableExists(0, 'system', 'query_log')
+
+    expectEveryClientReleased()
+  })
+
+  it('releases the pooled client after checkTableHasData', async () => {
+    mockClientQuery.mockResolvedValue({
+      json: () => Promise.resolve([{ has_data: 1 }]),
+    })
+
+    await checkTableHasData(0, 'system.query_log')
+
+    expectEveryClientReleased()
+  })
+
+  // Concurrent callers on a cold isolate used to each fire their own
+  // `SELECT version()` (issue #2953).
+  it('runs one query for concurrent version probes of the same host', async () => {
+    const results = await Promise.all([
+      getClickHouseVersion(0),
+      getClickHouseVersion(0),
+      getClickHouseVersion(0),
+    ])
+
+    expect(results).toEqual([
+      parseVersion('24.3.1.1'),
+      parseVersion('24.3.1.1'),
+      parseVersion('24.3.1.1'),
+    ])
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the in-flight entry so a failed probe can be retried', async () => {
+    mockClientQuery.mockRejectedValueOnce(new Error('connection refused'))
+
+    expect(await getClickHouseVersion(0)).toBeNull()
+    expect(mockClientQuery).toHaveBeenCalledTimes(1)
+
+    expect(await getClickHouseVersion(0)).toEqual(parseVersion('24.3.1.1'))
+    expect(mockClientQuery).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
+++ b/packages/clickhouse-client/src/__tests__/table-existence-cache.test.ts
@@ -5,6 +5,14 @@
 import * as cache from '../table-existence-cache'
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 
+// The L2 suite below loads the module under test through a `?test=l2`
+// cache-buster, so hold BOTH connection-pool instances and assert on whichever
+// one actually got leased (issue #2946 coverage).
+const { clientPool: bustedPool } = await import(
+  new URL('../clickhouse/connection-pool.ts?test=l2', import.meta.url).href
+)
+const { clientPool: plainPool } = await import('../clickhouse/connection-pool')
+
 // These tests only touch the public side-effect-free shims around the LRU
 // cache (size / invalidate / clear / metrics). The async checkTableExists
 // path is skipped here — it hits the ClickHouse client and lives in the
@@ -68,6 +76,8 @@ describe('checkTableExists — L2 (KV) cache wiring (issue #2183)', () => {
   let l2cache: typeof import('../table-existence-cache')
 
   beforeEach(async () => {
+    bustedPool.clear()
+    plainPool.clear()
     process.env.CLICKHOUSE_HOST = 'http://localhost:8123'
     process.env.CLICKHOUSE_USER = 'default'
     process.env.CLICKHOUSE_PASSWORD = ''
@@ -165,6 +175,77 @@ describe('checkTableExists — L2 (KV) cache wiring (issue #2183)', () => {
 
       expect(result).toBe('unknown')
       expect(setSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // Regression coverage for issue #2946: getClient() leases the pooled client
+  // (inUse++). Without a matching releaseClient the entry never drops back to
+  // 0, so cleanupStaleClients can never reclaim it and totalInUse grows
+  // monotonically.
+  describe('pooled client lease (issue #2946)', () => {
+    const expectEveryClientReleased = () => {
+      const entries = [
+        ...Array.from(bustedPool.values()),
+        ...Array.from(plainPool.values()),
+      ] as { inUse: number }[]
+      expect(entries.length).toBeGreaterThan(0)
+      expect(entries.map((entry) => entry.inUse)).toEqual(entries.map(() => 0))
+    }
+
+    it('releases the pooled client after a successful probe', async () => {
+      await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+      expectEveryClientReleased()
+    })
+
+    it('releases the pooled client when the probe throws', async () => {
+      mockClientQuery.mockRejectedValue(new Error('connection refused'))
+
+      await l2cache.checkTableExists(0, 'system', 'backup_log')
+
+      expectEveryClientReleased()
+    })
+  })
+
+  // Regression coverage for issue #2953: a cold isolate mounting a dozen
+  // charts used to fire a dozen identical probes that all raced to cache.set.
+  describe('in-flight probe dedup (issue #2953)', () => {
+    it('runs one query for concurrent probes of the same table', async () => {
+      const results = await Promise.all([
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+      ])
+
+      expect(results).toEqual([true, true, true])
+      expect(mockClientQuery).toHaveBeenCalledTimes(1)
+    })
+
+    it('still probes separately for different tables', async () => {
+      await Promise.all([
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+        l2cache.checkTableExists(0, 'system', 'error_log'),
+      ])
+
+      expect(mockClientQuery).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears the in-flight entry so a later probe can retry', async () => {
+      mockClientQuery.mockRejectedValueOnce(new Error('timeout'))
+
+      const [first, second] = await Promise.all([
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+        l2cache.checkTableExists(0, 'system', 'backup_log'),
+      ])
+      // Both joined the same failed probe — nothing cached.
+      expect(first).toBe('unknown')
+      expect(second).toBe('unknown')
+      expect(mockClientQuery).toHaveBeenCalledTimes(1)
+
+      // The registry entry was removed, so a fresh probe runs.
+      const retried = await l2cache.checkTableExists(0, 'system', 'backup_log')
+      expect(retried).toBe(true)
+      expect(mockClientQuery).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/clickhouse-client/src/clickhouse-version.ts
+++ b/packages/clickhouse-client/src/clickhouse-version.ts
@@ -20,7 +20,7 @@
 import type { VersionedSql } from '@chm/sql-builder'
 
 // Use getClient directly to avoid circular dependency with fetchData.
-import { getClient } from './clickhouse/clickhouse-client'
+import { getClient, releaseClient } from './clickhouse/clickhouse-client'
 import { getClickHouseConfigs } from './clickhouse/clickhouse-config'
 import { QUERY_COMMENT } from './clickhouse/constants'
 import { debug, error as logError } from '@chm/logger'
@@ -47,6 +47,13 @@ const versionCache = new Map<
 
 // Cache TTL: 24 hours (version only changes on server upgrade)
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Version probes already running, keyed by hostId. A cold isolate rendering a
+ * page fires one version query per concurrent data fetch; deduping means the
+ * first caller pays for it and the rest await the same promise (issue #2953).
+ */
+const inFlightVersions = new Map<number, Promise<ClickHouseVersion | null>>()
 
 /**
  * L2 cache contract for `getClickHouseVersion` (issue #2183) — survives Worker
@@ -139,6 +146,22 @@ export async function getClickHouseVersion(
     return cached.version
   }
 
+  const running = inFlightVersions.get(hostId)
+  if (running) {
+    debug(`[clickhouse-version] Joined in-flight probe for host ${hostId}`)
+    return running
+  }
+
+  const probe = fetchClickHouseVersion(hostId).finally(() => {
+    inFlightVersions.delete(hostId)
+  })
+  inFlightVersions.set(hostId, probe)
+  return probe
+}
+
+async function fetchClickHouseVersion(
+  hostId: number
+): Promise<ClickHouseVersion | null> {
   // L2: KV cache (survives Worker isolate churn). No-op when no provider is
   // registered (self-hosted Node/Docker, or Cloudflare before the KV
   // namespace is provisioned — see #2183).
@@ -170,32 +193,38 @@ export async function getClickHouseVersion(
 
     // Use raw client to avoid circular dependency with fetchData
     const client = await getClient({ clientConfig })
-    const resultSet = await client.query({
-      query: `${QUERY_COMMENT}SELECT version() as version`,
-      format: 'JSONEachRow',
-    })
+    // getClient leases the pooled client (inUse++) — release it so the pool
+    // entry stays reclaimable by cleanupStaleClients (issue #2946).
+    try {
+      const resultSet = await client.query({
+        query: `${QUERY_COMMENT}SELECT version() as version`,
+        format: 'JSONEachRow',
+      })
 
-    const data = (await resultSet.json()) as { version: string }[]
-    const versionStr = data?.[0]?.version
+      const data = (await resultSet.json()) as { version: string }[]
+      const versionStr = data?.[0]?.version
 
-    if (!versionStr) {
-      logError('[clickhouse-version] Failed to get version from response')
-      return null
-    }
-
-    const version = parseVersion(versionStr)
-    versionCache.set(hostId, { version, timestamp: Date.now() })
-
-    if (l2) {
-      try {
-        await l2.set(hostId, version, CACHE_TTL_MS / 1000)
-      } catch (err) {
-        logError('[clickhouse-version] L2 cache set error:', err)
+      if (!versionStr) {
+        logError('[clickhouse-version] Failed to get version from response')
+        return null
       }
-    }
 
-    debug(`[clickhouse-version] Host ${hostId}: ${version.raw}`)
-    return version
+      const version = parseVersion(versionStr)
+      versionCache.set(hostId, { version, timestamp: Date.now() })
+
+      if (l2) {
+        try {
+          await l2.set(hostId, version, CACHE_TTL_MS / 1000)
+        } catch (err) {
+          logError('[clickhouse-version] L2 cache set error:', err)
+        }
+      }
+
+      debug(`[clickhouse-version] Host ${hostId}: ${version.raw}`)
+      return version
+    } finally {
+      releaseClient({ clientConfig })
+    }
   } catch (err) {
     logError('[clickhouse-version] Error fetching version:', err)
     return null
@@ -221,16 +250,20 @@ export async function checkTableExists(
     if (!clientConfig) return false
 
     const client = await getClient({ clientConfig })
-    const resultSet = await client.query({
-      query:
-        QUERY_COMMENT +
-        `SELECT count() > 0 as exists FROM system.tables WHERE database = {database:String} AND name = {table:String}`,
-      query_params: { database, table },
-      format: 'JSONEachRow',
-    })
+    try {
+      const resultSet = await client.query({
+        query:
+          QUERY_COMMENT +
+          `SELECT count() > 0 as exists FROM system.tables WHERE database = {database:String} AND name = {table:String}`,
+        query_params: { database, table },
+        format: 'JSONEachRow',
+      })
 
-    const data = (await resultSet.json()) as { exists: number }[]
-    return data?.[0]?.exists === 1
+      const data = (await resultSet.json()) as { exists: number }[]
+      return data?.[0]?.exists === 1
+    } finally {
+      releaseClient({ clientConfig })
+    }
   } catch {
     return 'unknown'
   }
@@ -253,15 +286,19 @@ export async function checkTableHasData(
     if (!clientConfig) return false
 
     const client = await getClient({ clientConfig })
-    const resultSet = await client.query({
-      query:
-        QUERY_COMMENT +
-        `SELECT count() > 0 as has_data FROM ${fullTableName} LIMIT 1`,
-      format: 'JSONEachRow',
-    })
+    try {
+      const resultSet = await client.query({
+        query:
+          QUERY_COMMENT +
+          `SELECT count() > 0 as has_data FROM ${fullTableName} LIMIT 1`,
+        format: 'JSONEachRow',
+      })
 
-    const data = (await resultSet.json()) as { has_data: number }[]
-    return data?.[0]?.has_data === 1
+      const data = (await resultSet.json()) as { has_data: number }[]
+      return data?.[0]?.has_data === 1
+    } finally {
+      releaseClient({ clientConfig })
+    }
   } catch {
     return 'unknown'
   }

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-client.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-client.test.ts
@@ -31,7 +31,7 @@ const { getClient, releaseClient, isCloudflareWorkers, _resetEnvCache } =
     new URL('../clickhouse-client.ts?test=client', import.meta.url).href
   )
 // Import connection-pool to clear between tests
-const { clientPool, cleanupStaleClients } = await import(
+const { clientPool, cleanupStaleClients, getPoolKey } = await import(
   new URL('../connection-pool.ts?test=client', import.meta.url).href
 )
 
@@ -187,6 +187,29 @@ describe('getClient', () => {
     expect(client1).toBe(client2)
   })
 
+  // Regression coverage for issue #2945: the pool key used to ignore the
+  // password, so a long-lived process kept querying with the OLD credentials
+  // after a CLICKHOUSE_PASSWORD rotation.
+  it('creates a fresh client after a password rotation instead of reusing the old one', async () => {
+    // A distinct client object per createClient() call, so identity tells us
+    // whether the pool handed back the stale one.
+    mockCreateClient.mockImplementation(() => ({ query: mock(() => {}) }))
+
+    process.env.CLICKHOUSE_PASSWORD = 'old_pw'
+    _resetEnvCache()
+    const beforeRotation = await getClient({ web: false })
+
+    process.env.CLICKHOUSE_PASSWORD = 'rotated_pw'
+    _resetEnvCache()
+    const afterRotation = await getClient({ web: false })
+
+    expect(afterRotation).not.toBe(beforeRotation)
+    expect(mockCreateClient).toHaveBeenCalledTimes(2)
+    expect(mockCreateClient).toHaveBeenLastCalledWith(
+      expect.objectContaining({ password: 'rotated_pw' })
+    )
+  })
+
   it('creates separate clients for web and non-web', async () => {
     mockCreateClient.mockReturnValue({ query: () => {} })
     mockCreateClientWeb.mockReturnValue({ query: () => {} })
@@ -250,7 +273,11 @@ describe('releaseClient', () => {
     mockCreateClient.mockReturnValue({})
     await getClient({ web: false })
 
-    const key = 'http://localhost:8123:default:false'
+    // CLICKHOUSE_PASSWORD=',p2' → host 0 has an empty password (#2947).
+    const key = getPoolKey(
+      { id: 0, host: 'http://localhost:8123', user: 'default', password: '' },
+      false
+    )
     const pooled = clientPool.get(key)
     expect(pooled).toBeDefined()
     expect(pooled?.inUse).toBe(1)
@@ -267,7 +294,10 @@ describe('releaseClient', () => {
     mockCreateClient.mockReturnValue({})
     await getClient({ hostId: 1, web: false })
 
-    const key = 'host2:u2:false'
+    const key = getPoolKey(
+      { id: 1, host: 'host2', user: 'u2', password: 'p2' },
+      false
+    )
     const pooled = clientPool.get(key)
     expect(pooled).toBeDefined()
     expect(pooled?.inUse).toBe(1)
@@ -280,7 +310,10 @@ describe('releaseClient', () => {
     mockCreateClient.mockReturnValue({})
     await getClient({ web: false })
 
-    const key = 'http://localhost:8123:default:false'
+    const key = getPoolKey(
+      { id: 0, host: 'http://localhost:8123', user: 'default', password: '' },
+      false
+    )
     const pooled = clientPool.get(key)
     expect(pooled).toBeDefined()
 

--- a/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/clickhouse-config.test.ts
@@ -135,27 +135,101 @@ describe('getClickHouseConfigs', () => {
     expect(configs[1].password).toBe('shared_pw')
   })
 
-  it('falls back to "default" user when not enough user entries', () => {
-    process.env.CLICKHOUSE_HOST = 'host1,host2'
-    process.env.CLICKHOUSE_USER = 'only_one_user'
-    process.env.CLICKHOUSE_PASSWORD = 'pw1,pw2'
+  // Regression coverage for issue #2948: the "one credential for all hosts"
+  // shortcut used to require BOTH lists to be length 1, so a single user with
+  // per-host passwords silently degraded hosts 2..n to the 'default' username.
+  it('broadcasts a single user across hosts even when passwords are per-host (#2948)', () => {
+    process.env.CLICKHOUSE_HOST = 'host1,host2,host3'
+    process.env.CLICKHOUSE_USER = 'monitor'
+    process.env.CLICKHOUSE_PASSWORD = 'pw1,pw2,pw3'
 
     const configs = getClickHouseConfigs()
-    // When users.length !== 1 or passwords.length !== 1, per-index fallback applies
-    expect(configs[0].user).toBe('only_one_user')
-    expect(configs[1].user).toBe('default') // fallback
+    expect(configs.map((c) => c.user)).toEqual([
+      'monitor',
+      'monitor',
+      'monitor',
+    ])
+    expect(configs.map((c) => c.password)).toEqual(['pw1', 'pw2', 'pw3'])
   })
 
-  it('falls back to empty password when not enough password entries', () => {
+  it('broadcasts a single password across hosts even when users are per-host (#2948)', () => {
     process.env.CLICKHOUSE_HOST = 'host1,host2'
     process.env.CLICKHOUSE_USER = 'u1,u2'
     process.env.CLICKHOUSE_PASSWORD = 'only_one_pw'
 
     const configs = getClickHouseConfigs()
-    expect(configs[0].password).toBe('only_one_pw')
-    // users.length === 1 && passwords.length === 1 -> shared path
-    // Actually no: users has 2, passwords has 1 -> per-index fallback
-    expect(configs[1].password).toBe('')
+    expect(configs.map((c) => c.password)).toEqual([
+      'only_one_pw',
+      'only_one_pw',
+    ])
+  })
+
+  it('falls back to "default" user for hosts beyond the user list', () => {
+    process.env.CLICKHOUSE_HOST = 'host1,host2,host3'
+    process.env.CLICKHOUSE_USER = 'u1,u2'
+    process.env.CLICKHOUSE_PASSWORD = 'p1,p2,p3'
+
+    const configs = getClickHouseConfigs()
+    expect(configs.map((c) => c.user)).toEqual(['u1', 'u2', 'default'])
+  })
+
+  it('falls back to an empty password for hosts beyond the password list', () => {
+    process.env.CLICKHOUSE_HOST = 'host1,host2,host3'
+    process.env.CLICKHOUSE_USER = 'u1,u2,u3'
+    process.env.CLICKHOUSE_PASSWORD = 'p1,p2'
+
+    const configs = getClickHouseConfigs()
+    expect(configs.map((c) => c.password)).toEqual(['p1', 'p2', ''])
+  })
+
+  // Regression coverage for issue #2947: credential lists are positional, so
+  // dropping empty slots shifted every later value onto the wrong host —
+  // sending one host's password to another server.
+  describe('empty slots keep credential lists index-aligned (#2947)', () => {
+    it('does not shift passwords onto the wrong host', () => {
+      process.env.CLICKHOUSE_HOST = 'a,b,c'
+      process.env.CLICKHOUSE_USER = 'u1,u2,u3'
+      process.env.CLICKHOUSE_PASSWORD = 'p1,,p3'
+
+      const configs = getClickHouseConfigs()
+      expect(configs.map((c) => c.host)).toEqual(['a', 'b', 'c'])
+      // Host "b" has no password configured — it must NOT inherit "p3".
+      expect(configs.map((c) => c.password)).toEqual(['p1', '', 'p3'])
+    })
+
+    it('does not shift users onto the wrong host', () => {
+      process.env.CLICKHOUSE_HOST = 'a,b,c'
+      process.env.CLICKHOUSE_USER = 'u1,,u3'
+      process.env.CLICKHOUSE_PASSWORD = 'p1,p2,p3'
+
+      const configs = getClickHouseConfigs()
+      // The empty slot falls back to 'default', it does not consume 'u3'.
+      expect(configs.map((c) => c.user)).toEqual(['u1', 'default', 'u3'])
+    })
+
+    it('does not shift custom names onto the wrong host', () => {
+      process.env.CLICKHOUSE_HOST = 'a,b,c'
+      process.env.CLICKHOUSE_USER = 'u1,u2,u3'
+      process.env.CLICKHOUSE_PASSWORD = 'p1,p2,p3'
+      process.env.CLICKHOUSE_NAME = 'prod,,dev'
+
+      const configs = getClickHouseConfigs()
+      expect(configs.map((c) => c.customName)).toEqual([
+        'prod',
+        undefined,
+        'dev',
+      ])
+    })
+
+    it('still applies the per-field defaults when a list is entirely empty', () => {
+      process.env.CLICKHOUSE_HOST = 'a,b'
+      process.env.CLICKHOUSE_USER = ''
+      process.env.CLICKHOUSE_PASSWORD = ''
+
+      const configs = getClickHouseConfigs()
+      expect(configs.map((c) => c.user)).toEqual(['default', 'default'])
+      expect(configs.map((c) => c.password)).toEqual(['', ''])
+    })
   })
 
   it('assigns custom names from CLICKHOUSE_NAME', () => {

--- a/packages/clickhouse-client/src/clickhouse/__tests__/connection-pool.test.ts
+++ b/packages/clickhouse-client/src/clickhouse/__tests__/connection-pool.test.ts
@@ -25,8 +25,12 @@ describe('getPoolKey', () => {
       user: 'admin',
       password: 'secret',
     }
-    expect(getPoolKey(config, false)).toBe('http://localhost:8123:admin:false')
-    expect(getPoolKey(config, true)).toBe('http://localhost:8123:admin:true')
+    expect(getPoolKey(config, false)).toStartWith(
+      'http://localhost:8123:admin:false:'
+    )
+    expect(getPoolKey(config, true)).toStartWith(
+      'http://localhost:8123:admin:true:'
+    )
   })
 
   it('differentiates web vs non-web clients', () => {
@@ -44,6 +48,39 @@ describe('getPoolKey', () => {
     const c1 = { id: 0, host: 'host', user: 'user1', password: '' }
     const c2 = { id: 0, host: 'host', user: 'user2', password: '' }
     expect(getPoolKey(c1, false)).not.toBe(getPoolKey(c2, false))
+  })
+
+  // Regression coverage for issue #2945: the password is part of the client's
+  // identity. Without it, a rotated CLICKHOUSE_PASSWORD resolves to the pooled
+  // client built with the OLD credentials.
+  describe('password is part of the key (issue #2945)', () => {
+    it('differentiates a rotated password on the same host+user', () => {
+      const before = { id: 0, host: 'host', user: 'admin', password: 'old_pw' }
+      const after = { id: 0, host: 'host', user: 'admin', password: 'new_pw' }
+      expect(getPoolKey(before, false)).not.toBe(getPoolKey(after, false))
+    })
+
+    it('distinguishes an empty password from a set one', () => {
+      const none = { id: 0, host: 'host', user: 'admin', password: '' }
+      const some = { id: 0, host: 'host', user: 'admin', password: 'pw' }
+      expect(getPoolKey(none, false)).not.toBe(getPoolKey(some, false))
+    })
+
+    it('is stable for the same credentials (pooling still works)', () => {
+      const a = { id: 0, host: 'host', user: 'admin', password: 'same_pw' }
+      const b = { id: 9, host: 'host', user: 'admin', password: 'same_pw' }
+      expect(getPoolKey(a, false)).toBe(getPoolKey(b, false))
+    })
+
+    it('never embeds the raw secret — the key is debug-logged', () => {
+      const config = {
+        id: 0,
+        host: 'host',
+        user: 'admin',
+        password: 'super-secret-value',
+      }
+      expect(getPoolKey(config, false)).not.toContain('super-secret-value')
+    })
   })
 })
 
@@ -67,7 +104,7 @@ describe('getPooledClient', () => {
     expect(pooled.createdAt).toBeGreaterThan(0)
     expect(pooled.lastUsed).toBeGreaterThan(0)
     expect(pooled.inUse).toBe(0)
-    expect(clientPool.has('host1:admin:false')).toBe(true)
+    expect(clientPool.has(getPoolKey(config, false))).toBe(true)
   })
 
   it('reuses existing pooled client on subsequent calls', () => {
@@ -173,7 +210,7 @@ describe('getConnectionPoolStats', () => {
     expect(stats.totalInUse).toBe(3)
     expect(stats.totalIdle).toBe(0)
     expect(stats.clients).toHaveLength(1)
-    expect(stats.clients[0].key).toBe('host1:admin:false')
+    expect(stats.clients[0].key).toBe(getPoolKey(config, false))
     expect(stats.clients[0].inUse).toBe(3)
   })
 

--- a/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
+++ b/packages/clickhouse-client/src/clickhouse/clickhouse-config.ts
@@ -93,6 +93,20 @@ function splitByComma(value: string) {
     .filter(Boolean)
 }
 
+/**
+ * Split a credential list positionally: trim only, NO `filter(Boolean)`.
+ *
+ * Credentials are matched to hosts by index, so dropping empty slots shifts
+ * every later value onto the wrong host — with `CLICKHOUSE_PASSWORD=p1,,p3` the
+ * third host's password used to be sent to the second (issue #2947). An
+ * entirely empty value still
+ * yields `[]` so the per-field fallbacks ('default' / '') apply.
+ */
+function splitByCommaKeepEmpty(value: string) {
+  if (!value.trim()) return []
+  return value.split(',').map((item) => item.trim())
+}
+
 export const getClickHouseConfigs = (): ClickHouseConfig[] => {
   const env = validateClickHouseEnv()
   if (_cachedConfigs && _cachedEnv === env) return _cachedConfigs
@@ -127,9 +141,9 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
   }
 
   const hosts = splitByComma(hostEnv)
-  const users = splitByComma(userEnv)
-  const passwords = splitByComma(passwordEnv)
-  const customLabels = splitByComma(customNameEnv)
+  const users = splitByCommaKeepEmpty(userEnv)
+  const passwords = splitByCommaKeepEmpty(passwordEnv)
+  const customLabels = splitByCommaKeepEmpty(customNameEnv)
 
   debug('[ClickHouse Config] Parsed hosts count:', hosts.length)
 
@@ -142,23 +156,21 @@ export const getClickHouseConfigs = (): ClickHouseConfig[] => {
   }
 
   const configs = hosts.map((host, index) => {
-    // User and password fallback to the first value,
-    // supporting multiple hosts with the same user/password
-    let user, password
-    if (users.length === 1 && passwords.length === 1) {
-      user = users[0]
-      password = passwords[0]
-    } else {
-      user = users[index] || 'default'
-      password = passwords[index] || ''
-    }
+    // A single-entry list is broadcast to every host, so one credential can
+    // serve all of them. This is decided PER FIELD: a single CLICKHOUSE_USER
+    // with three passwords used to fall through to the 'default' username for
+    // hosts 2..n (issue #2948).
+    const user = (users.length === 1 ? users[0] : users[index]) || 'default'
+    const password =
+      (passwords.length === 1 ? passwords[0] : passwords[index]) ?? ''
 
     const config = {
       id: index,
       host,
       user,
       password,
-      customName: customLabels[index],
+      // Names are never broadcast — an empty slot means "no custom name".
+      customName: customLabels[index] || undefined,
     }
 
     if (isDebugEnabled()) {

--- a/packages/clickhouse-client/src/clickhouse/connection-pool.ts
+++ b/packages/clickhouse-client/src/clickhouse/connection-pool.ts
@@ -43,12 +43,31 @@ function startPeriodicCleanup(): void {
 }
 
 /**
+ * Short, non-reversible digest (FNV-1a 32-bit) used to fingerprint a secret
+ * inside a pool key. Deliberately dependency-free and synchronous — the
+ * WebCrypto digest API is async and `node:crypto` is unavailable on Workers.
+ * It is a change detector, not a security primitive.
+ */
+function secretFingerprint(secret: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < secret.length; i++) {
+    hash ^= secret.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+/**
  * Generate a pool key from client configuration and web flag
  */
 export function getPoolKey(config: ClickHouseConfig, web: boolean): PoolKey {
-  const base = `${config.host}:${config.user}:${web}`
-  // Scope a distinct pooled client per default database. Keys without a
-  // database are byte-identical to before, so existing pooling is unchanged.
+  // The password is part of the client's identity: without it, two configs
+  // sharing host+user+web+db collide, so a rotated CLICKHOUSE_PASSWORD kept
+  // reusing the client built with the OLD credentials (issue #2945). Only the
+  // digest goes into the key — the key itself is debug-logged below.
+  const pw = secretFingerprint(config.password ?? '')
+  const base = `${config.host}:${config.user}:${web}:pw=${pw}`
+  // Scope a distinct pooled client per default database.
   return config.database ? `${base}:db=${config.database}` : base
 }
 

--- a/packages/clickhouse-client/src/index.ts
+++ b/packages/clickhouse-client/src/index.ts
@@ -41,6 +41,7 @@ export {
   getClient,
   getConnectionPoolStats,
   isCloudflareWorkers,
+  releaseClient,
 } from './clickhouse/clickhouse-client'
 // Re-export configuration functions
 export {

--- a/packages/clickhouse-client/src/table-existence-cache.ts
+++ b/packages/clickhouse-client/src/table-existence-cache.ts
@@ -1,4 +1,4 @@
-import { getClient } from './clickhouse/clickhouse-client'
+import { getClient, releaseClient } from './clickhouse/clickhouse-client'
 import { debug, error } from '@chm/logger'
 import { LRUCache } from 'lru-cache'
 
@@ -58,6 +58,14 @@ export function setTableExistenceL2Provider(
  */
 export type TableExistsResult = boolean | 'unknown'
 
+/**
+ * Probes already running, keyed the same way as the L1 cache. A fresh Worker
+ * isolate mounting a dozen charts used to fire a dozen identical probes that
+ * all raced to `cache.set` (issue #2953); now the first one wins and the rest
+ * await its promise.
+ */
+const inFlightProbes = new Map<string, Promise<TableExistsResult>>()
+
 export async function checkTableExists(
   hostId: number,
   database: string,
@@ -69,6 +77,25 @@ export async function checkTableExists(
     return cached
   }
 
+  const running = inFlightProbes.get(key)
+  if (running) {
+    debug(`[Table Cache] Joined in-flight probe for ${key}`)
+    return running
+  }
+
+  const probe = probeTableExists(key, hostId, database, table).finally(() => {
+    inFlightProbes.delete(key)
+  })
+  inFlightProbes.set(key, probe)
+  return probe
+}
+
+async function probeTableExists(
+  key: string,
+  hostId: number,
+  database: string,
+  table: string
+): Promise<TableExistsResult> {
   // L2: KV cache (survives Worker isolate churn). No-op when no provider is
   // registered (self-hosted Node/Docker, or Cloudflare before the KV
   // namespace is provisioned — see #2183).
@@ -89,28 +116,34 @@ export async function checkTableExists(
   try {
     // getClient will auto-detect and use web client for Cloudflare Workers
     const client = await getClient({ hostId })
-    const result = await client.query({
-      query: `
-        SELECT COUNT() AS count
-        FROM system.tables
-        WHERE database = {database:String}
-          AND name     = {table:String}
-      `,
-      query_params: { database, table },
-      format: 'JSONEachRow',
-    })
-    const data = (await result.json()) as { count: string }[]
-    const exists = parseInt(data?.[0]?.count || '0', 10) > 0
+    // getClient leases the pooled client (inUse++); without the release the
+    // pool entry can never be reclaimed by cleanupStaleClients (issue #2946).
+    try {
+      const result = await client.query({
+        query: `
+          SELECT COUNT() AS count
+          FROM system.tables
+          WHERE database = {database:String}
+            AND name     = {table:String}
+        `,
+        query_params: { database, table },
+        format: 'JSONEachRow',
+      })
+      const data = (await result.json()) as { count: string }[]
+      const exists = parseInt(data?.[0]?.count || '0', 10) > 0
 
-    cache.set(key, exists)
-    if (l2) {
-      try {
-        await l2.set(key, exists, CACHE_TTL_MS / 1000)
-      } catch (err) {
-        error('[Table Cache] L2 cache set error:', err)
+      cache.set(key, exists)
+      if (l2) {
+        try {
+          await l2.set(key, exists, CACHE_TTL_MS / 1000)
+        } catch (err) {
+          error('[Table Cache] L2 cache set error:', err)
+        }
       }
+      return exists
+    } finally {
+      releaseClient({ hostId })
     }
-    return exists
   } catch (err) {
     error(`Error checking table ${database}.${table}:`, err)
     // Transient probe failure (network/timeout/auth) — NOT "table missing".


### PR DESCRIPTION
Five verified bugs from the automated audit of `packages/clickhouse-client`, each with regression tests.

## #2945 — pool key omitted the password
`getPoolKey` keyed on host+user+web(+db) only, so two configs sharing those collided: after a `CLICKHOUSE_PASSWORD` rotation a long-lived process kept querying with the pooled client built from the OLD credentials. The key now carries a short FNV-1a digest of the password (inline, no `node:crypto` — Workers-safe). The secret itself never enters the key, which is debug-logged.

## #2946 — `getClient` callers never released their lease
`getClient` increments `inUse`; `cleanupStaleClients` only evicts at `inUse === 0`, so unreleased leases made pool entries permanently unreclaimable and `totalInUse` grow monotonically. Added `try/finally releaseClient` in `table-existence-cache.ts`, `clickhouse-version.ts` (version probe plus `checkTableExists` / `checkTableHasData`, same bug class in the same file) and `apps/dashboard/src/lib/findings/findings-store.ts` (`ensureTable` + `recordFinding`). `releaseClient` is now exported from the package index.

## #2947 — `filter(Boolean)` misaligned credential lists
Credentials map to hosts positionally, so dropping empty slots shifted every later value: `CLICKHOUSE_HOST=a,b,c` + `CLICKHOUSE_PASSWORD=p1,,p3` sent host `c`'s password to host `b`. User / password / name lists now split with trim only; host lists keep the filter.

## #2948 — single user + multi password fell back to `default`
The "one credential for all hosts" shortcut required BOTH lists to be length 1. `CLICKHOUSE_USER=monitor` with three passwords silently gave hosts 2 and 3 the username `default`. The broadcast is now decided per field.

## #2953 — no in-flight dedup for probes
A cold Worker isolate mounting a dozen charts fired a dozen identical table-existence probes plus version queries, all racing to `cache.set`. Both `checkTableExists` and `getClickHouseVersion` now keep a `Map` of in-flight promises, joined on hit and deleted in `finally` so failures still retry.

## Tests
Regression tests added/updated in the package's existing suites (`connection-pool`, `clickhouse-client`, `clickhouse-config`, `table-existence-cache`, `clickhouse-version`) and `findings-store.test.ts`. Two config tests that encoded the old #2948 behaviour were rewritten. Pool-key literals in existing tests now go through `getPoolKey` instead of hardcoded strings.

Fixes #2945
Fixes #2946
Fixes #2947
Fixes #2948
Fixes #2953