### PR TITLE
docs(guide): DBA compare, TTL, and advisor workflows

### DIFF
--- a/apps/docs/scripts/sync-docs.mjs
+++ b/apps/docs/scripts/sync-docs.mjs
@@ -112,6 +112,7 @@ const FOLDER_META = {
       'memory-limit-total-exceeded',
       'upgrade-clickhouse',
       'diagnostics-cli',
+      'dba-workflows',
       '---Query optimization---',
       'clickhouse-query-optimization',
       'partition-key-best-practices',

--- a/docs/content/guide/features/explorer.mdx
+++ b/docs/content/guide/features/explorer.mdx
@@ -90,6 +90,7 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 ## Related
 
 <Cards>
+  <Card title="DBA workflows" href="/guide/guides/dba-workflows" description="Single-host Explorer DDL vs planned cross-host schema compare." />
   <Card title="Tables & storage" href="/guide/features/tables" description="Storage, parts, and replication for the tables you explore." />
   <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
   <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />

--- a/docs/content/guide/features/settings.mdx
+++ b/docs/content/guide/features/settings.mdx
@@ -8,7 +8,7 @@ Audit ClickHouse configuration without SQL — see every server setting with non
 
 <TypeTable
   type={{
-    Routes: { type: "/settings, /mergetree-settings, /replicated-merge-tree-settings", description: "Pages in this section" },
+    Routes: { type: "/settings, /mergetree-settings, /replicated-merge-tree-settings, /settings-diff", description: "Pages in this section" },
     "Feature id": { type: "settings", description: "Used by permission env vars and config" },
     "Default access": { type: "public", description: "Set CHM_FEATURE_SETTINGS_ACCESS=authenticated to gate" },
     "Requires auth": { type: "No", description: "Anonymous access allowed by default" },
@@ -35,12 +35,14 @@ This section covers **ClickHouse server** settings (read-only, from system table
 | Settings | `/settings` | All server settings; highlights non-defaults | `system.settings` |
 | MergeTree Settings | `/mergetree-settings` | MergeTree engine settings and values | `system.merge_tree_settings` |
 | Replicated MergeTree Settings | `/replicated-merge-tree-settings` | Replicated MergeTree settings; flags changed-from-default | `system.replicated_merge_tree_settings` |
+| Settings Diff | `/settings-diff` | Compare settings and MergeTree settings across configured hosts | `system.settings`, `system.merge_tree_settings` |
 
 ## Using it
 
 - Open `/settings` to review all server settings; non-default values are highlighted so you can spot unexpected overrides or confirm a change took effect.
 - Open `/mergetree-settings` to inspect MergeTree engine settings, and `/replicated-merge-tree-settings` for Replicated MergeTree settings with changed-from-default values flagged.
-- To change a setting, use ClickHouse SQL (`SET`, `ALTER TABLE ... MODIFY SETTING`) or edit the server config — these pages are read-only.
+- Open `/settings-diff` to compare `system.settings` and `system.merge_tree_settings` across every configured host.
+- To change a setting, use ClickHouse SQL (`SET`, `ALTER TABLE ... MODIFY SETTING`) or edit the server config — these pages are read-only. chmonitor never writes `config.xml`.
 
 ## Permissions & access
 
@@ -88,6 +90,7 @@ No feature-specific environment variables. The pages are read-only — chmonitor
 ## Related
 
 <Cards>
+  <Card title="DBA workflows" href="/guide/guides/dba-workflows" description="Settings Diff, advisor, TTL moves, and Explorer — what exists vs the roadmap." />
   <Card title="Settings reference" href="/reference/settings" description="Every dashboard configuration setting in one place." />
   <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
   <Card title="ClickHouse system.settings" href="https://clickhouse.com/docs/en/operations/system-tables/settings" description="Upstream reference for server settings." />

--- a/docs/content/guide/guides/dba-workflows.mdx
+++ b/docs/content/guide/guides/dba-workflows.mdx
@@ -1,0 +1,77 @@
+---
+title: DBA compare, TTL, and advisor workflows
+description: What chmonitor already does for settings compare, query/schema advice, TTL moves, and Explorer DDL — and what is still on the roadmap.
+icon: GitCompareArrows
+---
+
+Operators coming from other DBA tools often look for schema compare, change plans, and TTL inventory. This page is the map of **what ships today** versus **what is still planned**.
+
+<Callout type="warn" title="Recommend-only">
+chmonitor does **not** apply schema changes and does **not** edit `config.xml` (or any other ClickHouse server file). Advisor output is copyable SQL and settings you review and run yourself.
+</Callout>
+
+## What exists today
+
+| Workflow | Route | What it does |
+|---|---|---|
+| Settings compare | `/settings-diff` | Compares `system.settings` and `system.merge_tree_settings` across every configured host. Highlights values that differ between hosts and values changed from default. Export as CSV. |
+| Query advisor | `/advisor` (Query Advisor tab) | Ranked skip-index, projection, partition-key, and `PREWHERE` recommendations for a pasted query or a `query_id`. Recommend-only. |
+| Schema & settings lint | `/advisor` (Schema & Settings tab) | Scans a database (or one table) for schema lint and settings findings. Recommend-only. |
+| TTL moves vs inventory | `/storage-economics` | Per-table compression, storage policies, and **TTL storage move activity**. This is move history / current economics — not a full TTL and partition health inventory. |
+| Explorer DDL | `/explorer` | Shows the `CREATE TABLE` statement and schema for the **selected host** (`?host=`). Single-host, read-only. |
+
+### Settings compare (`/settings-diff`)
+
+Open **System → Settings Diff**. You need at least two hosts configured. Filter to rows that differ, or to settings changed from default. The page is gated by the `settings` feature id — see [Settings](/guide/features/settings).
+
+Nothing on this page writes to ClickHouse. To change a setting, use `SET`, `ALTER TABLE … MODIFY SETTING`, or edit the server config yourself.
+
+### Advisor (`/advisor`)
+
+Open **Queries → Advisor**. Two tabs:
+
+- **Query Advisor** — paste SQL or look up a `query_id` from `system.query_log`.
+- **Schema & Settings** — scan a database or table for lint findings.
+
+The same recommend-only engine is available from the [AI agent](/guide/ai-agent) and the MCP server. There is no Apply button.
+
+### Storage economics (`/storage-economics`)
+
+Open **System → Storage Economics**. Three tables:
+
+- Compression by table (from `system.parts`)
+- Storage policies
+- TTL storage moves (parts that already moved because of TTL)
+
+The inventory of *every* table's TTL expression, partition health, and "should this table have a TTL?" is **not** this page. That is [issue #3074](https://github.com/chmonitor/chmonitor/issues/3074).
+
+### Explorer single-host DDL (`/explorer`)
+
+The [Data Explorer](/guide/features/explorer) shows `CREATE TABLE` for the table on the **current host**. It does not compare DDL across hosts. Cross-host schema compare is [issue #3072](https://github.com/chmonitor/chmonitor/issues/3072).
+
+<Callout type="info" title="Read-only explorer">
+The explorer cannot create, alter, or drop objects.
+</Callout>
+
+## Roadmap
+
+These issues are **not** implemented yet. They are the planned follow-ups to the pages above.
+
+| Issue | Planned work |
+|---|---|
+| [#3072](https://github.com/chmonitor/chmonitor/issues/3072) | Compare table schemas across hosts |
+| [#3073](https://github.com/chmonitor/chmonitor/issues/3073) | Recommend-only schema change plan from a host diff |
+| [#3074](https://github.com/chmonitor/chmonitor/issues/3074) | TTL and partition health inventory |
+| [#3075](https://github.com/chmonitor/chmonitor/issues/3075) | Show table schema advisor on Explorer |
+| [#3077](https://github.com/chmonitor/chmonitor/issues/3077) | Role presets and customizable workspace in Settings |
+
+When those land, this guide will point at the new routes. Until then, use `/settings-diff`, `/advisor`, `/storage-economics`, and `/explorer` as listed above.
+
+## Related
+
+<Cards>
+  <Card title="Settings" href="/guide/features/settings" description="Server settings pages, including Settings Diff." />
+  <Card title="Data explorer" href="/guide/features/explorer" description="Single-host DDL, columns, indexes, and projections." />
+  <Card title="Tables & storage" href="/guide/features/tables" description="Table sizes, parts, and replication pages." />
+  <Card title="ClickHouse query optimization" href="/guide/guides/clickhouse-query-optimization" description="The six areas the query advisor reasons about." />
+</Cards>

--- a/docs/content/guide/guides/troubleshooting.mdx
+++ b/docs/content/guide/guides/troubleshooting.mdx
@@ -307,4 +307,5 @@ If the host uses `https://`, confirm TLS is allowed or `CLICKHOUSE_VERIFY_CERT=f
 <Card title="Upgrading ClickHouse" href="/guide/guides/upgrade-clickhouse" description="Upgrade safely while chmonitor stays connected." />
 <Card title="Zero-signup diagnostics CLI" href="/guide/guides/diagnostics-cli" description="Run a local, read-only health scan with no chmonitor account." />
 <Card title="ClickHouse query optimization" href="/guide/guides/clickhouse-query-optimization" description="Diagnose and fix slow ClickHouse queries — partition keys, PREWHERE, indices, and memory." />
+<Card title="DBA workflows" href="/guide/guides/dba-workflows" description="Settings compare, advisor, TTL moves, and Explorer — what exists vs planned." />
 </Cards>


### PR DESCRIPTION
## Summary

Operators could not tell what Chmonitor already does for DBA-style compare/advice vs what is still a roadmap item.

- Add `docs/content/guide/guides/dba-workflows.mdx` covering `/settings-diff`, `/advisor` (query + schema/settings lint, recommend-only), `/storage-economics` TTL moves (not full inventory), and Explorer single-host DDL
- State explicitly that Chmonitor does not apply schema or edit `config.xml`
- Link issues #3072–#3075 and #3077 as roadmap
- Register the page in the docs sidebar and link it from Settings, Explorer, and Troubleshooting

Closes #3076

## Test plan

- [ ] Docs page lists the four existing routes
- [ ] Roadmap table links #3072–#3075, #3077
- [ ] `SPEC.md` is not in the PR