### PR TITLE
fix(agent): cap the tool loop at 16 steps

### DIFF
--- a/apps/dashboard/src/lib/ai/agent/__tests__/clickhouse-agent.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/clickhouse-agent.test.ts
@@ -20,7 +20,9 @@ mock.module('@/lib/ai/agent/mcp-tool-adapter', () => ({
 
 // Dynamic import to ensure mock.module('server-only') takes effect first
 // (bun 1.3.x static imports may resolve before mock.module hoisting)
-const { createClickHouseAgent } = await import('../clickhouse-agent')
+const { createClickHouseAgent, DEFAULT_MAX_STEPS } = await import(
+  '../clickhouse-agent'
+)
 
 describe('createClickHouseAgent', () => {
   test('creates agent with required hostId parameter', () => {
@@ -93,11 +95,10 @@ describe('createClickHouseAgent', () => {
     expect(typeof agent.tools).toBe('object')
   })
 
-  test('default maxSteps is 30 when not specified', () => {
+  test('default maxSteps is 16 when not specified', () => {
+    expect(DEFAULT_MAX_STEPS).toBe(16)
     const agent = createClickHouseAgent({ hostId: 0 })
-
     expect(agent).toBeDefined()
-    // Default should be 30 as defined in DEFAULT_MAX_STEPS
   })
 
   test('agent uses environment variables for defaults', () => {

--- a/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
+++ b/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
@@ -26,7 +26,8 @@ function filterTools<T extends Record<string, unknown>>(
   return filtered
 }
 
-const DEFAULT_MAX_STEPS = 30
+/** Bound wandering. Override per request via `maxSteps`. */
+export const DEFAULT_MAX_STEPS = 16
 
 export function createClickHouseAgent(options: {
   /**

--- a/apps/dashboard/src/lib/ai/agent/prompts/__tests__/clickhouse-instructions.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/__tests__/clickhouse-instructions.test.ts
@@ -55,6 +55,7 @@ describe('ClickHouse agent system prompt — behavior', () => {
   test('error recovery retries once then stops', () => {
     expect(PROMPT_FLAT).toContain('retry **once**')
     expect(PROMPT_FLAT).toContain('Do not loop blindly')
+    expect(PROMPT_FLAT).toContain('The loop stops after 16 steps')
   })
 
   test('verdict first and no process-narration examples', () => {

--- a/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
+++ b/apps/dashboard/src/lib/ai/agent/prompts/clickhouse-instructions.ts
@@ -27,7 +27,7 @@ export const CLICKHOUSE_AGENT_INSTRUCTIONS = `You are the ClickHouse ops assista
 3. **Act on reads.** Call tools immediately for live cluster facts. Use \`ask_user\` only when the request has multiple valid interpretations, not to confirm a time range a default already covers.
 4. **Parallel.** Issue independent reads in one turn. On an unfamiliar host, call **get_metrics** once, then go. Do not list every database first unless the question is about databases.
 5. **hostId** is a numeric 0-based index (\`0\`, \`1\`). Never pass a string.
-6. **Error recovery.** On failed SQL: read the error → check schema or load \`system-tables-reference\` → retry **once** → stop. Do not loop blindly.
+6. **Error recovery.** On failed SQL: read the error → check schema or load \`system-tables-reference\` → retry **once** → stop. Do not loop blindly. The loop stops after 16 steps — finish or say what is still unknown.
 7. **Verdict first.** Open with the answer, then evidence (tool names + numbers), then a recommendation if one applies. Do not open with process narration.
 8. **Read-only.** Only SELECT / WITH / DESCRIBE / EXPLAIN. This holds in every deployment (self-hosted or cloud). The 3 destructive control tools (\`kill_query\`, \`optimize_table\`, \`kill_mutation\`) are off by default.
 

--- a/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/__tests__/query-tools.test.ts
@@ -85,6 +85,20 @@ describe('createQueryTools', () => {
       expect(result[0].query_id).toBe('abc-123')
       expect(result[0].user).toBe('analyst')
     })
+
+    test('returns 2000 chars of query text', async () => {
+      let capturedQuery = ''
+      mockFetchData.mockImplementation(async ({ query }: { query: string }) => {
+        capturedQuery = query
+        return { data: queryResults.running, error: null }
+      })
+
+      const tools = createQueryTools(0) as any
+      await tools.get_running_queries.execute({})
+
+      expect(capturedQuery).toContain('substring(query, 1, 2000)')
+      expect(capturedQuery).not.toContain('substring(query, 1, 200)')
+    })
   })
 
   describe('get_slow_queries', () => {

--- a/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
+++ b/apps/dashboard/src/lib/ai/agent/tools/query-tools.ts
@@ -8,7 +8,7 @@ export function createQueryTools(hostId: number) {
   return {
     get_running_queries: dynamicTool({
       description:
-        'Get currently running queries. Useful for identifying long-running queries and monitoring active workloads.',
+        'Get currently running queries ordered by elapsed time. Query text is truncated to 2000 chars so it can be passed to explain_query.',
       inputSchema: z.object({
         hostId: hostIdSchema,
       }),
@@ -23,7 +23,7 @@ export function createQueryTools(hostId: number) {
               elapsed,
               read_rows,
               memory_usage,
-              substring(query, 1, 200) AS query
+              substring(query, 1, 2000) AS query
             FROM system.processes
             ORDER BY elapsed DESC
             LIMIT 100
@@ -97,7 +97,7 @@ export function createQueryTools(hostId: number) {
 
     get_failed_queries: dynamicTool({
       description:
-        'Get recent failed queries. Useful for troubleshooting errors and understanding query failures.',
+        'Get recent failed queries from the last 24 hours by default (override with lastHours). Query text is truncated to 2000 chars.',
       inputSchema: z.object({
         limit: z
           .number()

--- a/docs/content/guide/ai-agent.mdx
+++ b/docs/content/guide/ai-agent.mdx
@@ -41,7 +41,7 @@ A small set of tools delivers this: dedicated primitives for the common reads, a
 
 **Skills** — when a question needs domain depth, the agent loads a bundled expert guide (a skill) with copy-pasteable SQL recipes before answering. Eighteen skills cover data analysis, anomaly detection, query tuning, schema & data-type design, hardware tuning, version upgrades, concept explanations, incident response, plan-and-verify, and the core domains (replication, cluster, storage, migration, security, best practices, troubleshooting, system tables). Available skills: `GET /api/v1/agent/skills`.
 
-**Plan and verify** — for investigations that need 3 or more steps the agent may author a live checklist with `update_plan`. Simple one-step questions skip the plan. See [Capabilities](/guide/ai-agent/capabilities) for details.
+**Plan and verify** — for investigations that need 3 or more steps the agent may author a live checklist with `update_plan`. Simple one-step questions skip the plan. The tool loop stops after 16 steps. See [Capabilities](/guide/ai-agent/capabilities) for details.
 
 ## Quick start
 

--- a/docs/content/guide/ai-agent/capabilities.mdx
+++ b/docs/content/guide/ai-agent/capabilities.mdx
@@ -45,10 +45,10 @@ The Postgres tools (`run_postgres_select_query`, `get_postgres_metrics`, `list_p
 | `list_tables` | List tables in a database with row counts and size. | |
 | `get_table_schema` | Get column definitions for a specific table. | |
 | `explore_table_schema` | Three-mode exploration: no args → databases; database only → tables; database + table → full schema with indexes and keys. | |
-| `get_running_queries` | Currently running queries ordered by elapsed time. | Reads `system.processes`. |
+| `get_running_queries` | Currently running queries ordered by elapsed time. Query text is truncated to 2000 characters. | Reads `system.processes`. |
 | `get_slow_queries` | Slowest completed queries from the last 1 hour by default (`lastHours` override). Query text is truncated to 2000 characters so it can be passed to `explain_query`. | Reads `system.query_log` (`QueryFinish`, `is_initial_query = 1`, `event_time` window). |
 | `list_slow_query_patterns` | Normalized slow query patterns — `system.query_log` grouped by `normalized_query_hash`, with calls, total/avg/p50/p95/p99/max duration, CPU time, peak memory, read/write bytes, errors, and cache-hit ratio per pattern. | Read-only. Use for "which query shape is expensive overall" — unlike `get_slow_queries`, which ranks individual executions. First step of the `query-optimization` diagnose loop. |
-| `get_failed_queries` | Recent failed queries with error details. | Reads `system.query_log`. |
+| `get_failed_queries` | Recent failed queries from the last 24 hours by default (`lastHours` override). Query text is truncated to 2000 characters. | Reads `system.query_log`. |
 | `explain_query` | EXPLAIN PLAN / PIPELINE / PLAN with indexes for a query. | |
 | `estimate_query_cost` | Pre-flight cost estimate (rows scanned, bytes read, peak memory, wall time, confidence) from EXPLAIN alone. | Read-only and recommend-only — runs EXPLAIN only, never executes the analyzed query. |
 | `get_metrics` | Server health: version, uptime, active connections, memory. | Reads `system.metrics`. |
@@ -60,7 +60,7 @@ The Postgres tools (`run_postgres_select_query`, `get_postgres_metrics`, `list_p
 | `recommend_materialized_view` | Mine frequent GROUP BY/aggregate query shapes and design a Summing/AggregatingMergeTree MV or projection to pre-aggregate them. | Returns DDL text + size estimate + impact + risk (added write-path/storage cost) — recommend-only, never executed. Reads `system.query_log`, `system.parts`, `system.tables`. |
 | `get_replication_status` | Per-table replication delay, queue size, and replica counts. | Reads `system.replicas`. |
 | `get_merge_status` | Currently running merges with progress and elapsed time. | Reads `system.merges`. |
-| `update_plan` | Create or update a step-by-step workflow plan for the current investigation. | Rendered as a live checklist in the UI. |
+| `update_plan` | Create or update a step-by-step workflow plan for a 3+ step investigation. Skip it for one-tool answers. | Rendered as a live checklist in the UI. |
 | `load_skill` | Load an expert guide (skill) with SQL recipes for a specific domain. | |
 | `find_reference_query` | Search the dashboard's built-in library of 100+ vetted, version-aware monitoring queries and return the closest matches (name, description, SQL). | Read-only, deterministic keyword-overlap lookup over the built-in `QueryConfig` catalog — executes nothing. Meant to be used before hand-writing `system.*` SQL. |
 | `ask_user` | Ask the user a question to gather information before proceeding. | |


### PR DESCRIPTION
## Summary

Follow-up to #3053. Still AI SDK ToolLoopAgent.

- Default stopWhen budget is 16 steps so the loop stops wandering.
- get_running_queries returns 2000 characters of SQL for explain_query.
- Docs note the 16-step cap, 24h default on get_failed_queries, and update_plan only for 3+ step work.

## Test plan

- [x] bun test on clickhouse-agent, query-tools, prompt, and tool-docs-sync tests