### PR TITLE
fix(sidebar): stop pin and drag icons overlapping in Favorites

### DIFF
--- a/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
@@ -45,12 +45,20 @@ interface NavFavoritesProps {
 function FavoriteDragHandle({
   listeners,
   attributes,
-}: Pick<ReturnType<typeof useSortable>, 'listeners' | 'attributes'>) {
+  hasBadge,
+}: Pick<ReturnType<typeof useSortable>, 'listeners' | 'attributes'> & {
+  /** The pin sits at `right-7` instead of `right-2` when the item has a
+   * badge slot, so the grip has to step one slot further left to match. */
+  hasBadge: boolean
+}) {
   return (
     <button
       type="button"
       aria-label="Reorder favorite"
-      className="absolute top-1/2 right-7 z-10 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded-md text-sidebar-foreground opacity-0 outline-hidden transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 active:cursor-grabbing group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 group-data-[collapsible=icon]:hidden"
+      className={cn(
+        'absolute top-1/2 right-7 z-10 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded-md text-sidebar-foreground opacity-0 outline-hidden transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 active:cursor-grabbing group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 group-data-[collapsible=icon]:hidden',
+        hasBadge && 'right-12'
+      )}
       {...attributes}
       {...listeners}
     >
@@ -91,7 +99,11 @@ function SortableFavoriteItem({
       }}
       leadingAction={
         dragEnabled ? (
-          <FavoriteDragHandle listeners={listeners} attributes={attributes} />
+          <FavoriteDragHandle
+            listeners={listeners}
+            attributes={attributes}
+            hasBadge={Boolean(item.isNew || item.countKey)}
+          />
         ) : undefined
       }
     />


### PR DESCRIPTION
## Problem

In the sidebar **Favorites** group, the reorder grip and the pin button could land on the exact same spot on hover.

`FavoriteDragHandle` was hardcoded to `right-7`, while `PinButton` sits at `right-2` normally but shifts to `right-7` when the item has a badge slot (`isNew` / `countKey`). For any favorited item with a badge, both icons stacked on top of each other.

## Fix

Pass `hasBadge` down to the drag handle and step it one slot further left (`right-12`) when the pin has already shifted. Non-badged items are unchanged.

## Verification

- `tsc --noEmit` clean
- `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A39CJTTjJmL4HgPrBCciK3