### PR TITLE
fix(agent): fix first-message-of-session failure, stop masking tool errors

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/__tests__/agent-stream-response.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/agent-stream-response.test.ts
@@ -1,0 +1,296 @@
+// @ts-nocheck — AI SDK generics (ToolLoopAgent / MockLanguageModelV3) are not
+// worth fighting in test code; matches the convention in the sibling
+// `scenarios.test.ts` / `clickhouse-agent.test.ts`.
+/**
+ * Regression tests for `createAgentStreamResponse` (POST /api/v1/agent):
+ *
+ * 1. The first message of a brand-new session must actually produce an
+ *    assistant reply. `buildUiMessages` (runtime.ts) threads a "the user is
+ *    viewing page X" hint ahead of the user's turn, but only on the first
+ *    turn of a thread (the client only sends `pageContext` then). That hint
+ *    used to be injected as a `role: 'system'` UIMessage — but the AI SDK's
+ *    `ToolLoopAgent`/`streamText` reject any `system`-role entry inside
+ *    `messages` (`allowSystemInMessages` defaults to `false` in
+ *    `standardizePrompt`), throwing `AI_InvalidPromptError` and turning the
+ *    very first reply of every new session into a dead stream instead of a
+ *    real answer — while every later message (no `pageContext`) worked fine.
+ *    Fixed by threading the hint in as `role: 'user'` instead.
+ *
+ * 2. A thrown tool error must reach the client with its real message, not the
+ *    AI SDK's generic, safe-by-default "An error occurred." `errorText` —
+ *    `result.toUIMessageStream()` was called with no `onError`, so both its
+ *    `error` and `tool-error` chunk cases fell back to that mask.
+ */
+import { describe, expect, mock, test } from 'bun:test'
+import { MockLanguageModelV3 } from 'ai/test'
+
+mock.module('server-only', () => ({}))
+mock.module('@chm/sql-builder', () => ({
+  validateSqlQuery: () => {},
+  getAllSqlStrings: (sql: unknown) =>
+    Array.isArray(sql) ? sql.map((s: { sql: string }) => s.sql) : [sql],
+}))
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: async () => ({ data: [], error: null }),
+  getClient: async () => ({
+    command: async () => ({}),
+    insert: async () => ({}),
+    query: async () => ({ json: async () => [] }),
+  }),
+}))
+
+const { createClickHouseAgent } = await import('../clickhouse-agent')
+const { buildUiMessages } = await import(
+  '../../../../routes/api/v1/-agent/runtime'
+)
+const { createAgentStreamResponse } = await import(
+  '../../../../routes/api/v1/-agent/stream'
+)
+const { ToolLoopAgent, isStepCount, tool } = await import('ai')
+const { z } = await import('zod')
+
+const STREAM_USAGE = { inputTokens: 5, outputTokens: 5, totalTokens: 10 }
+
+/** A scripted `doStream` result that emits a single plain-text reply. */
+function textStreamResult(text: string) {
+  return {
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'stream-start', warnings: [] })
+        controller.enqueue({ type: 'text-start', id: '1' })
+        controller.enqueue({ type: 'text-delta', id: '1', delta: text })
+        controller.enqueue({ type: 'text-end', id: '1' })
+        controller.enqueue({
+          type: 'finish',
+          finishReason: 'stop',
+          usage: STREAM_USAGE,
+        })
+        controller.close()
+      },
+    }),
+  }
+}
+
+/** A scripted `doStream` result that calls the given tool, then never
+ * produces a text reply — mirroring a tool whose failure ends the turn. */
+function toolCallStreamResult(toolName: string) {
+  return {
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({ type: 'stream-start', warnings: [] })
+        controller.enqueue({
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName,
+          input: '{}',
+        })
+        controller.enqueue({
+          type: 'finish',
+          finishReason: 'tool-calls',
+          usage: STREAM_USAGE,
+        })
+        controller.close()
+      },
+    }),
+  }
+}
+
+async function readSseBody(response: Response): Promise<string> {
+  return await response.text()
+}
+
+/** Parse an SSE UI-message-stream body into its `data:` JSON chunks. */
+function parseSseChunks(body: string): Array<Record<string, unknown>> {
+  return body
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => line.slice('data: '.length))
+    .filter((json) => json !== '[DONE]')
+    .map((json) => JSON.parse(json))
+}
+
+/** Reassemble the streamed assistant text from `text-delta` chunks — the AI
+ * SDK smooth-streams text one token/character at a time, so a literal
+ * substring match against the raw SSE body is unreliable. */
+function assembleText(chunks: Array<Record<string, unknown>>): string {
+  return chunks
+    .filter((c) => c.type === 'text-delta')
+    .map((c) => c.delta as string)
+    .join('')
+}
+
+function baseStreamOptions() {
+  return {
+    userMessage: 'hi',
+    model: 'test/mock',
+    requestedProvider: 'test',
+    billingOwnerId: null,
+    resolvedPlan: null,
+    releaseReservationOnce: async () => {},
+  }
+}
+
+describe('createAgentStreamResponse — first message of a new session', () => {
+  test('streams a real reply when pageContext is present on the first turn', async () => {
+    const model = new MockLanguageModelV3({
+      doStream: [textStreamResult('Hello! How can I help?')],
+    })
+    const agent = createClickHouseAgent({ hostId: 0, model })
+
+    // Mirrors exactly what the route builds for a brand-new session's first
+    // request: one user message + a client-supplied `pageContext` hint.
+    const uiMessages = buildUiMessages({
+      safeIncomingMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+      userMessage: 'hi',
+      pageContext: { route: '/merges', label: 'Merges' },
+      hostId: 0,
+    })
+
+    const response = createAgentStreamResponse({
+      ...baseStreamOptions(),
+      agent,
+      mcpCloseAll: null,
+      uiMessages,
+    })
+
+    const body = await readSseBody(response)
+    const chunks = parseSseChunks(body)
+
+    // Before the fix this was a short `data-error`/`error` stream with zero
+    // assistant text (AI_InvalidPromptError from the injected system-role
+    // message) — assert the real reply text actually made it through.
+    expect(assembleText(chunks)).toBe('Hello! How can I help?')
+    expect(chunks.some((c) => c.type === 'error')).toBe(false)
+    expect(chunks.some((c) => c.type === 'data-error')).toBe(false)
+  })
+
+  test('the pageContext hint is not injected as a disallowed system-role message', () => {
+    const uiMessages = buildUiMessages({
+      safeIncomingMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+      userMessage: 'hi',
+      pageContext: { route: '/merges', label: 'Merges' },
+      hostId: 0,
+    })
+
+    expect(uiMessages.some((m) => m.role === 'system')).toBe(false)
+    expect(
+      uiMessages.some(
+        (m) =>
+          m.role === 'user' &&
+          m.parts.some(
+            (p) =>
+              typeof p === 'object' &&
+              p !== null &&
+              'text' in p &&
+              typeof p.text === 'string' &&
+              p.text.includes('viewing the "Merges" page')
+          )
+      )
+    ).toBe(true)
+  })
+})
+
+describe('createAgentStreamResponse — error surfacing', () => {
+  test('a thrown tool error reaches the client with its real message, not "An error occurred."', async () => {
+    const failingTool = tool({
+      description: 'Always fails, for testing error surfacing.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        throw new Error('ClickHouse connection refused: too many connections')
+      },
+    })
+
+    const model = new MockLanguageModelV3({
+      doStream: [toolCallStreamResult('always_fails')],
+    })
+    const agent = new ToolLoopAgent({
+      id: 'test-agent',
+      model,
+      tools: { always_fails: failingTool },
+      instructions: 'test',
+      stopWhen: isStepCount(1),
+    })
+
+    const uiMessages = buildUiMessages({
+      safeIncomingMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+      userMessage: 'hi',
+      pageContext: undefined,
+      hostId: 0,
+    })
+
+    const response = createAgentStreamResponse({
+      ...baseStreamOptions(),
+      agent,
+      mcpCloseAll: null,
+      uiMessages,
+    })
+
+    const body = await readSseBody(response)
+    const chunks = parseSseChunks(body)
+    const errorChunks = chunks.filter(
+      (c) => c.type === 'error' || c.type === 'tool-output-error'
+    )
+
+    expect(errorChunks.length).toBeGreaterThan(0)
+    for (const chunk of errorChunks) {
+      expect(chunk.errorText).not.toBe('An error occurred.')
+    }
+    expect(
+      errorChunks.some((c) =>
+        String(c.errorText).includes('ClickHouse connection refused')
+      )
+    ).toBe(true)
+  })
+
+  test('a redacted secret never reaches the client in an error message', async () => {
+    const secretKey = 'sk-super-secret-value-1234567890'
+    const failingTool = tool({
+      description: 'Fails with a message that echoes a credential.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        throw new Error(
+          `Upstream call failed: Authorization: Bearer ${secretKey}`
+        )
+      },
+    })
+
+    const model = new MockLanguageModelV3({
+      doStream: [toolCallStreamResult('leaky_tool')],
+    })
+    const agent = new ToolLoopAgent({
+      id: 'test-agent',
+      model,
+      tools: { leaky_tool: failingTool },
+      instructions: 'test',
+      stopWhen: isStepCount(1),
+    })
+
+    const uiMessages = buildUiMessages({
+      safeIncomingMessages: [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      ],
+      userMessage: 'hi',
+      pageContext: undefined,
+      hostId: 0,
+    })
+
+    const response = createAgentStreamResponse({
+      ...baseStreamOptions(),
+      agent,
+      mcpCloseAll: null,
+      uiMessages,
+      byokApiKey: secretKey,
+    })
+
+    const body = await readSseBody(response)
+
+    expect(body).not.toContain(secretKey)
+    expect(body).toContain('Upstream call failed')
+  })
+})

