### PR TITLE
feat(agents): make follow-up suggestions tool-aware and anchor them to the composer

### DIFF
--- a/apps/dashboard/src/components/assistant-ui/-thread/follow-up-chips.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/follow-up-chips.tsx
@@ -3,12 +3,15 @@
 /**
  * Deterministic follow-up chips.
  *
- * Renders 2-3 rule-based next-step suggestions (from
+ * Renders up to 3 rule-based next-step suggestions (from
  * `lib/ai/agent/follow-up-prompts.ts`) as clickable chips. Unlike
  * `FollowUpSuggestions` (which fetches LLM-generated follow-ups from an
  * AI-enriched conversation backend), these are computed instantly, client-side,
  * from the last exchange — so they render for every backend, including
  * localStorage-only threads.
+ *
+ * Also reused by `FollowUpSuggestions` to render its AI-generated questions,
+ * so both follow-up affordances share one chip look.
  */
 
 import { cn } from '@/lib/utils'
@@ -18,24 +21,41 @@ interface FollowUpChipsProps {
   prompts: readonly string[]
   /** Called with the chip's text when clicked. */
   onSelect: (text: string) => void
+  /**
+   * Adds a top divider + padding so the strip reads as its own anchored row
+   * rather than a loose set of pills floating in whatever it's dropped into.
+   * `FollowUpSuggestions` already provides its own top border on the
+   * surrounding column (it also has to cover the "Suggested follow-ups"
+   * button state), so it leaves this off to avoid a doubled-up divider;
+   * `AssistantFollowUpChips` (rendered inline under a message, with nothing
+   * else providing that separation) turns it on.
+   */
+  anchored?: boolean
   className?: string
 }
 
 export function FollowUpChips({
   prompts,
   onSelect,
+  anchored = false,
   className,
 }: FollowUpChipsProps) {
   if (prompts.length === 0) return null
 
   return (
-    <div className={cn('flex flex-wrap items-center gap-1.5', className)}>
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-1.5',
+        anchored && 'border-border/60 border-t pt-2',
+        className
+      )}
+    >
       {prompts.map((prompt) => (
         <button
           key={prompt}
           type="button"
           onClick={() => onSelect(prompt)}
-          className="border-border text-foreground hover:bg-muted/60 rounded-full border px-2.5 py-1 text-[11.5px] transition-colors"
+          className="border-border/70 text-muted-foreground hover:border-border hover:bg-muted/60 hover:text-foreground focus-visible:ring-ring/50 rounded-full border px-2.5 py-1 text-[11.5px] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
         >
           {prompt}
         </button>

--- a/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
+++ b/apps/dashboard/src/components/assistant-ui/-thread/follow-up-suggestions.tsx
@@ -6,15 +6,20 @@
  * When the active conversation backend supports AI enrichment (AgentState) and
  * a persisted conversation exists, this renders a small "Suggested follow-ups"
  * control. Suggestions are fetched on demand (not automatically) and rendered
- * as clickable chips; clicking one appends it to the thread as a user message.
+ * as clickable chips (via `FollowUpChips`, shared with the deterministic
+ * per-message chips so both affordances read as one visual system); clicking
+ * one appends it to the thread as a user message.
  *
  * The component renders nothing unless enrichment is supported and a remote
  * conversation id is available, so it can be dropped into the thread
- * unconditionally.
+ * unconditionally. It sits directly above the composer (see `thread.tsx`), so
+ * its own top border + padding is what visually anchors it there rather than
+ * floating loose above the input.
  */
 
 import { SparklesIcon } from 'lucide-react'
 
+import { FollowUpChips } from './follow-up-chips'
 import { useThreadListItem, useThreadRuntime } from '@assistant-ui/react'
 import { useAgentAuthGate } from '@/components/assistant-ui/agent-auth-gate'
 import { Button } from '@/components/ui/button'
@@ -45,7 +50,7 @@ export function FollowUpSuggestions() {
   }
 
   return (
-    <div className="flex w-full flex-col gap-1.5">
+    <div className="border-border/60 flex w-full flex-col gap-1.5 border-t pt-2">
       {questions.length === 0 ? (
         <Button
           type="button"
@@ -64,16 +69,7 @@ export function FollowUpSuggestions() {
             <SparklesIcon className="size-3" />
             Follow-ups
           </span>
-          {questions.map((question) => (
-            <button
-              key={question}
-              type="button"
-              onClick={() => handlePick(question)}
-              className="border-border text-foreground hover:bg-muted/60 rounded-full border px-2.5 py-1 text-[11.5px] transition-colors"
-            >
-              {question}
-            </button>
-          ))}
+          <FollowUpChips prompts={questions} onSelect={handlePick} />
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -546,7 +546,12 @@ function AssistantFollowUpChips() {
   }
 
   return (
-    <FollowUpChips prompts={prompts} onSelect={handleSelect} className="mt-1" />
+    <FollowUpChips
+      prompts={prompts}
+      onSelect={handleSelect}
+      anchored
+      className="mt-2"
+    />
   )
 }
 

--- a/apps/dashboard/src/lib/ai/agent/__tests__/follow-up-prompts.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/follow-up-prompts.test.ts
@@ -3,116 +3,215 @@ import { STARTER_PROMPTS } from '../suggested-prompts'
 import { describe, expect, test } from 'bun:test'
 
 describe('getFollowUpPrompts', () => {
-  test('routes slow-query exchanges to performance follow-ups', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'What are the slowest queries today?',
-      lastAssistantText: 'Here are the 5 slowest queries in the last 24h.',
+  describe('tool-driven relevance (primary signal)', () => {
+    test('routes storage-tool exchanges to genuinely different next steps', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'Show me the largest tables by disk usage',
+        lastAssistantText: 'events_local uses 400GB of disk across 12 parts.',
+        toolsUsed: ['get_table_parts'],
+      })
+
+      // Must not re-ask for what get_table_parts already answered.
+      expect(prompts).not.toContain('Show largest partitions')
+      expect(prompts).toEqual([
+        'Suggest a TTL for this table',
+        'Forecast when disk fills up',
+        'Check current merge activity',
+      ])
     })
 
-    expect(prompts).toEqual([
-      'Explain the slowest one',
-      'Show its EXPLAIN plan',
-      'Compare to yesterday',
-    ])
-  })
+    test('routes replication-tool exchanges away from data the tool already returned', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'How is replication lag looking?',
+        lastAssistantText: 'All replicas are within 2 seconds of the leader.',
+        toolsUsed: ['get_replication_status'],
+      })
 
-  test('routes table/storage exchanges to storage follow-ups', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'Show me the largest tables by disk usage',
-      lastAssistantText: 'events_local uses 400GB of disk across 12 parts.',
+      // get_replication_status already returns queue_size/absolute_delay per
+      // replica, so re-asking for the queue or "which replica" is redundant.
+      expect(prompts).not.toContain('Show the replication queue')
+      expect(prompts).not.toContain('Which replica is behind?')
+      expect(prompts[0]).toBe('Check for a merge backlog on that table')
     })
 
-    expect(prompts).toEqual([
-      'Show largest partitions',
-      'Suggest a TTL',
-      'Break down by column',
-    ])
-  })
+    test('prioritizes the most recently used tool over earlier tools in the turn', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['get_metrics', 'get_slow_queries'],
+      })
 
-  test('routes replication exchanges to replication follow-ups', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'How is replication lag looking?',
-      lastAssistantText: 'All replicas are within 2 seconds of the leader.',
+      expect(prompts[0]).toBe("Explain the slowest query's plan")
     })
 
