### PR TITLE
test(agent): share promptfoo evals to promptfoo.app

### DIFF
--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -35,8 +35,8 @@ jobs:
       ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
       AGENT_API_TOKEN: ${{ secrets.AGENT_API_TOKEN }}
       AGENT_EVAL_URL: https://dash.chmonitor.dev/api/v1/agent
-      AGENT_EVAL_MODEL: anyrouter:google/gemma-4-26b-a4b-it
-      AGENT_EVAL_GRADER_MODEL: google/gemma-4-26b-a4b-it
+      AGENT_EVAL_MODEL: anyrouter:meituan/longcat-2.0
+      AGENT_EVAL_GRADER_MODEL: meituan/longcat-2.0
       ANYROUTER_API_BASE: https://anyrouter.dev/api/v1
       AGENT_EVAL_TAGS: ${{ github.event.inputs.tags || 'core,safety' }}
     steps:

--- a/.github/workflows/agent-eval.yml
+++ b/.github/workflows/agent-eval.yml
@@ -34,6 +34,7 @@ jobs:
     env:
       ANYROUTER_API_KEY: ${{ secrets.ANYROUTER_API_KEY }}
       AGENT_API_TOKEN: ${{ secrets.AGENT_API_TOKEN }}
+      PROMPTFOO_API_KEY: ${{ secrets.PROMPTFOO_API_KEY }}
       AGENT_EVAL_URL: https://dash.chmonitor.dev/api/v1/agent
       AGENT_EVAL_MODEL: anyrouter:meituan/longcat-2.0
       AGENT_EVAL_GRADER_MODEL: meituan/longcat-2.0

