### PR TITLE
feat(dashboard): compare table schemas and recommend a copy-only plan

### DIFF
--- a/apps/dashboard/src/lib/command-palette/nav-commands.ts
+++ b/apps/dashboard/src/lib/command-palette/nav-commands.ts
@@ -74,6 +74,12 @@ const NAV_ROUTES = [
     keywords: ['config', 'configuration', 'server'],
   },
   {
+    id: 'nav-schema-diff',
+    label: 'Schema Compare',
+    href: '/schema-diff',
+    keywords: ['schema', 'diff', 'ddl', 'compare', 'hosts'],
+  },
+  {
     id: 'nav-logs-text',
     label: 'Text Log',
     href: '/logs/text-log',

--- a/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
+++ b/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
@@ -556,6 +556,12 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
   },
   {
     "depth": 1,
+    "href": "/schema-diff",
+    "section": undefined,
+    "title": "Schema Compare",
+  },
+  {
+    "depth": 1,
     "href": "/disks",
     "section": undefined,
     "title": "Disks",

--- a/apps/dashboard/src/lib/og.ts
+++ b/apps/dashboard/src/lib/og.ts
@@ -153,6 +153,12 @@ export const OG_PAGES: Record<string, OgPage> = {
     description:
       'Compare system.settings and merge_tree_settings across all configured ClickHouse hosts.',
   },
+  'schema-diff': {
+    eyebrow: 'SCHEMA',
+    title: 'Cross-Host Schema Compare',
+    description:
+      'Compare table schemas across hosts and copy a recommend-only change plan.',
+  },
   users: {
     eyebrow: 'ACCESS',
     title: 'Users & Roles',

--- a/apps/dashboard/src/lib/schema-diff/catalog.ts
+++ b/apps/dashboard/src/lib/schema-diff/catalog.ts
@@ -1,0 +1,74 @@
+import type {
+  ColumnRow,
+  IndexRow,
+  ProjectionRow,
+  SchemaCatalog,
+  TableRow,
+  TableSchema,
+} from './types'
+
+export function tableKey(database: string, table: string): string {
+  return `${database}.${table}`
+}
+
+export function assembleCatalog(
+  tables: TableRow[],
+  columns: ColumnRow[],
+  indexes: IndexRow[] = [],
+  projections: ProjectionRow[] = []
+): SchemaCatalog {
+  const byKey = new Map<string, TableSchema>()
+
+  for (const row of tables) {
+    const key = tableKey(row.database, row.table)
+    byKey.set(key, {
+      database: row.database,
+      table: row.table,
+      engine: row.engine ?? '',
+      sortingKey: row.sorting_key ?? '',
+      partitionKey: row.partition_key ?? '',
+      primaryKey: row.primary_key ?? '',
+      createTableQuery: row.create_table_query ?? '',
+      columns: [],
+      indexes: [],
+      projections: [],
+    })
+  }
+
+  for (const col of columns) {
+    const table = byKey.get(tableKey(col.database, col.table))
+    if (!table) continue
+    table.columns.push({
+      name: col.name,
+      type: col.type ?? '',
+      codec: col.codec ?? '',
+    })
+  }
+
+  for (const idx of indexes) {
+    const table = byKey.get(tableKey(idx.database, idx.table))
+    if (!table) continue
+    table.indexes.push({
+      name: idx.name,
+      type: idx.type ?? '',
+      expr: idx.expr ?? '',
+      granularity: String(idx.granularity ?? ''),
+    })
+  }
+
+  for (const proj of projections) {
+    const table = byKey.get(tableKey(proj.database, proj.table))
+    if (!table) continue
+    table.projections.push({
+      name: proj.name,
+      type: proj.type ?? '',
+      query: proj.query ?? '',
+    })
+  }
+
+  return {
+    tables: [...byKey.values()].sort((a, b) =>
+      tableKey(a.database, a.table).localeCompare(tableKey(b.database, b.table))
+    ),
+  }
+}

--- a/apps/dashboard/src/lib/schema-diff/compare.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/compare.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+
+import { assembleCatalog } from './catalog'
+import { compareCatalogs } from './compare'
+import type { TableSchema } from './types'
+
+function table(partial: Partial<TableSchema> & Pick<TableSchema, 'database' | 'table'>): TableSchema {
+  return {
+    engine: 'MergeTree',
+    sortingKey: 'id',
+    partitionKey: '',
+    primaryKey: 'id',
+    createTableQuery: `CREATE TABLE ${partial.database}.${partial.table} (id UInt64) ENGINE = MergeTree ORDER BY id`,
+    columns: [{ name: 'id', type: 'UInt64', codec: '' }],
+    indexes: [],
+    projections: [],
+    ...partial,
+  }
+}
+
+describe('assembleCatalog', () => {
+  test('nests columns, indexes, and projections under tables', () => {
+    const catalog = assembleCatalog(
+      [
+        {
+          database: 'app',
+          table: 'events',
+          engine: 'MergeTree',
+          sorting_key: 'ts',
+          partition_key: 'toYYYYMM(ts)',
+          primary_key: 'ts',
+          create_table_query: 'CREATE TABLE app.events ...',
+        },
+      ],
+      [
+        {
+          database: 'app',
+          table: 'events',
+          name: 'ts',
+          type: 'DateTime',
+          codec: '',
+        },
+        {
+          database: 'app',
+          table: 'events',
+          name: 'payload',
+          type: 'String',
+          codec: 'CODEC(ZSTD(1))',
+        },
+      ],
+      [
+        {
+          database: 'app',
+          table: 'events',
+          name: 'idx_ts',
+          type: 'minmax',
+          expr: 'ts',
+          granularity: '1',
+        },
+      ],
+      [
+        {
+          database: 'app',
+          table: 'events',
+          name: 'by_day',
+          type: 'Normal',
+          query: 'SELECT * ORDER BY ts',
+        },
+      ]
+    )
+
+    expect(catalog.tables).toHaveLength(1)
+    expect(catalog.tables[0].columns.map((c) => c.name)).toEqual(['ts', 'payload'])
+    expect(catalog.tables[0].indexes).toHaveLength(1)
+    expect(catalog.tables[0].projections[0].name).toBe('by_day')
+  })
+})
+
+describe('compareCatalogs', () => {
+  test('buckets missing table, extra column, and type change', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'only_src',
+          createTableQuery: 'CREATE TABLE app.only_src (id UInt64) ENGINE = MergeTree ORDER BY id',
+        }),
+        table({
+          database: 'app',
+          table: 'shared',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'extra', type: 'String', codec: '' },
+            { name: 'amount', type: 'Float64', codec: '' },
+          ],
+        }),
+      ],
+    }
+    const target = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'shared',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'amount', type: 'Float32', codec: '' },
+          ],
+        }),
+      ],
+    }
+
+    const diff = compareCatalogs(source, target)
+
+    expect(diff.onlySource.map((r) => r.key)).toEqual(['app.only_src'])
+    expect(diff.onlyTarget).toEqual([])
+    expect(diff.changed).toHaveLength(1)
+    expect(diff.changed[0].key).toBe('app.shared')
+    expect(diff.changed[0].changes.map((c) => c.field).sort()).toEqual([
+      'column:extra',
+      'column_type:amount',
+    ])
+  })
+
+  test('identical tables land in identical', () => {
+    const t = table({ database: 'app', table: 'same' })
+    const diff = compareCatalogs({ tables: [t] }, { tables: [structuredClone(t)] })
+    expect(diff.identical.map((r) => r.key)).toEqual(['app.same'])
+    expect(diff.changed).toEqual([])
+  })
+
+  test('table only on target is only_target', () => {
+    const diff = compareCatalogs(
+      { tables: [] },
+      { tables: [table({ database: 'app', table: 'tgt' })] }
+    )
+    expect(diff.onlyTarget.map((r) => r.key)).toEqual(['app.tgt'])
+  })
+})

