### PR TITLE
feat(agent): polish chat messages, tools, and markdown

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -90,12 +90,14 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   (`components/assistant-ui/{reasoning,tool-group}.tsx`) are plain
   `icon + label + chevron` text rows — no `bg-muted/50` slab — so the
   assistant's prose stays the loudest element, not two stacked grey cards.
-  Tool-call headers show a short capped summary
-  (`summarizeToolInput`), never a raw `key=value` param dump; long params
-  (e.g. `sql`) render as a syntax-highlighted `CodeBlock` in the "Parameters"
-  disclosure, not inline. Tool errors render via `summarizeToolError` as a
-  compact `border-destructive/30` row with an expandable "Details" disclosure
-  — never a raw `{"error":...}` blob. Don't add a `.markdown-content`
+  Tool-call headers show a family icon + short capped summary
+  (`summarizeToolOutput` when done, else `summarizeToolInput`), never a raw
+  `key=value` param dump; long params (e.g. `sql`) render as a
+  syntax-highlighted `CodeBlock` in the "Parameters" disclosure, not inline.
+  Running rows use a muted label + tiny spinner. Tool errors render via
+  `summarizeToolError` as a compact `border-destructive/30` row with an
+  expandable "Details" disclosure — never a raw `{"error":...}` blob. Don't
+  add a `.markdown-content`
   `pre`/`code` background rule — Streamdown's own `code:` renderer already
   owns that styling with token-based Tailwind classes; a sitewide override
   paints a second box INSIDE its already-bordered fenced-block card. See

--- a/apps/dashboard/src/components/agents/chat/tool-output/__tests__/output-shape.test.ts
+++ b/apps/dashboard/src/components/agents/chat/tool-output/__tests__/output-shape.test.ts
@@ -4,8 +4,10 @@ import {
   getPromotedOutputType,
   getRowsFromOutput,
   isLongToolInputValue,
+  getToolFamily,
   summarizeToolError,
   summarizeToolInput,
+  summarizeToolOutput,
   toolInputCodeLanguage,
 } from '@/components/agents/chat/tool-output/output-shape'
 
@@ -166,5 +168,38 @@ describe('summarizeToolError', () => {
       message: 'Connection timed out',
       detail: null,
     })
+  })
+})
+
+describe('getToolFamily', () => {
+  test('maps well-known tool names onto presentational families', () => {
+    expect(getToolFamily('query')).toBe('query')
+    expect(getToolFamily('get_table_schema')).toBe('schema')
+    expect(getToolFamily('get_metrics')).toBe('health')
+    expect(getToolFamily('get_disk_usage')).toBe('disk')
+    expect(getToolFamily('get_replication_status')).toBe('replication')
+    expect(getToolFamily('get_merge_status')).toBe('merge')
+    expect(getToolFamily('load_skill')).toBe('skill')
+    expect(getToolFamily('update_plan')).toBe('plan')
+    expect(getToolFamily('query_and_visualize')).toBe('visualize')
+    expect(getToolFamily('ask_user')).toBe('ask_user')
+    expect(getToolFamily('unknown_widget')).toBe('generic')
+  })
+})
+
+describe('summarizeToolOutput', () => {
+  test('summarizes a rows array by count', () => {
+    expect(summarizeToolOutput([{ a: 1 }, { a: 2 }])).toBe('2 rows')
+    expect(summarizeToolOutput({ rows: [{ a: 1 }] })).toBe('1 row')
+  })
+
+  test('prefers a table name or lag scalar over dumping the payload', () => {
+    expect(summarizeToolOutput({ tableName: 'events' })).toBe('events')
+    expect(summarizeToolOutput({ absolute_delay: 12 })).toBe('lag 12s')
+  })
+
+  test('returns null for empty or unreadable output', () => {
+    expect(summarizeToolOutput(null)).toBeNull()
+    expect(summarizeToolOutput({})).toBeNull()
   })
 })

--- a/apps/dashboard/src/components/agents/chat/tool-output/output-shape.ts
+++ b/apps/dashboard/src/components/agents/chat/tool-output/output-shape.ts
@@ -153,6 +153,93 @@ export function summarizeToolError(
   return { message: trimmed, detail: null }
 }
 
