### PR TITLE
fix(agent): keep tool loop after first call and persist AgentState titles

### DIFF
--- a/apps/dashboard/.env.production
+++ b/apps/dashboard/.env.production
@@ -47,8 +47,8 @@ LLM_MODEL=anyrouter:anyrouter/free
 OPENROUTER_REFERER=https://chmonitor.dev
 OPENROUTER_APP_NAME=chmonitor
 # AgentState conversation store: the AGENTSTATE_API_KEY secret alone activates
-# the backend. All other AgentState knobs (base URL, AI-enrich) use code
-# defaults — keep them unset here.
+# the backend. Enable AI titles/follow-ups on cloud (non-secret).
+AGENTSTATE_AI_ENRICH=true
 
 # ── Sentry (error tracking) ─────────────────────────────────────────────────
 # The DSN is a PUBLIC client-side value (shipped in the browser bundle), so it

--- a/apps/dashboard/src/lib/ai/agent/__tests__/agent-stream-response.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/agent-stream-response.test.ts
@@ -73,7 +73,10 @@ function textStreamResult(text: string) {
 
 /** A scripted `doStream` result that calls the given tool, then never
  * produces a text reply — mirroring a tool whose failure ends the turn. */
-function toolCallStreamResult(toolName: string) {
+function toolCallStreamResult(
+  toolName: string,
+  finishReason: string = 'tool-calls'
+) {
   return {
     stream: new ReadableStream({
       start(controller) {
@@ -86,7 +89,7 @@ function toolCallStreamResult(toolName: string) {
         })
         controller.enqueue({
           type: 'finish',
-          finishReason: 'tool-calls',
+          finishReason,
           usage: STREAM_USAGE,
         })
         controller.close()
@@ -189,6 +192,61 @@ describe('createAgentStreamResponse — first message of a new session', () => {
               typeof p.text === 'string' &&
               p.text.includes('viewing the "Merges" page')
           )
+      )
+    ).toBe(true)
+  })
+})
+
+describe('createAgentStreamResponse — tool loop continues after first tool', () => {
+  test('streams a follow-up answer when the first step is a tool call with finishReason stop', async () => {
+    const model = new MockLanguageModelV3({
+      doStream: [
+        toolCallStreamResult('list_databases', 'stop'),
+        textStreamResult('default has the most tables.'),
+      ],
+    })
+    const agent = createClickHouseAgent({ hostId: 0, model })
+
+    const uiMessages = buildUiMessages({
+      safeIncomingMessages: [
+        {
+          id: 'u1',
+          role: 'user',
+          parts: [
+            {
+              type: 'text',
+              text: 'What databases are available and which ones have the most tables?',
+            },
+          ],
+        },
+      ],
+      userMessage:
+        'What databases are available and which ones have the most tables?',
+      pageContext: undefined,
+      hostId: 0,
+    })
+
+    const response = createAgentStreamResponse({
+      ...baseStreamOptions(),
+      agent,
+      mcpCloseAll: null,
+      uiMessages,
+      userMessage:
+        'What databases are available and which ones have the most tables?',
+    })
+
+    const body = await readSseBody(response)
+    const chunks = parseSseChunks(body)
+
+    expect(chunks.some((c) => c.type === 'error')).toBe(false)
+    expect(chunks.some((c) => c.type === 'data-error')).toBe(false)
+    expect(assembleText(chunks)).toContain('default has the most tables')
+    expect(
+      chunks.some(
+        (c) =>
+          c.type === 'tool-input-available' ||
+          c.type === 'tool-call' ||
+          c.toolName === 'list_databases'
       )
     ).toBe(true)
   })

--- a/apps/dashboard/src/lib/ai/agent/__tests__/scenarios.test.ts
+++ b/apps/dashboard/src/lib/ai/agent/__tests__/scenarios.test.ts
@@ -114,7 +114,11 @@ const USAGE = {
 }
 
 /** One scripted LLM turn that calls a single tool. */
-function toolCallTurn(toolName: string, input: Record<string, unknown>) {
+function toolCallTurn(
+  toolName: string,
+  input: Record<string, unknown>,
+  finishReason: string = 'tool-calls'
+) {
   return {
     content: [
       {
@@ -124,7 +128,7 @@ function toolCallTurn(toolName: string, input: Record<string, unknown>) {
         input: JSON.stringify(input),
       },
     ],
-    finishReason: 'tool-calls',
+    finishReason,
     usage: USAGE,
     warnings: [],
   }
@@ -196,6 +200,26 @@ function assertNoDestructiveExecution(result: {
 }
 
 // ── Golden scenarios ────────────────────────────────────────────────────────
+
+describe('agent golden scenarios — tool loop continues', () => {
+  test('list_databases with finishReason stop still takes a second model step', async () => {
+    const answer =
+      'default has the most tables; system and information_schema are metadata.'
+    const { result, toolCallNames } = await runAgentScenario({
+      prompt: 'What databases are available and which ones have the most tables?',
+      turns: [
+        toolCallTurn('list_databases', {}, 'stop'),
+        textTurn(answer),
+      ],
+    })
+
+    expect(toolCallNames).toEqual(['list_databases'])
+    expect(result.toolResults).toHaveLength(1)
+    expect(result.steps.length).toBeGreaterThanOrEqual(2)
+    expect(result.text).toBe(answer)
+    assertNoDestructiveExecution(result)
+  })
+})
 
 describe('agent golden scenarios — query performance', () => {
   test('slow query: explains the cause and recommends an index/PREWHERE fix', async () => {

--- a/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
+++ b/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
@@ -110,11 +110,11 @@ export function createClickHouseAgent(options: {
  */
 export function stopWhenIdleOrMaxSteps(maxSteps: number) {
   const atCap = isStepCount(maxSteps)
-  return ({ steps }: { steps: Array<{ toolCalls?: unknown[] }> }) => {
-    const last = steps[steps.length - 1]
-    if (last?.toolCalls && last.toolCalls.length > 0 && steps.length < maxSteps) {
+  return (options: Parameters<typeof atCap>[0]) => {
+    const last = options.steps[options.steps.length - 1]
+    if (last?.toolCalls.length > 0 && options.steps.length < maxSteps) {
       return false
     }
-    return atCap({ steps })
+    return atCap(options)
   }
 }

--- a/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
+++ b/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
@@ -92,7 +92,29 @@ export function createClickHouseAgent(options: {
     model: modelInstance,
     tools,
     instructions: systemPrompt,
-    stopWhen: isStepCount(maxSteps),
+    // Cap wandering at maxSteps, but never treat a step that emitted
+    // tool calls as terminal. Some OpenAI-compat providers (Gemma) send
+    // finishReason "stop" on the same step as a tool call; the SDK still
+    // continues when those calls are recorded as client outputs. This
+    // guard keeps isStepCount from ending the loop early if a step is
+    // counted before tools are folded into the next model turn.
+    stopWhen: stopWhenIdleOrMaxSteps(maxSteps),
     ...(providerOptions && { providerOptions }),
   })
+}
+
+/**
+ * Stop only when the step cap is reached, or when the latest step did not
+ * emit tool calls (the SDK already stops then). A tool-bearing step always
+ * continues until `maxSteps`.
+ */
+export function stopWhenIdleOrMaxSteps(maxSteps: number) {
+  const atCap = isStepCount(maxSteps)
+  return ({ steps }: { steps: Array<{ toolCalls?: unknown[] }> }) => {
+    const last = steps[steps.length - 1]
+    if (last?.toolCalls && last.toolCalls.length > 0 && steps.length < maxSteps) {
+      return false
+    }
+    return atCap({ steps })
+  }
 }

--- a/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
+++ b/apps/dashboard/src/lib/ai/agent/clickhouse-agent.ts
@@ -112,7 +112,11 @@ export function stopWhenIdleOrMaxSteps(maxSteps: number) {
   const atCap = isStepCount(maxSteps)
   return (options: Parameters<typeof atCap>[0]) => {
     const last = options.steps[options.steps.length - 1]
-    if (last?.toolCalls.length > 0 && options.steps.length < maxSteps) {
+    if (
+      last !== undefined &&
+      last.toolCalls.length > 0 &&
+      options.steps.length < maxSteps
+    ) {
       return false
     }
     return atCap(options)

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.test.ts
@@ -652,6 +652,35 @@ describe('AI enrichment', () => {
     )
     expect(callsTo('generateTitle')).toHaveLength(1)
     expect(callsTo('generateTitle')[0].args[0]).toBe('internal-1')
+    expect(callsTo('updateConversation')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          args: ['internal-1', { title: 'AI Title' }],
+        }),
+      ])
+    )
+  })
+
+  test('calls generateTitle when title is New Chat and persists the result', async () => {
+    existingNone()
+    const store = new AgentStateStore({ apiKey: 'k', aiEnrich: true })
+    await store.upsert(
+      storedConversation({
+        title: 'New Chat',
+        messages: [
+          uiMessage('m1', 'user', 'hi'),
+          uiMessage('m2', 'assistant', 'hello'),
+        ],
+      })
+    )
+    expect(callsTo('generateTitle')).toHaveLength(1)
+    expect(callsTo('updateConversation')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          args: ['internal-1', { title: 'AI Title' }],
+        }),
+      ])
+    )
   })
 
   test('does NOT call generateTitle when aiEnrich is false', async () => {

--- a/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
+++ b/apps/dashboard/src/lib/conversation-store/agentstate-store.ts
@@ -52,7 +52,9 @@ const APP_ID = 'clickhouse-monitoring'
  */
 const GENERIC_TITLES = new Set([
   'New Conversation',
+  'New Chat',
   'Untitled Conversation',
+  'Untitled',
   '',
 ])
 
@@ -587,6 +589,10 @@ export class AgentStateStore implements ConversationStore {
         internalId,
         title,
       })
+      const nextTitle = typeof title === 'string' ? title.trim() : ''
+      if (nextTitle && !GENERIC_TITLES.has(nextTitle)) {
+        await this.client.updateConversation(internalId, { title: nextTitle })
+      }
     } catch (err) {
       // Swallow — enrichment is best-effort and must never fail the upsert.
       logError(

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -414,7 +414,7 @@ Configure a backend at runtime via `CONVERSATION_STORE_BACKEND`.
 |---|---|---|
 | `AGENTSTATE_API_KEY` | — | AgentState API key. Required when `CONVERSATION_STORE_BACKEND=agentstate`. |
 | `AGENTSTATE_BASE_URL` | `https://agentstate.app/api` | AgentState API base URL. |
-| `AGENTSTATE_AI_ENRICH` | `false` | Set `true` to enable AI enrichment of stored conversations. |
+| `AGENTSTATE_AI_ENRICH` | `false` (cloud production: `true`) | Set `true` to enable AI titles and follow-up suggestions. |
 
 **Cloudflare D1 backend:**
 

--- a/docs/knowledge/agentstate-conversation-store.md
+++ b/docs/knowledge/agentstate-conversation-store.md
@@ -3,7 +3,7 @@ id: agentstate-conversation-store
 title: AgentState Conversation Store
 type: spec
 status: active
-updated: 2026-06-17
+updated: 2026-08-18
 related:
   - agent-conversation-storage
   - ai-insights
@@ -74,11 +74,15 @@ isolation requires an authenticated identity (Clerk: `VITE_AUTH_PROVIDER=clerk` 
 
 When AgentState is active **and** `AGENTSTATE_AI_ENRICH=true`:
 
-- **Auto-title** — AgentState generates a concise conversation title.
+- **Auto-title** — if the stored title is generic (`New Chat`, `New Conversation`,
+  empty), `generateTitle` runs and the returned title is persisted via
+  `updateConversation` so the next list shows it.
 - **Follow-ups** — AgentState suggests follow-up questions, surfaced in the chat.
 
-With enrichment off, conversations persist normally but no titles/follow-ups are
-generated. `supportsAiEnrichment` in the backend endpoint reflects this.
+Cloud production sets `AGENTSTATE_AI_ENRICH=true` in
+`apps/dashboard/.env.production`. With enrichment off, conversations persist
+normally but no titles/follow-ups are generated. `supportsAiEnrichment` in the
+backend endpoint reflects this.
 
 ## Routes
 


### PR DESCRIPTION
## Summary
- Keep the agent model loop going after a tool-bearing step (Gemma-style `finishReason: stop` + `list_databases`) so users get a second step and a real answer. Cap remains 16.
- Turn on `AGENTSTATE_AI_ENRICH` for cloud production. Treat `New Chat` as generic and persist `generateTitle` via `updateConversation`.

## Test plan
- [x] `bun test` on scenarios, stream response, agentstate-store, clickhouse-agent, resolve-store
- [ ] Required CI: `unit-tests` + `dashboard`