--- a/apps/dashboard/src/lib/schema-diff/compare.ts
+++ b/apps/dashboard/src/lib/schema-diff/compare.ts
@@ -1,0 +1,165 @@
+import { tableKey } from './catalog'
+import type {
+  FieldChange,
+  SchemaCatalog,
+  SchemaDiffResult,
+  TableDiff,
+  TableSchema,
+} from './types'
+
+function byTableKey(catalog: SchemaCatalog): Map<string, TableSchema> {
+  const map = new Map<string, TableSchema>()
+  for (const table of catalog.tables) {
+    map.set(tableKey(table.database, table.table), table)
+  }
+  return map
+}
+
+function mapByName<T extends { name: string }>(items: T[]): Map<string, T> {
+  return new Map(items.map((item) => [item.name, item]))
+}
+
+function collectChanges(source: TableSchema, target: TableSchema): FieldChange[] {
+  const changes: FieldChange[] = []
+
+  const scalar: Array<keyof Pick<
+    TableSchema,
+    'engine' | 'sortingKey' | 'partitionKey' | 'primaryKey'
+  >> = ['engine', 'sortingKey', 'partitionKey', 'primaryKey']
+
+  for (const field of scalar) {
+    if (source[field] !== target[field]) {
+      changes.push({ field, source: source[field], target: target[field] })
+    }
+  }
+
+  const sourceCols = mapByName(source.columns)
+  const targetCols = mapByName(target.columns)
+
+  for (const [name, col] of sourceCols) {
+    const other = targetCols.get(name)
+    if (!other) {
+      changes.push({ field: `column:${name}`, source: col.type, target: '' })
+      continue
+    }
+    if (col.type !== other.type) {
+      changes.push({
+        field: `column_type:${name}`,
+        source: col.type,
+        target: other.type,
+      })
+    }
+    if (col.codec !== other.codec) {
+      changes.push({
+        field: `column_codec:${name}`,
+        source: col.codec,
+        target: other.codec,
+      })
+    }
+  }
+
+  for (const [name, col] of targetCols) {
+    if (!sourceCols.has(name)) {
+      changes.push({ field: `column:${name}`, source: '', target: col.type })
+    }
+  }
+
+  const sourceIdx = mapByName(source.indexes)
+  const targetIdx = mapByName(target.indexes)
+  for (const [name, idx] of sourceIdx) {
+    const other = targetIdx.get(name)
+    if (!other) {
+      changes.push({
+        field: `index:${name}`,
+        source: `${idx.type} ${idx.expr}`,
+        target: '',
+      })
+      continue
+    }
+    if (
+      idx.type !== other.type ||
+      idx.expr !== other.expr ||
+      idx.granularity !== other.granularity
+    ) {
+      changes.push({
+        field: `index:${name}`,
+        source: `${idx.type} ${idx.expr} ${idx.granularity}`,
+        target: `${other.type} ${other.expr} ${other.granularity}`,
+      })
+    }
+  }
+  for (const [name, idx] of targetIdx) {
+    if (!sourceIdx.has(name)) {
+      changes.push({
+        field: `index:${name}`,
+        source: '',
+        target: `${idx.type} ${idx.expr}`,
+      })
+    }
+  }
+
+  const sourceProj = mapByName(source.projections)
+  const targetProj = mapByName(target.projections)
+  for (const [name, proj] of sourceProj) {
+    if (!targetProj.has(name)) {
+      changes.push({
+        field: `projection:${name}`,
+        source: proj.type,
+        target: '',
+      })
+    }
+  }
+  for (const [name, proj] of targetProj) {
+    if (!sourceProj.has(name)) {
+      changes.push({
+        field: `projection:${name}`,
+        source: '',
+        target: proj.type,
+      })
+    }
+  }
+
+  return changes
+}
+
+export function compareCatalogs(
+  source: SchemaCatalog,
+  target: SchemaCatalog
+): SchemaDiffResult {
+  const sourceMap = byTableKey(source)
+  const targetMap = byTableKey(target)
+  const keys = new Set([...sourceMap.keys(), ...targetMap.keys()])
+
+  const onlySource: TableDiff[] = []
+  const onlyTarget: TableDiff[] = []
+  const changed: TableDiff[] = []
+  const identical: TableDiff[] = []
+
+  for (const key of [...keys].sort()) {
+    const src = sourceMap.get(key)
+    const tgt = targetMap.get(key)
+
+    if (src && !tgt) {
+      onlySource.push({ key, kind: 'only_source', source: src, changes: [] })
+      continue
+    }
+    if (tgt && !src) {
+      onlyTarget.push({ key, kind: 'only_target', target: tgt, changes: [] })
+      continue
+    }
+    if (!src || !tgt) continue
+
+    const changes = collectChanges(src, tgt)
+    const row: TableDiff = {
+      key,
+      kind: changes.length > 0 ? 'changed' : 'identical',
+      source: src,
+      target: tgt,
+      changes,
+    }
+    if (changes.length > 0) changed.push(row)
+    else identical.push(row)
+  }
+
+  return { onlySource, onlyTarget, changed, identical }
+}