-    expect(prompts).toEqual([
-      'Show the replication queue',
-      'Which replica is behind?',
-    ])
-  })
+    test('drops a candidate whose related tool ran earlier in the same turn', () => {
+      // get_disk_usage's "show which tables use the most space" candidate
+      // maps to get_table_parts, which already ran — must be filtered.
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['get_disk_usage', 'get_table_parts'],
+      })
 
-  test('matches on assistant text alone when the user question is generic', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'What just happened?',
-      lastAssistantText: 'One replica fell behind in the ZooKeeper queue.',
+      expect(prompts).not.toContain('Show which tables use the most space')
     })
 
-    expect(prompts[0]).toBe('Show the replication queue')
-  })
+    test('merges candidates from multiple tools used in one turn, deduped', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['get_merge_status', 'get_disk_usage'],
+        limit: 5,
+      })
 
-  test('matches on tool names used, not just message text', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'Anything I should know?',
-      lastAssistantText: 'Everything looks fine.',
-      toolsUsed: ['get_replication_queue'],
+      const unique = new Set(prompts)
+      expect(unique.size).toBe(prompts.length)
+      expect(prompts.length).toBeGreaterThan(0)
     })
 
-    expect(prompts[0]).toBe('Show the replication queue')
-  })
+    test('never suggests a destructive control-tool action', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['kill_query'],
+        lastAssistantText: 'Killed the runaway query.',
+      })
 
-  test('matches the plural form of a keyword (e.g. "tables")', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'How many tables do we have?',
-      lastAssistantText: 'There are 42 tables across 3 databases.',
+      for (const prompt of prompts) {
+        expect(prompt.toLowerCase()).not.toContain('kill')
+      }
     })
 
