### PR TITLE
fix(landing): match boss email width to the license cards

### DIFF
--- a/apps/landing/src/pages/pricing.astro
+++ b/apps/landing/src/pages/pricing.astro
@@ -157,7 +157,7 @@ const breadcrumbJsonLd = {
     .boss-band{padding-top:8px;padding-bottom:0}
     .boss-band .sec-head{margin-bottom:22px}
     .boss-band .sec-head p{margin-inline:auto}
-    .mail{max-width:760px;margin:0 auto;border:1px solid var(--border);border-radius:14px;background:var(--card);overflow:hidden;box-shadow:var(--shadow-float, 0 12px 40px rgba(0,0,0,.08))}
+    .mail{width:100%;max-width:none;margin:0;border:1px solid var(--border);border-radius:14px;background:var(--card);overflow:hidden;box-shadow:var(--shadow-float, 0 12px 40px rgba(0,0,0,.08))}
     .mail-bar{display:flex;align-items:center;gap:10px;min-height:48px;padding:8px 12px 8px 16px;border-bottom:1px solid var(--border);background:var(--bg-soft, rgba(127,127,127,.05))}
     .mail-lights{display:flex;gap:6px}
     .mail-lights i{width:10px;height:10px;border-radius:50%;display:block;background:var(--border)}


### PR DESCRIPTION
## Summary

The compose window sat at 760px while the license cards use the 1080px wrap. Drop the extra cap so both sections share the same width.

---

Co-Authored-By: duyetbot <bot@duyet.net>