--- a/apps/dashboard/src/lib/schema-diff/index.ts
+++ b/apps/dashboard/src/lib/schema-diff/index.ts
@@ -1,0 +1,22 @@
+export { assembleCatalog, tableKey } from './catalog'
+export { compareCatalogs } from './compare'
+export { buildChangePlan } from './plan'
+export type {
+  ColumnRow,
+  FieldChange,
+  IndexRow,
+  PlanItem,
+  PlanItemKind,
+  PlanRisk,
+  ProjectionRow,
+  SchemaCatalog,
+  SchemaChangePlan,
+  SchemaColumn,
+  SchemaDiffResult,
+  SchemaIndex,
+  SchemaProjection,
+  TableDiff,
+  TableDiffKind,
+  TableRow,
+  TableSchema,
+} from './types'

--- a/apps/dashboard/src/lib/schema-diff/plan.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/plan.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test'
+
+import { compareCatalogs } from './compare'
+import { buildChangePlan } from './plan'
+import type { TableSchema } from './types'
+
+function table(partial: Partial<TableSchema> & Pick<TableSchema, 'database' | 'table'>): TableSchema {
+  return {
+    engine: 'MergeTree',
+    sortingKey: 'id',
+    partitionKey: '',
+    primaryKey: 'id',
+    createTableQuery: `CREATE TABLE ${partial.database}.${partial.table} (id UInt64) ENGINE = MergeTree ORDER BY id`,
+    columns: [{ name: 'id', type: 'UInt64', codec: '' }],
+    indexes: [],
+    projections: [],
+    ...partial,
+  }
+}
+
+describe('buildChangePlan', () => {
+  test('additive-only fixture produces only CREATE and ALTER ADD', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'new_tbl',
+          createTableQuery:
+            'CREATE TABLE app.new_tbl (`id` UInt64) ENGINE = MergeTree ORDER BY id',
+        }),
+        table({
+          database: 'app',
+          table: 'events',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'note', type: 'String', codec: '' },
+          ],
+          indexes: [
+            { name: 'idx_note', type: 'bloom_filter', expr: 'note', granularity: '1' },
+          ],
+        }),
+      ],
+    }
+    const target = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'events',
+          columns: [{ name: 'id', type: 'UInt64', codec: '' }],
+        }),
+      ],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    expect(plan.items.every((i) => i.kind !== 'manual')).toBe(true)
+    expect(plan.safeStatements.every((s) => /^(CREATE|ALTER TABLE .+ ADD )/i.test(s))).toBe(
+      true
+    )
+    expect(plan.safeStatements.some((s) => s.startsWith('CREATE TABLE'))).toBe(true)
+    expect(plan.safeStatements.some((s) => s.includes('ADD COLUMN'))).toBe(true)
+    expect(plan.safeStatements.some((s) => s.includes('ADD INDEX'))).toBe(true)
+    expect(plan.items.some((i) => /DROP/i.test(i.statement))).toBe(false)
+  })
+
+  test('engine or ORDER BY mismatch is flagged, not rewritten', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 't',
+          engine: 'ReplacingMergeTree',
+          sortingKey: 'id, ts',
+        }),
+      ],
+    }
+    const target = {
+      tables: [table({ database: 'app', table: 't', engine: 'MergeTree', sortingKey: 'id' })],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    const manuals = plan.items.filter((i) => i.kind === 'manual')
+    expect(manuals.length).toBeGreaterThanOrEqual(2)
+    expect(manuals.every((i) => i.risk === 'rewrite' && i.statement === '')).toBe(true)
+    expect(plan.safeStatements).toEqual([])
+    expect(plan.items.some((i) => /ENGINE\s*=/i.test(i.statement))).toBe(false)
+    expect(plan.items.some((i) => /MODIFY ORDER BY/i.test(i.statement))).toBe(false)
+  })
+
+  test('drop column is a manual note, never a DROP statement', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 't',
+          columns: [{ name: 'id', type: 'UInt64', codec: '' }],
+        }),
+      ],
+    }
+    const target = {
+      tables: [
+        table({
+          database: 'app',
+          table: 't',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'gone', type: 'String', codec: '' },
+          ],
+        }),
+      ],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    expect(plan.items).toHaveLength(1)
+    expect(plan.items[0].kind).toBe('manual')
+    expect(plan.items[0].statement).toBe('')
+    expect(plan.items[0].summary).toContain('gone')
+    expect(plan.safeStatements).toEqual([])
+  })
+
+  test('type change emits MODIFY COLUMN as mutation, not safe', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 't',
+          columns: [{ name: 'id', type: 'UInt128', codec: '' }],
+        }),
+      ],
+    }
+    const target = {
+      tables: [
+        table({
+          database: 'app',
+          table: 't',
+          columns: [{ name: 'id', type: 'UInt64', codec: '' }],
+        }),
+      ],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    expect(plan.items).toHaveLength(1)
+    expect(plan.items[0].kind).toBe('modify_column')
+    expect(plan.items[0].risk).toBe('mutation')
+    expect(plan.items[0].safe).toBe(false)
+    expect(plan.items[0].statement).toContain('MODIFY COLUMN')
+    expect(plan.safeStatements).toEqual([])
+  })
+})