-    expect(prompts[0]).toBe('Show largest partitions')
+    test('ignores unmapped/unknown tool names and falls through gracefully', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['some_unmapped_tool'],
+        lastUserText: 'Hello there',
+        lastAssistantText: 'Hi! How can I help?',
+      })
+
+      expect(prompts).toEqual(STARTER_PROMPTS.slice(0, 2).map((p) => p.text))
+    })
   })
 
-  test('does not match a keyword that is only a substring of another word', () => {
-    // "table" must not fire on "notable"/"acceptable" — whole-word match only.
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'Anything worth flagging?',
-      lastAssistantText: 'There are no notable or acceptable anomalies.',
+  describe('keyword fallback (no matching tool call)', () => {
+    test('routes slow-query exchanges to performance follow-ups', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'What are the slowest queries today?',
+        lastAssistantText: 'Here are the 5 slowest queries in the last 24h.',
+      })
+
+      expect(prompts).toEqual([
+        "Explain the slowest query's plan",
+        'Estimate its cost',
+        'Check for repeating slow patterns',
+      ])
     })
 
-    expect(prompts).toEqual(
-      STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
-    )
-  })
+    test('routes table/storage exchanges to storage follow-ups', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'Show me the largest tables by disk usage',
+        lastAssistantText: 'events_local uses 400GB of disk across 12 parts.',
+      })
 
-  test('falls back to starter prompts when nothing matches', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'Hello there',
-      lastAssistantText: 'Hi! How can I help?',
+      expect(prompts).toEqual([
+        'Show largest partitions',
+        'Suggest a TTL',
+        'Forecast when disk fills up',
+      ])
     })
 
-    expect(prompts).toEqual(
-      STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
-    )
-  })
+    test('matches on assistant text alone when the user question is generic', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'What just happened?',
+        lastAssistantText: 'One replica fell behind in the ZooKeeper queue.',
+      })
 
-  test('respects a smaller limit', () => {
-    const prompts = getFollowUpPrompts({
-      lastUserText: 'slowest query please',
-      lastAssistantText: '',
-      limit: 1,
+      expect(prompts[0]).toBe('Show the replication queue')
     })
 
-    expect(prompts).toEqual(['Explain the slowest one'])
+    test('routes to the rule with the most keyword hits, not the first declared', () => {
+      // "per-table" trips the Storage keyword "table", but this is a
+      // replication answer through and through (two Replication keyword hits
+      // vs. Storage's one) — it must not fall into Storage just because
+      // Storage happens to be declared before Replication.
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'How is replication doing?',
+        lastAssistantText:
+          'All 3 replicas for the per-table replication queue are in sync.',
+      })
+
+      expect(prompts).toEqual([
+        'Show the replication queue',
+        'Which replica is behind?',
+        'Check for a merge backlog',
+      ])
+    })
+
+    test('matches the plural form of a keyword (e.g. "tables")', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'How many tables do we have?',
+        lastAssistantText: 'There are 42 tables across 3 databases.',
+      })
+
+      expect(prompts[0]).toBe('Show largest partitions')
+    })
+
+    test('does not match a keyword that is only a substring of another word', () => {
+      // "table" must not fire on "notable"/"acceptable" — whole-word match only.
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'Anything worth flagging?',
+        lastAssistantText: 'There are no notable or acceptable anomalies.',
+      })
+
+      expect(prompts).toEqual(
+        STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
+      )
+    })
+
+    test('falls back to starter prompts when nothing matches', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'Hello there',
+        lastAssistantText: 'Hi! How can I help?',
+      })
+
+      expect(prompts).toEqual(
+        STARTER_PROMPTS.slice(0, 2).map((prompt) => prompt.text)
+      )
+    })
   })
 
