### PR TITLE
feat(billing): collect company details before Polar checkout

### DIFF
--- a/apps/cloud-hooks/src/license-checkout.test.ts
+++ b/apps/cloud-hooks/src/license-checkout.test.ts
@@ -54,6 +54,31 @@ describe('GET /checkout/license', () => {
     expect(called).toBe('https://sandbox-api.polar.sh/v1/checkouts/')
   })
 
+  test('forwards email and company into Polar checkout', async () => {
+    const fetchImpl = mock(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as Record<
+        string,
+        unknown
+      >
+      expect(body.customer_email).toBe('ops@acme.example')
+      expect(body.metadata).toMatchObject({
+        company: 'Acme',
+        website: 'https://acme.example',
+      })
+      return new Response(JSON.stringify({ url: 'https://polar.sh/c' }), {
+        status: 200,
+      })
+    })
+    const res = await handleLicenseCheckout(
+      req(
+        'sku=team&term=yearly&email=ops@acme.example&company=Acme&website=https://acme.example'
+      ),
+      env,
+      { fetchImpl }
+    )
+    expect(res.status).toBe(302)
+  })
+
   test('lifetime unlimited uses the lifetime product and production host', async () => {
     const fetchImpl = mock(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body ?? '{}')) as Record<

--- a/apps/cloud-hooks/src/license-checkout.ts
+++ b/apps/cloud-hooks/src/license-checkout.ts
@@ -65,17 +65,29 @@ export async function handleLicenseCheckout(
   try {
     const externalId = licenseCheckoutExternalId(skuRaw, termRaw, deps.uuid?.())
     const successUrl = licenseSuccessUrl(skuRaw, termRaw, successOrigin(env))
+    const email = (url.searchParams.get('email') ?? '').trim()
+    const company = (url.searchParams.get('company') ?? '').trim().slice(0, 120)
+    const website = (url.searchParams.get('website') ?? '').trim().slice(0, 200)
+    const metadata: Record<string, string> = {
+      kind: 'selfhost-license',
+      sku: skuRaw,
+      term: termRaw,
+    }
+    if (company) metadata.company = company
+    if (website) metadata.website = website
+    const body: Record<string, unknown> = {
+      products: [productId],
+      external_customer_id: externalId,
+      success_url: successUrl,
+      metadata,
+    }
+    if (email.includes('@')) body.customer_email = email
     const polar = await polarFetch(
       env,
       '/v1/checkouts/',
       {
         method: 'POST',
-        body: JSON.stringify({
-          products: [productId],
-          external_customer_id: externalId,
-          success_url: successUrl,
-          metadata: { kind: 'selfhost-license', sku: skuRaw, term: termRaw },
-        }),
+        body: JSON.stringify(body),
       },
       deps.fetchImpl ?? fetch
     )

--- a/apps/cloud-hooks/src/license-register.test.ts
+++ b/apps/cloud-hooks/src/license-register.test.ts
@@ -90,6 +90,30 @@ describe('POST /licenses/register', () => {
     })
   })
 
+  test('intent without checkout_id is stored but stays off the public wall', async () => {
+    const kv = makeKV()
+    const res = await handleLicenseRegister(
+      post({
+        company: 'Lead Co',
+        website: 'https://lead.example',
+        sku: 'team',
+        term: 'yearly',
+        list_public: true,
+        email: 'ops@lead.example',
+      }),
+      {},
+      { kv, uuid: () => 'lead-1' }
+    )
+    expect(res.status).toBe(201)
+    expect(await kv.get(`${LICENSE_REG_KEY_PREFIX}lead-1`)).toContain('Lead Co')
+    const pub = await handleLicensePublic(
+      new Request('https://hooks.chmonitor.dev/licenses/public'),
+      {},
+      { kv }
+    )
+    expect(await pub.json()).toEqual({ licenses: [] })
+  })
+
   test('private rows stay off GET /licenses/public', async () => {
     const kv = makeKV()
     await handleLicenseRegister(

--- a/apps/cloud-hooks/src/license-register.ts
+++ b/apps/cloud-hooks/src/license-register.ts
@@ -160,7 +160,8 @@ export async function handleLicenseRegister(
 
   try {
     await kv.put(`${LICENSE_REG_KEY_PREFIX}${row.id}`, JSON.stringify(row))
-    if (row.list_public) {
+    // Public wall only after Polar proof (checkout_id). Intent rows stay private.
+    if (row.list_public && checkoutId) {
       const index = await readPublicIndex(kv)
       if (index.length < PUBLIC_CAP) {
         index.push(toPublic(row))

--- a/apps/dashboard/src/routes/(dashboard)/billing.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/billing.tsx
@@ -36,7 +36,7 @@ const ClerkSignInButton:
   | null = isClerkEnabled() ? ClerkSignInButtonImpl : null
 
 function licenseCheckoutHref(sku: PaidLicenseId, term: LicenseTerm): string {
-  return `/api/v1/billing/license-checkout?sku=${sku}&term=${term}`
+  return `https://chmonitor.dev/license/register?sku=${sku}&term=${term}`
 }
 
 function BillingPage() {

--- a/apps/landing/src/data/licenses.test.ts
+++ b/apps/landing/src/data/licenses.test.ts
@@ -1,5 +1,5 @@
 import { publicLicensedCompanies } from './licensed-companies'
-import { buyHref, invoiceMailto, paidLicenseSkus } from './licenses'
+import { bossPitch, buyHref, invoiceMailto, paidLicenseSkus } from './licenses'
 import { describe, expect, test } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -32,6 +32,22 @@ describe('landing license offer', () => {
     )
     expect(paidLicenseSkus.map((s) => s.id)).toEqual(['team', 'unlimited'])
     expect(LICENSE_SKU_LIST).toHaveLength(3)
+  })
+
+  test('boss pitch is a paste-ready ask with Team price and no license key', () => {
+    expect(bossPitch).toContain('$499')
+    expect(bossPitch).toContain('https://chmonitor.dev/pricing/')
+    expect(bossPitch).toMatch(/no license key/i)
+    expect(bossPitch).toContain('Subject:')
+    const src = readFileSync(
+      join(landingRoot, 'src/pages/pricing.astro'),
+      'utf8'
+    )
+    expect(src).toContain('Copy this to your boss')
+    expect(src).toContain('bossPitch')
+    expect(src.indexOf('tell-your-boss')).toBeLessThan(
+      src.indexOf('pricing-faq')
+    )
   })
 
   test('invoice mailto is honor-system and asks for company + website', () => {

--- a/apps/landing/src/data/licenses.test.ts
+++ b/apps/landing/src/data/licenses.test.ts
@@ -19,16 +19,16 @@ describe('landing license offer', () => {
     expect(invoiceMailto(personal, 'yearly')).toBe(PERSONAL_SELFHOST_HREF)
   })
 
-  test('paid CTA goes to Polar license checkout', () => {
+  test('paid CTA goes to the company form before Polar', () => {
     const team = getLicense('team')
     expect(buyHref(team, 'yearly')).toBe(
-      'https://hooks.chmonitor.dev/checkout/license?sku=team&term=yearly'
+      '/license/register?sku=team&term=yearly'
     )
     expect(buyHref(team, 'lifetime')).toBe(
-      'https://hooks.chmonitor.dev/checkout/license?sku=team&term=lifetime'
+      '/license/register?sku=team&term=lifetime'
     )
     expect(buyHref(getLicense('unlimited'), 'yearly')).toBe(
-      'https://hooks.chmonitor.dev/checkout/license?sku=unlimited&term=yearly'
+      '/license/register?sku=unlimited&term=yearly'
     )
     expect(paidLicenseSkus.map((s) => s.id)).toEqual(['team', 'unlimited'])
     expect(LICENSE_SKU_LIST).toHaveLength(3)

--- a/apps/landing/src/data/licenses.ts
+++ b/apps/landing/src/data/licenses.ts
@@ -25,9 +25,23 @@ export const LICENSE_HOOKS_ORIGIN =
       ?.PUBLIC_LICENSE_CHECKOUT_ORIGIN) ||
   'https://hooks.chmonitor.dev'
 
+/** Pricing Buy → company form first, then Polar. */
 export function buyHref(sku: LicenseSku, term: LicenseTerm): string {
   if (!isPaidLicense(sku.id)) return PERSONAL_SELFHOST_HREF
   const params = new URLSearchParams({ sku: sku.id, term })
+  return `/license/register?${params}`
+}
+
+export function polarCheckoutHref(
+  sku: LicenseSku,
+  term: LicenseTerm,
+  extras?: { email?: string; company?: string; website?: string }
+): string {
+  if (!isPaidLicense(sku.id)) return PERSONAL_SELFHOST_HREF
+  const params = new URLSearchParams({ sku: sku.id, term })
+  if (extras?.email) params.set('email', extras.email)
+  if (extras?.company) params.set('company', extras.company)
+  if (extras?.website) params.set('website', extras.website)
   return `${LICENSE_HOOKS_ORIGIN}/checkout/license?${params}`
 }
 
@@ -93,5 +107,13 @@ export const licenseFaqs = [
   {
     q: 'Need a PO or vendor form?',
     a: `Buy on Polar from the pricing page. For a PO or Net-30 invoice, email ${LICENSE_SALES_EMAIL}.`,
+  },
+  {
+    q: 'Where do I paste the license key?',
+    a: 'You do not. There is no key. Polar emails the payment receipt. Register your company after pay, or look up the order with the Polar checkout id / billing email. The app never asks for a key.',
+  },
+  {
+    q: 'Who emails me after I pay?',
+    a: 'Polar sends the receipt. We (hello@chmonitor.dev) only write if you asked for a PO or if lookup cannot find the order.',
   },
 ]

--- a/apps/landing/src/data/licenses.ts
+++ b/apps/landing/src/data/licenses.ts
@@ -79,6 +79,23 @@ export function invoiceMailto(sku: LicenseSku, term: LicenseTerm): string {
   return `mailto:${LICENSE_SALES_EMAIL}?subject=${subject}&body=${body}`
 }
 
+/** Slack/email paste for the engineer who needs a signature. */
+export const bossPitch = `Subject: $499 so I stop SSHing into ClickHouse at 2am
+
+Hi —
+
+I already run chmonitor next to our ClickHouse. GPL-3.0, self-hosted, no license key, no SaaS, no phoning home.
+
+The Team license is $499/year for 3 hosts ($1,349 lifetime if finance hates renewals). Unlimited is $999/year. Polar takes the card; they email the receipt. There is nothing to paste into the app.
+
+What we get: a commercial invoice, priority email, and I stop writing Grafana panels that lie about system.parts.
+
+That's cheaper than one incident where someone asks "why is the merge queue 400" and I open eleven browser tabs.
+
+Please approve. I'll buy it here: https://chmonitor.dev/pricing/
+
+Thanks`
+
 export const licenseFaqs = [
   {
     q: 'The software is already free. Why buy a license?',

--- a/apps/landing/src/pages/license/register.astro
+++ b/apps/landing/src/pages/license/register.astro
@@ -12,6 +12,7 @@ import Nav from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import {
   invoiceMailto,
+  LICENSE_HOOKS_ORIGIN,
   licenseRegisterApiHref,
   paidLicenseSkus,
 } from '../../data/licenses'
@@ -44,8 +45,8 @@ const registerApi = licenseRegisterApiHref()
           <h1>Buy &amp; register</h1>
           <p>
             {paid
-              ? 'Payment received. Register your company name and website — honor system, no license key.'
-              : 'Pay on Polar (Buy from the pricing page), then register your company. Or email hello@chmonitor.dev for an invoice.'}
+              ? 'Polar received payment and emailed you a receipt. Register your company here — there is no license key.'
+              : 'Enter company details, then pay on Polar. Polar emails the receipt. There is no license key to paste into the app.'}
           </p>
         </div>
 
@@ -99,7 +100,7 @@ const registerApi = licenseRegisterApiHref()
             <textarea name="notes" rows="4" maxlength="2000"></textarea>
           </label>
           <button class={btnPrimaryBlock} type="submit" id="send">
-            {paid ? 'Register company' : `Email ${LICENSE_SALES_EMAIL} to purchase`}
+            {paid ? 'Register company' : 'Continue to Polar to pay'}
           </button>
         </form>
 
@@ -125,7 +126,7 @@ const registerApi = licenseRegisterApiHref()
     .hint,.trust,.alt{font-size:13px;color:var(--muted-fg);line-height:1.5;margin-top:12px}
     .alt{display:flex;flex-wrap:wrap;align-items:center;gap:10px}
   </style>
-  <script is:inline define:vars={{ paid, registerApi }}>
+  <script is:inline define:vars={{ paid, registerApi, hooksOrigin: LICENSE_HOOKS_ORIGIN }}>
     (function () {
       var form = document.getElementById('reg-form')
       var done = document.getElementById('done')
@@ -159,30 +160,47 @@ const registerApi = licenseRegisterApiHref()
         var list = form.list_public.checked ? 'yes' : 'no'
         var notes = form.notes.value.trim()
         var checkoutId = form.checkout_id ? form.checkout_id.value.trim() : ''
-        if (!paid) {
-          mailtoFallback(company, website, email, sku, term, list, notes)
-          return
+        var payload = {
+          company: company,
+          website: website,
+          sku: sku,
+          term: term,
+          list_public: list === 'yes',
+          checkout_id: checkoutId || undefined,
+          email: email || undefined,
+          notes: notes || undefined,
+        }
+        function goPolar() {
+          var dest =
+            hooksOrigin +
+            '/checkout/license?sku=' +
+            encodeURIComponent(sku) +
+            '&term=' +
+            encodeURIComponent(term)
+          if (email) dest += '&email=' + encodeURIComponent(email)
+          if (company) dest += '&company=' + encodeURIComponent(company)
+          if (website) dest += '&website=' + encodeURIComponent(website)
+          window.location.href = dest
         }
         fetch(registerApi, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({
-            company: company,
-            website: website,
-            sku: sku,
-            term: term,
-            list_public: list === 'yes',
-            checkout_id: checkoutId || undefined,
-            email: email || undefined,
-            notes: notes || undefined,
-          }),
+          body: JSON.stringify(payload),
         })
           .then(function (res) {
+            if (!paid) {
+              goPolar()
+              return
+            }
             if (!res.ok) throw new Error('register failed')
             form.hidden = true
             if (done) done.hidden = false
           })
           .catch(function () {
+            if (!paid) {
+              goPolar()
+              return
+            }
             mailtoFallback(company, website, email, sku, term, list, notes)
           })
       })

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -4,8 +4,9 @@ import Nav from '../components/Nav.astro'
 import Pricing from '../components/Pricing.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
-import { licenseFaqs } from '../data/licenses'
+import { bossPitch, licenseFaqs } from '../data/licenses'
 import { pricingFaqs } from '../data/pricing'
+import { btnOutline } from '../lib/button-classes'
 
 const allFaqs = [...licenseFaqs, ...pricingFaqs]
 const faqJsonLd = {
@@ -51,6 +52,24 @@ const breadcrumbJsonLd = {
     <!-- Plan cards (shared section, compact: no duplicate header) -->
     <Pricing compact={true} />
 
+    <section id="tell-your-boss" class="band boss-band">
+      <div class="wrap">
+        <div class="boss-card reveal">
+          <div class="boss-head">
+            <div>
+              <span class="eyebrow">Procurement, but funny</span>
+              <h2>Copy this to your boss</h2>
+              <p>A short note you can paste into Slack. We already did the begging.</p>
+            </div>
+            <button type="button" class={btnOutline} id="copy-boss" data-copied="Copied">
+              Copy for Slack
+            </button>
+          </div>
+          <pre id="boss-pitch" class="boss-pre">{bossPitch}</pre>
+        </div>
+      </div>
+    </section>
+
     <!-- Pricing FAQ -->
     <section id="pricing-faq" class="band">
       <div class="wrap">
@@ -77,6 +96,30 @@ const breadcrumbJsonLd = {
   <Footer />
 
   <script type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} is:inline />
+  <script is:inline>
+    ;(function () {
+      var btn = document.getElementById('copy-boss')
+      var pre = document.getElementById('boss-pitch')
+      if (!btn || !pre) return
+      var idle = btn.textContent
+      btn.addEventListener('click', function () {
+        var text = pre.textContent || ''
+        function done() {
+          btn.textContent = btn.getAttribute('data-copied') || 'Copied'
+          window.setTimeout(function () {
+            btn.textContent = idle
+          }, 1600)
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            window.prompt('Copy this to your boss', text)
+          })
+        } else {
+          window.prompt('Copy this to your boss', text)
+        }
+      })
+    })()
+  </script>
 
   <style>
     /* Centered page intro: the shared .sec-head p is max-width:62ch with no
@@ -98,6 +141,13 @@ const breadcrumbJsonLd = {
     .cmp-scroll{overscroll-behavior-x:contain;-webkit-overflow-scrolling:touch}
     .cmp-note{margin-top:20px;text-align:center;font-size:13px;color:var(--muted-fg);padding:0 4px}
     .cmp-note a{color:var(--orange);text-decoration:underline;text-underline-offset:3px}
+
+    .boss-band{padding-top:8px;padding-bottom:0}
+    .boss-card{max-width:760px;margin:0 auto;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);padding:22px 22px 18px}
+    .boss-head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap}
+    .boss-head h2{margin:10px 0 6px;font-size:clamp(1.25rem,3.5vw,1.6rem);letter-spacing:-.02em}
+    .boss-head p{margin:0;max-width:46ch;font-size:14px;color:var(--muted-fg)}
+    .boss-pre{margin:16px 0 0;padding:14px 16px;border-radius:10px;background:var(--bg-soft, rgba(127,127,127,.06));border:1px solid var(--border);font-size:13px;line-height:1.55;white-space:pre-wrap;text-wrap:pretty;color:var(--foreground)}
 
     .pfaq{max-width:760px;margin:36px auto 0;display:flex;flex-direction:column;gap:10px}
     .pfaq-item{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);overflow:hidden}

--- a/docs/content/operate/advanced/commercial-license.mdx
+++ b/docs/content/operate/advanced/commercial-license.mdx
@@ -26,14 +26,80 @@ A **host** is one monitored connection (one ClickHouse endpoint, or one Postgres
 
 Source of truth: `@chm/pricing` (`packages/pricing/src/licenses.ts`) and [chmonitor.dev/pricing](https://chmonitor.dev/pricing/).
 
-## How to buy
+## There is no license key
 
-1. Open [pricing](https://chmonitor.dev/pricing/) and click Buy (Polar checkout).
-2. After payment, Polar returns you to [register](https://chmonitor.dev/license/register) — enter **company name** and **website**. We trust you.
-3. Optionally opt in to the [customers](https://chmonitor.dev/customers) list. Default is private.
-4. Need a PO? Email [hello@chmonitor.dev](mailto:hello@chmonitor.dev).
+The dashboard never asks for a key. There is no `CHM_LICENSE_KEY` env var and
+the binary does not phone home. A license is a **commercial agreement**
+(invoice + support + optional public listing), not a DRM unlock.
 
-There is no `CHM_LICENSE_KEY` and you should not add one. Do not gate OSS features on a license.
+To check a purchase later, use [Look up an order](https://chmonitor.dev/license/lookup)
+with the **Polar checkout id** from the receipt, or the **billing email** you
+used at Polar. That page does not unlock features.
+
+## How purchase actually works
+
+```
+You                    Polar                         chmonitor
+──                     ─────                         ─────────
+Pricing → Buy
+  or fill company +
+  website + email
+  then Pay
+         ──────────►  hosted checkout
+                      card / invoice
+                      Polar emails the receipt
+         ◄──────────  back to /license/register?paid=1&checkout_id=…
+                      register company (honor system)
+                      optional list on /customers
+```
+
+1. Open [pricing](https://chmonitor.dev/pricing/) and click **Buy Team** or
+   **Buy Unlimited**. That opens the company form first (name, website,
+   billing email). We save that, then send you to **Polar** with the same
+   customer email so Polar has your details on the payment.
+2. **Polar** collects payment (card). Polar — not chmonitor — sends the
+   **receipt email**. We do not send a license-key email.
+3. Polar returns you to
+   [register](https://chmonitor.dev/license/register?paid=1) with a
+   `checkout_id`. Enter **company name**, **website**, and billing email.
+   Optionally opt in to the [customers](https://chmonitor.dev/customers)
+   page (off by default).
+4. Need a PO / Net-30 / vendor form instead of card? Email
+   [hello@chmonitor.dev](mailto:hello@chmonitor.dev) — we invoice; Polar is
+   skipped.
+
+You may also start on `/license/register` **before** paying: fill the
+company form and click Pay — we pass email (and company as metadata) into
+Polar so the receipt is addressed to you.
+
+## How to “validate” a purchase
+
+| What you have | What to do |
+|---|---|
+| Polar receipt email | Keep it. Polar is the payment record. |
+| Checkout / order id | [Look up](https://chmonitor.dev/license/lookup) |
+| Billing email used at Polar | Same lookup page |
+| A license key field in the app | **Does not exist.** Do not add one. |
+
+If lookup misses, email [hello@chmonitor.dev](mailto:hello@chmonitor.dev)
+with the Polar receipt. We do not automatically email a “you are licensed”
+message after register.
+
+## Who sends email?
+
+- **Polar** — payment receipt / invoice PDF (their branding).
+- **hello@chmonitor.dev** — only if you wrote us (PO, lookup miss, support).
+  Register does not trigger a mail from us.
+
+## How to buy (short)
+
+1. [Pricing](https://chmonitor.dev/pricing/) → Buy → Polar pay.
+2. Land on register → company + website.
+3. Optional: [lookup](https://chmonitor.dev/license/lookup) later.
+4. PO? Email hello@chmonitor.dev.
+
+There is no `CHM_LICENSE_KEY` and you should not add one. Do not gate OSS
+features on a license.
 
 ## What you get
 

--- a/docs/content/reference/faq.mdx
+++ b/docs/content/reference/faq.mdx
@@ -18,7 +18,7 @@ No. The GPL-3.0 build is free, unlimited, and has no license key. An optional [c
 
 <Accordion title="How do commercial licenses work?">
 
-Personal Self Hosted is free. Team is $499/year or $1,349 lifetime (3 hosts). Unlimited is $999/year or $2,999 lifetime. After payment, register your company name and website. We trust you. See [pricing](https://chmonitor.dev/pricing/).
+There is **no license key**. Buy on [pricing](https://chmonitor.dev/pricing/) → Polar takes the card and **Polar emails the receipt**. Then register company + website on `/license/register`. To check a purchase later, use [lookup](https://chmonitor.dev/license/lookup) with the Polar checkout id or billing email. We (hello@chmonitor.dev) only email if you write us or need a PO. Full flow: [commercial license](/operate/advanced/commercial-license).
 
 </Accordion>
 

--- a/docs/knowledge/commercial-license.md
+++ b/docs/knowledge/commercial-license.md
@@ -26,15 +26,14 @@ self-host ClickHouse. Hosted Polar SaaS stays as a convenience path only.
 - Yearly and lifetime on Team and Unlimited. Personal is $0.
 - Buy + register: company name + website; listing on `/customers` is opt-in.
 - Trust model: Polar checkout on **cloud-hooks**
-  (`GET https://hooks.chmonitor.dev/checkout/license?sku=&term=`), then
-  register company + website. Polar `success_url` **must** include the
-  literal `{CHECKOUT_ID}` placeholder (Polar 422s without it — that is why
-  dash.chmonitor.dev/api/v1/billing/license-checkout 500'd). The dash route
-  now 302s to hooks and never calls Polar. Lookup:
-  `GET /licenses/lookup?q=` (checkout id or billing email). Register persist:
-  `POST /licenses/register` → KV `license-reg:v1:{uuid}`; opt-in names on
-  `GET /licenses/public`. Products:
-  `CHM_POLAR_LICENSE_{TEAM|UNLIMITED}_{YEARLY|LIFETIME}` from `polar-setup.ts`.
+  (`GET https://hooks.chmonitor.dev/checkout/license?sku=&term=`), optional
+  `email`/`company`/`website` query params (customer_email + metadata).
+  Polar emails the **receipt**. We do not send a license-key email.
+  Register company + website after `paid=1`. Polar `success_url` **must**
+  include `{CHECKOUT_ID}`. Dash URL 302s to hooks. Lookup:
+  `GET /licenses/lookup?q=` (checkout id or billing email) — not a key.
+  Register persist: `POST /licenses/register`. User-facing how-to:
+  `docs/content/operate/advanced/commercial-license.mdx`.
   Do **not** add `CHM_LICENSE_KEY` to the OSS dashboard.
 
 ## SKUs (USD)


### PR DESCRIPTION
## Summary

Collect company details before Polar checkout, and add a short copy-to-your-boss pitch on the pricing page.

## Changes

- Landing Buy CTA and dashboard billing Buy go to `/license/register` first.
- Unpaid form posts an intent, then redirects to Polar with email/company/website.
- Hooks checkout forwards `customer_email` and metadata to Polar.
- Public customers wall requires Polar `checkout_id`.
- Pricing page: **Copy this to your boss** section above Pricing questions, with a Slack-ready note and copy button.
- Docs: no license key; Polar sends the receipt.

## Test plan

- [x] Unit tests for Polar email/metadata forwarding
- [x] Unpaid register intent stays off `/licenses/public`
- [x] Landing `buyHref` and boss-pitch tests
- [ ] CI lint / unit-tests
- [x] Docs updated in `docs/content/`

## Notes for reviewer

There is still no `CHM_LICENSE_KEY`. Polar emails the receipt.

---

Co-Authored-By: duyetbot <bot@duyet.net>