### PR TITLE
ci(agent): post promptfoo eval results on the PR

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -9,6 +9,7 @@ on:
       - 'tests/agent/**'
       - 'scripts/agent-eval.ts'
       - 'scripts/agent-eval-improve.ts'
+      - 'scripts/agent-eval-comment.ts'
       - '.github/workflows/agent-eval.yml'
   workflow_dispatch:
     inputs:
@@ -24,6 +25,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   promptfoo:
@@ -36,6 +38,7 @@ jobs:
       AGENT_EVAL_MODEL: anyrouter:google/gemma-4-26b-a4b-it
       AGENT_EVAL_GRADER_MODEL: google/gemma-4-26b-a4b-it
       ANYROUTER_API_BASE: https://anyrouter.dev/api/v1
+      AGENT_EVAL_TAGS: ${{ github.event.inputs.tags || 'core,safety' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -59,10 +62,22 @@ jobs:
         run: bun test tests/agent/parse-agent-sse.test.ts --isolate
 
       - name: Live promptfoo (public agent)
+        id: eval
         if: steps.gate.outputs.skip == 'false'
+        continue-on-error: true
+        run: bun scripts/agent-eval.ts --tags "$AGENT_EVAL_TAGS"
+
+      - name: Comment promptfoo results on the PR
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          TAGS='${{ github.event.inputs.tags || 'core,safety' }}'
-          bun scripts/agent-eval.ts --tags "$TAGS"
+          if [ '${{ steps.gate.outputs.skip }}' = 'true' ]; then
+            bun scripts/agent-eval-comment.ts --skip "ANYROUTER_API_KEY or AGENT_API_TOKEN unset" --post --pr "$PR_NUMBER"
+          else
+            bun scripts/agent-eval-comment.ts --post --pr "$PR_NUMBER"
+          fi
 
       - name: Upload eval artifacts
         if: always() && steps.gate.outputs.skip == 'false'
@@ -71,3 +86,7 @@ jobs:
           name: agent-eval-results
           path: tests/agent/results/
           if-no-files-found: ignore
+
+      - name: Fail job when live eval failed
+        if: steps.gate.outputs.skip == 'false' && steps.eval.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm run test:packages:ci
 
       - name: Agent eval SSE parser
-        run: bun test tests/agent/parse-agent-sse.test.ts --isolate
+        run: bun test tests/agent --isolate
 
       - name: Upload Bun coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/TESTING.md
+++ b/TESTING.md
@@ -159,7 +159,8 @@ pnpm run test:agent:improve             # eval then AnyRouter notes (does not ed
 
 See `tests/agent/README.md`. PRs that change system prompts or `.agents/skills/`
 trigger `.github/workflows/agent-eval.yml` against the public agent when
-GitHub secrets are set.
+GitHub secrets are set. The job upserts a sticky PR comment with the
+pass/fail table (or a skip note if secrets are missing).
 
 Each golden asserts the agent emits a `[tool:...]` call (not a memory answer)
 and stays under a latency threshold. Treat the pass rate + latency as the

--- a/docs/knowledge/agent-eval.md
+++ b/docs/knowledge/agent-eval.md
@@ -31,7 +31,8 @@ this suite measures live tool-first + recommend-only behavior.
 | `tests/agent/parse-agent-sse.js` | SSE → `[tool:…]` + answer text |
 | `scripts/agent-eval.ts` | Expand env, run promptfoo |
 | `scripts/agent-eval-improve.ts` | Eval, then AnyRouter notes (no prompt rewrite) |
-| `.github/workflows/agent-eval.yml` | PR path filter → public `dash.chmonitor.dev` |
+| `scripts/agent-eval-comment.ts` | Format + upsert a sticky PR comment |
+| `.github/workflows/agent-eval.yml` | PR path filter → public agent + comment results |
 
 ## Env (no secrets in git)
 
@@ -43,7 +44,8 @@ this suite measures live tool-first + recommend-only behavior.
 - `ANYROUTER_API_BASE` — default `https://anyrouter.dev/api/v1`
 
 CI uses repo secrets `ANYROUTER_API_KEY` and `AGENT_API_TOKEN`. Forks without
-secrets skip the live job.
+secrets skip the live job but still post a skip comment on the PR. Live
+results are upserted onto one sticky comment (`<!-- agent-eval-comment -->`).
 
 ## When to add a case
 

--- a/scripts/agent-eval-comment.ts
+++ b/scripts/agent-eval-comment.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+/**
+ * Write tests/agent/results/pr-comment.md and optionally upsert it on a PR.
+ *
+ *   bun scripts/agent-eval-comment.ts
+ *   bun scripts/agent-eval-comment.ts --skip "ANYROUTER_API_KEY unset"
+ *   bun scripts/agent-eval-comment.ts --post   # needs GH_TOKEN + PR number
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import {
+  MARKER,
+  formatEvalComment,
+  formatSkipComment,
+} from '../tests/agent/format-eval-comment.js'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const outDir = join(root, 'tests/agent/results')
+const jsonPath = join(outDir, 'latest.json')
+const mdPath = join(outDir, 'pr-comment.md')
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag)
+  if (i === -1) return undefined
+  return process.argv[i + 1]
+}
+
+const skip = argValue('--skip')
+mkdirSync(outDir, { recursive: true })
+
+let body: string
+if (skip) {
+  body = formatSkipComment(skip)
+} else {
+  let json: unknown = {}
+  try {
+    json = JSON.parse(readFileSync(jsonPath, 'utf8'))
+  } catch {
+    json = {}
+  }
+  body = formatEvalComment(json, {
+    tags: process.env.AGENT_EVAL_TAGS || '',
+    model: process.env.AGENT_EVAL_MODEL || '',
+    url: process.env.AGENT_EVAL_URL || '',
+  })
+}
+
+writeFileSync(mdPath, body)
+process.stdout.write(body)
+if (!body.endsWith('\n')) process.stdout.write('\n')
+
+if (!process.argv.includes('--post')) {
+  process.exit(0)
+}
+
+const repo = process.env.GITHUB_REPOSITORY
+const pr =
+  argValue('--pr') ||
+  process.env.AGENT_EVAL_PR ||
+  process.env.PR_NUMBER ||
+  ''
+const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+
+if (!repo || !pr || !token) {
+  console.error(
+    '[agent-eval-comment] --post needs GITHUB_REPOSITORY, PR number, and GITHUB_TOKEN'
+  )
+  process.exit(2)
+}
+
+const [owner, name] = repo.split('/')
+const list = spawnSync(
+  'gh',
+  [
+    'api',
+    `repos/${owner}/${name}/issues/${pr}/comments`,
+    '--paginate',
+    '--jq',
+    '.[] | {id, body}',
+  ],
+  { encoding: 'utf8', env: process.env }
+)
+
+if (list.status !== 0) {
+  console.error(list.stderr)
+  process.exit(list.status ?? 1)
+}
+
+type Comment = { id: number; body: string }
+const comments: Comment[] = []
+for (const line of list.stdout.split('\n')) {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('{')) continue
+  try {
+    comments.push(JSON.parse(trimmed) as Comment)
+  } catch {
+    // paginate --jq may emit a JSON array; parse once below
+  }
+}
+
+let existingId: number | undefined
+if (comments.length === 0) {
+  try {
+    const all = JSON.parse(list.stdout) as Comment[]
+    existingId = all.find((c) => c.body?.includes(MARKER))?.id
+  } catch {
+    existingId = undefined
+  }
+} else {
+  existingId = comments.find((c) => c.body?.includes(MARKER))?.id
+}
+
+const tmp = join(outDir, 'pr-comment.body.md')
+writeFileSync(tmp, body)
+
+if (existingId) {
+  const upd = spawnSync(
+    'gh',
+    [
+      'api',
+      '-X',
+      'PATCH',
+      `repos/${owner}/${name}/issues/comments/${existingId}`,
+      '-F',
+      `body=@${tmp}`,
+    ],
+    { encoding: 'utf8', env: process.env }
+  )
+  if (upd.status !== 0) {
+    console.error(upd.stderr)
+    process.exit(upd.status ?? 1)
+  }
+  console.error(`[agent-eval-comment] updated comment ${existingId}`)
+} else {
+  const create = spawnSync(
+    'gh',
+    [
+      'api',
+      '-X',
+      'POST',
+      `repos/${owner}/${name}/issues/${pr}/comments`,
+      '-F',
+      `body=@${tmp}`,
+    ],
+    { encoding: 'utf8', env: process.env }
+  )
+  if (create.status !== 0) {
+    console.error(create.stderr)
+    process.exit(create.status ?? 1)
+  }
+  console.error('[agent-eval-comment] posted new comment')
+}

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -27,7 +27,9 @@ Never commit keys. CI reads `secrets.ANYROUTER_API_KEY` and `secrets.AGENT_API_T
 | `pnpm run test:agent` | `core` + `safety` tags |
 | `pnpm run test:agent:all` | also `tools`, `quality`, `extended` |
 | `pnpm run test:agent:improve` | eval, then AnyRouter notes in `tests/agent/results/improve.md` |
-| `bun test tests/agent/parse-agent-sse.test.ts` | SSE parser (no key) |
+| `bun test tests/agent/*.test.ts` | SSE parser + PR comment formatter (no key) |
+
+CI posts a sticky PR comment (`## Agent eval (promptfoo)`) on prompt/skill PRs.
 
 Improve loop (manual apply):
 

--- a/tests/agent/format-eval-comment.js
+++ b/tests/agent/format-eval-comment.js
@@ -1,0 +1,121 @@
+/**
+ * Turn promptfoo JSON (or a skip reason) into a sticky PR comment body.
+ */
+
+const MARKER = '<!-- agent-eval-comment -->'
+
+function extractRows(json) {
+  if (Array.isArray(json)) return json
+  if (!json || typeof json !== 'object') return []
+  if (Array.isArray(json.results)) return json.results
+  const inner = json.results
+  if (inner && typeof inner === 'object' && Array.isArray(inner.results)) {
+    return inner.results
+  }
+  return []
+}
+
+function rowPassed(row) {
+  if (typeof row.success === 'boolean') return row.success
+  if (row.gradingResult && typeof row.gradingResult.pass === 'boolean') {
+    return row.gradingResult.pass
+  }
+  return false
+}
+
+function rowDescription(row, index) {
+  return (
+    row.description ||
+    row.testCase?.description ||
+    row.vars?.prompt ||
+    row.testCase?.vars?.prompt ||
+    `case ${index + 1}`
+  )
+}
+
+function failReason(row) {
+  const bits = []
+  if (row.gradingResult?.reason) bits.push(String(row.gradingResult.reason))
+  for (const part of row.gradingResult?.componentResults ?? []) {
+    if (part && part.pass === false && part.reason) {
+      bits.push(String(part.reason))
+    }
+  }
+  if (row.error) bits.push(String(row.error))
+  const text = bits.join(' ').replace(/\s+/g, ' ').trim()
+  return text.length > 240 ? `${text.slice(0, 237)}…` : text
+}
+
+function formatSkipComment(reason) {
+  return `${MARKER}
+## Agent eval (promptfoo)
+
+_Skipped:_ ${reason}
+
+Set repo secrets \`ANYROUTER_API_KEY\` and \`AGENT_API_TOKEN\` to run live
+goldens against \`/api/v1/agent\`. SSE parser tests still run in \`unit-tests\`.
+`
+}
+
+function formatEvalComment(json, meta = {}) {
+  const rows = extractRows(json)
+  const passed = rows.filter(rowPassed).length
+  const failed = rows.length - passed
+  const status =
+    rows.length === 0
+      ? 'no cases parsed'
+      : failed === 0
+        ? 'all passed'
+        : `${failed} failed`
+
+  const model = meta.model || process.env.AGENT_EVAL_MODEL || ''
+  const tags = meta.tags || ''
+  const url = meta.url || process.env.AGENT_EVAL_URL || ''
+
+  const lines = [
+    MARKER,
+    '## Agent eval (promptfoo)',
+    '',
+    `**${passed}/${rows.length} passed** — ${status}`,
+  ]
+  if (tags || model || url) {
+    lines.push('')
+    const bits = []
+    if (tags) bits.push(`tags \`${tags}\``)
+    if (model) bits.push(`model \`${model}\``)
+    if (url) bits.push(`url \`${url}\``)
+    lines.push(bits.join(' · '))
+  }
+
+  if (rows.length > 0) {
+    lines.push('')
+    lines.push('| Result | Case |')
+    lines.push('|---|---|')
+    for (const [i, row] of rows.entries()) {
+      const ok = rowPassed(row)
+      const desc = String(rowDescription(row, i)).replace(/\|/g, '\\|')
+      const extra = !ok ? failReason(row) : ''
+      const label = extra ? `${desc}<br>${extra.replace(/\|/g, '\\|')}` : desc
+      lines.push(`| ${ok ? 'pass' : 'FAIL'} | ${label} |`)
+    }
+  } else {
+    lines.push('')
+    lines.push(
+      'No scored rows in `tests/agent/results/latest.json`. See the workflow artifact.'
+    )
+  }
+
+  lines.push('')
+  lines.push(
+    'Informational — does not block merge. Re-run via **Agent eval** workflow dispatch.'
+  )
+  lines.push('')
+  return lines.join('\n')
+}
+
+module.exports = {
+  MARKER,
+  extractRows,
+  formatSkipComment,
+  formatEvalComment,
+}

--- a/tests/agent/format-eval-comment.test.ts
+++ b/tests/agent/format-eval-comment.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  MARKER,
+  formatEvalComment,
+  formatSkipComment,
+} from './format-eval-comment.js'
+
+describe('formatEvalComment', () => {
+  test('summarizes mixed results as a PR table', () => {
+    const md = formatEvalComment(
+      {
+        results: {
+          results: [
+            {
+              success: true,
+              testCase: { description: 'Grounding — version' },
+            },
+            {
+              success: false,
+              testCase: { description: 'Safety — DROP TABLE' },
+              gradingResult: { reason: 'Claimed it already dropped the table' },
+            },
+          ],
+        },
+      },
+      { tags: 'core,safety', model: 'anyrouter:google/gemma-4-26b-a4b-it' }
+    )
+    expect(md.startsWith(MARKER)).toBe(true)
+    expect(md).toContain('**1/2 passed**')
+    expect(md).toContain('| pass | Grounding — version |')
+    expect(md).toContain('FAIL')
+    expect(md).toContain('Claimed it already dropped')
+    expect(md).toContain('tags `core,safety`')
+  })
+
+  test('handles an empty parse', () => {
+    const md = formatEvalComment({})
+    expect(md).toContain('no cases parsed')
+    expect(md).toContain('latest.json')
+  })
+})
+
+describe('formatSkipComment', () => {
+  test('explains missing secrets', () => {
+    const md = formatSkipComment('ANYROUTER_API_KEY unset')
+    expect(md.startsWith(MARKER)).toBe(true)
+    expect(md).toContain('_Skipped:_ ANYROUTER_API_KEY unset')
+  })
+})


### PR DESCRIPTION
## Summary
- After live promptfoo, upsert one sticky PR comment with pass/fail per case.
- If `ANYROUTER_API_KEY` / `AGENT_API_TOKEN` are missing, comment that the live eval was skipped.
- Eval `continue-on-error` so the comment still lands when cases fail.

## Test plan
- [x] `bun test tests/agent`
- [ ] Required CI: unit-tests + dashboard
- [ ] This PR touches `tests/agent/**` so Agent eval should comment here if secrets exist