### PR TITLE
feat(explorer): show table schema advisor on overview

### DIFF
--- a/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+/**
+ * Table-overview wiring for the existing schema/settings tuning API.
+ * Recommend-only: Scan is explicit (no first-paint request). Findings render
+ * through TuningFindingsPanel — no apply/run control. See issue #3075.
+ */
+
+import { SlidersHorizontalIcon, WandSparklesIcon } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  type TuningFindingsOutput,
+  TuningFindingsPanel,
+} from '@/components/agents/tuning-findings-panel'
+import { ErrorAlert } from '@/components/feedback'
+import { TableSkeleton } from '@/components/skeletons'
+import { AppLink as Link } from '@/components/ui/app-link'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import {
+  type ClusterReplicaRow,
+  formatDistributedTopologyNote,
+  parseDistributedEngine,
+} from '@/lib/explorer/engine-kind'
+import { useHostId } from '@/lib/swr'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { buildUrl, splitHref } from '@/lib/url/url-builder'
+
+interface TuningApiResponse extends TuningFindingsOutput {
+  success: true
+}
+interface TuningApiError {
+  success: false
+  error: string
+}
+
+interface TopologyApiResponse {
+  success?: boolean
+  data?: ClusterReplicaRow[]
+}
+
+const fetchTuning = async (url: string): Promise<TuningApiResponse> => {
+  const res = await apiFetch(url)
+  const body = (await res.json()) as TuningApiResponse | TuningApiError
+  if (!res.ok || !body.success) {
+    throw new Error(
+      (body as TuningApiError).error || `Scan failed (HTTP ${res.status})`
+    )
+  }
+  return body
+}
+
+const fetchTopology = async (url: string): Promise<ClusterReplicaRow[]> => {
+  const res = await apiFetch(url)
+  if (!res.ok) return []
+  const body = (await res.json()) as TopologyApiResponse
+  return Array.isArray(body.data) ? body.data : []
+}
+
+export function ExplorerTuningSection({
+  database,
+  table,
+  engine,
+  engineFull,
+}: {
+  database: string
+  table: string
+  engine?: string | null
+  engineFull?: string | null
+}) {
+  const hostId = useHostId()
+  const [scanKey, setScanKey] = useState<string | null>(null)
+  const tableKey = `${database}.${table}`
+
+  useEffect(() => {
+    setScanKey(null)
+  }, [tableKey])
+
+  const dist = useMemo(
+    () =>
+      engine === 'Distributed' || (engineFull ?? '').includes('Distributed')
+        ? parseDistributedEngine(engineFull)
+        : null,
+    [engine, engineFull]
+  )
+
+  const tuningUrl =
+    scanKey === tableKey
+      ? `/api/v1/advisor/tuning?hostId=${hostId}&database=${encodeURIComponent(database)}&table=${encodeURIComponent(table)}`
+      : null
+
+  const { data, error, isLoading, isFetching } = useQuery<TuningApiResponse>({
+    queryKey: [tuningUrl],
+    queryFn: () => fetchTuning(tuningUrl as string),
+    enabled: Boolean(tuningUrl),
+  })
+
+  const topologyUrl =
+    scanKey === tableKey && dist
+      ? `/api/v1/tables/clusters-topology?hostId=${hostId}`
+      : null
+
+  const { data: topologyRows } = useQuery<ClusterReplicaRow[]>({
+    queryKey: [topologyUrl],
+    queryFn: () => fetchTopology(topologyUrl as string),
+    enabled: Boolean(topologyUrl),
+  })
+
+  const output = useMemo(() => {
+    if (!data) return null
+    const notes = [...data.notes]
+    if (dist) {
+      notes.unshift(formatDistributedTopologyNote(dist, topologyRows))
+    }
+    return { ...data, notes }
+  }, [data, dist, topologyRows])
+
+  const advisorHref = buildUrl('/advisor', { host: hostId })
+
+  return (
+    <section className="space-y-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5">
+          <WandSparklesIcon
+            className="size-4 text-muted-foreground"
+            strokeWidth={1.5}
+          />
+          <h2 className="text-sm font-medium text-foreground">Advisor</h2>
+        </div>
+        <Link
+          {...splitHref(advisorHref)}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          Analyze a slow query on this table
+        </Link>
+      </div>
+
+      {tuningUrl === null ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border bg-card px-3 py-3">
+          <p className="text-[13px] text-muted-foreground">
+            Scan for copyable schema and settings suggestions. Nothing is
+            applied automatically.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setScanKey(tableKey)}
+          >
+            <SlidersHorizontalIcon className="size-3.5" />
+            Scan this table
+          </Button>
+        </div>
+      ) : null}
+
+      {isLoading || (isFetching && !data) ? <TableSkeleton rows={3} /> : null}
+
+      {error ? (
+        <ErrorAlert
+          title="Scan failed"
+          message={error instanceof Error ? error.message : String(error)}
+        />
+      ) : null}
+
+      {!isLoading && !error && output ? (
+        output.findings.length === 0 && !dist ? (
+          <div className="rounded-lg border bg-card px-3 py-4">
+            <EmptyState
+              compact
+              variant="no-data"
+              title="No tuning opportunities"
+              description="Columns and settings look well-tuned for this table."
+            />
+          </div>
+        ) : (
+          <TuningFindingsPanel output={output} />
+        )
+      ) : null}
+    </section>
+  )
+}

