### PR TITLE
feat(agent): allow cloud demo guests to chat

### DIFF
--- a/.claude/skills/cloud-saas-mode/SKILL.md
+++ b/.claude/skills/cloud-saas-mode/SKILL.md
@@ -67,7 +67,7 @@ on mismatch. The reverse (cloud build, runtime unset) is safe — fail-closed.
 | Env hosts | real, full access | `source:'demo'`, read-only |
 | Anonymous | env hosts | the demo |
 | Signed-in | env hosts | demo HIDDEN → own D1 connections; zero → welcome/setup |
-| Agent (anon) | unlimited (IP RL only) | daily guest cap (default 3) + tighter RL (5/min); D1 `guest:<ip-hash>` |
+| Agent (anon) | Clerk-gated if access=authenticated | reachable on demo host via `authorizeAgentApiRequest` guest wrapper (not `CHM_FEATURE_AGENT_ACCESS=public`); daily cap 3 + RL 5/min; D1 `guest:<ip-hash>`; deploy `ANYROUTER_API_KEY` + `anyrouter:auto` |
 
 Implemented in `lib/swr/use-merged-hosts.ts` (tag demo, hide-when-signed-in;
 returns `cloudMode`/`isSignedIn`). Switcher badges + `demo`-as-`env` status in
@@ -104,14 +104,26 @@ connected. Full detail: `docs/knowledge/cloud-saas-mode.md`.
 
 ## Guest AI credits (Cloud only)
 
-Anonymous Cloud visitors can use the agent. They get a **dedicated daily
-message cap** (`CHM_GUEST_AI_REQUESTS_PER_DAY`, default 3) and a **tighter
-per-identity rate limit** (`RATE_LIMIT_AGENT_GUEST_PER_MIN`, default 5) so
-they cannot burn the shared AnyRouter key. Usage is stored in the existing
-D1 `ai_usage_daily` table under `guest:<sha256-ip-prefix>` — never the
-literal owner id `guest`. `GET /api/v1/billing/usage` returns a slim Guest
-payload for unsigned Cloud callers so the quota chip can render. OSS skips
-this (IP RL only, no daily gate). Helpers: `lib/billing/guest-ai.ts`. Gate:
+Anonymous Cloud visitors **can chat** on the demo host. Reachability is
+**not** `CHM_FEATURE_AGENT_ACCESS=public` (agent is `operation: 'write'`;
+Clerk public-read still 401s unsigned POSTs). `authorizeAgentApiRequest`
+allows unsigned Cloud + public-read on agent POST / models / config-check /
+followups only. UI: `agent-auth-gate.tsx` `ensureAuthed()` true for Cloud
+unsigned; OSS Clerk stays gated.
+
+Guests bill the deploy `ANYROUTER_API_KEY` and default to `anyrouter:auto`.
+Server strips BYOK `apiKey`, ignores `mcpServers` / user MCP, allowlists
+auto + free, hostId env/demo only. Conversations stay Clerk-only (local
+thread for unsigned Cloud).
+
+They get a **dedicated daily message cap** (`CHM_GUEST_AI_REQUESTS_PER_DAY`,
+default 3) and a **tighter per-identity rate limit**
+(`RATE_LIMIT_AGENT_GUEST_PER_MIN`, default 5) so they cannot burn the
+shared AnyRouter key. Usage is stored in the existing D1 `ai_usage_daily`
+table under `guest:<sha256-ip-prefix>` — never the literal owner id
+`guest`. `GET /api/v1/billing/usage` returns a slim Guest payload for
+unsigned Cloud callers so the quota chip can render. OSS skips this (IP RL
+only, no daily gate). Helpers: `lib/billing/guest-ai.ts`. Gate:
 `applyAiUsageGate` in `routes/api/v1/-agent/billing.ts`. 402 reason:
 `guest_daily_limit` (sign in for more — no Polar jargon).
 