--- a/apps/dashboard/src/lib/schema-diff/plan.ts
+++ b/apps/dashboard/src/lib/schema-diff/plan.ts
@@ -1,0 +1,238 @@
+import { tableKey } from './catalog'
+import type {
+  PlanItem,
+  SchemaChangePlan,
+  SchemaColumn,
+  SchemaDiffResult,
+  SchemaIndex,
+  SchemaProjection,
+  TableSchema,
+} from './types'
+
+function quoteIdent(name: string): string {
+  return `\`${name.replace(/`/g, '``')}\``
+}
+
+function qualifiedTable(table: TableSchema): string {
+  return `${quoteIdent(table.database)}.${quoteIdent(table.table)}`
+}
+
+function columnSuffix(col: SchemaColumn): string {
+  return col.codec ? ` ${col.codec}` : ''
+}
+
+function addColumnStatement(table: TableSchema, col: SchemaColumn): string {
+  return `ALTER TABLE ${qualifiedTable(table)} ADD COLUMN ${quoteIdent(col.name)} ${col.type}${columnSuffix(col)}`
+}
+
+function modifyColumnStatement(table: TableSchema, col: SchemaColumn): string {
+  return `ALTER TABLE ${qualifiedTable(table)} MODIFY COLUMN ${quoteIdent(col.name)} ${col.type}${columnSuffix(col)}`
+}
+
+function addIndexStatement(table: TableSchema, idx: SchemaIndex): string {
+  const gran = idx.granularity ? ` GRANULARITY ${idx.granularity}` : ''
+  return `ALTER TABLE ${qualifiedTable(table)} ADD INDEX ${quoteIdent(idx.name)} ${idx.expr} TYPE ${idx.type}${gran}`
+}
+
+function addProjectionStatement(
+  table: TableSchema,
+  proj: SchemaProjection
+): string | null {
+  if (!proj.query) return null
+  return `ALTER TABLE ${qualifiedTable(table)} ADD PROJECTION ${quoteIdent(proj.name)} (${proj.query})`
+}
+
+function mapByName<T extends { name: string }>(items: T[]): Map<string, T> {
+  return new Map(items.map((item) => [item.name, item]))
+}
+
+function planForMissingTable(source: TableSchema): PlanItem[] {
+  const statement = source.createTableQuery.trim()
+  return [
+    {
+      id: `create:${tableKey(source.database, source.table)}`,
+      tableKey: tableKey(source.database, source.table),
+      kind: 'create_table',
+      risk: 'lightweight',
+      statement,
+      summary: `Create ${tableKey(source.database, source.table)} on the target`,
+      safe: Boolean(statement),
+    },
+  ]
+}
+
+function planForChangedTable(source: TableSchema, target: TableSchema): PlanItem[] {
+  const items: PlanItem[] = []
+  const key = tableKey(source.database, source.table)
+
+  if (source.engine !== target.engine) {
+    items.push({
+      id: `engine:${key}`,
+      tableKey: key,
+      kind: 'manual',
+      risk: 'rewrite',
+      statement: '',
+      summary: `Engine differs (${target.engine || '∅'} → ${source.engine || '∅'}). Do not auto-rewrite; migrate manually.`,
+      safe: false,
+    })
+  }
+
+  if (source.sortingKey !== target.sortingKey) {
+    items.push({
+      id: `order:${key}`,
+      tableKey: key,
+      kind: 'manual',
+      risk: 'rewrite',
+      statement: '',
+      summary: `ORDER BY / sorting key differs. Do not auto-rewrite; rebuild the table manually.`,
+      safe: false,
+    })
+  }
+
+  if (source.primaryKey !== target.primaryKey) {
+    items.push({
+      id: `pk:${key}`,
+      tableKey: key,
+      kind: 'manual',
+      risk: 'rewrite',
+      statement: '',
+      summary: `Primary key differs. Rebuild the table manually.`,
+      safe: false,
+    })
+  }
+
+  if (source.partitionKey !== target.partitionKey) {
+    items.push({
+      id: `partition:${key}`,
+      tableKey: key,
+      kind: 'manual',
+      risk: 'rewrite',
+      statement: '',
+      summary: `Partition key differs. Rebuild the table manually.`,
+      safe: false,
+    })
+  }
+
+  const sourceCols = mapByName(source.columns)
+  const targetCols = mapByName(target.columns)
+
+  for (const [name, col] of sourceCols) {
+    const existing = targetCols.get(name)
+    if (!existing) {
+      items.push({
+        id: `add-col:${key}:${name}`,
+        tableKey: key,
+        kind: 'add_column',
+        risk: 'lightweight',
+        statement: addColumnStatement(source, col),
+        summary: `Add column ${name} (${col.type})`,
+        safe: true,
+      })
+      continue
+    }
+    if (col.type !== existing.type || col.codec !== existing.codec) {
+      items.push({
+        id: `mod-col:${key}:${name}`,
+        tableKey: key,
+        kind: 'modify_column',
+        risk: 'mutation',
+        statement: modifyColumnStatement(source, col),
+        summary: `Modify column ${name} (${existing.type} → ${col.type})`,
+        safe: false,
+      })
+    }
+  }
+
+  for (const [name] of targetCols) {
+    if (!sourceCols.has(name)) {
+      items.push({
+        id: `drop-col:${key}:${name}`,
+        tableKey: key,
+        kind: 'manual',
+        risk: 'rewrite',
+        statement: '',
+        summary: `Column ${name} exists only on the target. Dropping it is destructive — review manually.`,
+        safe: false,
+      })
+    }
+  }
+
+  const sourceIdx = mapByName(source.indexes)
+  const targetIdx = mapByName(target.indexes)
+  for (const [name, idx] of sourceIdx) {
+    if (!targetIdx.has(name)) {
+      items.push({
+        id: `add-idx:${key}:${name}`,
+        tableKey: key,
+        kind: 'add_index',
+        risk: 'mutation',
+        statement: addIndexStatement(source, idx),
+        summary: `Add index ${name}`,
+        safe: true,
+      })
+    }
+  }
+  for (const [name] of targetIdx) {
+    if (!sourceIdx.has(name)) {
+      items.push({
+        id: `drop-idx:${key}:${name}`,
+        tableKey: key,
+        kind: 'manual',
+        risk: 'rewrite',
+        statement: '',
+        summary: `Index ${name} exists only on the target. Dropping it is destructive — review manually.`,
+        safe: false,
+      })
+    }
+  }
+
+  const sourceProj = mapByName(source.projections)
+  const targetProj = mapByName(target.projections)
+  for (const [name, proj] of sourceProj) {
+    if (targetProj.has(name)) continue
+    const statement = addProjectionStatement(source, proj)
+    if (statement) {
+      items.push({
+        id: `add-proj:${key}:${name}`,
+        tableKey: key,
+        kind: 'add_projection',
+        risk: 'mutation',
+        statement,
+        summary: `Add projection ${name}`,
+        safe: true,
+      })
+    } else {
+      items.push({
+        id: `add-proj:${key}:${name}`,
+        tableKey: key,
+        kind: 'manual',
+        risk: 'rewrite',
+        statement: '',
+        summary: `Projection ${name} is missing on the target. Copy its definition from the source DDL.`,
+        safe: false,
+      })
+    }
+  }
+
+  return items
+}
+
+export function buildChangePlan(diff: SchemaDiffResult): SchemaChangePlan {
+  const items: PlanItem[] = []
+
+  for (const row of diff.onlySource) {
+    if (row.source) items.push(...planForMissingTable(row.source))
+  }
+
+  for (const row of diff.changed) {
+    if (row.source && row.target) {
+      items.push(...planForChangedTable(row.source, row.target))
+    }
+  }
+
+  const safeStatements = items
+    .filter((item) => item.safe && item.statement)
+    .map((item) => item.statement)
+
+  return { items, safeStatements }
+}