--- a/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/lib/explorer/engine-kind'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
-import { buildUrl, splitHref } from '@/lib/url/url-builder'
+import { buildUrl } from '@/lib/url/url-builder'
 
 interface TuningApiResponse extends TuningFindingsOutput {
   success: true
@@ -130,7 +130,7 @@ export function ExplorerTuningSection({
           <h2 className="text-sm font-medium text-foreground">Advisor</h2>
         </div>
         <Link
-          {...splitHref(advisorHref)}
+          href={advisorHref}
           className="text-xs text-muted-foreground hover:text-foreground"
         >
           Analyze a slow query on this table

--- a/apps/dashboard/src/components/explorer/tabs/overview-tab.tsx
+++ b/apps/dashboard/src/components/explorer/tabs/overview-tab.tsx
@@ -15,6 +15,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import type { ReactNode } from 'react'
 
+import { ExplorerTuningSection } from '../explorer-tuning-section'
 import { useExplorerState } from '../hooks/use-explorer-state'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
@@ -548,6 +549,15 @@ export function OverviewTab() {
           <Clock className="size-3.5" strokeWidth={1.5} />
           This engine does not expose part-level storage statistics.
         </p>
+      ) : null}
+
+      {!isViewLike && !isDictionary ? (
+        <ExplorerTuningSection
+          database={database}
+          table={table}
+          engine={summary?.engine}
+          engineFull={summary?.engine_full}
+        />
       ) : null}
     </div>
   )

--- a/apps/dashboard/src/lib/explorer/engine-kind.test.ts
+++ b/apps/dashboard/src/lib/explorer/engine-kind.test.ts
@@ -1,9 +1,11 @@
 import {
   classifyEngine,
   engineKindLabel,
+  formatDistributedTopologyNote,
   formatTimestamp,
   hasPartStorage,
   isEpochZero,
+  parseDistributedEngine,
   parseMaterializedViewTarget,
 } from './engine-kind'
 import { describe, expect, test } from 'bun:test'
@@ -58,6 +60,64 @@ describe('engineKindLabel', () => {
       'Materialized view'
     )
     expect(engineKindLabel(classifyEngine('MergeTree'))).toBe('Table')
+  })
+})
+
+describe('parseDistributedEngine', () => {
+  test('parses quoted Distributed engine_full', () => {
+    expect(
+      parseDistributedEngine(
+        "Distributed('analytics', 'default', 'events_local', cityHash64(id))"
+      )
+    ).toEqual({
+      cluster: 'analytics',
+      database: 'default',
+      table: 'events_local',
+      shardingKey: 'cityHash64(id)',
+    })
+  })
+
+  test('parses unquoted identifiers and optional sharding key', () => {
+    expect(
+      parseDistributedEngine('Distributed(cluster, db, local_table)')
+    ).toEqual({
+      cluster: 'cluster',
+      database: 'db',
+      table: 'local_table',
+      shardingKey: null,
+    })
+  })
+
+  test('returns null for non-Distributed engines', () => {
+    expect(parseDistributedEngine('MergeTree')).toBeNull()
+    expect(parseDistributedEngine('')).toBeNull()
+    expect(parseDistributedEngine(null)).toBeNull()
+  })
+})
+
+describe('formatDistributedTopologyNote', () => {
+  const dist = {
+    cluster: 'analytics',
+    database: 'default',
+    table: 'events_local',
+    shardingKey: 'rand()',
+  }
+
+  test('includes shard and replica counts when topology rows exist', () => {
+    expect(
+      formatDistributedTopologyNote(dist, [
+        { cluster: 'analytics', shard_num: 1 },
+        { cluster: 'analytics', shard_num: 1 },
+        { cluster: 'analytics', shard_num: 2 },
+        { cluster: 'other', shard_num: 1 },
+      ])
+    ).toContain('2 shards × 2 replicas')
+  })
+
+  test('omits counts when the cluster is missing from topology', () => {
+    expect(formatDistributedTopologyNote(dist, [])).toBe(
+      'Distributed wrapper over local table default.events_local on cluster analytics. Apply schema changes on the local table, then keep this Distributed table in sync.'
+    )
   })
 })
 

