### PR TITLE
test(agent): run promptfoo on AnyRouter LongCat 2.0

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -35,8 +35,8 @@ jobs:
       ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
       AGENT_API_TOKEN: ${{ secrets.AGENT_API_TOKEN }}
       AGENT_EVAL_URL: https://dash.chmonitor.dev/api/v1/agent
-      AGENT_EVAL_MODEL: anyrouter:google/gemma-4-26b-a4b-it
-      AGENT_EVAL_GRADER_MODEL: google/gemma-4-26b-a4b-it
+      AGENT_EVAL_MODEL: anyrouter:meituan/longcat-2.0
+      AGENT_EVAL_GRADER_MODEL: meituan/longcat-2.0
       ANYROUTER_API_BASE: https://anyrouter.dev/api/v1
       AGENT_EVAL_TAGS: ${{ github.event.inputs.tags || 'core,safety' }}
     steps:

--- a/TESTING.md
+++ b/TESTING.md
@@ -173,9 +173,8 @@ The suite also has an **LLM-judge answer-quality + safety** section (#2326):
 tool presence — e.g. does a "why is my database slow?" answer name a concrete
 cause and a read-only next step, and does a "kill the longest query" answer
 explain the procedure without ever claiming to have already killed/altered
-anything (destructive control tools are gated off by default). The grader
-grader is AnyRouter (`AGENT_EVAL_GRADER_MODEL`, default
-`google/gemma-4-26b-a4b-it`). Add a rubric in `tests/agent/cases/` whenever a
+anything (destructive control tools are gated off by default). The grader is AnyRouter (`AGENT_EVAL_GRADER_MODEL`, default
+`meituan/longcat-2.0`). Add a rubric in `tests/agent/cases/` whenever a
 prompt/skill change could affect correctness or recommendation safety.
 
 ## Writing New Component Tests

--- a/docs/knowledge/agent-eval.md
+++ b/docs/knowledge/agent-eval.md
@@ -39,8 +39,8 @@ this suite measures live tool-first + recommend-only behavior.
 - `ANYROUTER_API_KEY` — rubric + local agent
 - `AGENT_API_TOKEN` — Bearer for the agent route
 - `AGENT_EVAL_URL` — default `http://localhost:3000/api/v1/agent`
-- `AGENT_EVAL_MODEL` — default `anyrouter:google/gemma-4-26b-a4b-it`
-- `AGENT_EVAL_GRADER_MODEL` — default `google/gemma-4-26b-a4b-it`
+- `AGENT_EVAL_MODEL` — default `anyrouter:meituan/longcat-2.0`
+- `AGENT_EVAL_GRADER_MODEL` — default `meituan/longcat-2.0`
 - `ANYROUTER_API_BASE` — default `https://anyrouter.dev/api/v1`
 
 CI uses repo secrets `ANYROUTER_API_KEY` and `AGENT_API_TOKEN`. Forks without

--- a/scripts/agent-eval-improve.ts
+++ b/scripts/agent-eval-improve.ts
@@ -23,7 +23,7 @@ const apiBase =
   process.env.ANYROUTER_API_BASE || 'https://anyrouter.dev/api/v1'
 const apiKey = process.env.ANYROUTER_API_KEY
 const grader =
-  process.env.AGENT_EVAL_GRADER_MODEL || 'google/gemma-4-26b-a4b-it'
+  process.env.AGENT_EVAL_GRADER_MODEL || 'meituan/longcat-2.0'
 
 if (!apiKey) {
   console.error('ANYROUTER_API_KEY is required for improve notes.')

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -4,8 +4,8 @@
  *
  * Defaults:
  *   AGENT_EVAL_URL=http://localhost:3000/api/v1/agent
- *   AGENT_EVAL_MODEL=anyrouter:google/gemma-4-26b-a4b-it
- *   AGENT_EVAL_GRADER_MODEL=google/gemma-4-26b-a4b-it
+ *   AGENT_EVAL_MODEL=anyrouter:meituan/longcat-2.0
+ *   AGENT_EVAL_GRADER_MODEL=meituan/longcat-2.0
  *   ANYROUTER_API_BASE=https://anyrouter.dev/api/v1
  *
  * Tags: --tags core,safety  (default)   --tags all
@@ -53,9 +53,9 @@ const defaults = {
   AGENT_EVAL_URL:
     process.env.AGENT_EVAL_URL || 'http://localhost:3000/api/v1/agent',
   AGENT_EVAL_MODEL:
-    process.env.AGENT_EVAL_MODEL || 'anyrouter:google/gemma-4-26b-a4b-it',
+    process.env.AGENT_EVAL_MODEL || 'anyrouter:meituan/longcat-2.0',
   AGENT_EVAL_GRADER_MODEL:
-    process.env.AGENT_EVAL_GRADER_MODEL || 'google/gemma-4-26b-a4b-it',
+    process.env.AGENT_EVAL_GRADER_MODEL || 'meituan/longcat-2.0',
   ANYROUTER_API_BASE:
     process.env.ANYROUTER_API_BASE || 'https://anyrouter.dev/api/v1',
   AGENT_API_TOKEN: process.env.AGENT_API_TOKEN || '',

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -10,8 +10,8 @@ export ANYROUTER_API_KEY=...          # secret — local or GH secret
 export AGENT_API_TOKEN=...            # Bearer for POST /api/v1/agent
 export AGENT_EVAL_URL=http://localhost:3000/api/v1/agent
 # optional
-export AGENT_EVAL_MODEL=anyrouter:google/gemma-4-26b-a4b-it
-export AGENT_EVAL_GRADER_MODEL=google/gemma-4-26b-a4b-it
+export AGENT_EVAL_MODEL=anyrouter:meituan/longcat-2.0
+export AGENT_EVAL_GRADER_MODEL=meituan/longcat-2.0
 export ANYROUTER_API_BASE=https://anyrouter.dev/api/v1
 ```
 

--- a/tests/agent/format-eval-comment.test.ts
+++ b/tests/agent/format-eval-comment.test.ts
@@ -23,7 +23,7 @@ describe('formatEvalComment', () => {
           ],
         },
       },
-      { tags: 'core,safety', model: 'anyrouter:google/gemma-4-26b-a4b-it' }
+      { tags: 'core,safety', model: 'anyrouter:meituan/longcat-2.0' }
     )
     expect(md.startsWith(MARKER)).toBe(true)
     expect(md).toContain('| Status | **FAIL** |')


### PR DESCRIPTION
## Summary
- Default promptfoo agent + grader is AnyRouter \`meituan/longcat-2.0\`.
- Smoke: greeting case **PASS 1/1 (100%)** against dash.chmonitor.dev.

## Test plan
- [x] Live greeting eval with LongCat
- [ ] Required CI: unit-tests + dashboard