-  test('returns an empty array for a zero or negative limit', () => {
-    expect(
-      getFollowUpPrompts({ lastUserText: 'slow query', limit: 0 })
-    ).toEqual([])
-    expect(
-      getFollowUpPrompts({ lastUserText: 'slow query', limit: -5 })
-    ).toEqual([])
-  })
+  describe('cap, dedupe, and edge cases', () => {
+    test('respects a smaller limit', () => {
+      const prompts = getFollowUpPrompts({
+        lastUserText: 'slowest query please',
+        lastAssistantText: '',
+        limit: 1,
+      })
 
-  test('handles no arguments at all', () => {
-    const prompts = getFollowUpPrompts()
-    expect(prompts).toEqual(STARTER_PROMPTS.slice(0, 2).map((p) => p.text))
+      expect(prompts).toEqual(["Explain the slowest query's plan"])
+    })
+
+    test('never returns more than the default cap of 3', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['get_table_parts'],
+      })
+
+      expect(prompts.length).toBeLessThanOrEqual(3)
+    })
+
+    test('returns an empty array for a zero or negative limit', () => {
+      expect(
+        getFollowUpPrompts({ lastUserText: 'slow query', limit: 0 })
+      ).toEqual([])
+      expect(
+        getFollowUpPrompts({ lastUserText: 'slow query', limit: -5 })
+      ).toEqual([])
+    })
+
+    test('never returns duplicate suggestions', () => {
+      const prompts = getFollowUpPrompts({
+        toolsUsed: ['get_slow_queries', 'get_running_queries'],
+        limit: 6,
+      })
+
+      expect(new Set(prompts).size).toBe(prompts.length)
+    })
+
+    test('handles no arguments at all', () => {
+      const prompts = getFollowUpPrompts()
+      expect(prompts).toEqual(STARTER_PROMPTS.slice(0, 2).map((p) => p.text))
+    })
   })
 })

