### PR TITLE
chore(ops): keep scheduled desk as herdr-desk config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,10 @@ next-env.d.ts
 # Turborepo
 .turbo
 
+# herdr-desk run state (config + extra.md stay tracked)
+.herdr-desk/runs/*/
+!.herdr-desk/runs/.gitkeep
+
 # IDE
 .idea
 .vscode

--- a/.herdr-desk.json
+++ b/.herdr-desk.json
@@ -1,0 +1,19 @@
+{
+  "name": "chmonitor",
+  "tasks": [
+    {
+      "id": "issues",
+      "label": "GitHub issues and PRs",
+      "task": "github-issues",
+      "agentName": "chm-desk",
+      "kind": "grok",
+      "maxChildren": 3,
+      "stateDir": ".herdr-desk/runs/issues",
+      "extraPrompt": ".herdr-desk/extra.md",
+      "schedule": {
+        "morning": "0 7 * * *",
+        "nightly": "0 22 * * *"
+      }
+    }
+  ]
+}

--- a/.herdr-desk/extra.md
+++ b/.herdr-desk/extra.md
@@ -1,0 +1,7 @@
+# chmonitor addendum
+
+- Required CI: `unit-tests` and `dashboard`. Arm `gh pr merge --auto --squash`
+  and babysit. Do not wait on `e2e-test`, `e2e-test-tsr`, or `component-test`.
+- Never auto-merge release-please PRs.
+- Children may open PRs. Manager does not implement on `main`.
+- State is local; do not commit `.herdr-desk/runs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,12 @@ Pass in the spawn prompt: `HERDR_MANAGER=manager` and the manager pane id
 (`$HERDR_PANE_ID` from the manager). Children must not `herdr workspace
 close` the manager workspace.
 
+## Scheduled desk (herdr-desk plugin)
+
+Config only: `.herdr-desk.json`. The Herdr plugin
+(`herdr plugin install duyet/herdr-desk`) picks this workspace up
+automatically. Do not put scheduler/spawn logic in this repo.
+
 ## Project Overview
 
 This is a monorepo ClickHouse monitoring dashboard. The primary (and only) dashboard app is `apps/dashboard` (TanStack Start, as of v0.3). The Next.js migration is complete — the TanStack Start app has replaced the legacy Next.js app and is now at `apps/dashboard`. The application connects to ClickHouse instances and provides real-time insights into clusters through system tables — metrics, query performance, table information, and cluster health.
@@ -233,6 +239,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Architecture | [memory-optimization.md](docs/knowledge/memory-optimization.md) | Pooling, memoization, cache limits, monitoring |
 | Operations | [deployment.md](docs/knowledge/deployment.md) | Docker + Cloudflare Workers dual deployment |
 | Operations | [core-memory.md](docs/knowledge/core-memory.md) | Automation memory: code-smell scans, dead-code rules |
+| Operations | [issue-desk.md](docs/knowledge/issue-desk.md) | Scheduled desk: `.herdr-desk.json` only; CLI is ~/project/herdr-desk |
 | Operations | [secret-rotation.md](docs/knowledge/secret-rotation.md) | Redeploy after `wrangler secret put` |
 | Operations | [k8s-health-probes.md](docs/knowledge/k8s-health-probes.md) | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image CrashLoop incident; non-helm manifest + migration prompt |
 | Specs | [cloud-saas-mode.md](docs/knowledge/cloud-saas-mode.md) | One codebase, two products: cloud-mode flag, demo hosts for anon, welcome/setup, per-user D1 connections, connection-error classifier |

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -33,6 +33,7 @@ Agents discover knowledge in this order:
 | **Operations** | [worker-bundle-size.md](worker-bundle-size.md) | decision | Worker gzip 1.82 MiB (under limit); bundle breakdown; @opentelemetry/api probed = 6.5 KiB, NOT worth stubbing |
 | **Operations** | [monorepo-refactor.md](monorepo-refactor.md) | operations | Bun-workspaces + Turborepo migration: status, workflow, gotchas, Phase 5 TODO |
 | **Operations** | [core-memory.md](core-memory.md) | workflow | Automation core memory: code-smell scans, dead-code rules |
+| **Operations** | [issue-desk.md](issue-desk.md) | workflow | `.herdr-desk.json` only; scheduled manager CLI is ~/project/herdr-desk |
 | **Operations** | [secret-rotation.md](secret-rotation.md) | workflow | Cloudflare Workers secret rotation: redeploy after wrangler secret put |
 | **Operations** | [github-repo-metadata.md](github-repo-metadata.md) | workflow | Canonical GitHub repo description + topics; banned nextjs/vercel; re-check on stack/positioning change |
 | **Operations** | [k8s-health-probes.md](k8s-health-probes.md) | reference | /healthz (liveness, static) vs /api/healthz (readiness, CH-gated); startupProbe; :latest stale-image incident; non-helm manifest + migration prompt |

--- a/docs/knowledge/issue-desk.md
+++ b/docs/knowledge/issue-desk.md
@@ -1,0 +1,28 @@
+---
+id: issue-desk
+title: Scheduled Herdr desk (external CLI)
+type: workflow
+status: active
+updated: 2026-08-17
+tags:
+  - herdr
+  - cron
+  - agents
+  - github
+related:
+  - core-memory
+  - conventions
+---
+
+# Scheduled Herdr desk
+
+Unattended morning pass is the **herdr-desk Herdr plugin**. This repo
+only has `.herdr-desk.json` and `.herdr-desk/extra.md`. Open this
+workspace once; the plugin remembers it and fires the schedule.
+
+```bash
+herdr plugin install duyet/herdr-desk
+herdr plugin action invoke herdr-desk.start
+```
+
+State: `.herdr-desk/runs/issues/YYYY-MM-DD/` (gitignored).


### PR DESCRIPTION
## Summary
- Add `.herdr-desk.json` so the [herdr-desk](https://github.com/duyet/herdr-desk) plugin can auto-pick this repo.
- Document the split: this repo is config only; the plugin owns spawn/schedule.

## Test plan
- [x] Plugin `status` lists chmonitor from the open workspace
- [ ] Morning fire starts `chm-desk` (07:00 local)