### PR TITLE
fix(ai): break mv-designer module's circular type imports

### DIFF
--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/ddl.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/ddl.ts
@@ -11,7 +11,8 @@ import {
   quoteIdentifier,
 } from '@/lib/ai/agent/tools/sql-analysis'
 
-import type { AggregateCall, Design, DesignKind } from './index'
+import type { Design, DesignKind } from './design-selection'
+import type { AggregateCall } from './sql-parsing'
 
 function normalizeForAlias(s: string): string {
   return s

--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/design-selection.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/design-selection.ts
@@ -5,10 +5,24 @@
  * See `./index.ts` for the module overview.
  */
 
-import type { AggregateCall, Design, DesignInput } from './index'
+import type { AggregateCall } from './sql-parsing'
 
 /** ClickHouse aggregate functions whose merge semantics are a plain sum (safe for SummingMergeTree). Everything else needs `-State`/`-Merge` (AggregatingMergeTree). */
 const SUM_COMPATIBLE_FUNCTIONS = new Set(['sum', 'count'])
+
+export type DesignKind = 'projection' | 'summing_mv' | 'aggregating_mv'
+
+export interface DesignInput {
+  tableCount: number
+  groupByKeys: string[]
+  sortingKeyCols: string[]
+  aggregateCalls: AggregateCall[]
+}
+
+export interface Design {
+  kind: DesignKind
+  rationale: string
+}
 
 function normalizeKey(key: string): string {
   return key.trim().replace(/\s+/g, ' ').toLowerCase()

--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/index.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/index.ts
@@ -40,7 +40,9 @@
 
 import { formatQualifiedTable } from '@/lib/ai/agent/tools/sql-analysis'
 
+import type { DesignKind } from './design-selection'
 import type { MinedShape } from './shape-mining'
+import type { ImpactEstimate, SizeEstimate } from './size-estimator'
 
 import { buildDdl, buildRiskNote } from './ddl'
 import { chooseDesign } from './design-selection'
@@ -97,31 +99,18 @@ const QUERY_LOG_UNAVAILABLE_MESSAGE =
 
 // ---------------------------------------------------------------------------
 // Types
+//
+// `AggregateCall` lives in `./sql-parsing` (where it's first produced),
+// `DesignKind`/`Design`/`DesignInput` in `./design-selection`, and
+// `SizeEstimate`/`ImpactEstimate`/`SizeEstimateInput` in `./size-estimator` —
+// each owned by the module that defines it, so the sibling modules never need
+// to import back from this orchestrator file (which would create a circular
+// dependency, since this file already imports their functions). All of them
+// are re-exported below via `export * from './<sibling>'`, so the full type
+// surface is still available from `@/lib/ai/advisor/mv-designer` exactly as
+// before. Only the result-level types below — used solely by this file's own
+// orchestrator — are declared here.
 // ---------------------------------------------------------------------------
-
-export type DesignKind = 'projection' | 'summing_mv' | 'aggregating_mv'
-
-export interface AggregateCall {
-  func: string
-  arg: string
-}
-
-export interface SizeEstimate {
-  /** Estimated row count for the MV/projection — approximated by the estimated distinct grouping-key combinations. */
-  estimatedRows: number
-  estimatedBytes: number
-  readableEstimatedBytes: string
-  /** distinctCombinations / sourceRows, clamped to [0, 1]. */
-  aggregationRatio: number
-  label: 'estimate'
-}
-
-export interface ImpactEstimate {
-  callsInWindow: number
-  currentReadBytesTotal: number
-  estimatedBytesSavedTotal: number
-  label: 'estimate'
-}
 
 export interface MvRecommendation {
   kind: DesignKind
@@ -153,24 +142,6 @@ export interface MvDesignerResult {
 }
 
 export type DesignResult = MvDesignerUnavailable | MvDesignerResult
-
-export interface DesignInput {
-  tableCount: number
-  groupByKeys: string[]
-  sortingKeyCols: string[]
-  aggregateCalls: AggregateCall[]
-}
-
-export interface Design {
-  kind: DesignKind
-  rationale: string
-}
-
-export interface SizeEstimateInput {
-  sourceRows: number
-  sourceBytes: number
-  distinctCombinations: number
-}
 
 // ---------------------------------------------------------------------------
 // Orchestration — ClickHouse-backed. Thin wrappers around the pure logic in

--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/shape-mining.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/shape-mining.ts
@@ -13,7 +13,7 @@ import {
   formatQualifiedTable,
 } from '@/lib/ai/agent/tools/sql-analysis'
 
-import type { AggregateCall } from './index'
+import type { AggregateCall } from './sql-parsing'
 
 import { scaleCardinality } from './size-estimator'
 import {

--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/size-estimator.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/size-estimator.ts
@@ -6,7 +6,28 @@
 
 import { formatBytes } from '@/lib/utils'
 
-import type { ImpactEstimate, SizeEstimate, SizeEstimateInput } from './index'
+export interface SizeEstimate {
+  /** Estimated row count for the MV/projection — approximated by the estimated distinct grouping-key combinations. */
+  estimatedRows: number
+  estimatedBytes: number
+  readableEstimatedBytes: string
+  /** distinctCombinations / sourceRows, clamped to [0, 1]. */
+  aggregationRatio: number
+  label: 'estimate'
+}
+
+export interface ImpactEstimate {
+  callsInWindow: number
+  currentReadBytesTotal: number
+  estimatedBytesSavedTotal: number
+  label: 'estimate'
+}
+
+export interface SizeEstimateInput {
+  sourceRows: number
+  sourceBytes: number
+  distinctCombinations: number
+}
 
 /**
  * MV/projection size ≈ source parts size × aggregation ratio, where the

--- a/apps/dashboard/src/lib/ai/advisor/mv-designer/sql-parsing.ts
+++ b/apps/dashboard/src/lib/ai/advisor/mv-designer/sql-parsing.ts
@@ -5,7 +5,10 @@
  * See `./index.ts` for the module overview.
  */
 
-import type { AggregateCall } from './index'
+export interface AggregateCall {
+  func: string
+  arg: string
+}
 
 const AGGREGATE_FUNCTION_NAMES = [
   'count',


### PR DESCRIPTION
## Summary

Follow-up to #2960, which merged before its second (fixup) commit had run through CI — `depcruise`'s `no-circular` rule flags `apps/dashboard/src/lib/ai/advisor/mv-designer/index.ts` and its siblings on main right now.

- `tsPreCompilationDeps: true` in `.dependency-cruiser.cjs` makes the `no-circular` rule treat `import type` edges as real edges. The original split had `index.ts` own all shared types while also importing functions from each sibling for the `designMaterializedViews` orchestrator, and siblings type-imported those shared types back from `./index` — a real cycle under this rule (even though it's fine at runtime, since type-only imports are erased).
- Fix: move each type to the sibling that first produces it — `AggregateCall` to `sql-parsing.ts`, `DesignKind`/`Design`/`DesignInput` to `design-selection.ts`, `SizeEstimate`/`ImpactEstimate`/`SizeEstimateInput` to `size-estimator.ts`. `index.ts` now only owns its own orchestrator-only result types (`MvRecommendation`, `MvDesignerUnavailable`, `MvDesignerResult`, `DesignResult`) and re-exports everything via `export * from './<sibling>'`, exactly as before.
- Verified: no file in `mv-designer/` imports from `./index` anymore, and all 25 originally-exported symbols are still exported exactly once (no duplicates).

## Test plan

- [x] `grep -rn "from './index'" apps/dashboard/src/lib/ai/advisor/mv-designer/` returns nothing
- [x] Every originally-exported symbol (types + functions + constants) traced to exactly one `export` declaration across the six files
- [ ] CI: `depcruise` green, `unit-tests` (includes `mv-designer.test.ts`) and `dashboard` required checks green
