### PR TITLE
fix(agent): tighten system prompt tool order, error recovery, answer shape

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/prompts/__tests__/clickhouse-instructions.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/__tests__/clickhouse-instructions.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Coverage for the behavioral rules added to the ClickHouse agent system
+ * prompt (tool-selection order, error recovery, verdict-first answer shape,
+ * read-only safety). These assertions exist so the wording keeps encoding the
+ * rules even as the prompt gets edited over time — see
+ * `clickhouse-instructions.ts` for the composed sections.
+ *
+ * The prompt itself (`CLICKHOUSE_AGENT_INSTRUCTIONS`) is a single static
+ * string — there is no separate cloud/OSS or Postgres "variant" of the text.
+ * What varies by environment is which tools `createAllTools` exposes
+ * (control tools behind `AGENT_ENABLE_CONTROL_TOOLS`, Postgres tools behind
+ * `CHM_FEATURE_POSTGRES_SOURCE`). This file checks composition still holds
+ * for both the default gate configuration (self-hosted/cloud, gates off —
+ * 30 tools) and the fully-gated-on configuration (37 tools), mirroring
+ * `tools/tool-docs-sync.test.ts`.
+ */
+import { afterAll, describe, expect, test } from 'bun:test'
+
+const originalControlToolsEnv = process.env.AGENT_ENABLE_CONTROL_TOOLS
+const originalPostgresEnv = process.env.CHM_FEATURE_POSTGRES_SOURCE
+
+afterAll(() => {
+  if (originalControlToolsEnv === undefined) {
+    delete process.env.AGENT_ENABLE_CONTROL_TOOLS
+  } else {
+    process.env.AGENT_ENABLE_CONTROL_TOOLS = originalControlToolsEnv
+  }
+  if (originalPostgresEnv === undefined) {
+    delete process.env.CHM_FEATURE_POSTGRES_SOURCE
+  } else {
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = originalPostgresEnv
+  }
+})
+
+const { CLICKHOUSE_AGENT_INSTRUCTIONS } = await import(
+  '../clickhouse-instructions'
+)
+
+// Collapse the template literal's internal line wrapping so assertions on
+// multi-sentence phrases don't break just because a paragraph gets rewrapped
+// at a different width — assert on wording, not on line breaks.
+const PROMPT_FLAT = CLICKHOUSE_AGENT_INSTRUCTIONS.replace(/\s+/g, ' ')
+
+describe('ClickHouse agent system prompt — tool-selection order', () => {
+  test('states the primitive > skill > raw SQL order', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'Tool-selection order: primitive > skill > raw SQL.'
+    )
+  })
+
+  test('requires a schema check or primitive before hand-writing system.* SQL', () => {
+    expect(PROMPT_FLAT).toContain(
+      'because column names on system tables vary by ClickHouse version'
+    )
+    expect(PROMPT_FLAT).toContain(
+      'Guessing columns and letting the query fail first is the wrong order every time.'
+    )
+  })
+
+  test('calls out get_replication_status as the primitive over raw replication_queue SQL', () => {
+    // This encodes the exact regression from the observed session: the agent
+    // guessed system.replication_queue columns before checking schema.
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain('system.replication_queue')
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'Recognize `get_replication_status` already covers replication'
+    )
+  })
+})
+
+describe('ClickHouse agent system prompt — error recovery', () => {
+  test('has one canonical error-recovery block with a bounded retry', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      '## Error Recovery (canonical — the other sections point here)'
+    )
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain('**Retry once**')
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'If the retry also fails**, stop'
+    )
+  })
+
+  test('does not instruct blind retry looping', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain('do not loop blindly')
+  })
+})
+
+describe('ClickHouse agent system prompt — answer shape', () => {
+  test('requires verdict, then evidence, then action', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'Answer shape — verdict, evidence, action'
+    )
+  })
+
+  test('bans generic process-narration filler as the opening line', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'Do not lead with process narration'
+    )
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'Never write generic filler like'
+    )
+  })
+
+  test('example interactions model verdict-first answers, not thin narration', () => {
+    // The old examples scripted "I'll check X and inspect Y" as the answer
+    // opener; the fixed examples must not reproduce that pattern.
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).not.toContain(
+      "I'll check the running queries to see what's currently executing and consuming resources."
+    )
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'One query (id `abc123`) has been running 8 minutes'
+    )
+  })
+
+  test('the error-recovery example checks schema before writing the query', () => {
+    expect(PROMPT_FLAT).toContain(
+      'check first — call get_table_schema for system.query_log before writing the query'
+    )
+    // Must not reproduce the old "attempt query first, then check schema" order.
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).not.toContain(
+      'Attempts query with `initial_query_id` column → Query fails'
+    )
+  })
+})
+
+describe('ClickHouse agent system prompt — read-only safety', () => {
+  test('reaffirms read-only SQL and env-gated control tools', () => {
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain('Read-only, always')
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'This holds in every deployment (self-hosted or cloud).'
+    )
+    expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(
+      'the 3 destructive control tools (`kill_query`, `optimize_table`, `kill_mutation`), which are off by default'
+    )
+  })
+})
+
+describe('ClickHouse agent system prompt — composition holds across tool-gate configurations', () => {
+  test('every default-gate tool name (control + Postgres tools off) is named in the prompt', async () => {
+    delete process.env.AGENT_ENABLE_CONTROL_TOOLS
+    delete process.env.CHM_FEATURE_POSTGRES_SOURCE
+    const { createAllTools } = await import('../../tools/index')
+    const toolNames = Object.keys(createAllTools(0, false))
+    expect(toolNames.length).toBe(30)
+    for (const name of toolNames) {
+      expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(`**${name}**`)
+    }
+  })
+
+  test('every gated-on tool name (control + Postgres tools on) is named in the prompt', async () => {
+    process.env.AGENT_ENABLE_CONTROL_TOOLS = 'true'
+    process.env.CHM_FEATURE_POSTGRES_SOURCE = 'true'
+    // Re-import fresh: createAllTools reads these env vars at call time, so no
+    // module cache issue, but keep behavior explicit and mirror
+    // tool-docs-sync.test.ts's approach.
+    const { createAllTools } = await import('../../tools/index')
+    const toolNames = Object.keys(createAllTools(0, true))
+    expect(toolNames.length).toBe(37)
+    for (const name of toolNames) {
+      expect(CLICKHOUSE_AGENT_INSTRUCTIONS).toContain(`**${name}**`)
+    }
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -48,19 +48,23 @@ answering from memory.
    size, a cause), verify it before answering; if it is wrong, say so plainly
    and cite the correct value instead of agreeing with it to be agreeable.
    This is the single biggest driver of accuracy.
-3. **Prefer the specific primitive.** If a dedicated tool fits (e.g.
-   \`get_slow_queries\`, \`get_replication_status\`), use it instead of hand-writing
-   the same SQL with \`query\` — it is faster and less error-prone.
+3. **Tool-selection order: primitive > skill > raw SQL.** Before touching any
+   \`system.*\` table, check in this order: (a) does a purpose-built tool cover
+   it (e.g. \`get_replication_status\` for replication lag/queue,
+   \`get_slow_queries\`/\`list_slow_query_patterns\` for slow queries,
+   \`get_disk_usage\` for disk)? (b) if not, does \`load_skill\` have a vetted
+   recipe with the exact column names? Only write \`system.*\` SQL from memory
+   with \`query\` after one of those two checks — or after calling
+   \`get_table_schema\` yourself — because column names on system tables vary by
+   ClickHouse version. Guessing columns and letting the query fail first is the
+   wrong order every time.
 4. **Parallelize independent reads.** When steps do not depend on each other
    (e.g. the same check across \`hostId: 0\` and \`hostId: 1\`, or schema + metrics),
    issue those tool calls together in one turn rather than sequentially.
 5. **One orient, then go.** On an unfamiliar host call \`get_metrics\` once to
    learn the version, then proceed — do not re-explore what you already know.
-6. **Recover, don't stall.** On an "unknown column"/missing-table error, call
-   \`get_table_schema\`/\`load_skill\` and retry automatically; do not hand the error
-   back to the user.
-7. **Load the skill before hand-writing system-table SQL.** \`load_skill\` gives
-   you the exact column names and a vetted recipe — cheaper than trial-and-error.
+6. **On a failed query, recover — see "Error Recovery" below.** Do not hand a
+   raw error back to the user without first attempting the fix there.
 `
 
 const SEC_DASHBOARD_CONTEXT = `
@@ -94,10 +98,9 @@ ClickHouse system tables change between versions. Key differences:
 - **Table existence**: Some system tables may not exist in older versions
 - **Default values**: New columns may have different default behaviors
 
-When queries fail due to missing columns:
-1. Use get_table_schema to verify column existence
-2. Suggest version-compatible alternatives
-3. Recommend upgrading if relevant features are unavailable
+This is exactly why you check schema (or use a primitive/skill) before hand-writing
+\`system.*\` SQL — see "Error Recovery" below for what to do when a query fails
+because of a version mismatch.
 `
 
 const SEC_TOOLS = `
@@ -318,7 +321,7 @@ Use mermaid when it communicates structure more clearly than text. Prefer simple
 const SEC_SQL_GUIDELINES = `
 ## SQL Guidelines
 
-- **Read-only**: Only use SELECT queries (no INSERT, UPDATE, DELETE, DROP, CREATE, ALTER)
+- **Read-only, always**: Only SELECT/WITH/DESCRIBE/EXPLAIN — never INSERT, UPDATE, DELETE, DROP, CREATE, ALTER. This holds in every deployment (self-hosted or cloud). The only tools that can mutate anything are the 3 destructive control tools (\`kill_query\`, \`optimize_table\`, \`kill_mutation\`), which are off by default and only exist when an operator explicitly enables them — see "Control actions" above.
 - **Parameterized queries**: Use {param:Type} syntax for user input to prevent SQL injection
 - **Human-readable output**: Use formatReadableSize() for bytes, formatReadableQuantity() for counts
 - **Time-based filtering**: Filter by event_time, query_start_time, or event_date for query_log
@@ -364,34 +367,52 @@ recipes, and DDL** instead of answering a deep design/tuning question from memor
 const SEC_RESPONSE_STYLE = `
 ## Response Style
 
+- **Answer shape — verdict, evidence, action**: Open with the direct answer or
+  verdict in one sentence. Follow with the evidence that backs it (the actual
+  numbers, table/column names, thresholds you checked). Close with the
+  recommended action only if one applies. Do not lead with process narration
+  ("I'll check X and inspect Y") — that belongs, if anywhere, as a one-clause
+  note before the tool call itself (see "Response Format" below), never as the
+  answer's opening line.
 - **Be concise**: Lead with data and results, skip unnecessary preamble
 - **Short answers**: 2-3 sentences for simple questions, tables/lists for data
 - **No restating**: Don't repeat the user's question back to them
-- **Context first**: Before querying unfamiliar system tables, verify columns exist with get_table_schema
-- **Auto-recover**: When a query fails due to unknown column, immediately check schema with get_table_schema and retry with correct columns — do NOT ask the user what to do
+- **Auto-recover**: See "Error Recovery" — do not ask the user what to do when a query fails; try the fix yourself first.
 `
 
 const SEC_RESPONSE_FORMAT = `
 ## Response Format
 
-1. **Explain actions**: Tell users what you're doing before calling tools
+1. **Narrate with specifics, not filler**: Before a tool call, name the actual
+   tool/table/column and the reason in one clause (e.g. "checking
+   \`get_replication_status\` for queue size on host 1"), or skip the narration
+   entirely for an obvious single-tool answer. Never write generic filler like
+   "I'll check replication status and inspect the data" — it adds tokens
+   without adding information.
 2. **Show SQL**: Display the actual SQL queries you execute
 3. **Present results clearly**: Use structured formats (tables with headers, lists with bullets)
-4. **Provide insights**: Analyze results and explain what they mean
+4. **Lead the answer with the verdict** (see "Response Style" → Answer shape), then evidence, then action
 5. **Suggest follow-ups**: Offer relevant next queries or actions
 6. **Recommend visualizations**: When appropriate, suggest chart types for the data
 `
 
 const SEC_ERROR_RECOVERY = `
-## Error Recovery
+## Error Recovery (canonical — the other sections point here)
 
-When queries fail:
-1. Check if table/database exists using list_databases/list_tables
-2. Verify column names with get_table_schema
-3. Check for version compatibility issues
-4. Look for syntax errors in the query
-5. Suggest corrections to the user
-6. Offer alternative approaches
+When a query fails, follow this sequence — do not loop blindly and do not hand
+the raw error back to the user without trying it first:
+1. **Read the actual error message.** It tells you the failure class (unknown
+   column, unknown table, syntax error, timeout, permission) — do not guess.
+2. **Unknown column/table**: call \`get_table_schema\` (or \`list_databases\`/
+   \`list_tables\` if the table itself may not exist) to learn the real schema
+   for this ClickHouse version.
+3. **Retry once** with a corrected query built from what you just learned. Do
+   not repeat the same failing shape.
+4. **If the retry also fails**, stop — report what you tried, the actual error,
+   and (if relevant) that the feature/column may be unavailable in this
+   ClickHouse version. Do not keep guessing.
+5. Prefer a purpose-built tool over a third raw-SQL attempt when one exists —
+   see "Tool-selection order" above.
 `
 
 const SEC_EXAMPLE_INTERACTIONS = `
@@ -399,17 +420,17 @@ const SEC_EXAMPLE_INTERACTIONS = `
 
 ### Basic Exploration
 **User**: "Show me all databases"
-**You**: "I'll list all databases in your ClickHouse cluster." → Call list_databases
+**You**: Call list_databases → "12 databases. \`analytics\` (2.1 TB) and \`default\` (340 GB) are the largest; the rest are under 5 GB."
 
 **User**: "What are the largest tables?"
-**You**: "I'll check the tables by size. First, let me get the databases." → list_databases → list_tables with database → Sort results by size
+**You**: list_databases → list_tables per database, sorted by size → "\`analytics.events\` is the largest table at 890 GB / 4.2B rows, followed by \`analytics.sessions\` at 210 GB."
 
 ### Performance Analysis
 **User**: "Show slow queries from the last hour"
-**You**: "I'll retrieve the slowest queries from the query log, filtered for the last hour." → Call get_slow_queries with time filter or use query tool with: \`SELECT * FROM system.query_log WHERE type = 'QueryFinish' AND event_time > now() - INTERVAL 1 HOUR ORDER BY query_duration_ms DESC LIMIT 10\`
+**You**: Call get_slow_queries with a 1-hour window → "3 queries exceeded 10s in the last hour, all against \`analytics.events\`; the slowest ran 47s with a full scan (no PREWHERE)." (SQL shown below the answer)
 
 **User**: "What's causing high CPU usage?"
-**You**: "I'll check the running queries to see what's currently executing and consuming resources." → get_running_queries → Analyze for long-running queries with high memory_usage or read_rows
+**You**: get_running_queries → "One query (id \`abc123\`) has been running 8 minutes with 12 GB memory and 2.1B rows read — that's the driver. It's an unfiltered \`GROUP BY\` on \`analytics.events\`."
 
 ### Multi-Host Queries
 **User**: "Compare merge status across both clusters"
@@ -424,7 +445,19 @@ const SEC_EXAMPLE_INTERACTIONS = `
 
 ### Error Recovery Example
 **User**: "Show me the initial_query_id for recent queries"
-**You**: Attempts query with \`initial_query_id\` column → Query fails → "Let me check if this column exists in your ClickHouse version" → get_table_schema for system.query_log → If column missing: "The \`initial_query_id\` column was added in ClickHouse v23.8. Your version may not have it. Would you like me to use \`query_id\` instead?"
+**You**: Column availability varies by version, so check first — call
+get_table_schema for system.query_log before writing the query. If
+\`initial_query_id\` is absent (added in v23.8), retry once using \`query_id\`
+instead and answer directly: "Your version predates \`initial_query_id\`
+(added in v23.8) — showing \`query_id\` instead: [results]."
+
+### Anti-pattern: don't guess a system-table's columns and let the query fail
+**Wrong**: Write \`SELECT * FROM system.replication_queue WHERE ...\` from
+memory, get an "unknown column" error, and only then call get_table_schema.
+**Right**: Recognize \`get_replication_status\` already covers replication
+queue/lag — call it directly. If a case genuinely needs raw
+\`system.replication_queue\` SQL, call get_table_schema (or load_skill
+\`replication-guide\`) first, then write the query once, correctly.
 
 ### Query Optimization Example
 **User**: "This query is slow: SELECT * FROM events WHERE user_id = 123 ORDER BY event_time"


### PR DESCRIPTION
## Summary

A real session showed the ClickHouse agent hand-writing SQL against
`system.replication_queue` from memory, failing on an unknown column, and
only then calling `get_table_schema` — the inverse of the intended order. Its
narration was also thin/generic ("I'll check replication status and
inspect") without leading with a concrete answer.

This PR tightens `apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts`
only (prompt wording + tests) to fix that:

- **Tool-selection order**: purpose-built tool > `load_skill` recipe > raw
  `query`. Never hand-write `system.*` SQL from memory without checking
  schema (or having a matching primitive/skill) first — added the
  `replication_queue` case as a named anti-pattern example, since that's the
  exact regression observed.
- **Error recovery**: consolidated four scattered blocks (Operating Rules,
  Response Style, Version Compatibility, Error Recovery) into one canonical
  section — read the actual error, check schema, retry once with a
  corrected query, then stop and report if the retry also fails. No blind
  looping.
- **Answer shape**: responses must lead with the verdict, then evidence
  (numbers, table/column names), then the recommended action. Narration
  before a tool call must name the specific tool/table, not generic filler
  ("I'll check X and inspect Y").
- **Read-only safety**: reaffirmed — only SELECT/WITH/DESCRIBE/EXPLAIN,
  holds in every deployment mode; the 3 destructive control tools stay
  env-gated off by default.
- Rewrote the example interactions (`SEC_EXAMPLE_INTERACTIONS`) that
  previously modeled the bad pattern (query-then-schema, thin narration) so
  the model imitates the fixed behavior instead of the old one.

## Notes on scope

- `CLICKHOUSE_AGENT_INSTRUCTIONS` is a single static string — there is no
  separate cloud/OSS or Postgres "variant" of the prompt text. What varies
  by environment is which tools `createAllTools` exposes (`AGENT_ENABLE_CONTROL_TOOLS`,
  `CHM_FEATURE_POSTGRES_SOURCE`). The new test covers composition holding
  for both gate configurations (30 tools default-off, 37 fully-gated-on),
  mirroring `tools/tool-docs-sync.test.ts`.
- No agent tool, skill, or env var was added/renamed/removed, so
  `docs/content/guide/ai-agent.mdx` needed no update — verified its
  read-only (`:22`) and plan-and-verify (`:8`) claims are still accurate.
- Did not touch `src/components/**` (other PRs own that in parallel).

## Test plan
- [x] `bun test src/lib/ai/agent/prompts/__tests__/clickhouse-instructions.test.ts` — 12/12 pass, asserting the new rules are present and the old anti-pattern wording is gone
- [x] `bun test src/lib/ai/agent/tools/tool-docs-sync.test.ts` — still passes (every tool name still appears in the prompt)
- [x] `bun test src/lib/ai/agent --isolate` — 507/507 pass
- [x] `pnpm run test:unit` (root) — 7749/7749 pass
- [x] `pnpm run lint` — clean on changed files (2 pre-existing unrelated warnings elsewhere)

Co-Authored-By: duyetbot <bot@duyet.net>