### PR TITLE
fix(sql-builder): render SqlFragment columns via toSql in ExtendedBuilder

### DIFF
--- a/packages/sql-builder/src/__tests__/extension.test.ts
+++ b/packages/sql-builder/src/__tests__/extension.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { sql } from '../builder'
+import { col } from '../column'
+import { raw } from '../raw'
 import { SqlBuilderError } from '../validator'
 import { describe, expect, it } from 'bun:test'
 
@@ -617,6 +619,43 @@ describe('ExtendedBuilder', () => {
 
       // ext1 should still be the same
       expect(ext1.build()).toBe(ext1Query)
+    })
+  })
+
+  describe('SqlFragment columns (#2966)', () => {
+    it('should render col() columns via toSql, not [object Object]', () => {
+      const base = sql().select('id').from('users')
+      const extended = base.extend().addColumn(col('bytes').readable())
+
+      const query = extended.build()
+      expect(query).toContain('formatReadableSize(bytes) AS readable_bytes')
+      expect(query).not.toContain('[object Object]')
+    })
+
+    it('should render raw() columns via toSql, not [object Object]', () => {
+      const base = sql().select('id').from('users')
+      const extended = base.extend().addColumn(raw('COUNT(*) AS total'))
+
+      const query = extended.build()
+      expect(query).toContain('COUNT(*) AS total')
+      expect(query).not.toContain('[object Object]')
+    })
+
+    it('should render a mix of plain string, col(), and raw() columns', () => {
+      const base = sql().select('id').from('users')
+      const extended = base
+        .extend()
+        .addColumn(col('elapsed').pctOfMax())
+        .addColumn(raw('now() AS ts'))
+        .addColumn('name')
+
+      const query = extended.build()
+      expect(query).toContain(
+        'round(100 * elapsed / max(elapsed) OVER (), 2) AS pct_elapsed'
+      )
+      expect(query).toContain('now() AS ts')
+      expect(query).toContain('name')
+      expect(query).not.toContain('[object Object]')
     })
   })
 })

--- a/packages/sql-builder/src/render.ts
+++ b/packages/sql-builder/src/render.ts
@@ -306,8 +306,8 @@ export function renderExtendedQuery(
   // SELECT
   const columns = state.columns.map((col) => {
     if (typeof col === 'string') return col
-    if ('toString' in col && typeof col.toString === 'function') {
-      return col.toString()
+    if ('toSql' in col && typeof col.toSql === 'function') {
+      return col.toSql()
     }
     return String(col)
   })


### PR DESCRIPTION
## Summary
- `renderExtendedQuery` (ExtendedBuilder) rendered `col(...)`/`raw(...)` SqlFragment columns as `[object Object]` because its guard `'toString' in col` is always true (inherited from `Object.prototype`), so it called the default `Object.prototype.toString()` instead of the fragment's `toSql()`.
- Fix: check for a callable `toSql` first and call it; fall back to `String(col)` for anything else.
- Added tests in `packages/sql-builder/src/__tests__/extension.test.ts` covering `col()`, `raw()`, and mixed string/fragment columns in `ExtendedBuilder` output.

Fixes #2966

## Test plan
- [x] New unit tests added to `extension.test.ts`
- [ ] CI: `unit-tests` / `dashboard` required checks green