### PR TITLE
feat(landing): render the boss pitch as an email draft

### DIFF
--- a/apps/landing/src/data/licenses.test.ts
+++ b/apps/landing/src/data/licenses.test.ts
@@ -1,11 +1,19 @@
 import { publicLicensedCompanies } from './licensed-companies'
-import { bossPitch, buyHref, invoiceMailto, paidLicenseSkus } from './licenses'
+import {
+  bossPitch,
+  bossPitchPaste,
+  buyHref,
+  invoiceMailto,
+  PRICING_PAGE_HREF,
+  paidLicenseSkus,
+} from './licenses'
 import { describe, expect, test } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   getLicense,
   LICENSE_SKU_LIST,
+  licensePriceUsd,
   PERSONAL_SELFHOST_HREF,
 } from '@chm/pricing'
 
@@ -34,17 +42,39 @@ describe('landing license offer', () => {
     expect(LICENSE_SKU_LIST).toHaveLength(3)
   })
 
-  test('boss pitch is a paste-ready ask with Team price and no license key', () => {
-    expect(bossPitch).toContain('$499')
-    expect(bossPitch).toContain('https://chmonitor.dev/pricing/')
-    expect(bossPitch).toMatch(/no license key/i)
-    expect(bossPitch).toContain('Subject:')
+  test('boss pitch is built from catalog prices and pastes as one email', () => {
+    const team = getLicense('team')
+    const unlimited = getLicense('unlimited')
+    const yearly = licensePriceUsd(team, 'yearly')
+    const lifetime = licensePriceUsd(team, 'lifetime')
+    const unlimitedYearly = licensePriceUsd(unlimited, 'yearly')
+
+    expect(bossPitch.subject).toContain(`$${yearly}`)
+    expect(bossPitch.body).toContain(`$${yearly}/year`)
+    expect(bossPitch.body).toContain(`$${lifetime}`)
+    expect(bossPitch.body).toContain(`$${unlimitedYearly}/year`)
+    expect(bossPitch.body).toContain(PRICING_PAGE_HREF)
+    expect(bossPitch.body).toMatch(/no license key/i)
+    expect(bossPitch.body).toMatch(/invoice/i)
+    expect(bossPitch.body).not.toMatch(/2am|begging|eleven browser tabs/i)
+
+    expect(bossPitchPaste).toBe(
+      `Subject: ${bossPitch.subject}\n\n${bossPitch.body}`
+    )
+  })
+
+  test('pricing page renders the email composer from the same pitch', () => {
     const src = readFileSync(
       join(landingRoot, 'src/pages/pricing.astro'),
       'utf8'
     )
+    expect(src).toContain('bossPitch.to')
+    expect(src).toContain('bossPitch.subject')
+    expect(src).toContain('bossPitch.body')
+    expect(src).toContain('bossPitchPaste')
     expect(src).toContain('Copy this to your boss')
-    expect(src).toContain('bossPitch')
+    expect(src).toContain('New message')
+    expect(src).not.toContain('Copy for Slack')
     expect(src.indexOf('tell-your-boss')).toBeLessThan(
       src.indexOf('pricing-faq')
     )

--- a/apps/landing/src/data/licenses.ts
+++ b/apps/landing/src/data/licenses.ts
@@ -2,6 +2,7 @@
  * Landing view of self-hosted licenses. Numbers come from @chm/pricing.
  */
 import {
+  getLicense,
   isPaidLicense,
   LICENSE_SALES_EMAIL,
   LICENSE_SKU_LIST,
@@ -80,21 +81,38 @@ export function invoiceMailto(sku: LicenseSku, term: LicenseTerm): string {
 }
 
 /** Slack/email paste for the engineer who needs a signature. */
-export const bossPitch = `Subject: $499 so I stop SSHing into ClickHouse at 2am
+const team = getLicense('team')
+const unlimited = getLicense('unlimited')
+const teamYearly = licensePriceUsd(team, 'yearly')
+const teamLifetime = licensePriceUsd(team, 'lifetime')
+const unlimitedYearly = licensePriceUsd(unlimited, 'yearly')
 
-Hi —
+export const PRICING_PAGE_HREF = 'https://chmonitor.dev/pricing/'
 
-I already run chmonitor next to our ClickHouse. GPL-3.0, self-hosted, no license key, no SaaS, no phoning home.
+export const bossPitch = {
+  to: 'Your boss',
+  subject: `Approve chmonitor ${team.name} license — $${teamYearly}/year, self-hosted`,
+  body: `Hi,
 
-The Team license is $499/year for 3 hosts ($1,349 lifetime if finance hates renewals). Unlimited is $999/year. Polar takes the card; they email the receipt. There is nothing to paste into the app.
+I'd like approval to buy a commercial license for chmonitor, the ClickHouse monitoring dashboard we already self-host.
 
-What we get: a commercial invoice, priority email, and I stop writing Grafana panels that lie about system.parts.
+Why this, not another SaaS:
+• It runs next to our cluster. GPL-3.0. No license key, no cloud tenant, no data leaving our network.
+• ${team.name} is $${teamYearly}/year for ${team.hosts} hosts ($${teamLifetime} lifetime if we want to stop renewing). ${unlimited.name} is $${unlimitedYearly}/year.
+• We get an invoice, a named vendor, and email support. Polar takes the card and emails the receipt. Nothing to paste into the app.
 
-That's cheaper than one incident where someone asks "why is the merge queue 400" and I open eleven browser tabs.
+The software itself is already free. The license is paperwork and support — not a feature unlock.
 
-Please approve. I'll buy it here: https://chmonitor.dev/pricing/
+That is less than one hour of someone grepping system.query_log during an incident.
 
-Thanks`
+Please approve. I can check out here: ${PRICING_PAGE_HREF}
+
+Thanks`,
+} as const
+
+export const bossPitchPaste = `Subject: ${bossPitch.subject}
+
+${bossPitch.body}`
 
 export const licenseFaqs = [
   {

--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -4,7 +4,7 @@ import Nav from '../components/Nav.astro'
 import Pricing from '../components/Pricing.astro'
 import FinalCta from '../components/FinalCta.astro'
 import Footer from '../components/Footer.astro'
-import { bossPitch, licenseFaqs } from '../data/licenses'
+import { bossPitch, bossPitchPaste, licenseFaqs } from '../data/licenses'
 import { pricingFaqs } from '../data/pricing'
 import { btnOutline } from '../lib/button-classes'
 
@@ -54,19 +54,31 @@ const breadcrumbJsonLd = {
 
     <section id="tell-your-boss" class="band boss-band">
       <div class="wrap">
-        <div class="boss-card reveal">
-          <div class="boss-head">
-            <div>
-              <span class="eyebrow">Procurement, but funny</span>
-              <h2>Copy this to your boss</h2>
-              <p>A short note you can paste into Slack. We already did the begging.</p>
-            </div>
-            <button type="button" class={btnOutline} id="copy-boss" data-copied="Copied">
-              Copy for Slack
-            </button>
-          </div>
-          <pre id="boss-pitch" class="boss-pre">{bossPitch}</pre>
+        <div class="sec-head reveal" style="text-align:center">
+          <h2>Copy this to your boss</h2>
+          <p>A short note you can paste into Slack or email.</p>
         </div>
+        <article class="mail reveal" aria-label="Draft email to your boss">
+          <header class="mail-bar">
+            <span class="mail-lights" aria-hidden="true"><i></i><i></i><i></i></span>
+            <span class="mail-ttl">New message</span>
+            <button type="button" class={btnOutline} id="copy-boss" data-copied="Copied">
+              Copy
+            </button>
+          </header>
+          <dl class="mail-meta">
+            <div class="mail-row">
+              <dt>To</dt>
+              <dd>{bossPitch.to}</dd>
+            </div>
+            <div class="mail-row">
+              <dt>Subject</dt>
+              <dd>{bossPitch.subject}</dd>
+            </div>
+          </dl>
+          <div class="mail-body" id="boss-pitch-body">{bossPitch.body}</div>
+          <pre id="boss-pitch" class="sr-only">{bossPitchPaste}</pre>
+        </article>
       </div>
     </section>
 
@@ -143,11 +155,24 @@ const breadcrumbJsonLd = {
     .cmp-note a{color:var(--orange);text-decoration:underline;text-underline-offset:3px}
 
     .boss-band{padding-top:8px;padding-bottom:0}
-    .boss-card{max-width:760px;margin:0 auto;border:1px solid var(--border);border-radius:var(--radius);background:var(--card);padding:22px 22px 18px}
-    .boss-head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap}
-    .boss-head h2{margin:10px 0 6px;font-size:clamp(1.25rem,3.5vw,1.6rem);letter-spacing:-.02em}
-    .boss-head p{margin:0;max-width:46ch;font-size:14px;color:var(--muted-fg)}
-    .boss-pre{margin:16px 0 0;padding:14px 16px;border-radius:10px;background:var(--bg-soft, rgba(127,127,127,.06));border:1px solid var(--border);font-size:13px;line-height:1.55;white-space:pre-wrap;text-wrap:pretty;color:var(--foreground)}
+    .boss-band .sec-head{margin-bottom:22px}
+    .boss-band .sec-head p{margin-inline:auto}
+    .mail{max-width:760px;margin:0 auto;border:1px solid var(--border);border-radius:14px;background:var(--card);overflow:hidden;box-shadow:var(--shadow-float, 0 12px 40px rgba(0,0,0,.08))}
+    .mail-bar{display:flex;align-items:center;gap:10px;min-height:48px;padding:8px 12px 8px 16px;border-bottom:1px solid var(--border);background:var(--bg-soft, rgba(127,127,127,.05))}
+    .mail-lights{display:flex;gap:6px}
+    .mail-lights i{width:10px;height:10px;border-radius:50%;display:block;background:var(--border)}
+    .mail-lights i:nth-child(1){background:#ff5f57}
+    .mail-lights i:nth-child(2){background:#febc2e}
+    .mail-lights i:nth-child(3){background:#28c840}
+    .mail-ttl{font-size:13px;font-weight:600;color:var(--muted-fg);flex:1}
+    .mail-bar .h-10{height:34px;padding-inline:12px;font-size:13px}
+    .mail-meta{margin:0;border-bottom:1px solid var(--border)}
+    .mail-row{display:grid;grid-template-columns:72px 1fr;gap:10px;align-items:baseline;padding:11px 18px;border-bottom:1px solid var(--border)}
+    .mail-row:last-child{border-bottom:0}
+    .mail-row dt{margin:0;font-size:12px;font-weight:600;letter-spacing:.02em;text-transform:uppercase;color:var(--muted-fg)}
+    .mail-row dd{margin:0;font-size:15px;font-weight:550}
+    .mail-body{padding:18px 20px 22px;font-size:14.5px;line-height:1.65;white-space:pre-wrap;text-wrap:pretty}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
     .pfaq{max-width:760px;margin:36px auto 0;display:flex;flex-direction:column;gap:10px}
     .pfaq-item{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);overflow:hidden}


### PR DESCRIPTION
## Summary

Turn the pricing-page boss pitch into a compose-window draft and keep prices in sync with the license catalog.

## Changes

- Email chrome: New message, To, Subject, body, Copy.
- Pitch built from `@chm/pricing` Team/Unlimited amounts.
- Tests assert catalog prices and that the page reads the same object.

## Test plan

- [x] `bun test src/data/licenses.test.ts` in `apps/landing`
- [ ] CI

---

Co-Authored-By: duyetbot <bot@duyet.net>