+export type ToolFamily =
+  | 'query'
+  | 'schema'
+  | 'health'
+  | 'disk'
+  | 'replication'
+  | 'merge'
+  | 'skill'
+  | 'plan'
+  | 'visualize'
+  | 'ask_user'
+  | 'generic'
+
+const TOOL_FAMILY_MATCHERS: readonly {
+  readonly family: ToolFamily
+  readonly pattern: RegExp
+}[] = [
+  { family: 'ask_user', pattern: /ask_user/i },
+  { family: 'visualize', pattern: /visuali[sz]|chart/i },
+  { family: 'skill', pattern: /skill|reference_query/i },
+  { family: 'plan', pattern: /plan|workflow/i },
+  { family: 'replication', pattern: /replicat|keeper/i },
+  { family: 'merge', pattern: /merge|mutation/i },
+  { family: 'disk', pattern: /disk|parts|storage/i },
+  { family: 'health', pattern: /health|metric|error|anomaly/i },
+  { family: 'schema', pattern: /schema|table|database|column/i },
+  { family: 'query', pattern: /query|sql|explain/i },
+]
+
+/** Maps a tool name onto a presentational family for the chat row icon. */
+export function getToolFamily(toolName: string): ToolFamily {
+  for (const { family, pattern } of TOOL_FAMILY_MATCHERS) {
+    if (pattern.test(toolName)) return family
+  }
+  return 'generic'
+}
+
+/**
+ * One-line success summary for a finished tool row. Prefers a row count,
+ * then a well-known scalar (table, lag, status), then a promoted type label.
+ * Never dumps the raw payload.
+ */
+export function summarizeToolOutput(output: unknown): string | null {
+  if (output == null) return null
+
+  if (typeof output === 'string') {
+    const trimmed = output.trim()
+    if (!trimmed) return null
+    return trimmed.length > 60 ? `${trimmed.slice(0, 59)}…` : trimmed
+  }
+
+  if (Array.isArray(output)) {
+    return output.length === 1 ? '1 row' : `${output.length} rows`
+  }
+
+  if (typeof output !== 'object') return null
+
+  const obj = output as Record<string, unknown>
+  const rows = getRowsFromOutput(output)
+  if (rows.length > 0) {
+    return rows.length === 1 ? '1 row' : `${rows.length} rows`
+  }
+
+  const table =
+    (typeof obj.table === 'string' && obj.table) ||
+    (typeof obj.tableName === 'string' && obj.tableName) ||
+    (typeof obj.name === 'string' && obj.name)
+  if (table) return table
+
+  if (typeof obj.absolute_delay === 'number') {
+    return `lag ${obj.absolute_delay}s`
+  }
+  if (typeof obj.lag === 'number') {
+    return `lag ${obj.lag}s`
+  }
+  if (typeof obj.status === 'string') return obj.status
+
+  const promoted = getPromotedOutputType(output)
+  if (promoted) return promoted.replace(/_/g, ' ')
+
+  if (typeof obj.count === 'number') {
+    return obj.count === 1 ? '1 item' : `${obj.count} items`
+  }
+
+  return null
+}
+
 export function getPromotedOutputType(output: unknown) {
   if (typeof output !== 'object' || output === null) return null
 

--- a/apps/dashboard/src/components/agents/chat/tool-output/tool-call-part.tsx
+++ b/apps/dashboard/src/components/agents/chat/tool-output/tool-call-part.tsx
@@ -1,19 +1,34 @@
 'use client'
 
 import {
+  ActivityIcon,
   AlertCircleIcon,
+  BarChart3Icon,
+  BookOpenIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  DatabaseIcon,
   DownloadIcon,
+  GitBranchIcon,
+  GitMergeIcon,
+  HardDriveIcon,
+  ListTreeIcon,
+  LoaderCircleIcon,
+  MessageCircleQuestionIcon,
+  Table2Icon,
+  WrenchIcon,
 } from 'lucide-react'
 
 import {
   createResultQueryConfig,
   getPromotedOutputType,
   getRowsFromOutput,
+  getToolFamily,
   isLongToolInputValue,
   summarizeToolError,
   summarizeToolInput,
+  summarizeToolOutput,
+  type ToolFamily,
   toolInputCodeLanguage,
 } from './output-shape'
 import {
@@ -29,7 +44,6 @@ import {
   isAskUserOutput,
 } from '@/components/agents/ask-user-widget'
 import { CodeBlock } from '@/components/ai-elements/code-block'
-import { Badge } from '@/components/ui/badge'
 import {
   Collapsible,
   CollapsibleContent,
@@ -54,35 +68,29 @@ interface ToolCallPartProps {
   readonly isMessageStreaming?: boolean
 }
 
-/**
- * Animated ellipsis — the single "in progress" motion for a running tool.
- * Three dots pulse in a staggered wave; `bg-current` inherits the label colour.
- */
-function AnimatedDots() {
-  return (
-    <span className="inline-flex items-center gap-0.5" aria-hidden>
-      {[0, 200, 400].map((delay) => (
-        <span
-          key={delay}
-          className="size-1 shrink-0 animate-pulse rounded-full bg-current"
-          style={{ animationDelay: `${delay}ms` }}
-        />
-      ))}
-    </span>
-  )
+const TOOL_FAMILY_ICONS: Record<ToolFamily, typeof WrenchIcon> = {
+  query: DatabaseIcon,
+  schema: Table2Icon,
+  health: ActivityIcon,
+  disk: HardDriveIcon,
+  replication: GitBranchIcon,
+  merge: GitMergeIcon,
+  skill: BookOpenIcon,
+  plan: ListTreeIcon,
+  visualize: BarChart3Icon,
+  ask_user: MessageCircleQuestionIcon,
+  generic: WrenchIcon,
 }
 
-/**
- * The one, unmistakable "Running…" acknowledgement — replaces the old scattered
- * label + "Executing…" badge + body spinner with a single animated indicator.
- */
-function RunningIndicator() {
-  return (
-    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-[var(--chart-yellow)]">
-      Running
-      <AnimatedDots />
-    </span>
-  )
+function ToolFamilyIcon({
+  toolName,
+  className,
+}: {
+  readonly toolName: string
+  readonly className?: string
+}) {
+  const Icon = TOOL_FAMILY_ICONS[getToolFamily(toolName)]
+  return <Icon className={className} strokeWidth={1.5} />
 }
 
 /**
@@ -201,7 +209,9 @@ export function ToolCallPart({
   // Short, single-line summary for the header — long values (e.g. a `sql`
   // param) are truncated instead of dumping every key=value pair inline; the
   // full input is always available in the "Parameters" disclosure below.
-  const toolSummary = summarizeToolInput(part.input)
+  const inputSummary = summarizeToolInput(part.input)
+  const outputSummary = hasOutput ? summarizeToolOutput(part.output) : null
+  const toolSummary = outputSummary ?? inputSummary
 
   const inputParamCount =
     part.input && typeof part.input === 'object'
@@ -248,56 +258,43 @@ export function ToolCallPart({
         >
           <span className="text-muted-foreground shrink-0">
             {isExpanded ? (
-              <ChevronDownIcon className="size-3" />
+              <ChevronDownIcon className="size-3" strokeWidth={1.5} />
             ) : (
-              <ChevronRightIcon className="size-3" />
+              <ChevronRightIcon className="size-3" strokeWidth={1.5} />
             )}
           </span>
 
-          <div
-            className={cn(
-              'size-1.5 shrink-0 rounded-full',
-              isActive && 'animate-pulse bg-[var(--chart-yellow)]',
-              hasOutput && 'bg-[var(--chart-green)]',
-              hasError && 'bg-destructive'
-            )}
+          <ToolFamilyIcon
+            toolName={toolName}
+            className="size-3.5 shrink-0 text-muted-foreground"
           />
 
           <div className="flex min-w-0 items-center gap-1.5">
             {isActive ? (
-              <RunningIndicator />
+              <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                <LoaderCircleIcon
+                  className="size-3 animate-spin motion-reduce:animate-none"
+                  strokeWidth={1.5}
+                />
+                {toolName}
+              </span>
             ) : (
-              <span className="text-muted-foreground text-xs">
-                {hasError ? 'Failed' : 'Ran'}
+              <span
+                className={cn(
+                  'text-xs font-medium',
+                  hasError ? 'text-destructive' : 'text-muted-foreground'
+                )}
+              >
+                {toolName}
               </span>
             )}
-            <span className="font-mono text-xs font-medium">{toolName}</span>
             {toolSummary && (
               <span
-                className="text-muted-foreground/70 truncate font-mono text-xs"
+                className="truncate text-xs text-muted-foreground/70"
                 title={toolSummary}
               >
                 {toolSummary}
               </span>
-            )}
-          </div>
-
-          <div className="ml-auto flex items-center gap-1.5">
-            {hasOutput && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-[var(--chart-green)]"
-              >
-                ✓ Done
-              </Badge>
-            )}
-            {hasError && (
-              <Badge
-                variant="outline"
-                className="shrink-0 text-[10px] text-destructive"
-              >
-                ✗ Failed
-              </Badge>
             )}
           </div>
         </button>

--- a/apps/dashboard/src/components/assistant-ui/json-render-message.tsx
+++ b/apps/dashboard/src/components/assistant-ui/json-render-message.tsx
@@ -188,23 +188,17 @@ export function JsonRenderMessage() {
   const isRunning = useMessage((message) => message.status?.type === 'running')
   const jsonRender = useSafeJsonRender(parts ?? [])
 
-  if (!jsonRender.hasSpec && !jsonRender.parseError) return null
+  if (!jsonRender.hasSpec || !jsonRender.spec) return null
 
   return (
     <div className="mt-2">
-      {jsonRender.hasSpec && jsonRender.spec ? (
-        <ErrorBoundary fallbackRender={() => null}>
-          <Renderer
-            spec={jsonRender.spec}
-            registry={AGENT_JSON_RENDER_REGISTRY}
-            loading={isRunning}
-          />
-        </ErrorBoundary>
-      ) : (
-        <div className="rounded border border-[var(--chart-yellow)]/40 bg-[var(--chart-yellow)]/10 p-2 text-xs text-[var(--chart-yellow)]">
-          {jsonRender.parseError}
-        </div>
-      )}
+      <ErrorBoundary fallbackRender={() => null}>
+        <Renderer
+          spec={jsonRender.spec}
+          registry={AGENT_JSON_RENDER_REGISTRY}
+          loading={isRunning}
+        />
+      </ErrorBoundary>
     </div>
   )
 }

--- a/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
@@ -1,26 +1,22 @@
 'use client'
 
 import type { TextMessagePartComponent } from '@assistant-ui/react'
-import type { MermaidErrorComponentProps } from 'streamdown'
+import type {
+  Components,
+  ExtraProps,
+  MermaidErrorComponentProps,
+} from 'streamdown'
 
 import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
 import { useTheme } from 'next-themes'
-import {
-  type ComponentProps,
-  type ReactNode,
-  memo,
-  useMemo,
-} from 'react'
+import { type ComponentProps, memo, useMemo } from 'react'
 import { Streamdown } from 'streamdown'
-
-type StreamdownNodeProps = Record<string, unknown> & {
-  children?: ReactNode
-  href?: string
-  className?: string
-}
 
 import '@/components/agents/markdown-code.css'
 import { cn } from '@/lib/utils'
+
+type MarkdownLinkProps = ComponentProps<'a'> & ExtraProps
+type MarkdownTableProps = ComponentProps<'table'> & ExtraProps
 
 /**
  * Fallback shown when a mermaid diagram fails to parse or render.
@@ -40,7 +36,7 @@ function MermaidError({ chart, error }: MermaidErrorComponentProps) {
   )
 }
 
-function MarkdownLink({ href, children, className }: StreamdownNodeProps) {
+function MarkdownLink({ href, children, className }: MarkdownLinkProps) {
   const isExternal = typeof href === 'string' && href.startsWith('http')
   return (
     <a
@@ -55,15 +51,21 @@ function MarkdownLink({ href, children, className }: StreamdownNodeProps) {
   )
 }
 
-function MarkdownTable({ children, className }: StreamdownNodeProps) {
+function MarkdownTable({ children, className }: MarkdownTableProps) {
   return (
     <div className="my-3 overflow-x-auto">
-      <table className={className ? `${className} w-full text-sm` : 'w-full text-sm'}>
-        {children}
-      </table>
+      <table className={cn('w-full text-sm', className)}>{children}</table>
     </div>
   )
 }
+
+// Streamdown `Components` intersects per-tag props with a string index of
+// `Record<string, unknown> & ExtraProps`. Typed renderers use the per-tag
+// ExtraProps shape; the map is asserted so tsc does not reject the object.
+const streamdownComponents = {
+  a: MarkdownLink,
+  table: MarkdownTable,
+} as Components
 
 /**
  * Markdown renderer for assistant-ui text message parts.
@@ -104,10 +106,7 @@ const MarkdownTextImpl: TextMessagePartComponent = ({ text }) => {
           errorComponent: MermaidError,
         }}
         plugins={{ mermaid: mermaidPlugin }}
-        components={{
-          a: MarkdownLink,
-          table: MarkdownTable,
-        }}
+        components={streamdownComponents}
       >
         {text ?? ''}
       </Streamdown>

--- a/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
@@ -6,15 +6,21 @@ import type { MermaidErrorComponentProps } from 'streamdown'
 import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
 import { useTheme } from 'next-themes'
 import {
-  type AnchorHTMLAttributes,
   type ComponentProps,
+  type ReactNode,
   memo,
-  type TableHTMLAttributes,
   useMemo,
 } from 'react'
 import { Streamdown } from 'streamdown'
 
+type StreamdownNodeProps = Record<string, unknown> & {
+  children?: ReactNode
+  href?: string
+  className?: string
+}
+
 import '@/components/agents/markdown-code.css'
+import { cn } from '@/lib/utils'
 
 /**
  * Fallback shown when a mermaid diagram fails to parse or render.
@@ -34,16 +40,12 @@ function MermaidError({ chart, error }: MermaidErrorComponentProps) {
   )
 }
 
-function MarkdownLink({
-  href,
-  children,
-  ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement>) {
-  const isExternal = href?.startsWith('http')
+function MarkdownLink({ href, children, className }: StreamdownNodeProps) {
+  const isExternal = typeof href === 'string' && href.startsWith('http')
   return (
     <a
       href={href}
-      {...props}
+      className={className}
       {...(isExternal
         ? { target: '_blank', rel: 'noopener noreferrer' }
         : {})}
@@ -53,13 +55,10 @@ function MarkdownLink({
   )
 }
 
-function MarkdownTable({
-  children,
-  ...props
-}: TableHTMLAttributes<HTMLTableElement>) {
+function MarkdownTable({ children, className }: StreamdownNodeProps) {
   return (
     <div className="my-3 overflow-x-auto">
-      <table {...props} className="w-full text-sm">
+      <table className={className ? `${className} w-full text-sm` : 'w-full text-sm'}>
         {children}
       </table>
     </div>

--- a/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/dashboard/src/components/assistant-ui/markdown-text.tsx
@@ -5,7 +5,13 @@ import type { MermaidErrorComponentProps } from 'streamdown'
 
 import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
 import { useTheme } from 'next-themes'
-import { type ComponentProps, memo, useMemo } from 'react'
+import {
+  type AnchorHTMLAttributes,
+  type ComponentProps,
+  memo,
+  type TableHTMLAttributes,
+  useMemo,
+} from 'react'
 import { Streamdown } from 'streamdown'
 
 import '@/components/agents/markdown-code.css'
@@ -16,13 +22,46 @@ import '@/components/agents/markdown-code.css'
  */
 function MermaidError({ chart, error }: MermaidErrorComponentProps) {
   return (
-    <div className="my-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm">
-      <p className="mb-2 font-medium text-destructive">
-        Diagram error: {error}
+    <div className="my-3 rounded-md border border-border/60 px-3 py-2 text-sm">
+      <p className="mb-1.5 text-xs text-muted-foreground">
+        Diagram could not be rendered
+        {error ? ` — ${error}` : ''}
       </p>
-      <pre className="overflow-x-auto rounded bg-muted p-2 font-mono text-xs text-muted-foreground">
+      <pre className="overflow-x-auto font-mono text-xs text-muted-foreground">
         {chart}
       </pre>
+    </div>
+  )
+}
+
+function MarkdownLink({
+  href,
+  children,
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const isExternal = href?.startsWith('http')
+  return (
+    <a
+      href={href}
+      {...props}
+      {...(isExternal
+        ? { target: '_blank', rel: 'noopener noreferrer' }
+        : {})}
+    >
+      {children}
+    </a>
+  )
+}
+
+function MarkdownTable({
+  children,
+  ...props
+}: TableHTMLAttributes<HTMLTableElement>) {
+  return (
+    <div className="my-3 overflow-x-auto">
+      <table {...props} className="w-full text-sm">
+        {children}
+      </table>
     </div>
   )
 }
@@ -66,6 +105,10 @@ const MarkdownTextImpl: TextMessagePartComponent = ({ text }) => {
           errorComponent: MermaidError,
         }}
         plugins={{ mermaid: mermaidPlugin }}
+        components={{
+          a: MarkdownLink,
+          table: MarkdownTable,
+        }}
       >
         {text ?? ''}
       </Streamdown>

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -211,10 +211,10 @@ const UserMessage: FC = () => {
     <MessageScrollerItem messageId={messageId} scrollAnchor className="w-full">
       <MessagePrimitive.Root className="w-full py-3">
         <Message align="end">
-          <MessageContent className="items-end">
+          <MessageContent className="max-w-[min(100%,36rem)] items-end">
             <UserActionBar />
-            <Bubble variant="secondary" align="end">
-              <BubbleContent className="break-words text-sm">
+            <Bubble variant="secondary" align="end" className="max-w-full">
+              <BubbleContent className="overflow-x-auto whitespace-pre-wrap break-words text-sm">
                 <MessagePrimitive.Parts />
               </BubbleContent>
             </Bubble>
@@ -231,7 +231,7 @@ function UserActionBar() {
     <ActionBarPrimitive.Root
       hideWhenRunning
       autohide="not-last"
-      className="flex items-center"
+      className="flex items-center opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100 focus-within:opacity-100"
     >
       <ActionBarPrimitive.Edit asChild>
         <TooltipIconButton tooltip="Edit" className="text-muted-foreground">
@@ -244,7 +244,7 @@ function UserActionBar() {
 
 const EditComposer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="bg-muted mx-auto my-2 flex w-full max-w-[var(--thread-max-width)] flex-col gap-2 rounded-2xl p-3">
+    <ComposerPrimitive.Root className="mx-auto my-2 flex w-full max-w-[var(--thread-max-width)] flex-col gap-2 rounded-xl border border-border bg-card p-3">
       <ComposerPrimitive.Input
         className="text-foreground min-h-12 w-full resize-none bg-transparent text-sm outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
         autoFocus
@@ -444,7 +444,7 @@ const AssistantMessage: FC = () => {
     <MessageScrollerItem messageId={messageId} className="w-full">
       <MessagePrimitive.Root className="mx-auto w-full max-w-[var(--assistant-max-width)] py-3">
         <Message align="start">
-          <MessageContent className="text-foreground w-full max-w-full gap-1.5">
+          <MessageContent className="w-full max-w-full gap-1 text-foreground">
             {/* Task #1: loading dots while no parts exist yet */}
             <LoadingIndicator />
 
@@ -471,7 +471,7 @@ const AssistantMessage: FC = () => {
                 message looks dead. */}
             <AgentDataError />
 
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100 focus-within:opacity-100">
               <BranchPicker />
               <AssistantActionBar />
             </div>

--- a/apps/dashboard/src/components/assistant-ui/tool-group.tsx
+++ b/apps/dashboard/src/components/assistant-ui/tool-group.tsx
@@ -162,7 +162,7 @@ export function ToolGroupContent({
     >
       {/* Indented under the trigger's icon + label — each contained tool row
           keeps its own accent bar / disclosures, this just groups them. */}
-      <div className={cn('flex flex-col gap-0 pl-3.5', className)}>
+      <div className={cn('flex flex-col gap-0.5 pl-3.5', className)}>
         {children}
       </div>
     </CollapsibleContent>

--- a/apps/dashboard/src/styles.css
+++ b/apps/dashboard/src/styles.css
@@ -287,9 +287,22 @@
  */
 
 .markdown-content table {
-  margin: 0.75em 0;
+  margin: 0;
   width: 100%;
   border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.markdown-content th {
+  background-color: color-mix(in oklch, var(--muted) 40%, transparent);
+  font-weight: 600;
+  text-align: left;
+}
+
+.markdown-content th,
+.markdown-content td {
+  border: 1px solid var(--border);
+  padding: 0.375rem 0.625rem;
 }
 
 .markdown-content a {

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -341,14 +341,19 @@ it. Implemented in `components/assistant-ui/{reasoning,tool-group}.tsx` +
   between them; a bare row differentiates by icon (Sparkles vs Wrench) and
   label instead. Their content indents under the trigger (`pl-5` /
   `pl-3.5`) rather than adding another box.
-- **Tool-call header: a short summary, never a raw param dump.** The
-  collapsed row shows `toolName` + `summarizeToolInput(part.input)`
-  (`tool-output/output-shape.ts`) — a single-line, whitespace-collapsed,
-  ~60-char-capped string (prefers a primary `sql`/`query`/`prompt` param
-  alone over concatenating every `key=value`). The full input always lives in
-  the "Parameters" disclosure in the expanded body; a long/multiline value
-  there (`isLongToolInputValue`) renders as a `CodeBlock` (sql-aware,
-  horizontally scrollable) instead of an inline JSON string.
+- **Tool-call header: family icon + short summary, never a raw param dump.**
+  The collapsed row shows a lucide family icon (`getToolFamily`: query,
+  schema, health, disk, replication, merge, skill, plan, visualize,
+  ask_user) + `toolName` + a one-line summary. While running, the name stays
+  muted with a tiny spinner. On success, `summarizeToolOutput` wins (row
+  count, table name, lag, …); otherwise `summarizeToolInput` (`output-shape.ts`)
+  — a single-line, whitespace-collapsed, ~60-char-capped string (prefers a
+  primary `sql`/`query`/`prompt` param alone over concatenating every
+  `key=value`). The full input always lives in the "Parameters" disclosure
+  in the expanded body; a long/multiline value there (`isLongToolInputValue`)
+  renders as a `CodeBlock` (sql-aware, horizontally scrollable) instead of an
+  inline JSON string. Do not add Done/Failed badges on the header — the
+  summary (or the compact error row) is enough.
 - **Tool errors: a compact destructive row, never raw JSON.** A failed tool
   renders `summarizeToolError(part.errorText)` — a short human message
   (extracted from a `{error:...}`/`{message:...}` JSON payload when present,
@@ -375,7 +380,15 @@ it. Implemented in `components/assistant-ui/{reasoning,tool-group}.tsx` +
   override. (`.markdown-content` has exactly one consumer, `markdown-text.tsx`
   — safe to keep spare.) The heading/blockquote overrides that DO remain in
   `styles.css` are intentional chat-width right-sizing (Streamdown's own h1 is
-  `text-3xl`, tuned for full-page docs) — don't remove those.
+  `text-3xl`, tuned for full-page docs) — don't remove those. Tables wrap in
+  a horizontal scroll container (`text-sm`, header `bg-muted/40`). Mermaid
+  parse failures stay muted (border + source), not a destructive slab.
+  Dropped json-render patches (`json-render-patch-guard` or spec validation)
+  fail quiet — no empty Card and no yellow warning chip.
+- **Message chrome stays quiet.** User turns are a compact end-aligned bubble
+  (`max-w` + wrap for long SQL). Assistant prose is flush, no full-answer
+  bubble. Copy / retry / edit appear on hover or focus-visible, not as
+  standing chrome. One loading indicator after submit.
 
 ### Settings channel grid (configured-first)
 


### PR DESCRIPTION
## Summary
Polish the agent chat thread without changing the backend loop.

- Tighten user bubbles vs flush assistant prose; hide copy/retry until hover or focus
- Tool rows: family icons, muted running spinner, one-line output/input summaries
- Calmer mermaid fallback; GFM tables scroll with muted headers; external links open in a new tab
- Dropped json-render patches fail quiet (no empty card)
- Product-design skill + knowledge note updated

## Test plan
- [x] `bun test` on `output-shape` (24 pass)
- [ ] Browser: send a message, confirm one loading indicator, hover actions, tool row icons
- [ ] Markdown table + mermaid error + visualize patch in a live thread