--- a/apps/dashboard/src/lib/ai/agent/follow-up-prompts.ts
+++ b/apps/dashboard/src/lib/ai/agent/follow-up-prompts.ts
@@ -7,13 +7,290 @@ const DEFAULT_LIMIT = 3
 const FALLBACK_COUNT = 2
 
 /**
- * A deterministic, rule-based follow-up suggestion set for one topic. Matched
- * by simple keyword lookup against the last exchange — no LLM call involved.
+ * A candidate next-step suggestion.
+ *
+ * `relatedTool` names the agent tool that clicking this suggestion would most
+ * likely trigger. When that tool is already present in `toolsUsed` for the
+ * current exchange, the candidate is dropped — its answer was already
+ * surfaced this turn, so resurfacing the same question is noise. Candidates
+ * that are still useful even after a repeat call (e.g. "look at a different
+ * column") omit `relatedTool` and are never filtered this way.
+ */
+interface FollowUpCandidate {
+  readonly text: string
+  readonly relatedTool?: string
+}
+
+/**
+ * Next-step suggestions keyed by the agent tool that was just used to answer
+ * the current turn. This is the primary, high-precision signal: the exact
+ * tool call tells us exactly what the user already saw, so suggestions here
+ * are genuinely different follow-on investigations rather than a restatement
+ * of the same data. Only tools that commonly end a turn (i.e. the ones a user
+ * would naturally want to drill into further) are mapped; internal-only tools
+ * (`ask_user`, `update_plan`, `load_skill`) and destructive control tools
+ * (`kill_query`, `optimize_table`, `kill_mutation`) are intentionally
+ * excluded — the latter should never be nudged via a passive suggestion chip.
+ */
+const TOOL_FOLLOW_UPS: Readonly<Record<string, readonly FollowUpCandidate[]>> =
+  {
+    // Query / performance
+    get_running_queries: [
+      { text: "Explain the top query's plan", relatedTool: 'explain_query' },
+      {
+        text: 'Check for repeating slow patterns',
+        relatedTool: 'list_slow_query_patterns',
+      },
+      { text: 'Look at overall cluster health', relatedTool: 'get_metrics' },
+    ],
+    get_slow_queries: [
+      {
+        text: "Explain the slowest query's plan",
+        relatedTool: 'explain_query',
+      },
+      { text: 'Estimate its cost', relatedTool: 'estimate_query_cost' },
+      {
+        text: 'Check for repeating slow patterns',
+        relatedTool: 'list_slow_query_patterns',
+      },
+    ],
+    list_slow_query_patterns: [
+      {
+        text: 'Get tuning suggestions for the worst pattern',
+        relatedTool: 'get_tuning_suggestions',
+      },
+      {
+        text: "Explain the top pattern's plan",
+        relatedTool: 'explain_query',
+      },
+      {
+        text: 'Check currently running queries',
+        relatedTool: 'get_running_queries',
+      },
+    ],
+    get_failed_queries: [
+      { text: 'Explain why the top one failed', relatedTool: 'explain_query' },
+      {
+        text: 'Check currently running queries',
+        relatedTool: 'get_running_queries',
+      },
+      { text: 'Look at overall cluster health', relatedTool: 'get_metrics' },
+    ],
+    explain_query: [
+      { text: 'Estimate its cost', relatedTool: 'estimate_query_cost' },
+      { text: 'Get tuning suggestions', relatedTool: 'get_tuning_suggestions' },
+      {
+        text: 'Get optimization recommendations',
+        relatedTool: 'get_optimization_recommendations',
+      },
+    ],
+    estimate_query_cost: [
+      {
+        text: 'Get tuning suggestions to reduce it',
+        relatedTool: 'get_tuning_suggestions',
+      },
+      { text: 'Show its EXPLAIN plan', relatedTool: 'explain_query' },
+    ],
+    query_and_visualize: [
+      { text: 'Break it down by another column' },
+      { text: 'Turn this into a dashboard', relatedTool: 'suggest_dashboard' },
+    ],
+
+    // Storage
+    get_table_parts: [
+      {
+        text: 'Suggest a TTL for this table',
+        relatedTool: 'suggest_ttl_adjustment',
+      },
+      {
+        text: 'Forecast when disk fills up',
+        relatedTool: 'forecast_disk_capacity',
+      },
+      { text: 'Check current merge activity', relatedTool: 'get_merge_status' },
+    ],
+    forecast_disk_capacity: [
+      {
+        text: 'Suggest a TTL to slow growth',
+        relatedTool: 'suggest_ttl_adjustment',
+      },
+      {
+        text: 'Show which tables use the most space',
+        relatedTool: 'get_table_parts',
+      },
+    ],
+    suggest_ttl_adjustment: [
+      {
+        text: 'Estimate the mutation impact',
+        relatedTool: 'estimate_mutation_impact',
+      },
+      {
+        text: 'Forecast disk capacity after the change',
+        relatedTool: 'forecast_disk_capacity',
+      },
+    ],
+    estimate_mutation_impact: [
+      { text: 'Check current merge activity', relatedTool: 'get_merge_status' },
+      { text: 'Review disk headroom', relatedTool: 'get_disk_usage' },
+    ],
+
+    // Replication / merges
+    get_replication_status: [
+      {
+        text: 'Check for a merge backlog on that table',
+        relatedTool: 'get_merge_status',
+      },
+      { text: 'Look at overall cluster health', relatedTool: 'get_metrics' },
+      {
+        text: 'Get tuning suggestions for the lagging table',
+        relatedTool: 'get_tuning_suggestions',
+      },
+    ],
+    get_merge_status: [
+      { text: 'Check disk headroom', relatedTool: 'get_disk_usage' },
+      {
+        text: 'Suggest a TTL to reduce merge pressure',
+        relatedTool: 'suggest_ttl_adjustment',
+      },
+      {
+        text: 'Look at replication status',
+        relatedTool: 'get_replication_status',
+      },
+    ],
+
+    // Health
+    get_metrics: [
+      { text: 'Check disk usage', relatedTool: 'get_disk_usage' },
+      {
+        text: 'Check replication status',
+        relatedTool: 'get_replication_status',
+      },
+      {
+        text: 'See currently running queries',
+        relatedTool: 'get_running_queries',
+      },
+    ],
+    get_disk_usage: [
+      {
+        text: 'Forecast when disk fills up',
+        relatedTool: 'forecast_disk_capacity',
+      },
+      {
+        text: 'Show which tables use the most space',
+        relatedTool: 'get_table_parts',
+      },
+      {
+        text: 'Suggest a TTL to reclaim space',
+        relatedTool: 'suggest_ttl_adjustment',
+      },
+    ],
+
+    // Schema
+    list_tables: [
+      { text: 'Show the largest tables', relatedTool: 'get_table_parts' },
+      { text: 'Explore a table schema', relatedTool: 'explore_table_schema' },
+    ],
+    get_table_schema: [
+      {
+        text: 'Recommend a materialized view for it',
+        relatedTool: 'recommend_materialized_view',
+      },
+      { text: 'Show its largest partitions', relatedTool: 'get_table_parts' },
+      {
+        text: 'Get optimization recommendations',
+        relatedTool: 'get_optimization_recommendations',
+      },
+    ],
+    explore_table_schema: [
+      {
+        text: 'Recommend a materialized view for it',
+        relatedTool: 'recommend_materialized_view',
+      },
+      { text: 'Show its largest partitions', relatedTool: 'get_table_parts' },
+      {
+        text: 'Get optimization recommendations',
+        relatedTool: 'get_optimization_recommendations',
+      },
+    ],
+
+    // Advisor
+    get_optimization_recommendations: [
+      {
+        text: 'Get more detailed tuning suggestions',
+        relatedTool: 'get_tuning_suggestions',
+      },
+      {
+        text: 'Estimate the impact on a running mutation',
+        relatedTool: 'estimate_mutation_impact',
+      },
+    ],
+    get_tuning_suggestions: [
+      { text: "Show the query's EXPLAIN plan", relatedTool: 'explain_query' },
+      {
+        text: 'Get broader optimization recommendations',
+        relatedTool: 'get_optimization_recommendations',
+      },
+    ],
+
+    // MV designer / insight / report / dashboard
+    recommend_materialized_view: [
+      {
+        text: 'Estimate the mutation impact',
+        relatedTool: 'estimate_mutation_impact',
+      },
+      { text: 'Check the table schema', relatedTool: 'get_table_schema' },
+    ],
+    explain_anomaly_score: [
+      {
+        text: 'Check currently running queries',
+        relatedTool: 'get_running_queries',
+      },
+      { text: 'Look at overall cluster health', relatedTool: 'get_metrics' },
+    ],
+    generate_cluster_report: [
+      { text: 'Check disk usage', relatedTool: 'get_disk_usage' },
+      {
+        text: 'Check replication status',
+        relatedTool: 'get_replication_status',
+      },
+    ],
+    suggest_dashboard: [
+      {
+        text: 'Visualize one of these metrics',
+        relatedTool: 'query_and_visualize',
+      },
+    ],
+
+    // Postgres (only reachable when CHM_FEATURE_POSTGRES_SOURCE is enabled)
+    run_postgres_select_query: [
+      {
+        text: 'Check Postgres table stats',
+        relatedTool: 'get_postgres_table_stats',
+      },
+    ],
+    list_postgres_slow_query_patterns: [
+      { text: 'Check Postgres metrics', relatedTool: 'get_postgres_metrics' },
+    ],
+    get_postgres_metrics: [
+      {
+        text: 'Check Postgres table stats',
+        relatedTool: 'get_postgres_table_stats',
+      },
+    ],
+    get_postgres_table_stats: [
+      { text: 'Check Postgres metrics', relatedTool: 'get_postgres_metrics' },
+    ],
+  }
+
+/**
+ * Fallback rules matched by keyword when no exchange tool call maps to
+ * {@link TOOL_FOLLOW_UPS} (e.g. the assistant answered from general
+ * knowledge without calling a tool). Less precise than the tool-driven path,
+ * so it is only consulted as a second choice.
  */
 interface FollowUpRule {
   readonly category: SuggestedPromptCategory
   readonly keywords: readonly string[]
-  readonly prompts: readonly string[]
+  readonly prompts: readonly FollowUpCandidate[]
 }
 
 const FOLLOW_UP_RULES: readonly FollowUpRule[] = [
@@ -28,24 +305,43 @@ const FOLLOW_UP_RULES: readonly FollowUpRule[] = [
       'duration',
     ],
     prompts: [
-      'Explain the slowest one',
-      'Show its EXPLAIN plan',
-      'Compare to yesterday',
+      {
+        text: "Explain the slowest query's plan",
+        relatedTool: 'explain_query',
+      },
+      { text: 'Estimate its cost', relatedTool: 'estimate_query_cost' },
+      {
+        text: 'Check for repeating slow patterns',
+        relatedTool: 'list_slow_query_patterns',
+      },
     ],
   },
   {
     category: 'Storage',
     keywords: ['table', 'storage', 'disk', 'partition', 'compression'],
     prompts: [
-      'Show largest partitions',
-      'Suggest a TTL',
-      'Break down by column',
+      { text: 'Show largest partitions', relatedTool: 'get_table_parts' },
+      { text: 'Suggest a TTL', relatedTool: 'suggest_ttl_adjustment' },
+      {
+        text: 'Forecast when disk fills up',
+        relatedTool: 'forecast_disk_capacity',
+      },
     ],
   },
   {
     category: 'Replication',
     keywords: ['replication', 'replica', 'zookeeper', 'keeper'],
-    prompts: ['Show the replication queue', 'Which replica is behind?'],
+    prompts: [
+      {
+        text: 'Show the replication queue',
+        relatedTool: 'get_replication_status',
+      },
+      {
+        text: 'Which replica is behind?',
+        relatedTool: 'get_replication_status',
+      },
+      { text: 'Check for a merge backlog', relatedTool: 'get_merge_status' },
+    ],
   },
 ] as const
 
