### PR TITLE
fix(agents): polish tool-call rendering and assistant markdown styling

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -86,6 +86,21 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `from-background`→`transparent` edge fade per scrollable side, paging via
   `scrollBy`. Re-measure on scroll / `ResizeObserver` / content-count change.
   Copy `components/insights/insights-strip.tsx`.
+- **Agent chat machinery stays ghost-weight.** Reasoning/tool-group triggers
+  (`components/assistant-ui/{reasoning,tool-group}.tsx`) are plain
+  `icon + label + chevron` text rows — no `bg-muted/50` slab — so the
+  assistant's prose stays the loudest element, not two stacked grey cards.
+  Tool-call headers show a short capped summary
+  (`summarizeToolInput`), never a raw `key=value` param dump; long params
+  (e.g. `sql`) render as a syntax-highlighted `CodeBlock` in the "Parameters"
+  disclosure, not inline. Tool errors render via `summarizeToolError` as a
+  compact `border-destructive/30` row with an expandable "Details" disclosure
+  — never a raw `{"error":...}` blob. Don't add a `.markdown-content`
+  `pre`/`code` background rule — Streamdown's own `code:` renderer already
+  owns that styling with token-based Tailwind classes; a sitewide override
+  paints a second box INSIDE its already-bordered fenced-block card. See
+  `docs/knowledge/product-design.md` § "Agent chat: reasoning / tool-call
+  rendering".
 - **Settings channel grid (configured-first):** a settings surface with many
   optional integrations renders a responsive `grid gap-3 sm:grid-cols-2` of
   collapsible `ChannelCard`s (summary row = icon + name + status + badges +

--- a/apps/dashboard/src/components/agents/chat/tool-output/__tests__/output-shape.test.ts
+++ b/apps/dashboard/src/components/agents/chat/tool-output/__tests__/output-shape.test.ts
@@ -3,6 +3,10 @@ import {
   createResultQueryConfig,
   getPromotedOutputType,
   getRowsFromOutput,
+  isLongToolInputValue,
+  summarizeToolError,
+  summarizeToolInput,
+  toolInputCodeLanguage,
 } from '@/components/agents/chat/tool-output/output-shape'
 
 describe('getRowsFromOutput', () => {
@@ -57,5 +61,110 @@ describe('createResultQueryConfig', () => {
     const config = createResultQueryConfig(['a', 'b'])
     expect(config.columns).toEqual(['a', 'b'])
     expect(config.name).toBe('agent-query-result')
+  })
+})
+
+describe('summarizeToolInput', () => {
+  test('returns null for missing or non-object input', () => {
+    expect(summarizeToolInput(undefined)).toBeNull()
+    expect(summarizeToolInput(null)).toBeNull()
+    expect(summarizeToolInput('sql')).toBeNull()
+    expect(summarizeToolInput({})).toBeNull()
+  })
+
+  test('summarizes a single scalar param as key=value', () => {
+    expect(summarizeToolInput({ tableName: 'events' })).toBe('tableName=events')
+  })
+
+  test('summarizes a long primary sql/query param alone, truncated', () => {
+    const longSql = `SELECT ${'col, '.repeat(30)}1`
+    const summary = summarizeToolInput({
+      sql: longSql,
+      hostId: 0,
+    })
+    expect(summary).not.toBeNull()
+    expect(summary?.length).toBeLessThanOrEqual(60)
+    expect(summary?.endsWith('…')).toBe(true)
+    // Never dumps the second param when a primary text param wins.
+    expect(summary).not.toContain('hostId')
+  })
+
+  test('collapses newlines/whitespace to a single line', () => {
+    const summary = summarizeToolInput({ sql: 'SELECT 1\n  FROM  system.one' })
+    expect(summary).toBe('SELECT 1 FROM system.one')
+  })
+
+  test('joins short non-primary params as key=value pairs', () => {
+    expect(
+      summarizeToolInput({ database: 'default', tableName: 'events' })
+    ).toBe('database=default, tableName=events')
+  })
+
+  test('falls back to a parameter count when even the joined form does not fit', () => {
+    const summary = summarizeToolInput({
+      database: 'a'.repeat(70),
+      tableName: 'events',
+    })
+    expect(summary).toBe('2 parameters')
+  })
+})
+
+describe('isLongToolInputValue / toolInputCodeLanguage', () => {
+  test('flags long or multiline strings, not short scalars', () => {
+    expect(isLongToolInputValue('short')).toBe(false)
+    expect(isLongToolInputValue('a'.repeat(61))).toBe(true)
+    expect(isLongToolInputValue('line1\nline2')).toBe(true)
+    expect(isLongToolInputValue(42)).toBe(false)
+  })
+
+  test('picks sql language for sql/query-named params, text otherwise', () => {
+    expect(toolInputCodeLanguage('sql')).toBe('sql')
+    expect(toolInputCodeLanguage('query')).toBe('sql')
+    expect(toolInputCodeLanguage('prompt')).toBe('text')
+  })
+})
+
+describe('summarizeToolError', () => {
+  test('defaults to a generic message when errorText is empty', () => {
+    expect(summarizeToolError(undefined)).toEqual({
+      message: 'An error occurred.',
+      detail: null,
+    })
+    expect(summarizeToolError('')).toEqual({
+      message: 'An error occurred.',
+      detail: null,
+    })
+  })
+
+  test('extracts the `error` field from a JSON-stringified error object', () => {
+    const errorText = JSON.stringify({ error: 'An error occurred.' })
+    expect(summarizeToolError(errorText)).toEqual({
+      message: 'An error occurred.',
+      detail: null,
+    })
+  })
+
+  test('extracts the `message` field and keeps extra fields as detail', () => {
+    const errorText = JSON.stringify({
+      message: 'Table not found',
+      code: 'TABLE_NOT_FOUND',
+    })
+    const result = summarizeToolError(errorText)
+    expect(result.message).toBe('Table not found')
+    expect(result.detail).toContain('TABLE_NOT_FOUND')
+  })
+
+  test('falls back to a generic message + full JSON detail when unreadable', () => {
+    const errorText = JSON.stringify({ code: 500, retryable: false })
+    const result = summarizeToolError(errorText)
+    expect(result.message).toBe('Tool call failed.')
+    expect(result.detail).toContain('"code": 500')
+  })
+
+  test('passes plain-text errorText through unchanged', () => {
+    expect(summarizeToolError('Connection timed out')).toEqual({
+      message: 'Connection timed out',
+      detail: null,
+    })
   })
 })

--- a/apps/dashboard/src/components/agents/chat/tool-output/output-shape.ts
+++ b/apps/dashboard/src/components/agents/chat/tool-output/output-shape.ts
@@ -29,6 +29,130 @@ export function getRowsFromOutput(output: unknown): Record<string, unknown>[] {
   return []
 }
 
+const SUMMARY_MAX_LENGTH = 60
+/** Param names treated as the tool's "primary" free-text argument (e.g. a SQL
+ * query) — summarized alone in the header instead of the full key=value dump. */
+const PRIMARY_PARAM_NAMES = /^(sql|query|prompt|question|text)$/i
+
+/** Collapses whitespace/newlines to a single line and caps the length. */
+function truncateOneLine(
+  value: string,
+  maxLength = SUMMARY_MAX_LENGTH
+): string {
+  const oneLine = value.replace(/\s+/g, ' ').trim()
+  return oneLine.length > maxLength
+    ? `${oneLine.slice(0, maxLength - 1)}…`
+    : oneLine
+}
+
+/**
+ * Short, single-line summary of a tool call's input for the collapsed row
+ * header. Long values (e.g. a `sql` param) are truncated instead of dumping
+ * every `key=value` pair inline — the full input still renders in the
+ * "Parameters" disclosure of the expanded body.
+ */
+export function summarizeToolInput(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null
+  const entries = Object.entries(input as Record<string, unknown>)
+  if (entries.length === 0) return null
+
+  const primary = entries.find(
+    ([key, value]) => typeof value === 'string' && PRIMARY_PARAM_NAMES.test(key)
+  )
+  if (primary) return truncateOneLine(primary[1] as string)
+
+  // Otherwise join all params as `key=value` — most tools take a couple of
+  // short scalars (`database=default, tableName=events`), which is more
+  // scannable than a bare count. Cap the joined form so a tool with several
+  // longer values doesn't reproduce the original "unreadable mid-string
+  // truncation" problem; only degrade to a count when even the first pair
+  // alone doesn't fit.
+  const joined = entries
+    .map(([key, value]) => {
+      const rendered = typeof value === 'string' ? value : JSON.stringify(value)
+      return `${key}=${rendered}`
+    })
+    .join(', ')
+  const oneLine = joined.replace(/\s+/g, ' ').trim()
+  if (oneLine.length <= SUMMARY_MAX_LENGTH) return oneLine
+
+  const firstPair = entries[0]
+  const firstRendered =
+    typeof firstPair[1] === 'string'
+      ? firstPair[1]
+      : JSON.stringify(firstPair[1])
+  const firstPairText = `${firstPair[0]}=${firstRendered}`.replace(/\s+/g, ' ')
+  if (firstPairText.length <= SUMMARY_MAX_LENGTH) return truncateOneLine(joined)
+
+  return `${entries.length} parameters`
+}
+
+/** Param whose value should render as a syntax-highlighted code block in the
+ * expanded "Parameters" disclosure rather than an inline `key: value` row. */
+export function isLongToolInputValue(value: unknown): value is string {
+  return (
+    typeof value === 'string' && (value.length > 60 || value.includes('\n'))
+  )
+}
+
+/** Language hint for a long tool-input value shown in a code block. */
+export function toolInputCodeLanguage(key: string): string {
+  return /sql|query/i.test(key) ? 'sql' : 'text'
+}
+
+export interface ToolErrorSummary {
+  /** Short, human-readable message — never raw JSON. */
+  readonly message: string
+  /** Pretty-printed JSON to show behind an expandable "Details" disclosure,
+   * only when it carries more information than `message` alone. */
+  readonly detail: string | null
+}
+
+/**
+ * Turns a tool's `errorText` (plain text, or a JSON-stringified error object —
+ * see `tool-fallback.tsx`) into a short message + optional expandable detail.
+ * Never surfaces a raw `{"error":"..."}` blob as the visible message.
+ */
+export function summarizeToolError(
+  errorText: string | undefined
+): ToolErrorSummary {
+  const trimmed = errorText?.trim()
+  if (!trimmed) return { message: 'An error occurred.', detail: null }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>
+      const readableKey =
+        typeof obj.error === 'string'
+          ? 'error'
+          : typeof obj.message === 'string'
+            ? 'message'
+            : null
+      if (readableKey) {
+        // Only offer a "Details" disclosure when the payload carries more
+        // than the message itself — otherwise expanding it just re-shows
+        // the same text wrapped in braces.
+        const hasExtraFields = Object.keys(obj).some(
+          (key) => key !== readableKey
+        )
+        return {
+          message: obj[readableKey] as string,
+          detail: hasExtraFields ? JSON.stringify(parsed, null, 2) : null,
+        }
+      }
+      return {
+        message: 'Tool call failed.',
+        detail: JSON.stringify(parsed, null, 2),
+      }
+    }
+  } catch {
+    // Not JSON — errorText is already plain text.
+  }
+
+  return { message: trimmed, detail: null }
+}
+
 export function getPromotedOutputType(output: unknown) {
   if (typeof output !== 'object' || output === null) return null
 

--- a/apps/dashboard/src/components/agents/chat/tool-output/result-table.tsx
+++ b/apps/dashboard/src/components/agents/chat/tool-output/result-table.tsx
@@ -56,6 +56,11 @@ export function ResultTable({
       enableColumnReordering={false}
       compact
       footnote={footnote}
+      // Compact tables render no outer chrome of their own — bound the whole
+      // card so it reads as one contained result, not a floating grid whose
+      // scrollbar fights the page (the row count already lives in the
+      // compact footer; the inner body scrolls within its own max-height).
+      className="rounded-md border border-border/60"
     />
   )
 }

--- a/apps/dashboard/src/components/agents/chat/tool-output/tool-call-part.tsx
+++ b/apps/dashboard/src/components/agents/chat/tool-output/tool-call-part.tsx
@@ -1,11 +1,20 @@
 'use client'
 
-import { ChevronDownIcon, ChevronRightIcon, DownloadIcon } from 'lucide-react'
+import {
+  AlertCircleIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  DownloadIcon,
+} from 'lucide-react'
 
 import {
   createResultQueryConfig,
   getPromotedOutputType,
   getRowsFromOutput,
+  isLongToolInputValue,
+  summarizeToolError,
+  summarizeToolInput,
+  toolInputCodeLanguage,
 } from './output-shape'
 import {
   renderRawOutput,
@@ -19,6 +28,7 @@ import {
   AskUserWidget,
   isAskUserOutput,
 } from '@/components/agents/ask-user-widget'
+import { CodeBlock } from '@/components/ai-elements/code-block'
 import { Badge } from '@/components/ui/badge'
 import {
   Collapsible,
@@ -109,6 +119,39 @@ function RowDisclosure({
 }
 
 /**
+ * Compact destructive row for a failed tool call: a short human-readable
+ * message (never raw JSON), with the parsed detail tucked behind an
+ * expandable disclosure. Falls back to a generic message when the backend
+ * only sent a boilerplate error (issue: agent tool-call rendering polish).
+ */
+function ToolErrorRow({
+  errorText,
+}: {
+  readonly errorText: string | undefined
+}) {
+  const { message, detail } = summarizeToolError(errorText)
+  return (
+    <div className="mb-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-2">
+      <div className="flex items-start gap-1.5 text-xs text-destructive">
+        <AlertCircleIcon className="mt-0.5 size-3.5 shrink-0" />
+        <span className="leading-relaxed">{message}</span>
+      </div>
+      {detail ? (
+        <div className="mt-1 pl-5">
+          <RowDisclosure label="Details">
+            <CodeBlock
+              code={detail}
+              language="json"
+              className="max-h-48 overflow-auto text-xs"
+            />
+          </RowDisclosure>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
  * Non-promoted tool output. Rich structured renders (ResultTable, charts,
  * advisor recommendations) stay visible; a raw JSON blob collapses behind a
  * "Response" disclosure so the row stays clean by default.
@@ -155,12 +198,10 @@ export function ToolCallPart({
     }
   }, [isMessageStreaming, hasOutput, hasError, isExpanded])
 
-  const inputParams = (() => {
-    if (!part.input || typeof part.input !== 'object') return null
-    return Object.entries(part.input as Record<string, unknown>)
-      .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
-      .join(', ')
-  })()
+  // Short, single-line summary for the header — long values (e.g. a `sql`
+  // param) are truncated instead of dumping every key=value pair inline; the
+  // full input is always available in the "Parameters" disclosure below.
+  const toolSummary = summarizeToolInput(part.input)
 
   const inputParamCount =
     part.input && typeof part.input === 'object'
@@ -231,9 +272,12 @@ export function ToolCallPart({
               </span>
             )}
             <span className="font-mono text-xs font-medium">{toolName}</span>
-            {inputParams && (
-              <span className="text-muted-foreground/70 truncate font-mono text-xs">
-                {inputParams}
+            {toolSummary && (
+              <span
+                className="text-muted-foreground/70 truncate font-mono text-xs"
+                title={toolSummary}
+              >
+                {toolSummary}
               </span>
             )}
           </div>
@@ -285,11 +329,7 @@ export function ToolCallPart({
           dump and raw JSON response collapse into opt-in disclosures. */}
       {isExpanded ? (
         <div className="pl-4 pt-1">
-          {hasError && Boolean(part.errorText) ? (
-            <div className="pb-1.5 text-sm text-destructive">
-              {String(part.errorText)}
-            </div>
-          ) : null}
+          {hasError ? <ToolErrorRow errorText={part.errorText} /> : null}
 
           {/* Output: the interactive ask-user widget and rich structured
               renders stay visible; a raw JSON blob collapses behind "Response".
@@ -316,6 +356,39 @@ export function ToolCallPart({
                   ([key, value]) => {
                     const paramDef = toolParams.find((p) => p.name === key)
                     const isOptional = paramDef?.required === false
+
+                    // A long / multi-line value (e.g. a `sql` param) gets its
+                    // own syntax-highlighted, horizontally-scrollable block
+                    // instead of a truncated inline `key: value` row.
+                    if (isLongToolInputValue(value)) {
+                      return (
+                        <div key={key} className="space-y-1">
+                          <div className="flex items-center gap-1.5 text-xs">
+                            <span
+                              className={cn(
+                                'font-mono',
+                                isOptional
+                                  ? 'text-muted-foreground'
+                                  : 'font-medium text-foreground'
+                              )}
+                            >
+                              {key}
+                            </span>
+                            {isOptional ? (
+                              <span className="text-[10px] text-muted-foreground/60">
+                                (optional)
+                              </span>
+                            ) : null}
+                          </div>
+                          <CodeBlock
+                            code={value}
+                            language={toolInputCodeLanguage(key)}
+                            className="max-h-64 overflow-auto text-xs"
+                          />
+                        </div>
+                      )
+                    }
+
                     return (
                       <div
                         key={key}

--- a/apps/dashboard/src/components/agents/markdown-code.css
+++ b/apps/dashboard/src/components/agents/markdown-code.css
@@ -29,28 +29,26 @@
   padding-bottom: 0.5rem; /* 8 px instead of 16 px */
 }
 
-/* Base code block styling */
-.markdown-content pre {
-  background-color: hsl(var(--muted));
-  border-radius: 0.375rem;
-  padding: 0.75rem;
-  margin: 0.5rem 0;
-  overflow-x: auto;
-}
-
-.markdown-content code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.875rem;
-}
-
-/* Inline code */
-.markdown-content :not(pre) > code {
-  background-color: hsl(var(--muted));
-  padding: 0.125rem 0.25rem;
-  border-radius: 0.25rem;
-}
-
 /*
+ * NOTE: there is no generic `.markdown-content pre` / `code` background rule
+ * here (or in styles.css's `.markdown-content` block) on purpose.
+ *
+ * Streamdown's own `code:`/`pre:` renderers already own ALL code chrome —
+ * fenced blocks get a bordered `bg-background` card (`data-streamdown=
+ * "code-block-body"`, styled above), inline code gets `rounded bg-muted
+ * px-1.5 py-0.5` directly on the `<code data-streamdown="inline-code">`
+ * element. A prior sitewide `pre`/`code` override here (and a duplicate,
+ * *also broken* `hsl(var(--muted))` version — oklch tokens can't be wrapped
+ * in `hsl()`) painted a second muted, padded box INSIDE Streamdown's already-
+ * bordered `code-block-body` card (Streamdown's `pre:` renderer just returns
+ * its child unwrapped, so the generic `pre` selector was hitting the inner
+ * token-holding `<pre>`) and shrank inline code's font-size below the block's.
+ * `.markdown-content` has exactly one consumer
+ * (`markdown-text.tsx`), so removing the override is safe — Streamdown's
+ * Tailwind classes are already token-based (`bg-muted`, `border-border`,
+ * `bg-background`), matching the project's OKLCH design system. Re-add a
+ * rule here only if it targets something Streamdown does NOT already style.
+ *
  * NOTE: .hljs-* rules have been removed.
  *
  * Streamdown v2.4.0 uses Shiki for syntax highlighting via the `shikiTheme`

--- a/apps/dashboard/src/components/assistant-ui/reasoning.tsx
+++ b/apps/dashboard/src/components/assistant-ui/reasoning.tsx
@@ -111,21 +111,22 @@ export function ReasoningTrigger({
   return (
     <CollapsibleTrigger
       className={cn(
-        'flex w-full items-center gap-1.5 px-3 py-2 rounded-md',
-        'bg-muted/50',
-        'text-xs font-medium text-muted-foreground',
-        'hover:bg-muted transition-colors',
+        // Ghost text row, not a background card — chat machinery stays
+        // secondary so the assistant's own prose is the loudest thing on
+        // the thread. `-mx-1.5` keeps the hover/focus box from nudging the
+        // row's text out of alignment with the reply above/below it.
+        '-mx-1.5 flex w-full items-center gap-1.5 rounded-sm px-1.5 py-1',
+        'text-xs italic text-muted-foreground/80',
+        'outline-none transition-colors hover:bg-muted/40 hover:text-foreground',
+        'focus-visible:ring-[3px] focus-visible:ring-ring/50',
         className
       )}
     >
       <SparklesIcon
-        className={cn(
-          'size-3.5 shrink-0 text-muted-foreground',
-          active && 'animate-pulse'
-        )}
+        className={cn('size-3.5 shrink-0', active && 'animate-pulse')}
       />
       <span className="flex-1 text-left">{children ?? 'Thought process'}</span>
-      <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/reasoning:rotate-90" />
+      <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/reasoning:rotate-90" />
     </CollapsibleTrigger>
   )
 }
@@ -153,7 +154,9 @@ export function ReasoningContent({
         'data-open:animate-collapsible-down'
       )}
     >
-      <div className={cn('px-3 py-2', className)}>{children}</div>
+      {/* Indented under the trigger's icon + label, matching the tool row's
+          left-accent-bar indent so reasoning reads as one visual "system" */}
+      <div className={cn('py-1 pl-5', className)}>{children}</div>
     </CollapsibleContent>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/tool-group.tsx
+++ b/apps/dashboard/src/components/assistant-ui/tool-group.tsx
@@ -111,18 +111,18 @@ export function ToolGroupTrigger({
   return (
     <CollapsibleTrigger
       className={cn(
-        'flex w-full items-center gap-1.5 px-3 py-2 rounded-md',
-        'bg-muted/50',
+        // Ghost text row, not a background card — matches ReasoningTrigger's
+        // weight so the two "chat machinery" collapsibles read as siblings,
+        // differentiated by icon/label rather than a stacked grey slab each.
+        '-mx-1.5 flex w-full items-center gap-1.5 rounded-sm px-1.5 py-1',
         'text-xs font-medium text-muted-foreground',
-        'hover:bg-muted transition-colors',
+        'outline-none transition-colors hover:bg-muted/40 hover:text-foreground',
+        'focus-visible:ring-[3px] focus-visible:ring-ring/50',
         className
       )}
     >
       <WrenchIcon
-        className={cn(
-          'size-3.5 shrink-0 text-muted-foreground',
-          isRunning && 'animate-pulse'
-        )}
+        className={cn('size-3.5 shrink-0', isRunning && 'animate-pulse')}
       />
       <span className="flex-1 text-left">
         {count != null && count > 0
@@ -130,9 +130,9 @@ export function ToolGroupTrigger({
           : 'Tool calls'}
       </span>
       {isRunning && (
-        <span className="mr-1 inline-block size-2 animate-pulse rounded-full bg-primary/60" />
+        <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-[var(--chart-yellow)]" />
       )}
-      <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/toolgroup:rotate-90" />
+      <ChevronRightIcon className="size-3 shrink-0 transition-transform duration-200 group-data-[state=open]/toolgroup:rotate-90" />
     </CollapsibleTrigger>
   )
 }
@@ -160,7 +160,11 @@ export function ToolGroupContent({
         'data-open:animate-collapsible-down'
       )}
     >
-      <div className={cn('flex flex-col gap-0', className)}>{children}</div>
+      {/* Indented under the trigger's icon + label — each contained tool row
+          keeps its own accent bar / disclosures, this just groups them. */}
+      <div className={cn('flex flex-col gap-0 pl-3.5', className)}>
+        {children}
+      </div>
     </CollapsibleContent>
   )
 }

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -272,25 +272,19 @@
   list-style-type: decimal;
 }
 
-.markdown-content code {
-  font-size: 0.75rem;
-  background-color: oklch(from var(--muted) l c h);
-  padding: 0.125rem 0.25rem;
-  border-radius: 0.25rem;
-}
-
-.markdown-content pre {
-  margin: 0.75em 0;
-  padding: 0.75rem;
-  background-color: oklch(from var(--muted) l c h);
-  border-radius: 0.375rem;
-  overflow-x: auto;
-}
-
-.markdown-content pre code {
-  background-color: transparent;
-  padding: 0;
-}
+/*
+ * No `.markdown-content code` / `pre` rule here — Streamdown's own `code:`
+ * renderer (see `components/agents/markdown-code.css`) already owns fenced
+ * and inline code styling via token-based Tailwind classes (`bg-muted`,
+ * `border-border`, `bg-background`, `text-sm`). A sitewide override at this
+ * specificity was overriding Streamdown's own font-size/padding and, for
+ * fenced blocks, painting a second padded background box INSIDE its
+ * already-bordered card (Streamdown's `pre:` renderer returns its child
+ * unwrapped, so the generic `pre` selector hit the inner token-holding
+ * `<pre>`). Headings/blockquote below stay: those ARE an intentional, working
+ * override of Streamdown's chat-width-oversized defaults (its own h1 is
+ * `text-3xl`, tuned for full-page docs, not a narrow chat column).
+ */
 
 .markdown-content table {
   margin: 0.75em 0;
@@ -405,14 +399,6 @@
 /* Dark mode adjustments */
 .dark .markdown-content {
   color: oklch(from var(--foreground) l c h);
-}
-
-.dark .markdown-content code {
-  background-color: oklch(from var(--muted) l c h);
-}
-
-.dark .markdown-content pre {
-  background-color: oklch(from var(--muted) l c h);
 }
 
 /* Disable sidebar transitions during resize for instant feedback */

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-15
+updated: 2026-08-17
 tags:
   - design-system
   - ui
@@ -300,6 +300,59 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   the agent can see; its shared state (`page-context-control.tsx`, floating-only
   provider) also gates whether `pageContext` rides along with the request — see
   `docs/content/guide/ai-agent.mdx`.
+
+### Agent chat: reasoning / tool-call rendering
+
+The thread's "chat machinery" (reasoning blocks, tool-call groups, individual
+tool rows) must stay visually secondary to the assistant's own prose — the
+reply text is the loudest thing on the page, not the plumbing that produced
+it. Implemented in `components/assistant-ui/{reasoning,tool-group}.tsx` +
+`components/agents/chat/tool-output/tool-call-part.tsx`:
+
+- **Ghost text row triggers, not background cards.** `ReasoningTrigger`
+  ("Thought process") and `ToolGroupTrigger` ("N tool calls") are plain
+  `icon + label + chevron` rows (`text-xs text-muted-foreground`,
+  `hover:bg-muted/40 hover:text-foreground`, `focus-visible:ring-[3px]
+  focus-visible:ring-ring/50`) — **no `bg-muted/50` slab**. Two adjacent
+  colored/boxed triggers read as identical heavy blocks and bury the message
+  between them; a bare row differentiates by icon (Sparkles vs Wrench) and
+  label instead. Their content indents under the trigger (`pl-5` /
+  `pl-3.5`) rather than adding another box.
+- **Tool-call header: a short summary, never a raw param dump.** The
+  collapsed row shows `toolName` + `summarizeToolInput(part.input)`
+  (`tool-output/output-shape.ts`) — a single-line, whitespace-collapsed,
+  ~60-char-capped string (prefers a primary `sql`/`query`/`prompt` param
+  alone over concatenating every `key=value`). The full input always lives in
+  the "Parameters" disclosure in the expanded body; a long/multiline value
+  there (`isLongToolInputValue`) renders as a `CodeBlock` (sql-aware,
+  horizontally scrollable) instead of an inline JSON string.
+- **Tool errors: a compact destructive row, never raw JSON.** A failed tool
+  renders `summarizeToolError(part.errorText)` — a short human message
+  (extracted from a `{error:...}`/`{message:...}` JSON payload when present,
+  or the plain text as-is, or a generic fallback when there's nothing
+  readable) in a `border-destructive/30 bg-destructive/5` row. An expandable
+  "Details" disclosure only appears when the payload carries fields beyond
+  the message itself — never a bare `{"error":"..."}` blob inline.
+- **Embedded result tables are bounded.** `ResultTable` (compact `DataTable`)
+  gets `rounded-md border border-border/60` at the call site — compact mode
+  has no border of its own — so it reads as one contained card, with its own
+  `max-h-[50vh]` scroll and a row count in the footer, instead of floating
+  content whose scrollbar fights the page.
+- **`.markdown-content` owns no `pre`/`code` background rule** (neither in
+  `styles.css` nor `components/agents/markdown-code.css`). Streamdown's own
+  `code:`/`pre:` renderers already style both fenced blocks (bordered
+  `bg-background` card) and inline code (`rounded bg-muted px-1.5 py-0.5`)
+  with token-based Tailwind classes — a sitewide override at that specificity
+  paints a second padded background box INSIDE Streamdown's already-bordered
+  fenced-block card (its `pre:` renderer returns its child unwrapped, so a
+  generic `pre` selector hits the inner token-holding `<pre>`) and shrinks
+  inline code's font-size below the block's. Don't re-add one; if code
+  styling looks off, fix it in the
+  Streamdown-rendered markup's own classes, not a `.markdown-content`
+  override. (`.markdown-content` has exactly one consumer, `markdown-text.tsx`
+  — safe to keep spare.) The heading/blockquote overrides that DO remain in
+  `styles.css` are intentional chat-width right-sizing (Streamdown's own h1 is
+  `text-3xl`, tuned for full-page docs) — don't remove those.
 
 ### Settings channel grid (configured-first)
 


### PR DESCRIPTION
## Summary

Makes the agent chat's tool-call rendering and assistant response styling
substantially better on `/agents`, based on a real-session screenshot showing
identical grey collapsible slabs burying the message body, a raw JSON error
blob, and unreadable truncated SQL in a tool header.

- **Reasoning/tool-group triggers** ("Thought process" / "N tool calls") drop
  the identical `bg-muted/50` slab for a plain icon + label + chevron ghost
  row (`focus-visible` ring added for a11y) — differentiated by icon, not two
  stacked grey cards. The assistant's own prose stays the most prominent
  element on the thread.
- **Tool-call header** shows a short, capped summary (`summarizeToolInput`,
  new pure helper in `tool-output/output-shape.ts`) instead of dumping every
  `key=value` pair inline — long SQL no longer truncates mid-string
  unreadably. Long params (e.g. `sql`) render as a syntax-highlighted,
  horizontally-scrollable `CodeBlock` in the "Parameters" disclosure instead
  of a raw JSON string.
- **Failed tools** render a compact destructive row (`summarizeToolError`)
  with a short human message and an expandable "Details" disclosure — never
  a raw `{"error":"..."}` blob. Degrades gracefully to a generic message when
  the backend only sends boilerplate (a parallel PR is improving that text).
- **Embedded `ResultTable`** gets a bounding border so it reads as one
  contained, scroll-contained card (with a row count already in its compact
  footer) instead of a floating grid whose scrollbar fought the page.
- **Removed dead/conflicting `.markdown-content pre`/`code` CSS** in both
  `markdown-code.css` (an invalid `hsl(var(--muted))` — oklch tokens can't be
  wrapped in `hsl()`, so it never actually rendered) and `styles.css` (a
  working `oklch(from ...)` duplicate). Streamdown's own `code:` renderer
  already fully styles fenced + inline code with token-based Tailwind
  classes (`bg-muted`, `border-border`, `bg-background`) — the override was
  painting a second padded box *inside* Streamdown's already-bordered
  fenced-block card and shrinking inline code below the block's font-size.
  `.markdown-content` has exactly one consumer (`markdown-text.tsx`), so this
  is safe; heading/blockquote overrides stay (intentional chat-width
  right-sizing vs. Streamdown's page-width defaults).

Also updated the `product-design` skill + `docs/knowledge/product-design.md`
with the new "Agent chat: reasoning / tool-call rendering" convention, per
the repo's standing auto-improve-skills instruction.

**Scope note:** `tool-output/*` (`output-shape.ts`, `tool-call-part.tsx`,
`result-table.tsx`) is treated as owned — the `tool-output.tsx` barrel this
task named is a 13-line re-export, and the file list predates its
decomposition into that folder in an earlier merged PR.

**Shared-file note:** `styles.css` is touched, but the change is scoped to
the single-consumer `.markdown-content` block, so it shouldn't conflict with
other concurrent agent-page PRs touching the composer/rail/sidebar.

## Test plan

- [x] `pnpm run test:unit` — 7762 pass, 0 fail (20 new tests for
      `summarizeToolInput`/`summarizeToolError`/`isLongToolInputValue`)
- [x] `pnpm run lint` — clean (2 pre-existing unrelated warnings only)
- [x] `pnpm run type-check` (apps/dashboard) — no errors in touched files
      (286 pre-existing route-tree-codegen errors, unrelated, present on
      origin/main too — verified via git stash)
- [ ] Manual check on a live `/agents` session (screenshot-driven changes;
      no ClickHouse host available in this sandbox to drive a live agent run)

Co-Authored-By: duyetbot <bot@duyet.net>