--- a/apps/dashboard/src/lib/ai/agent/errors.ts
+++ b/apps/dashboard/src/lib/ai/agent/errors.ts
@@ -288,6 +288,92 @@ function parseErrorPayload(error: unknown): {
 }
 
 /**
+ * Regex-shaped secrets to strip from any error text that reaches the client:
+ * URL userinfo (`https://user:pass@host`), `Authorization`/`Bearer` header
+ * values, and common provider API-key shapes (OpenAI-style `sk-…`, AgentState
+ * `as_live_…`, Google `AIza…`). Applied in addition to exact-match redaction
+ * of the deployment's own configured keys (see {@link redactSecrets}).
+ */
+const SECRET_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/(:\/\/)[^\s/@]+:[^\s/@]+@/g, '$1[redacted]@'],
+  [/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/-]{8,}=*/gi, '$1 [redacted]'],
+  [
+    /\bauthorization"?\s*[:=]\s*"?[A-Za-z0-9._~+/-]{8,}=*/gi,
+    'authorization: [redacted]',
+  ],
+  [/\bsk-[A-Za-z0-9_-]{10,}\b/g, '[redacted]'],
+  [/\bas_live_[A-Za-z0-9_-]{6,}\b/g, '[redacted]'],
+  [/\bAIza[0-9A-Za-z_-]{20,}\b/g, '[redacted]'],
+]
+
+/**
+ * Strip secrets from an error message before it reaches the client.
+ *
+ * Two layers of defense: `extraSecrets` are exact-match replaced (the
+ * request's BYOK key, this deployment's configured provider/DB credentials —
+ * anything we know the literal value of and never want echoed back verbatim),
+ * and {@link SECRET_PATTERNS} catches common credential *shapes* even when we
+ * don't know the exact value (e.g. a third-party upstream error that embeds
+ * its own token).
+ */
+export function redactSecrets(
+  text: string,
+  extraSecrets: readonly (string | null | undefined)[] = []
+): string {
+  let result = text
+  for (const secret of extraSecrets) {
+    if (!secret || secret.length < 6) continue
+    result = result.split(secret).join('[redacted]')
+  }
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    result = result.replace(pattern, replacement)
+  }
+  return result
+}
+
+/** Redact secrets from every free-text field of a classified {@link AgentError}. */
+export function sanitizeAgentError(
+  error: AgentError,
+  extraSecrets: readonly (string | null | undefined)[] = []
+): AgentError {
+  return {
+    ...error,
+    message: redactSecrets(error.message, extraSecrets),
+    details: error.details
+      ? redactSecrets(error.details, extraSecrets)
+      : error.details,
+    upstreamMessage: error.upstreamMessage
+      ? redactSecrets(error.upstreamMessage, extraSecrets)
+      : error.upstreamMessage,
+  }
+}
+
+/**
+ * Classify + sanitize + summarize an unknown error into a single display
+ * string, for contexts that need `errorText: string` rather than a
+ * structured {@link AgentError} — e.g. the AI SDK's UI-message-stream `error`
+ * / `tool-error` chunks (`toUIMessageStream({ onError })`). Without an
+ * explicit `onError`, the AI SDK masks every such chunk with the generic
+ * "An error occurred." (its safe default), which hides the real cause from
+ * both the user and the agent's own self-correction loop. This keeps the
+ * classified message + suggestion (the same information already shown for a
+ * top-level `data-error` part) while still redacting secrets.
+ */
+export function formatAgentErrorText(
+  error: unknown,
+  context: ClassifyErrorContext = {},
+  extraSecrets: readonly (string | null | undefined)[] = []
+): string {
+  const classified = sanitizeAgentError(
+    classifyError(error, context),
+    extraSecrets
+  )
+  return classified.suggestion
+    ? `${classified.message} — ${classified.suggestion}`
+    : classified.message
+}
+
+/**
  * Classifies an unknown error into a structured AgentError.
  *
  * Numeric HTTP status codes take priority over keyword matching so that

--- a/apps/dashboard/src/routes/api/v1/-agent/runtime.ts
+++ b/apps/dashboard/src/routes/api/v1/-agent/runtime.ts
@@ -96,6 +96,18 @@ export async function resolveAgentUserId(): Promise<string> {
  * NOT folded into `AGENT_JSON_RENDER_INLINE_PROMPT` (the cached system prompt)
  * — inserted as its own message instead, so provider prompt caching on the
  * system prompt is unaffected.
+ *
+ * The hint is threaded in with `role: 'user'`, never `'system'`: the AI SDK's
+ * `ToolLoopAgent`/`streamText` reject any `system`-role entry inside
+ * `messages` (`allowSystemInMessages` defaults to `false` — see
+ * `standardizePrompt` in the `ai` package), throwing `AI_InvalidPromptError`.
+ * Because `pageContext` is only present on the first turn, a `'system'` role
+ * here made every brand-new session's first message fail outright (caught,
+ * classified, and streamed back as a masked error part instead of a real
+ * reply) while every later message — with no `pageContext` — worked fine.
+ * The extra `'user'`-role line is never echoed back to the client (the
+ * response stream only carries new assistant content), so it does not appear
+ * as a stray chat bubble.
  */
 export function buildUiMessages(options: {
   safeIncomingMessages: ReadonlyArray<SafeAgentMessage>
@@ -133,7 +145,7 @@ export function buildUiMessages(options: {
     if (lastMessageIndex >= 0 && uiMessages[lastMessageIndex].role === 'user') {
       uiMessages.splice(lastMessageIndex, 0, {
         id: crypto.randomUUID(),
-        role: 'system',
+        role: 'user',
         parts: [
           {
             type: 'text' as const,

--- a/apps/dashboard/src/routes/api/v1/-agent/stream.ts
+++ b/apps/dashboard/src/routes/api/v1/-agent/stream.ts
@@ -24,9 +24,35 @@ import {
   type UITools,
 } from 'ai'
 import { aggregateUsageWithCost } from '@/lib/ai/agent/analytics'
-import { classifyError } from '@/lib/ai/agent/errors'
+import {
+  classifyError,
+  formatAgentErrorText,
+  sanitizeAgentError,
+} from '@/lib/ai/agent/errors'
 import { createJsonRenderPatchGuardStream } from '@/lib/ai/agent/json-render-patch-guard'
 import { meterAiOverage } from '@/lib/billing/ai-usage-store'
+
+/**
+ * Secrets that must never be echoed back to the client inside an error
+ * message: the deployment's own provider/DB credentials plus this request's
+ * BYOK key (if any). An upstream provider error, or a tool failure touching
+ * ClickHouse, can otherwise echo a credential verbatim in its message. Exact
+ * values only — shape-based redaction (URL userinfo, `Bearer …`, `sk-…`, …)
+ * is handled separately by `redactSecrets`.
+ */
+function collectSecretsToRedact(
+  byokApiKey: string | null
+): (string | null | undefined)[] {
+  return [
+    byokApiKey,
+    process.env.OPENROUTER_API_KEY,
+    process.env.ANYROUTER_API_KEY,
+    process.env.NVIDIA_API_KEY,
+    process.env.LLM_API_KEY,
+    process.env.CLICKHOUSE_PASSWORD,
+    process.env.AGENTSTATE_API_KEY,
+  ]
+}
 
 // Free / routed providers can take 20-40s between a tool call and the
 // follow-up summary. The previous 12s step/chunk budget killed the loop
@@ -45,6 +71,9 @@ export function createAgentStreamResponse(options: {
   billingOwnerId: string | null
   resolvedPlan: Plan | null
   releaseReservationOnce: () => Promise<void>
+  /** BYOK key for this request, if any — redacted from any error text that
+   * reaches the client (see `collectSecretsToRedact`). */
+  byokApiKey?: string | null
 }): Response {
   const {
     agent,
@@ -56,12 +85,26 @@ export function createAgentStreamResponse(options: {
     billingOwnerId,
     resolvedPlan,
     releaseReservationOnce,
+    byokApiKey = null,
   } = options
 
   const usageSteps: LanguageModelUsage[] = []
   // Tracks the provider-reported model ID from the last completed step.
   // Populated synchronously in onStepEnd so it is available after consumeStream().
   let lastStepModelId: string | undefined
+
+  const secretsToRedact = collectSecretsToRedact(byokApiKey)
+  // Formats an unknown thrown/streamed error into a client-safe display
+  // string (classified message + suggestion, secrets stripped) — used
+  // wherever the AI SDK asks for `errorText: string` rather than a
+  // structured AgentError, so those chunks never fall back to the SDK's
+  // masked "An error occurred." default.
+  const formatErrorText = (error: unknown) =>
+    formatAgentErrorText(
+      error,
+      { model, provider: requestedProvider },
+      secretsToRedact
+    )
 
   const buildStats = (resolvedModel: string) => ({
     ...aggregateUsageWithCost(usageSteps, model),
@@ -131,7 +174,14 @@ export function createAgentStreamResponse(options: {
 
         writer.merge(
           createJsonRenderPatchGuardStream(
-            pipeJsonRender(result.toUIMessageStream())
+            pipeJsonRender(
+              // `onError` formats `error` / `tool-error` chunk `errorText`
+              // (e.g. a dynamicTool's `execute` throwing) — without it the AI
+              // SDK falls back to its safe-by-default "An error occurred.",
+              // which hides the real cause from both the user and the
+              // agent's own self-correction loop.
+              result.toUIMessageStream({ onError: formatErrorText })
+            )
           )
         )
         await result.consumeStream()
@@ -171,10 +221,10 @@ export function createAgentStreamResponse(options: {
           }
         }
       } catch (error) {
-        const classified = classifyError(error, {
-          model,
-          provider: requestedProvider,
-        })
+        const classified = sanitizeAgentError(
+          classifyError(error, { model, provider: requestedProvider }),
+          secretsToRedact
+        )
         console.error('[Agent API] Classified error:', classified)
         writer.write({
           type: 'data-error',
@@ -203,10 +253,10 @@ export function createAgentStreamResponse(options: {
       }
     },
     onError: (error) => {
-      const classified = classifyError(error, {
-        model,
-        provider: requestedProvider,
-      })
+      const classified = sanitizeAgentError(
+        classifyError(error, { model, provider: requestedProvider }),
+        secretsToRedact
+      )
       console.error('[Agent API] Classified error:', classified)
       // A failure can surface here (rather than the inner execute catch) when it
       // is thrown inside the merged/piped stream after the reservation. If no
@@ -217,7 +267,13 @@ export function createAgentStreamResponse(options: {
       if (usageSteps.length === 0) {
         void releaseReservationOnce()
       }
-      return JSON.stringify(classified)
+      // Plain, redacted, human-readable text — matches `formatErrorText`
+      // above and how the client renders an `errorText` field (raw text, not
+      // JSON) for both the top-level `error` chunk and per-tool
+      // `tool-output-error` chunks (see `ToolFallback` / `MessageError`).
+      return classified.suggestion
+        ? `${classified.message} — ${classified.suggestion}`
+        : classified.message
     },
     onEnd: () => {
       // Close any connected custom MCP servers now that the stream is done.

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -172,6 +172,7 @@ async function handlePost(request: Request): Promise<Response> {
     billingOwnerId: gate.billingOwnerId,
     resolvedPlan: gate.resolvedPlan,
     releaseReservationOnce: gate.releaseReservationOnce,
+    byokApiKey: parsed.byokApiKey,
   })
 }
 


### PR DESCRIPTION
## Summary

- **Root cause of the first-message bug (Part 2):** `buildUiMessages()` (`src/routes/api/v1/-agent/runtime.ts`) threaded the "user is viewing page X" hint in as a `role: 'system'` UIMessage, but `pageContext` is only sent by the client on the first turn of a session. The AI SDK's `ToolLoopAgent`/`streamText` reject any `system`-role entry inside `messages` (`allowSystemInMessages` defaults to `false` in `standardizePrompt`), throwing `AI_InvalidPromptError` — so every brand-new session's first reply died with a masked error part instead of a real answer, while every later message (no `pageContext`) worked fine. Fixed by threading the hint in as `role: 'user'` instead; it is never echoed back to the client (the response stream only carries new assistant content), so it can't leak into the visible chat transcript.
- **Error surfacing (Part 1):** `result.toUIMessageStream()` (`src/routes/api/v1/-agent/stream.ts`) was called with no `onError`, so the AI SDK's `error` / `tool-error` chunk cases fell back to its safe-by-default `errorText: "An error occurred."` — hiding the real cause from both the user and the agent's own self-correction loop. Wired a shared `onError` that classifies the real error and formats it into a redacted, human-readable string. Also sanitized the `data-error` part (execute-catch) and the outer `createUIMessageStream` `onError` the same way.
- Added `redactSecrets` / `sanitizeAgentError` / `formatAgentErrorText` (`src/lib/ai/agent/errors.ts`) so none of these newly-surfaced error paths can leak the deployment's provider/DB credentials or a request's BYOK key (URL userinfo, `Authorization`/`Bearer` values, `sk-…`/`as_live_…`/`AIza…` key shapes, plus exact-match redaction of the request's own known secrets).

## Root cause evidence

Reproduced against real `ai@7.0.14` package code (not guessed): `standardizePrompt` in `node_modules/ai/dist/index.js` throws `AI_InvalidPromptError: System messages are not allowed in the prompt or messages fields. Use the instructions option instead.` whenever `messages` contains a `role: 'system'` entry and `allowSystemInMessages` isn't explicitly enabled — which `ToolLoopAgent.stream()` doesn't do. A driven repro (real `createClickHouseAgent()` + `MockLanguageModelV3`, no live LLM) confirmed the exact "first-turn-only" failure signature, and confirmed it disappears once the hint moves to `role: 'user'`.

Separately confirmed `toUIMessageChunk`'s `"tool-error"`/`"error"` cases call `onError(part.error)`, defaulting to `() => "An error occurred."` when `result.toUIMessageStream()` is called with no options — exactly the masked string reported.

## Test plan

- [x] New `apps/dashboard/src/lib/ai/agent/__tests__/agent-stream-response.test.ts` — 4 tests, all verified to **fail** against the pre-fix code (`git stash`) and **pass** after:
  - first message of a new session (with `pageContext`) streams a real reply instead of an error
  - the injected hint is `role: 'user'`, never `role: 'system'`
  - a thrown tool error reaches the client with its real message, not `"An error occurred."`
  - a redacted secret (BYOK key) never reaches the client in an error message
- [x] `pnpm run lint` — clean (no new warnings on touched files)
- [x] `pnpm run test:unit` — 7741 pass, 0 fail (full suite, includes the new test file)
- [x] `pnpm run type-check` on touched files — no new errors (pre-existing, unrelated `createFileRoute` route-tree codegen noise affects every route file identically in this uninitialized worktree, not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)