--- a/apps/dashboard/src/lib/explorer/engine-kind.ts
+++ b/apps/dashboard/src/lib/explorer/engine-kind.ts
@@ -89,6 +89,124 @@ export function engineKindLabel(kind: EngineKind): string {
  * (`CREATE MATERIALIZED VIEW x TO db.target (...) AS SELECT ...`). Returns
  * null for an inner-table MV (`ENGINE = ...`), which has no explicit target.
  */
+export interface DistributedEngine {
+  cluster: string
+  database: string
+  table: string
+  shardingKey: string | null
+}
+
+/**
+ * Parse `ENGINE = Distributed(cluster, db, local_table [, sharding_key])`
+ * from `system.tables.engine_full`. Quoted identifiers and string literals
+ * are accepted; missing or non-Distributed engines return null.
+ */
+export function parseDistributedEngine(
+  engineFull: string | null | undefined
+): DistributedEngine | null {
+  if (typeof engineFull !== 'string' || engineFull.trim() === '') return null
+
+  const match = engineFull.match(/Distributed\s*\(([\s\S]*)\)\s*$/i)
+  if (!match) return null
+
+  const args = splitEngineArgs(match[1])
+  if (args.length < 3) return null
+
+  const cluster = unquoteIdent(args[0])
+  const database = unquoteIdent(args[1])
+  const table = unquoteIdent(args[2])
+  if (!cluster || !database || !table) return null
+
+  const shardingKey = args[3]?.trim() ? args[3].trim() : null
+  return { cluster, database, table, shardingKey }
+}
+
+function splitEngineArgs(inner: string): string[] {
+  const args: string[] = []
+  let current = ''
+  let depth = 0
+  let quote: "'" | '"' | '`' | null = null
+
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]
+    const prev = i > 0 ? inner[i - 1] : ''
+
+    if (quote) {
+      current += ch
+      if (ch === quote && prev !== '\\') quote = null
+      continue
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch
+      current += ch
+      continue
+    }
+
+    if (ch === '(') {
+      depth += 1
+      current += ch
+      continue
+    }
+    if (ch === ')') {
+      depth = Math.max(0, depth - 1)
+      current += ch
+      continue
+    }
+
+    if (ch === ',' && depth === 0) {
+      args.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += ch
+  }
+
+  if (current.trim()) args.push(current.trim())
+  return args
+}
+
+function unquoteIdent(raw: string): string {
+  const value = raw.trim()
+  if (
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith('`') && value.endsWith('`'))
+  ) {
+    return value.slice(1, -1).replace(/\\(['"`])/g, '$1')
+  }
+  return value
+}
+
+export interface ClusterReplicaRow {
+  cluster: string
+  shard_num: string | number
+}
+
+/** Compact shard × replica note when topology rows exist for the cluster. */
+export function formatDistributedTopologyNote(
+  dist: DistributedEngine,
+  rows: ClusterReplicaRow[] | null | undefined
+): string {
+  const local = `${dist.database}.${dist.table}`
+  const matching = (rows ?? []).filter((row) => row.cluster === dist.cluster)
+  if (matching.length === 0) {
+    return `Distributed wrapper over local table ${local} on cluster ${dist.cluster}. Apply schema changes on the local table, then keep this Distributed table in sync.`
+  }
+
+  const perShard = new Map<string, number>()
+  for (const row of matching) {
+    const key = String(row.shard_num)
+    perShard.set(key, (perShard.get(key) ?? 0) + 1)
+  }
+  const shards = perShard.size
+  const replicas = Math.max(...perShard.values())
+  const shardLabel = shards === 1 ? 'shard' : 'shards'
+  const replicaLabel = replicas === 1 ? 'replica' : 'replicas'
+  return `Distributed wrapper over local table ${local} on cluster ${dist.cluster} (${shards} ${shardLabel} × ${replicas} ${replicaLabel}). Apply schema changes on the local table, then keep this Distributed table in sync.`
+}
+
 export function parseMaterializedViewTarget(
   createQuery: string | null | undefined
 ): string | null {


### PR DESCRIPTION
## Summary
- Add an Advisor section on Explorer table overview that calls the existing `GET /api/v1/advisor/tuning` endpoint and renders `TuningFindingsPanel`.
- Empty state + explicit **Scan this table** so first paint never hits the metered API.
- Distributed tables append a local-table + shard×replica note when `clusters-topology` is available.
- Deep-link to `/advisor` for query-shaped advice. Recommend-only — no apply/run.

Closes #3075

## Test plan
- [x] Unit tests for `parseDistributedEngine` and topology note formatting
- [ ] Open a MergeTree table in Explorer → Overview shows Advisor + Scan; first paint does not call `/advisor/tuning`
- [ ] Scan shows the same findings as `/advisor` Schema & Settings for that table
- [ ] Distributed table scan includes a local/distributed note when cluster metadata exists
- [ ] Views/dictionaries do not show the Advisor section
- [ ] No apply/run control on the findings