@@ -61,6 +357,34 @@ function keywordMatches(haystack: string, keyword: string): boolean {
   return new RegExp(`(?:^|[^a-z])${escaped}s?(?:$|[^a-z])`).test(haystack)
 }
 
+/**
+ * Picks the rule whose keywords match `haystack` the most, not just the
+ * first rule with any match — a reply about replication that happens to
+ * mention "table" (e.g. "per-table replication queue") must still route to
+ * Replication, not fall into Storage because it's declared earlier in
+ * {@link FOLLOW_UP_RULES}. Ties keep the earlier-declared rule.
+ */
+function matchBestRule(haystack: string): FollowUpRule | undefined {
+  let best: { rule: FollowUpRule; score: number } | undefined
+
+  for (const rule of FOLLOW_UP_RULES) {
+    const score = rule.keywords.reduce(
+      (count, keyword) => count + (keywordMatches(haystack, keyword) ? 1 : 0),
+      0
+    )
+    if (score > 0 && (!best || score > best.score)) {
+      best = { rule, score }
+    }
+  }
+
+  return best?.rule
+}
+
+/** Case/whitespace-insensitive dedupe key for a suggestion's text. */
+function dedupeKey(text: string): string {
+  return text.trim().toLowerCase()
+}
+
 export interface FollowUpPromptsInput {
   /** Text of the user's last message in the exchange. */
   readonly lastUserText?: string
@@ -73,11 +397,18 @@ export interface FollowUpPromptsInput {
 }
 
 /**
- * Derives 2-3 contextual next-step suggestions from the last chat exchange.
+ * Derives up to `limit` contextual next-step suggestions from the last chat
+ * exchange.
  *
- * Purely rule-based (keyword matching, no LLM call) so it is instant and
- * deterministic. Falls back to a couple of the existing STARTER_PROMPTS when
- * nothing in the exchange matches a known topic.
+ * Purely rule-based (tool-name + keyword matching, no LLM call) so it is
+ * instant and deterministic. Prefers the tools actually invoked to answer the
+ * turn — the most precise signal for "what does the user already know" — and
+ * falls back to keyword matching on the exchange text, then to a couple of
+ * the generic {@link STARTER_PROMPTS} when nothing matches.
+ *
+ * A candidate is dropped whenever its `relatedTool` was itself already called
+ * this turn: that tool's output already answers the suggestion, so
+ * resurfacing it would just repeat what the agent just said.
  */
 export function getFollowUpPrompts({
   lastUserText = '',
@@ -88,17 +419,45 @@ export function getFollowUpPrompts({
   const clampedLimit = Math.max(0, limit)
   if (clampedLimit === 0) return []
 
-  const haystack = [lastUserText, lastAssistantText, ...toolsUsed]
-    .join(' ')
-    .toLowerCase()
+  const usedTools = new Set(toolsUsed)
 
-  const matchedRule = FOLLOW_UP_RULES.find((rule) =>
-    rule.keywords.some((keyword) => keywordMatches(haystack, keyword))
+  // Prefer the most recently called tool's suggestions first, so the chips
+  // track what the agent JUST did rather than the first tool of the turn.
+  const uniqueToolsMostRecentFirst = [...new Set([...toolsUsed].reverse())]
+
+  const toolCandidates = uniqueToolsMostRecentFirst.flatMap(
+    (tool) => TOOL_FOLLOW_UPS[tool] ?? []
   )
 
-  const prompts = matchedRule
-    ? matchedRule.prompts
-    : STARTER_PROMPTS.slice(0, FALLBACK_COUNT).map((prompt) => prompt.text)
+  let candidates: readonly FollowUpCandidate[] = toolCandidates
 
-  return prompts.slice(0, clampedLimit)
+  if (candidates.length === 0) {
+    const haystack = [lastUserText, lastAssistantText, ...toolsUsed]
+      .join(' ')
+      .toLowerCase()
+
+    const matchedRule = matchBestRule(haystack)
+
+    candidates = matchedRule ? matchedRule.prompts : []
+  }
+
+  const seen = new Set<string>()
+  const filtered: string[] = []
+
+  for (const candidate of candidates) {
+    if (candidate.relatedTool && usedTools.has(candidate.relatedTool)) continue
+
+    const key = dedupeKey(candidate.text)
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    filtered.push(candidate.text)
+    if (filtered.length === clampedLimit) break
+  }
+
+  if (filtered.length > 0) return filtered
+
+  return STARTER_PROMPTS.slice(0, FALLBACK_COUNT)
+    .map((prompt) => prompt.text)
+    .slice(0, clampedLimit)
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-15
+updated: 2026-08-17
 tags:
   - design-system
   - ui
@@ -300,6 +300,29 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   the agent can see; its shared state (`page-context-control.tsx`, floating-only
   provider) also gates whether `pageContext` rides along with the request — see
   `docs/content/guide/ai-agent.mdx`.
+- **Follow-up suggestion chips (two affordances, one shared look):**
+  `-thread/follow-up-chips.tsx` (`FollowUpChips`) is the single pill component
+  — `rounded-full border border-border/70 text-muted-foreground`, foreground +
+  `bg-muted/60` on hover, `flex flex-wrap gap-1.5` so it wraps on narrow
+  widths without layout shift. It takes an `anchored` prop (`border-t
+  border-border/60 pt-2`) for callers with nothing else separating the strip
+  from what's above it. Two producers render it: (1) `AssistantFollowUpChips`
+  in `thread.tsx` passes `anchored` (it sits directly under
+  `MessageStatsFooter` inside the message column, with no divider of its
+  own) and is driven by `lib/ai/agent/follow-up-prompts.ts` — deterministic,
+  client-side, derived primarily from the tool(s) the agent just called
+  (`TOOL_FOLLOW_UPS`, keyed by tool name) rather than generic keyword
+  matching, so suggestions are genuinely different next steps instead of
+  re-asking what the last tool call already answered (a candidate is dropped
+  when its `relatedTool` is already in `toolsUsed` this turn); when no tool
+  maps, a keyword-rule fallback picks the *highest-scoring* rule (not just the
+  first one declared) so a reply that only incidentally mentions an unrelated
+  rule's keyword doesn't hijack the match. (2) `FollowUpSuggestions` — the
+  AgentState-backed "AI follow-ups" button/row that sits directly above the
+  composer — leaves `anchored` off and instead puts `border-t
+  border-border/60 pt-2` on its own outer column (it has to cover both the
+  ghost-button and populated-chips states), so it reads as part of the
+  composer rather than floating loose above it.
 
 ### Settings channel grid (configured-first)
 


### PR DESCRIPTION
## Summary

The `/agents` follow-up chips ("Show largest partitions" / "Suggest a TTL" /
"Break down by column") were often generic or unrelated to what the agent had
just answered, and read as loose pills floating above the composer.

- **Relevance**: `getFollowUpPrompts` (`lib/ai/agent/follow-up-prompts.ts`) now
  derives suggestions primarily from the tool(s) the agent just called
  (`TOOL_FOLLOW_UPS`, keyed by tool name) instead of generic keyword matching.
  A candidate is dropped when its `relatedTool` already ran this turn, so
  chips never re-ask what the last tool call just answered (e.g. after
  `get_replication_status`, which already returns queue size / delay per
  replica, the old rule-based fallback would still suggest "Show the
  replication queue" — that's now filtered out).
- **Keyword fallback fix**: for tool-less replies, the fallback now scores
  every rule by keyword-hit count and picks the highest scorer, instead of
  the first declared rule. This closes the actual bug behind the screenshot:
  a reply about replication that happens to mention "table" (e.g. "per-table
  replication queue") no longer gets routed into the Storage rule just
  because Storage is declared before Replication.
- **Presentation**: `FollowUpChips` gains an `anchored` prop (top divider +
  padding) so the per-message chip strip under `AssistantFollowUpChips`
  reads as anchored rather than floating loose; `FollowUpSuggestions` (the
  AgentState-backed "AI follow-ups" row above the composer) now reuses
  `FollowUpChips` instead of duplicating the pill markup, so both follow-up
  affordances share one muted-but-clickable look built entirely from
  existing OKLCH tokens (`border-border`, `text-muted-foreground`,
  `bg-muted/60`, `ring-ring`) — verified in light and dark.
- Cap stays at 3, suggestions are deduped, and destructive control tools
  (`kill_query`, `optimize_table`, `kill_mutation`) are intentionally excluded
  from the suggestion map so a passive chip never nudges a destructive action.

## Not changed (deliberately)

- `POST /api/v1/agent/followups` — grepped under `routes/api/v1/agent*` per
  scope, but it's unreferenced dead code (only `routeTree.gen.ts` imports it);
  wiring it up would add an LLM call per turn, and removing pre-existing dead
  code wasn't in scope, so it's left alone.
- `FollowUpSuggestions`' button→populated-chips height swap can still nudge
  the composer slightly when the AgentState backend is active and returns
  multi-line questions — a pre-existing characteristic of that affordance,
  not introduced here.
- When AgentState is on, users see two visually similar pill rows (the
  deterministic per-message chips and the AI-generated row above the
  composer) ~40px apart, differentiated by the uppercase "Follow-ups" label
  on the latter. Consolidating the two follow-up systems is a bigger product
  decision than this PR's scope.

## Test plan

- [x] `pnpm run lint` — clean (2 pre-existing warnings in unrelated files)
- [x] `pnpm run test:unit` — 7757 pass / 0 fail (19 tests in
      `follow-up-prompts.test.ts`, covering tool-driven relevance,
      relatedTool dedupe/redundancy filtering, control-tool exclusion,
      keyword-fallback scoring, cap, and dedupe)
- [ ] CI (unit-tests, dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)