--- a/apps/dashboard/src/lib/schema-diff/types.ts
+++ b/apps/dashboard/src/lib/schema-diff/types.ts
@@ -1,0 +1,119 @@
+export type SchemaColumn = {
+  name: string
+  type: string
+  codec: string
+}
+
+export type SchemaIndex = {
+  name: string
+  type: string
+  expr: string
+  granularity: string
+}
+
+export type SchemaProjection = {
+  name: string
+  type: string
+  query: string
+}
+
+export type TableSchema = {
+  database: string
+  table: string
+  engine: string
+  sortingKey: string
+  partitionKey: string
+  primaryKey: string
+  createTableQuery: string
+  columns: SchemaColumn[]
+  indexes: SchemaIndex[]
+  projections: SchemaProjection[]
+}
+
+export type TableRow = {
+  database: string
+  table: string
+  engine: string
+  sorting_key: string
+  partition_key: string
+  primary_key: string
+  create_table_query: string
+}
+
+export type ColumnRow = {
+  database: string
+  table: string
+  name: string
+  type: string
+  codec: string
+}
+
+export type IndexRow = {
+  database: string
+  table: string
+  name: string
+  type: string
+  expr: string
+  granularity: string
+}
+
+export type ProjectionRow = {
+  database: string
+  table: string
+  name: string
+  type: string
+  query: string
+}
+
+export type SchemaCatalog = {
+  tables: TableSchema[]
+}
+
+export type TableDiffKind = 'only_source' | 'only_target' | 'changed' | 'identical'
+
+export type FieldChange = {
+  field: string
+  source: string
+  target: string
+}
+
+export type TableDiff = {
+  key: string
+  kind: TableDiffKind
+  source?: TableSchema
+  target?: TableSchema
+  changes: FieldChange[]
+}
+
+export type SchemaDiffResult = {
+  onlySource: TableDiff[]
+  onlyTarget: TableDiff[]
+  changed: TableDiff[]
+  identical: TableDiff[]
+}
+
+export type PlanRisk = 'lightweight' | 'mutation' | 'rewrite'
+
+export type PlanItemKind =
+  | 'create_table'
+  | 'add_column'
+  | 'modify_column'
+  | 'add_index'
+  | 'add_projection'
+  | 'manual'
+
+export type PlanItem = {
+  id: string
+  tableKey: string
+  kind: PlanItemKind
+  risk: PlanRisk
+  /** Recommended statement, or empty when the item is a manual note. */
+  statement: string
+  summary: string
+  safe: boolean
+}
+
+export type SchemaChangePlan = {
+  items: PlanItem[]
+  safeStatements: string[]
+}