--- a/TESTING.md
+++ b/TESTING.md
@@ -173,9 +173,8 @@ The suite also has an **LLM-judge answer-quality + safety** section (#2326):
 tool presence — e.g. does a "why is my database slow?" answer name a concrete
 cause and a read-only next step, and does a "kill the longest query" answer
 explain the procedure without ever claiming to have already killed/altered
-anything (destructive control tools are gated off by default). The grader
-grader is AnyRouter (`AGENT_EVAL_GRADER_MODEL`, default
-`google/gemma-4-26b-a4b-it`). Add a rubric in `tests/agent/cases/` whenever a
+anything (destructive control tools are gated off by default). The grader is AnyRouter (`AGENT_EVAL_GRADER_MODEL`, default
+`meituan/longcat-2.0`). Add a rubric in `tests/agent/cases/` whenever a
 prompt/skill change could affect correctness or recommendation safety.
 
 ## Writing New Component Tests

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -19,6 +19,7 @@ CLICKHOUSE_PASSWORD=
 # ── Agent / LLM ─────────────────────────────────────────────────────────────
 # ANYROUTER_API_KEY=
 # LLM_API_KEY=
+# PROMPTFOO_API_KEY=   # optional: share live eval reports to promptfoo.app
 # LLM_MODEL=anyrouter:anyrouter/free
 # CHM_FEATURE_AGENT_ACCESS=public
 # CHM_AGENT_FIRECRAWL_MCP=true

--- a/docs/knowledge/agent-eval.md
+++ b/docs/knowledge/agent-eval.md
@@ -42,6 +42,8 @@ this suite measures live tool-first + recommend-only behavior.
 - `AGENT_EVAL_MODEL` — default `anyrouter:meituan/longcat-2.0`
 - `AGENT_EVAL_GRADER_MODEL` — default `meituan/longcat-2.0`
 - `ANYROUTER_API_BASE` — default `https://anyrouter.dev/api/v1`
+- `PROMPTFOO_API_KEY` — optional Promptfoo Cloud token (`promptfoo auth login`);
+  when set, `agent-eval` adds `--share` and links the report
 
 CI uses repo secrets `ANYROUTER_API_KEY` and `AGENT_API_TOKEN`. Forks without
 secrets skip the live job but still post a skip comment on the PR. Live

--- a/docs/knowledge/agent-eval.md
+++ b/docs/knowledge/agent-eval.md
@@ -39,8 +39,8 @@ this suite measures live tool-first + recommend-only behavior.
 - `ANYROUTER_API_KEY` — rubric + local agent
 - `AGENT_API_TOKEN` — Bearer for the agent route
 - `AGENT_EVAL_URL` — default `http://localhost:3000/api/v1/agent`
-- `AGENT_EVAL_MODEL` — default `anyrouter:google/gemma-4-26b-a4b-it`
-- `AGENT_EVAL_GRADER_MODEL` — default `google/gemma-4-26b-a4b-it`
+- `AGENT_EVAL_MODEL` — default `anyrouter:meituan/longcat-2.0`
+- `AGENT_EVAL_GRADER_MODEL` — default `meituan/longcat-2.0`
 - `ANYROUTER_API_BASE` — default `https://anyrouter.dev/api/v1`
 
 CI uses repo secrets `ANYROUTER_API_KEY` and `AGENT_API_TOKEN`. Forks without

--- a/scripts/agent-eval-improve.ts
+++ b/scripts/agent-eval-improve.ts
@@ -23,7 +23,7 @@ const apiBase =
   process.env.ANYROUTER_API_BASE || 'https://anyrouter.dev/api/v1'
 const apiKey = process.env.ANYROUTER_API_KEY
 const grader =
-  process.env.AGENT_EVAL_GRADER_MODEL || 'google/gemma-4-26b-a4b-it'
+  process.env.AGENT_EVAL_GRADER_MODEL || 'meituan/longcat-2.0'
 
 if (!apiKey) {
   console.error('ANYROUTER_API_KEY is required for improve notes.')

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -4,8 +4,8 @@
  *
  * Defaults:
  *   AGENT_EVAL_URL=http://localhost:3000/api/v1/agent
- *   AGENT_EVAL_MODEL=anyrouter:google/gemma-4-26b-a4b-it
- *   AGENT_EVAL_GRADER_MODEL=google/gemma-4-26b-a4b-it
+ *   AGENT_EVAL_MODEL=anyrouter:meituan/longcat-2.0
+ *   AGENT_EVAL_GRADER_MODEL=meituan/longcat-2.0
  *   ANYROUTER_API_BASE=https://anyrouter.dev/api/v1
  *
  * Tags: --tags core,safety  (default)   --tags all
@@ -53,9 +53,9 @@ const defaults = {
   AGENT_EVAL_URL:
     process.env.AGENT_EVAL_URL || 'http://localhost:3000/api/v1/agent',
   AGENT_EVAL_MODEL:
-    process.env.AGENT_EVAL_MODEL || 'anyrouter:google/gemma-4-26b-a4b-it',
+    process.env.AGENT_EVAL_MODEL || 'anyrouter:meituan/longcat-2.0',
   AGENT_EVAL_GRADER_MODEL:
-    process.env.AGENT_EVAL_GRADER_MODEL || 'google/gemma-4-26b-a4b-it',
+    process.env.AGENT_EVAL_GRADER_MODEL || 'meituan/longcat-2.0',
   ANYROUTER_API_BASE:
     process.env.ANYROUTER_API_BASE || 'https://anyrouter.dev/api/v1',
   AGENT_API_TOKEN: process.env.AGENT_API_TOKEN || '',

--- a/scripts/agent-eval.ts
+++ b/scripts/agent-eval.ts
@@ -106,6 +106,9 @@ const promptfooArgs = [
   jsonOut,
   ...extra,
 ]
+if (process.env.PROMPTFOO_API_KEY && !extra.includes('--share')) {
+  promptfooArgs.push('--share')
+}
 
 console.log(
   `[agent-eval] url=${defaults.AGENT_EVAL_URL} model=${defaults.AGENT_EVAL_MODEL} suite=${useAll ? 'all' : 'core,safety'}`
@@ -123,9 +126,18 @@ const result = spawnSync('bunx', promptfooArgs, {
 let summaryLine = ''
 try {
   const json = JSON.parse(readFileSync(jsonOut, 'utf8')) as unknown
+  const shareUrl =
+    json &&
+    typeof json === 'object' &&
+    typeof (json as { shareableUrl?: unknown }).shareableUrl === 'string'
+      ? String((json as { shareableUrl: string }).shareableUrl)
+      : ''
   const summary = summarize(json)
-  const board = formatScoreboard(summary)
+  const board = formatScoreboard(summary, { shareUrl })
   writeFileSync(join(outDir, 'scoreboard.md'), `${board}\n`)
+  if (shareUrl) {
+    writeFileSync(join(outDir, 'share-url.txt'), `${shareUrl}\n`)
+  }
   summaryLine = `\n${board}\n`
   console.log(summaryLine)
 } catch {

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -18,7 +18,9 @@ export ANYROUTER_API_BASE=https://anyrouter.dev/api/v1
 Local: run the dashboard (`pnpm run dev`) with ClickHouse + `ANYROUTER_API_KEY`.
 Public: set `AGENT_EVAL_URL=https://dash.chmonitor.dev/api/v1/agent`.
 
-Never commit keys. CI reads `secrets.ANYROUTER_API_KEY` and `secrets.AGENT_API_TOKEN`.
+Never commit keys. Put `PROMPTFOO_API_KEY` in `.env.local` (gitignored) so
+`pnpm run test:agent` publishes a shareable report to promptfoo.app. CI can use
+`secrets.PROMPTFOO_API_KEY` the same way.
 
 ## Commands
 

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -10,8 +10,8 @@ export ANYROUTER_API_KEY=...          # secret — local or GH secret
 export AGENT_API_TOKEN=...            # Bearer for POST /api/v1/agent
 export AGENT_EVAL_URL=http://localhost:3000/api/v1/agent
 # optional
-export AGENT_EVAL_MODEL=anyrouter:google/gemma-4-26b-a4b-it
-export AGENT_EVAL_GRADER_MODEL=google/gemma-4-26b-a4b-it
+export AGENT_EVAL_MODEL=anyrouter:meituan/longcat-2.0
+export AGENT_EVAL_GRADER_MODEL=meituan/longcat-2.0
 export ANYROUTER_API_BASE=https://anyrouter.dev/api/v1
 ```
 

--- a/tests/agent/format-eval-comment.js
+++ b/tests/agent/format-eval-comment.js
@@ -57,8 +57,8 @@ function summarize(json) {
   return { rows, passed, failed, total, scorePct, status }
 }
 
-function formatScoreboard(summary) {
-  return [
+function formatScoreboard(summary, extra = {}) {
+  const lines = [
     `| | |`,
     `|---|---|`,
     `| Status | **${summary.status}** |`,
@@ -66,7 +66,12 @@ function formatScoreboard(summary) {
     `| Tests | ${summary.total} |`,
     `| Passed | ${summary.passed} |`,
     `| Failed | ${summary.failed} |`,
-  ].join('\n')
+  ]
+  const shareUrl = extra.shareUrl || summary.shareUrl
+  if (shareUrl) {
+    lines.push(`| Report | [promptfoo.app](${shareUrl}) |`)
+  }
+  return lines.join('\n')
 }
 
 function formatSkipComment(reason) {
@@ -88,12 +93,17 @@ function formatEvalComment(json, meta = {}) {
   const model = meta.model || process.env.AGENT_EVAL_MODEL || ''
   const tags = meta.tags || ''
   const url = meta.url || process.env.AGENT_EVAL_URL || ''
+  const shareUrl =
+    meta.shareUrl ||
+    (json && typeof json === 'object' && typeof json.shareableUrl === 'string'
+      ? json.shareableUrl
+      : '')
 
   const lines = [
     MARKER,
     '## Agent eval (promptfoo)',
     '',
-    formatScoreboard(summary),
+    formatScoreboard(summary, { shareUrl }),
     '',
     `**${passed}/${total} passed** (${scorePct}%) — ${status}`,
   ]

--- a/tests/agent/format-eval-comment.test.ts
+++ b/tests/agent/format-eval-comment.test.ts
@@ -23,7 +23,7 @@ describe('formatEvalComment', () => {
           ],
         },
       },
-      { tags: 'core,safety', model: 'anyrouter:google/gemma-4-26b-a4b-it' }
+      { tags: 'core,safety', model: 'anyrouter:meituan/longcat-2.0' }
     )
     expect(md.startsWith(MARKER)).toBe(true)
     expect(md).toContain('| Status | **FAIL** |')

--- a/tests/agent/format-eval-comment.test.ts
+++ b/tests/agent/format-eval-comment.test.ts
@@ -38,6 +38,14 @@ describe('formatEvalComment', () => {
     expect(md).toContain('tags `core,safety`')
   })
 
+  test('includes a promptfoo share link when present', () => {
+    const md = formatEvalComment(
+      { results: { results: [{ success: true, testCase: { description: 'A' } }] } },
+      { shareUrl: 'https://www.promptfoo.app/eval/abc' }
+    )
+    expect(md).toContain('[promptfoo.app](https://www.promptfoo.app/eval/abc)')
+  })
+
   test('handles an empty parse', () => {
     const md = formatEvalComment({})
     expect(md).toContain('| Status | **NO_RESULTS** |')


### PR DESCRIPTION
## Summary
- When \`PROMPTFOO_API_KEY\` is in \`.env.local\` (or CI secrets), evals run with \`--share\`.
- Scoreboard and the PR comment include the promptfoo.app report link.
- The key is gitignored. Not committed.

## Test plan
- [x] \`promptfoo auth login\` as duyet / promptfoo.app
- [x] Shared smoke eval: https://www.promptfoo.app/eval/eval-Kxx-2026-08-17T19:27:27
- [ ] Required CI: unit-tests + dashboard