--- a/apps/dashboard/src/components/assistant-ui/agent-auth-gate.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-auth-gate.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { AGENT_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { resolveFeatureState } from '@/lib/feature-permissions/shared'
@@ -77,14 +78,19 @@ export function AgentAuthGate({ children }: { children: ReactNode }) {
     resolveFeatureState(AGENT_FEATURE_PERMISSION, config).access ===
     'authenticated'
 
+  const cloudGuest = isCloudModeClient() && !signedIn
+
   const ensureAuthed = useCallback(() => {
     // Optimistic while the permission config loads — the server still enforces
     // auth on /api/v1/agent regardless.
     if (isLoading) return true
+    // Cloud demo guests may chat (server guest allow + quota). OSS Clerk
+    // deployments stay gated when access is authenticated.
+    if (cloudGuest) return true
     if (!requiresAuth || signedIn) return true
     setOpen(true)
     return false
-  }, [isLoading, requiresAuth, signedIn])
+  }, [isLoading, requiresAuth, signedIn, cloudGuest])
 
   const value = useMemo<AgentAuthGateValue>(
     () => ({ ensureAuthed }),

--- a/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
+++ b/apps/dashboard/src/components/assistant-ui/agent-runtime-provider.tsx
@@ -22,6 +22,9 @@ import { type ReactNode, useMemo, useRef } from 'react'
 import { usePageContextControl } from '@/components/assistant-ui/page-context-control'
 import { buildPageContext } from '@/lib/ai/agent/page-context'
 import { trackEvent } from '@/lib/analytics/analytics'
+import { useClerkIsSignedIn as useClerkIsSignedInImpl } from '@/components/assistant-ui/use-clerk-is-signed-in'
+import { isClerkEnabled } from '@/lib/clerk/clerk-client'
+import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { resolveThreadListAdapter } from '@/lib/conversation-store/adapter/resolve-thread-list-adapter'
 import { useAgentModel } from '@/lib/hooks/use-agent-model'
 import { getAnyRouterToken } from '@/lib/hooks/use-anyrouter-token'
@@ -43,12 +46,18 @@ function trackedAgentFetch(
   return apiFetch(input, init)
 }
 
+const useClerkIsSignedIn: () => boolean = isClerkEnabled()
+  ? useClerkIsSignedInImpl
+  : () => true
+
 /**
  * Per-thread chat runtime. assistant-ui invokes this hook once per active
  * thread; it talks to the `/api/v1/agent` route.
  */
 function useAgentChatRuntime() {
   const hostId = useHostId()
+  const signedIn = useClerkIsSignedIn()
+  const cloudGuest = isCloudModeClient() && !signedIn
   const { disabledTools } = useToolConfig()
   const { model } = useAgentModel()
   const sessionId = useMemo(() => crypto.randomUUID(), [])
@@ -84,7 +93,13 @@ function useAgentChatRuntime() {
       new DefaultChatTransport({
         api: '/api/v1/agent',
         fetch: trackedAgentFetch as typeof globalThis.fetch,
-        body: { hostId, model, disabledTools, sessionId, mcpServers },
+        body: {
+          hostId,
+          model: cloudGuest ? 'anyrouter:auto' : model,
+          disabledTools,
+          sessionId,
+          mcpServers: cloudGuest ? [] : mcpServers,
+        },
         prepareSendMessagesRequest: ({
           id,
           messages,
@@ -113,7 +128,9 @@ function useAgentChatRuntime() {
           // or out takes effect on the next message without a rebuild. Only
           // sent for AnyRouter models — it is not a key for other providers.
           const byokApiKey =
-            typeof model === 'string' && model.startsWith('anyrouter:')
+            !cloudGuest &&
+            typeof model === 'string' &&
+            model.startsWith('anyrouter:')
               ? getAnyRouterToken()
               : null
 
@@ -124,6 +141,7 @@ function useAgentChatRuntime() {
               messages,
               trigger,
               messageId,
+              ...(cloudGuest ? { mcpServers: [] } : {}),
               ...(byokApiKey ? { apiKey: byokApiKey } : {}),
               ...(shouldSendPageContext
                 ? { pageContext: buildPageContext(pathname) }
@@ -143,6 +161,7 @@ function useAgentChatRuntime() {
       mcpServers,
       pathname,
       pageEnabledRef,
+      cloudGuest,
     ]
   )
 
@@ -155,7 +174,12 @@ function useAgentChatRuntime() {
  * floating modal each get an independent instance.
  */
 export function AgentRuntimeProvider({ children }: { children: ReactNode }) {
-  const adapter = useMemo(() => resolveThreadListAdapter(), [])
+  const signedIn = useClerkIsSignedIn()
+  const persistRemote = !(isCloudModeClient() && !signedIn)
+  const adapter = useMemo(
+    () => resolveThreadListAdapter({ persistRemote }),
+    [persistRemote]
+  )
 
   const runtime = useRemoteThreadListRuntime({
     runtimeHook: useAgentChatRuntime,

--- a/apps/dashboard/src/lib/auth/agent-api-auth.test.ts
+++ b/apps/dashboard/src/lib/auth/agent-api-auth.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Cloud guest allow for agent routes. Agent is a write; Clerk public-read
+ * still 401s unsigned POSTs. The wrapper must allow Cloud demo guests
+ * without opening OSS Clerk or other write routes.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({ env: {} }))
+
+let clerkAuthResult: { userId?: string } | null = null
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: async () => clerkAuthResult,
+}))
+
+const ENV_KEYS = [
+  'CHM_AUTH_PROVIDER',
+  'CHM_CLERK_PUBLIC_READ',
+  'CHM_CLOUD_MODE',
+  'CHM_DEPLOYMENT_MODE',
+  'CHM_FEATURE_AGENT_ACCESS',
+] as const
+
+function clearEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key]
+}
+
+async function resetConfig(): Promise<void> {
+  const { _resetAppConfigCache } = await import(
+    '@/lib/feature-permissions/server'
+  )
+  _resetAppConfigCache()
+}
+
+function agentPost(url = 'https://dash.chmonitor.dev/api/v1/agent'): Request {
+  return new Request(url, { method: 'POST' })
+}
+
+describe('authorizeAgentApiRequest — Cloud guest allow', () => {
+  beforeEach(async () => {
+    clearEnv()
+    clerkAuthResult = null
+    await resetConfig()
+  })
+
+  afterEach(async () => {
+    clearEnv()
+    await resetConfig()
+  })
+
+  test('Cloud + public-read + unsigned POST /api/v1/agent is not 401', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    process.env.CHM_CLOUD_MODE = 'true'
+    clerkAuthResult = null
+
+    const { authorizeAgentApiRequest } = await import('./agent-api-auth')
+    const denied = await authorizeAgentApiRequest(agentPost())
+    expect(denied).toBeNull()
+  })
+
+  test('OSS Clerk + public-read still 401s unsigned agent when access=authenticated', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    process.env.CHM_CLOUD_MODE = 'false'
+    clerkAuthResult = null
+
+    const { authorizeAgentApiRequest } = await import('./agent-api-auth')
+    const denied = await authorizeAgentApiRequest(agentPost())
+    expect(denied).not.toBeNull()
+    expect(denied?.status).toBe(401)
+  })
+
+  test('does not open unsigned Cloud MCP probe (not on the guest allowlist)', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    process.env.CHM_CLOUD_MODE = 'true'
+
+    const { authorizeAgentApiRequest } = await import('./agent-api-auth')
+    const denied = await authorizeAgentApiRequest(
+      new Request('https://dash.chmonitor.dev/api/v1/mcp/probe', {
+        method: 'POST',
+      })
+    )
+    expect(denied?.status).toBe(401)
+  })
+
+  test('allows unsigned Cloud models / config-check / followups', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_CLERK_PUBLIC_READ = 'true'
+    process.env.CHM_CLOUD_MODE = 'true'
+
+    const { authorizeAgentApiRequest } = await import('./agent-api-auth')
+    for (const path of [
+      '/api/v1/agents/models',
+      '/api/v1/agents/config-check',
+      '/api/v1/agent/followups',
+    ]) {
+      const denied = await authorizeAgentApiRequest(
+        new Request(`https://dash.chmonitor.dev${path}`)
+      )
+      expect(denied).toBeNull()
+    }
+  })
+})

--- a/apps/dashboard/src/lib/auth/agent-api-auth.ts
+++ b/apps/dashboard/src/lib/auth/agent-api-auth.ts
@@ -1,10 +1,53 @@
+import { isCloudModeServer } from '@/lib/cloud/cloud-mode'
 import { AGENT_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
-import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+import {
+  authorizeFeatureRequest,
+  isAnonymousPublicReadRequest,
+} from '@/lib/feature-permissions/server'
+
+/**
+ * Cloud anonymous visitors may hit these agent surfaces only. Other write
+ * routes (actions, SQL console, conversations, user-connections, MCP probe,
+ * AnyRouter OAuth) stay Clerk-gated. Do not flip AGENT access to `public` —
+ * Clerk public-read still 401s unsigned writes.
+ */
+const CLOUD_GUEST_AGENT_PATHS = new Set([
+  '/api/v1/agent',
+  '/api/v1/agents/models',
+  '/api/v1/agents/config-check',
+  '/api/v1/agent/followups',
+])
+
+function isCloudGuestAgentPath(request: Request): boolean {
+  try {
+    return CLOUD_GUEST_AGENT_PATHS.has(new URL(request.url).pathname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Cloud + public-read + unsigned → allow the demo-host agent chat only.
+ * Does not grant `anonymousCapabilities.write`.
+ */
+export async function isCloudGuestAgentRequest(
+  request: Request
+): Promise<boolean> {
+  if (!isCloudModeServer()) return false
+  if (!isCloudGuestAgentPath(request)) return false
+  return isAnonymousPublicReadRequest(request)
+}
 
 export async function authorizeAgentApiRequest(
   request: Request
 ): Promise<Response | null> {
-  return authorizeFeatureRequest(AGENT_FEATURE_PERMISSION, request, {
-    allowAgentBearerToken: true,
-  })
+  const denied = await authorizeFeatureRequest(
+    AGENT_FEATURE_PERMISSION,
+    request,
+    { allowAgentBearerToken: true }
+  )
+  if (!denied) return null
+  if (denied.status !== 401) return denied
+  if (await isCloudGuestAgentRequest(request)) return null
+  return denied
 }

--- a/apps/dashboard/src/lib/billing/guest-ai.test.ts
+++ b/apps/dashboard/src/lib/billing/guest-ai.test.ts
@@ -1,7 +1,9 @@
 import {
   DEFAULT_GUEST_AI_RATE_LIMIT_PER_MIN,
   GUEST_AI_REQUESTS_PER_DAY,
+  GUEST_DEFAULT_AGENT_MODEL,
   getGuestAiPlan,
+  isGuestAllowedAgentModel,
   getGuestAiRateLimitPerMin,
   getGuestAiRequestsPerDay,
   guestDailyLimitMessage,
@@ -118,6 +120,17 @@ describe('getGuestAiPlan', () => {
     expect(plan.aiRequestsPerDay).toBe(3)
     expect(plan.aiMonthlyUsdBudget).toBeNull()
     expect(plan.aiOverage).toBeNull()
+  })
+})
+
+describe('isGuestAllowedAgentModel', () => {
+  test('allows anyrouter:auto and free aliases only', () => {
+    expect(GUEST_DEFAULT_AGENT_MODEL).toBe('anyrouter:auto')
+    expect(isGuestAllowedAgentModel('anyrouter:auto')).toBe(true)
+    expect(isGuestAllowedAgentModel('anyrouter/free')).toBe(true)
+    expect(isGuestAllowedAgentModel('anyrouter:anyrouter/free')).toBe(true)
+    expect(isGuestAllowedAgentModel('openai:gpt-4o')).toBe(false)
+    expect(isGuestAllowedAgentModel('anyrouter:claude-opus')).toBe(false)
   })
 })
 

--- a/apps/dashboard/src/lib/billing/guest-ai.ts
+++ b/apps/dashboard/src/lib/billing/guest-ai.ts
@@ -12,8 +12,28 @@ import type { Plan } from './plans'
 
 import { BILLING_PLANS } from './plans'
 
+import { isAnyRouterAutoModelId } from '@/lib/ai/anyrouter-dynamic-models'
+
 /** Default daily message cap for anonymous Cloud visitors. ≤ Free (5). */
 export const GUEST_AI_REQUESTS_PER_DAY = 3
+
+/** Guests share the deploy AnyRouter key; default to top tool-capable models. */
+export const GUEST_DEFAULT_AGENT_MODEL = 'anyrouter:auto'
+
+const GUEST_ALLOWED_MODELS = new Set([
+  GUEST_DEFAULT_AGENT_MODEL,
+  'anyrouter/free',
+  'anyrouter:anyrouter/free',
+])
+
+/** True when a guest may keep this picker id (auto or free). Anything else is forced. */
+export function isGuestAllowedAgentModel(
+  model: string | undefined
+): boolean {
+  if (!model) return false
+  const id = model.trim()
+  return isAnyRouterAutoModelId(id) || GUEST_ALLOWED_MODELS.has(id)
+}
 
 /** Default per-minute identity rate limit for anonymous Cloud visitors. */
 export const DEFAULT_GUEST_AI_RATE_LIMIT_PER_MIN = 5

--- a/apps/dashboard/src/lib/conversation-store/adapter/resolve-thread-list-adapter.ts
+++ b/apps/dashboard/src/lib/conversation-store/adapter/resolve-thread-list-adapter.ts
@@ -24,7 +24,10 @@ export type ConversationBackend = 'd1' | 'local'
  * Returns `'d1'` when server-side conversation storage is enabled, otherwise
  * `'local'`. Exposed separately so the UI can surface where history lives.
  */
-export function resolveConversationBackend(): ConversationBackend {
+export function resolveConversationBackend(options?: {
+  persistRemote?: boolean
+}): ConversationBackend {
+  if (options?.persistRemote === false) return 'local'
   try {
     return featureFlags.conversationDb() ? 'd1' : 'local'
   } catch {
@@ -34,9 +37,12 @@ export function resolveConversationBackend(): ConversationBackend {
 
 /**
  * Build the active `RemoteThreadListAdapter` for the current deployment.
+ * Cloud unsigned visitors stay on local threads — conversation APIs are Clerk-only.
  */
-export function resolveThreadListAdapter(): RemoteThreadListAdapter {
-  return resolveConversationBackend() === 'd1'
+export function resolveThreadListAdapter(options?: {
+  persistRemote?: boolean
+}): RemoteThreadListAdapter {
+  return resolveConversationBackend(options) === 'd1'
     ? createD1ThreadListAdapter()
     : createLocalThreadListAdapter()
 }

--- a/apps/dashboard/src/routes/api/v1/-agent/request-parsing.ts
+++ b/apps/dashboard/src/routes/api/v1/-agent/request-parsing.ts
@@ -11,6 +11,10 @@ import type { CustomMcpServerInput } from '@/lib/ai/agent/mcp/connect-custom-ser
 
 import { AGENT_DEBUG_LOGS } from './debug'
 import { parseByokApiKey } from '@/lib/ai/agent/byok'
+import {
+  GUEST_DEFAULT_AGENT_MODEL,
+  isGuestAllowedAgentModel,
+} from '@/lib/billing/guest-ai'
 
 export const AGENT_MAX_REQUEST_SIZE_BYTES = 128 * 1024
 export const AGENT_MAX_MESSAGES = 64
@@ -448,5 +452,31 @@ export async function parseAgentRequest(
     byokApiKey,
     mcpServers,
     pageContext: sanitizePageContext(body.pageContext),
+  }
+}
+
+/**
+ * Cloud guest hardening: no BYOK, no custom MCP, demo/env hostId only,
+ * model allowlist (anyrouter:auto + free). Does not change message text.
+ */
+export function hardenGuestAgentRequest(
+  parsed: ParsedAgentRequest
+): ParsedAgentRequest {
+  const requested = parsed.body.model
+  const model = isGuestAllowedAgentModel(requested)
+    ? requested!.trim()
+    : GUEST_DEFAULT_AGENT_MODEL
+
+  return {
+    ...parsed,
+    body: {
+      ...parsed.body,
+      model,
+      apiKey: undefined,
+      mcpServers: undefined,
+    },
+    byokApiKey: null,
+    mcpServers: [],
+    hostId: Math.max(0, parsed.hostId),
   }
 }

--- a/apps/dashboard/src/routes/api/v1/-agent/runtime.ts
+++ b/apps/dashboard/src/routes/api/v1/-agent/runtime.ts
@@ -26,6 +26,7 @@ import {
 } from '@/lib/ai/anyrouter-dynamic-models'
 import { isProviderConfigured } from '@/lib/ai/providers'
 import { isClerkAuthProvider } from '@/lib/auth/provider'
+import { isGuestOwnerId } from '@/lib/billing/guest-ai'
 
 export type AgentUiMessage = {
   id: string
@@ -197,7 +198,9 @@ export async function createAgentRuntime(options: {
   let extraTools: Record<string, unknown> | undefined
 
   try {
-    const registeredServers = await loadUserRegisteredServers(options.userId)
+    const registeredServers = isGuestOwnerId(options.userId)
+      ? []
+      : await loadUserRegisteredServers(options.userId)
     const mergedMcpServers = mergeMcpServers(
       options.requestMcpServers,
       registeredServers

--- a/apps/dashboard/src/routes/api/v1/__tests__/agent-request-parsing.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/agent-request-parsing.test.ts
@@ -14,6 +14,7 @@ import {
   AGENT_MAX_PART_TEXT_LENGTH,
   AGENT_MAX_REQUEST_SIZE_BYTES,
   AGENT_MAX_USER_MESSAGE_LENGTH,
+  hardenGuestAgentRequest,
   parseAgentRequest,
 } from '../-agent/request-parsing'
 import { describe, expect, test } from 'bun:test'
@@ -177,5 +178,41 @@ describe('parseAgentRequest', () => {
     expect(result.ok).toBe(true)
     if (!result.ok) return
     expect(result.mcpServers).toHaveLength(4)
+  })
+
+  test('hardenGuestAgentRequest strips BYOK, MCP, and expensive models', async () => {
+    const result = await parseAgentRequest(
+      postRequest({
+        message: 'hello',
+        apiKey: 'sk-guest-must-not-use-this',
+        model: 'openai:gpt-4o',
+        mcpServers: [
+          {
+            id: 'evil',
+            name: 'evil',
+            endpoint: 'https://mcp.example.com',
+          },
+        ],
+        hostId: -3,
+      })
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    const hardened = hardenGuestAgentRequest(result)
+    expect(hardened.byokApiKey).toBeNull()
+    expect(hardened.mcpServers).toEqual([])
+    expect(hardened.body.apiKey).toBeUndefined()
+    expect(hardened.body.model).toBe('anyrouter:auto')
+    expect(hardened.hostId).toBe(0)
+  })
+
+  test('hardenGuestAgentRequest keeps anyrouter:auto', async () => {
+    const result = await parseAgentRequest(
+      postRequest({ message: 'hello', model: 'anyrouter:auto' })
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(hardenGuestAgentRequest(result).body.model).toBe('anyrouter:auto')
   })
 })

--- a/apps/dashboard/src/routes/api/v1/agent.ts
+++ b/apps/dashboard/src/routes/api/v1/agent.ts
@@ -24,7 +24,10 @@ import {
   providerNotConfiguredResponse,
   unhandledErrorResponse,
 } from './-agent/errors'
-import { parseAgentRequest } from './-agent/request-parsing'
+import {
+  hardenGuestAgentRequest,
+  parseAgentRequest,
+} from './-agent/request-parsing'
 import {
   buildUiMessages,
   createAgentRuntime,
@@ -78,8 +81,17 @@ async function handlePost(request: Request): Promise<Response> {
   const authResponse = await authorizeAgentApiRequest(request)
   if (authResponse) return authResponse
 
-  const parsed = await parseAgentRequest(request)
-  if (!parsed.ok) return parseFailureResponse(parsed)
+  const parsedRaw = await parseAgentRequest(request)
+  if (!parsedRaw.ok) return parseFailureResponse(parsedRaw)
+
+  const clerkUserId = await resolveAgentUserId()
+  const isGuest = clerkUserId === 'guest'
+  const guestOwnerId =
+    isGuest && isCloudModeServer() ? await guestOwnerIdFromIp(ip) : undefined
+  const parsed =
+    guestOwnerId !== undefined
+      ? hardenGuestAgentRequest(parsedRaw)
+      : parsedRaw
 
   const model = await resolveAgentModel(parsed.body.model)
   const byok = parsed.byokApiKey !== null
@@ -91,13 +103,10 @@ async function handlePost(request: Request): Promise<Response> {
     return providerNotConfiguredResponse(model, requestedProvider)
   }
 
-  // Resolve user ID for OpenRouter / AnyRouter attribution. Cloud guests get a
-  // stable per-IP `guest:<hash>` so usage explorer can group by visitor, not a
-  // single shared `guest` string. OSS guests stay the literal `guest`.
-  const clerkUserId = await resolveAgentUserId()
-  const isGuest = clerkUserId === 'guest'
-  const guestOwnerId =
-    isGuest && isCloudModeServer() ? await guestOwnerIdFromIp(ip) : undefined
+  // Cloud guests get a stable per-IP `guest:<hash>` so usage explorer can
+  // group by visitor, not a single shared `guest` string. OSS guests stay
+  // the literal `guest`. Identity is resolved before hardening so BYOK/MCP
+  // never reach the runtime for Cloud guests.
   const userId = guestOwnerId ?? clerkUserId
   const openRouterUser = `${userId}/${parsed.sessionId}`
 

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -171,10 +171,29 @@ Docs: `docs/content/guide/guides/connection-errors.mdx` (slug
 
 ## Guest AI credits — cloud SaaS only
 
-Anonymous Cloud visitors can use the agent (public-read + demo host). They are
-**not** unlimited: a dedicated daily message cap and a tighter per-identity
-rate limit sit in front of the shared AnyRouter key. OSS / self-host skips
-this entirely (fail-closed to self-hosted).
+Anonymous Cloud visitors can **actually reach** the agent on the demo host
+(`dash.chmonitor.dev`). Clerk public-read still 401s unsigned writes, so
+**do not** flip `CHM_FEATURE_AGENT_ACCESS=public`. The guest allow is a
+wrapper in `lib/auth/agent-api-auth.ts`: `isCloudModeServer()` +
+`publicReadEnabled()` + unsigned → allow only `/api/v1/agent`,
+`/api/v1/agents/models`, `/api/v1/agents/config-check`, and
+`/api/v1/agent/followups`. `anonymousCapabilities.write` stays false;
+actions, SQL console, user-connections, and conversation persist stay
+Clerk-only. OSS Clerk deployments stay gated.
+
+The client (`agent-auth-gate.tsx`) treats Cloud + unsigned as a guest
+(`ensureAuthed()` true). Unsigned Cloud threads stay in localStorage —
+conversation APIs remain Clerk-only.
+
+Guests share the deploy `ANYROUTER_API_KEY`, defaulting to
+`anyrouter:auto` (top tool-capable models). Server hardening
+(`hardenGuestAgentRequest`) strips body `apiKey` (no BYOK), ignores
+`mcpServers` / user-registered MCP, allowlists auto + `anyrouter/free`,
+and keeps `hostId` on env/demo (`>= 0`).
+
+They are **not** unlimited: a dedicated daily message cap and a tighter
+per-identity rate limit sit in front of the shared AnyRouter key. OSS /
+self-host skips this entirely (fail-closed to self-hosted).
 
 - **Identity**: `guestOwnerIdFromIp(ip)` in `lib/billing/guest-ai.ts` →
   `guest:` + first 16 hex chars of SHA-256(client IP). Do **not** key D1 /


### PR DESCRIPTION
## Summary

Let anonymous visitors on dash.chmonitor.dev chat with the AI agent on the demo host, billed to the deploy `ANYROUTER_API_KEY` (`anyrouter:auto`). Does **not** flip `CHM_FEATURE_AGENT_ACCESS=public` — agent stays a write; Clerk public-read still 401s unsigned POSTs.

## Changes

- `authorizeAgentApiRequest` wrapper: Cloud + public-read + unsigned → allow only agent POST, models, config-check, followups. `anonymousCapabilities.write` stays false.
- `agent-auth-gate.tsx`: Cloud unsigned `ensureAuthed()` is true; OSS Clerk stays gated.
- Guest harden: strip BYOK `apiKey`, ignore `mcpServers` / user MCP, force/allowlist `anyrouter:auto` + free, hostId env/demo only.
- Unsigned Cloud threads stay local; conversation APIs remain Clerk-only.
- Docs/skill: `docs/knowledge/cloud-saas-mode.md` + `.claude/skills/cloud-saas-mode/SKILL.md`.

## Test plan

- [x] Cloud + anon POST `/api/v1/agent` is not 401
- [x] OSS Clerk + public-read still 401s unsigned agent
- [x] Guest BYOK / MCP / expensive model stripped
- [x] Guest usage 402 `guest_daily_limit` after cap (existing billing tests)
- [x] MCP probe stays 401 for unsigned Cloud

## Notes for reviewer

Stay on AI SDK `ToolLoopAgent`. Quota 3/day + 5/min guest RL unchanged.

---

Co-Authored-By: duyetbot <bot@duyet.net>