--- a/apps/dashboard/src/menu/system.ts
+++ b/apps/dashboard/src/menu/system.ts
@@ -59,6 +59,16 @@ export const systemItems: MenuItem[] = [
         permission: { feature: 'settings' },
       },
       {
+        title: 'Schema Compare',
+        href: '/schema-diff',
+        description:
+          'Compare table schemas across hosts and copy a recommend-only change plan',
+        icon: GitCompareArrowsIcon,
+        isNew: true,
+        permission: { feature: 'settings' },
+        tableCheck: 'system.tables',
+      },
+      {
         title: 'Disks',
         href: '/disks',
         description: 'Storage disk configuration and usage',

--- a/apps/dashboard/src/routes/(dashboard)/schema-diff.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/schema-diff.tsx
@@ -1,0 +1,408 @@
+/**
+ * Schema Compare
+ * Route: /(dashboard)/schema-diff
+ *
+ * Read-only table-schema compare + recommend-only change plan.
+ * Copy statements only — never apply DDL.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { createFileRoute, useNavigate, useSearch } from '@tanstack/react-router'
+import { CopyIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import {
+  CodeBlock,
+  CodeBlockCopyButton,
+} from '@/components/ai-elements/code-block'
+import { PageHeader } from '@/components/layout/page-header'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { pageOgHead } from '@/lib/og'
+import type { PlanItem, SchemaDiffResult, TableDiff } from '@/lib/schema-diff'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { useHostId } from '@/lib/swr/use-host'
+import { buildUrl } from '@/lib/url/url-builder'
+import { copyToClipboard } from '@/lib/utils/clipboard'
+
+type HostInfo = { id: number; name: string }
+
+type SchemaDiffResponse = {
+  success: boolean
+  hosts: HostInfo[]
+  sourceHostId: number | null
+  targetHostId: number | null
+  diff: SchemaDiffResult
+  plan: { items: PlanItem[]; safeStatements: string[] }
+  error?: string
+  unavailable?: { reason: string; message: string }
+}
+
+async function fetchSchemaDiff(
+  source?: number,
+  target?: number
+): Promise<SchemaDiffResponse> {
+  const params = new URLSearchParams()
+  if (source !== undefined) params.set('source', String(source))
+  if (target !== undefined) params.set('target', String(target))
+  const qs = params.toString()
+  const res = await apiFetch(`/api/v1/schema-diff${qs ? `?${qs}` : ''}`)
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(
+      (body as { error?: string }).error ??
+        `Request failed (${res.status} ${res.statusText})`
+    )
+  }
+  return res.json()
+}
+
+function riskLabel(risk: PlanItem['risk']): string {
+  if (risk === 'lightweight') return 'Lightweight'
+  if (risk === 'mutation') return 'Mutation'
+  return 'Manual rewrite'
+}
+
+function SchemaDiffPage() {
+  const hostId = useHostId()
+  const navigate = useNavigate()
+  const search = useSearch({ strict: false }) as {
+    host?: number
+    source?: number
+    target?: number
+  }
+
+  const sourceParam = Number.isFinite(search.source) ? search.source : undefined
+  const targetParam = Number.isFinite(search.target) ? search.target : undefined
+
+  const [showDiffsOnly, setShowDiffsOnly] = useState(true)
+  const [nameFilter, setNameFilter] = useState('')
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [copiedSafe, setCopiedSafe] = useState(false)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['schema-diff', sourceParam, targetParam],
+    queryFn: () => fetchSchemaDiff(sourceParam, targetParam),
+    staleTime: 60_000,
+  })
+
+  const hosts = data?.hosts ?? []
+
+  const setPair = (source: number, target: number) => {
+    navigate({
+      href: buildUrl(
+        '/schema-diff',
+        { host: search.host ?? hostId, source, target },
+        undefined
+      ),
+      replace: true,
+    })
+  }
+
+  const rows: TableDiff[] = useMemo(() => {
+    if (!data?.diff) return []
+    const all = [
+      ...data.diff.onlySource,
+      ...data.diff.onlyTarget,
+      ...data.diff.changed,
+      ...(showDiffsOnly ? [] : data.diff.identical),
+    ]
+    if (!nameFilter) return all
+    const q = nameFilter.toLowerCase()
+    return all.filter((row) => row.key.toLowerCase().includes(q))
+  }, [data, nameFilter, showDiffsOnly])
+
+  const selected = rows.find((r) => r.key === selectedKey) ?? rows[0] ?? null
+  const selectedPlan = (data?.plan.items ?? []).filter(
+    (item) => item.tableKey === selected?.key
+  )
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title="Schema Compare"
+          description="Compare table schemas across hosts. Recommend only — copy statements, never apply."
+        />
+        <EmptyState variant="loading" compact />
+      </div>
+    )
+  }
+
+  if (error || !data?.success) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : (data?.error ?? 'Failed to load schema diff')
+    return (
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title="Schema Compare"
+          description="Compare table schemas across hosts. Recommend only — copy statements, never apply."
+        />
+        <EmptyState variant="error" title="Failed to load schema diff" description={message} />
+      </div>
+    )
+  }
+
+  if (hosts.length < 2) {
+    return (
+      <div className="flex flex-col gap-4">
+        <PageHeader
+          title="Schema Compare"
+          description="Compare table schemas across hosts. Recommend only — copy statements, never apply."
+        />
+        <EmptyState
+          variant="no-data"
+          title="Need at least two hosts"
+          description={
+            data.unavailable?.message ??
+            'Schema compare needs two configured ClickHouse hosts (for example staging and production).'
+          }
+        />
+      </div>
+    )
+  }
+
+  const sourceHostId = data.sourceHostId ?? hosts[0].id
+  const targetHostId = data.targetHostId ?? hosts[1].id
+  const sourceHost = hosts.find((h) => h.id === sourceHostId)
+  const targetHost = hosts.find((h) => h.id === targetHostId)
+  const diffCount =
+    data.diff.onlySource.length +
+    data.diff.onlyTarget.length +
+    data.diff.changed.length
+
+  const copySafe = async () => {
+    const text = data.plan.safeStatements.join(';\n\n')
+    if (!text) return
+    await copyToClipboard(text)
+    setCopiedSafe(true)
+    window.setTimeout(() => setCopiedSafe(false), 1500)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Schema Compare"
+        description={`Comparing ${sourceHost?.name ?? sourceHostId} → ${targetHost?.name ?? targetHostId} — ${diffCount} table${diffCount !== 1 ? 's' : ''} differ. Recommend only; copy statements, never apply.`}
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={copySafe}
+            disabled={data.plan.safeStatements.length === 0}
+          >
+            <CopyIcon className="mr-2 size-3.5" strokeWidth={1.5} />
+            {copiedSafe ? 'Copied' : 'Copy safe statements'}
+          </Button>
+        }
+      />
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <label className="flex items-center gap-2 text-[13px]">
+          <span className="text-muted-foreground">Source</span>
+          <select
+            className="h-8 rounded-md border border-border bg-background px-2 text-[13px]"
+            value={sourceHostId}
+            onChange={(e) => {
+              const next = Number(e.target.value)
+              const nextTarget = next === targetHostId ? sourceHostId : targetHostId
+              setPair(next, nextTarget)
+            }}
+          >
+            {hosts.map((h) => (
+              <option key={h.id} value={h.id}>
+                {h.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-[13px]">
+          <span className="text-muted-foreground">Target</span>
+          <select
+            className="h-8 rounded-md border border-border bg-background px-2 text-[13px]"
+            value={targetHostId}
+            onChange={(e) => {
+              const next = Number(e.target.value)
+              const nextSource = next === sourceHostId ? targetHostId : sourceHostId
+              setPair(nextSource, next)
+            }}
+          >
+            {hosts.map((h) => (
+              <option key={h.id} value={h.id}>
+                {h.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <Input
+          placeholder="Filter tables…"
+          value={nameFilter}
+          onChange={(e) => setNameFilter(e.target.value)}
+          className="h-8 w-full sm:w-64"
+        />
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <Switch checked={showDiffsOnly} onCheckedChange={setShowDiffsOnly} />
+          Differences only
+        </label>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
+        <Card className="rounded-xl border bg-card shadow-sm">
+          <CardContent className="p-0">
+            <ul className="divide-y divide-border">
+              {rows.length === 0 ? (
+                <li className="p-4">
+                  <EmptyState
+                    variant="filtered-empty"
+                    compact
+                    title="No tables match"
+                    description="Try a different filter or turn off differences only."
+                  />
+                </li>
+              ) : (
+                rows.map((row) => (
+                  <li key={row.key}>
+                    <button
+                      type="button"
+                      className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] hover:bg-muted ${
+                        selected?.key === row.key ? 'bg-muted' : ''
+                      }`}
+                      onClick={() => setSelectedKey(row.key)}
+                    >
+                      <span className="font-mono truncate">{row.key}</span>
+                      <Badge variant="outline" className="shrink-0 text-muted-foreground">
+                        {row.kind === 'only_source'
+                          ? 'source only'
+                          : row.kind === 'only_target'
+                            ? 'target only'
+                            : row.kind === 'changed'
+                              ? 'changed'
+                              : 'same'}
+                      </Badge>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <div className="flex flex-col gap-4">
+          {selected ? (
+            <>
+              <div className="grid gap-3 md:grid-cols-2">
+                <Card className="rounded-xl border bg-card shadow-sm">
+                  <CardContent className="p-4">
+                    <p className="mb-2 text-xs text-muted-foreground">
+                      Source DDL
+                    </p>
+                    {selected.source?.createTableQuery ? (
+                      <CodeBlock
+                        code={selected.source.createTableQuery}
+                        language="sql"
+                      >
+                        <CodeBlockCopyButton />
+                      </CodeBlock>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        Not on source
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+                <Card className="rounded-xl border bg-card shadow-sm">
+                  <CardContent className="p-4">
+                    <p className="mb-2 text-xs text-muted-foreground">
+                      Target DDL
+                    </p>
+                    {selected.target?.createTableQuery ? (
+                      <CodeBlock
+                        code={selected.target.createTableQuery}
+                        language="sql"
+                      >
+                        <CodeBlockCopyButton />
+                      </CodeBlock>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        Not on target
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+
+              <Card className="rounded-xl border bg-card shadow-sm">
+                <CardContent className="p-4">
+                  <h2 className="mb-3 text-sm font-medium text-foreground">
+                    Recommended change plan
+                  </h2>
+                  {selectedPlan.length === 0 ? (
+                    <EmptyState
+                      variant="no-data"
+                      compact
+                      title="No recommended statements"
+                      description="This table matches, or every delta is a manual rewrite."
+                    />
+                  ) : (
+                    <ul className="flex flex-col gap-2">
+                      {selectedPlan.map((item) => (
+                        <li
+                          key={item.id}
+                          className="rounded-md border border-border p-3"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div>
+                              <p className="text-sm">{item.summary}</p>
+                              <p className="mt-0.5 text-xs text-muted-foreground">
+                                {riskLabel(item.risk)}
+                                {item.safe ? ' · safe to copy' : ''}
+                              </p>
+                            </div>
+                            {item.statement ? (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-8 shrink-0"
+                                onClick={() => copyToClipboard(item.statement)}
+                              >
+                                <CopyIcon className="size-3.5" strokeWidth={1.5} />
+                                Copy
+                              </Button>
+                            ) : null}
+                          </div>
+                          {item.statement ? (
+                            <pre className="mt-2 overflow-x-auto font-mono text-xs text-muted-foreground">
+                              {item.statement}
+                            </pre>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
+            </>
+          ) : (
+            <EmptyState
+              variant="no-data"
+              title="Select a table"
+              description="Pick a table on the left to see side-by-side DDL and a copyable plan."
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/schema-diff')({
+  component: SchemaDiffPage,
+  head: () => pageOgHead('schema-diff'),
+  validateSearch: (search: Record<string, unknown>) => search,
+})

--- a/apps/dashboard/src/routes/api/v1/schema-diff.ts
+++ b/apps/dashboard/src/routes/api/v1/schema-diff.ts
@@ -1,0 +1,206 @@
+/**
+ * Schema Diff API
+ * GET /api/v1/schema-diff?source=0&target=1
+ *
+ * Read-only catalog compare between two env-configured hosts.
+ * Never executes DDL.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { fetchData } from '@chm/clickhouse-client'
+import { getClickHouseConfigsFromEnv } from '@/lib/api/clickhouse-config'
+import { bridgeClickHouseEnv } from '@/lib/api/server-env'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
+import {
+  assembleCatalog,
+  buildChangePlan,
+  compareCatalogs,
+  type ColumnRow,
+  type IndexRow,
+  type ProjectionRow,
+  type TableRow,
+} from '@/lib/schema-diff'
+
+const USER_DB_FILTER = `database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')`
+
+const TABLES_QUERY = `
+  SELECT
+    database,
+    name AS table,
+    engine,
+    sorting_key,
+    partition_key,
+    primary_key,
+    create_table_query
+  FROM system.tables
+  WHERE ${USER_DB_FILTER}
+  ORDER BY database, name
+`
+
+const COLUMNS_QUERY = `
+  SELECT
+    database,
+    table,
+    name,
+    type,
+    ifNull(compression_codec, '') AS codec
+  FROM system.columns
+  WHERE ${USER_DB_FILTER}
+  ORDER BY database, table, position
+`
+
+const INDEXES_QUERY = `
+  SELECT
+    database,
+    table,
+    name,
+    type,
+    expr,
+    toString(granularity) AS granularity
+  FROM system.data_skipping_indices
+  WHERE ${USER_DB_FILTER}
+  ORDER BY database, table, name
+`
+
+const PROJECTIONS_QUERY = `
+  SELECT
+    database,
+    table,
+    name,
+    type,
+    ifNull(query, '') AS query
+  FROM system.projections
+  WHERE ${USER_DB_FILTER}
+  ORDER BY database, table, name
+`
+
+async function queryRows<T>(hostId: number, query: string): Promise<T[]> {
+  const result = await fetchData<T[]>({
+    query,
+    hostId,
+    format: 'JSONEachRow',
+  })
+  if (result.error || !result.data) return []
+  return result.data
+}
+
+async function loadCatalog(hostId: number) {
+  const [tables, columns, indexes, projections] = await Promise.all([
+    queryRows<TableRow>(hostId, TABLES_QUERY),
+    queryRows<ColumnRow>(hostId, COLUMNS_QUERY),
+    queryRows<IndexRow>(hostId, INDEXES_QUERY).catch(() => [] as IndexRow[]),
+    queryRows<ProjectionRow>(hostId, PROJECTIONS_QUERY).catch(
+      () => [] as ProjectionRow[]
+    ),
+  ])
+  return assembleCatalog(tables, columns, indexes, projections)
+}
+
+function parseHostId(raw: string | null): number | null {
+  if (raw === null || raw === '') return null
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) ? n : null
+}
+
+export const Route = createFileRoute('/api/v1/schema-diff')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        bridgeClickHouseEnv(env as Record<string, string | undefined>)
+
+        const configs = getClickHouseConfigsFromEnv(
+          env as Record<string, string | undefined>
+        )
+
+        if (configs.length === 0) {
+          return Response.json(
+            { success: false, error: 'No ClickHouse hosts configured' },
+            { status: 503 }
+          )
+        }
+
+        if (
+          await isDemoHostBlockedForRequest(
+            0,
+            env as Record<string, string | undefined>
+          )
+        ) {
+          return Response.json({
+            success: true,
+            hosts: [],
+            sourceHostId: null,
+            targetHostId: null,
+            diff: {
+              onlySource: [],
+              onlyTarget: [],
+              changed: [],
+              identical: [],
+            },
+            plan: { items: [], safeStatements: [] },
+            unavailable: demoHiddenUnavailable(),
+          })
+        }
+
+        const hosts = configs.map((c) => ({
+          id: c.id,
+          name: c.customName ?? c.host,
+        }))
+
+        if (hosts.length < 2) {
+          return Response.json({
+            success: true,
+            hosts,
+            sourceHostId: hosts[0]?.id ?? null,
+            targetHostId: null,
+            diff: {
+              onlySource: [],
+              onlyTarget: [],
+              changed: [],
+              identical: [],
+            },
+            plan: { items: [], safeStatements: [] },
+          })
+        }
+
+        const searchParams = new URL(request.url).searchParams
+        const requestedSource = parseHostId(searchParams.get('source'))
+        const requestedTarget = parseHostId(searchParams.get('target'))
+
+        const ids = new Set(hosts.map((h) => h.id))
+        const sourceHostId =
+          requestedSource !== null && ids.has(requestedSource)
+            ? requestedSource
+            : hosts[0].id
+        const fallbackTarget = hosts.find((h) => h.id !== sourceHostId)!.id
+        const targetHostId =
+          requestedTarget !== null &&
+          ids.has(requestedTarget) &&
+          requestedTarget !== sourceHostId
+            ? requestedTarget
+            : fallbackTarget
+
+        const [sourceCatalog, targetCatalog] = await Promise.all([
+          loadCatalog(sourceHostId),
+          loadCatalog(targetHostId),
+        ])
+
+        const diff = compareCatalogs(sourceCatalog, targetCatalog)
+        const plan = buildChangePlan(diff)
+
+        return Response.json({
+          success: true,
+          hosts,
+          sourceHostId,
+          targetHostId,
+          diff,
+          plan,
+        })
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Read-only schema compare across configured hosts (`/schema-diff`, `GET /api/v1/schema-diff`) plus a recommend-only change plan. Copy CREATE / ALTER ADD statements; never apply DDL.

- Missing table, extra column, and type change land in the right buckets
- Single-host / demo-hidden: empty state, no compare
- Engine / ORDER BY / drop column are manual rewrite notes, not generated DROP/rebuild SQL

Closes #3072
Closes #3073

## Test plan

- [x] Unit tests for catalog assemble, compare buckets, additive-only plan, rewrite flags
- [ ] Required CI: `unit-tests`, `dashboard`