### PR TITLE
feat(dashboard): role workspace presets in Settings

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -247,20 +247,25 @@ second settings store — always `SettingsDialog` + `useUserSettings`.
 
 The Settings dialog (`components/settings/settings-form.tsx`) exposes units
 (`byteUnit`, `numberFormat`), chart palette (`chartPalette`), table density
-(`tableDensity`) and default time range on `UserSettings`. Header is Settings
+(`tableDensity`), default time range, and workspace preset
+(`workspacePreset`, `hiddenMenuHrefs`) on `UserSettings`. Header is Settings
 icon + title + one-line "Local to this browser"; surface is
 `rounded-xl border bg-card p-0` with a **stable height** (`h-[min(36rem,85vh)]`)
 and `select-text` so labels copy. Left rail is a flat column (no boxed
 tab well): section labels + icon rows, selected = muted pill, `border-r`
 divider. Content pane shows the active tab title. Theme (Light / Dark /
 System) is a settings row (label left, three window thumbnails right)
-on Appearance only. Navigation uses the same row + two
-window-style demos (Dim / Hide) for unavailable menu pages.
+on Appearance only. Navigation leads with a `SegmentedControl` workspace
+preset (Full / DBA / Engineer / SRE / Custom) plus a searchable hide
+picker — never a 40-checkbox wall — then the Dim / Hide unavailable-page
+demos. Hidden pages stay routable. Filter through
+`getVisibleMenuItems` so sidebar and ⌘K match.
 Timezone uses `timezone-combobox.tsx`
 (search + browser zone on top). Palette is a card picker with mini bars, not
 a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
-Every DEFAULT reproduces the prior look byte-for-byte. Applied by
+Every DEFAULT reproduces the prior look byte-for-byte (`workspacePreset:
+'full'`). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
 `data-chart-palette` / `data-density` on `<html>`. For 2–3 choices use

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -19,8 +19,10 @@ import { GUEST_USER } from '@/lib/clerk/guest-user'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { isMenuItemActive } from '@/lib/menu/breadcrumb'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
+import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
 
 export function AppSidebar() {
   const { config } = useFeaturePermissions()
@@ -28,7 +30,12 @@ export function AppSidebar() {
   // resolved in one place — see lib/menu/visible-items.ts. The active engine
   // swaps the menu to Postgres pages when a Postgres source is selected (#2450).
   const engine = useActiveHostEngine()
-  const menuItems = getVisibleMenuItems(config, engine)
+  const { settings } = useUserSettings()
+  const menuItems = getVisibleMenuItems(
+    config,
+    engine,
+    workspaceFromSettings(settings)
+  )
   // Footer nav rows (Billing / Organization / About). Same visibility pipeline
   // as the body, so cloud-only + permission + engine gating still applies; they
   // render as compact rows in the footer instead of a labelled body group.

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -21,8 +21,10 @@ import { useFavoriteHrefs } from '@/hooks/use-favorites'
 import { useUrlSearchParams } from '@/hooks/use-url-search-params'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
 import { getVisibleMenuItems } from '@/lib/menu/visible-items'
+import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl, splitHref } from '@/lib/url/url-builder'
@@ -65,7 +67,12 @@ export const CommandPalette = function CommandPalette({
 
   const { config } = useFeaturePermissions()
   const engine = useActiveHostEngine()
-  const menuItems = getVisibleMenuItems(config, engine)
+  const { settings } = useUserSettings()
+  const menuItems = getVisibleMenuItems(
+    config,
+    engine,
+    workspaceFromSettings(settings)
+  )
   const favoriteHrefs = useFavoriteHrefs()
   const favoriteMenuItems = getFavoriteMenuItems(menuItems, favoriteHrefs)
   const { setTheme, resolvedTheme } = useTheme()

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -24,6 +24,7 @@ import type { SegmentedOption } from './segmented-control'
 
 import { SegmentedControl } from './segmented-control'
 import { TimezoneCombobox } from './timezone-combobox'
+import { WorkspacePresetPicker } from './workspace-preset-picker'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -723,6 +724,18 @@ export function SettingsForm({
 
             {/* Navigation */}
             <TabsContent value="navigation" className="space-y-4 px-1 pb-2">
+              <Field
+                label="Workspace"
+                icon={LayoutGrid}
+                description="Slim the sidebar and command palette to a role. Hidden pages stay reachable by URL."
+              >
+                <WorkspacePresetPicker
+                  preset={settings.workspacePreset}
+                  hiddenMenuHrefs={settings.hiddenMenuHrefs}
+                  onChange={(next) => onUpdate(next)}
+                />
+              </Field>
+
               <div className="space-y-2">
                 <SettingsRow label="Unavailable pages">
                   <UnavailablePagesPicker

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -1,0 +1,221 @@
+import { Search } from 'lucide-react'
+import { menuItemsConfig } from '@/menu'
+
+import type { WorkspacePreset } from '@/lib/types/user-settings'
+
+import { SegmentedControl } from './segmented-control'
+import { useMemo, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  collectMenuLeaves,
+  hrefsOutsidePresetGroups,
+  PRESET_GROUP_TITLES,
+} from '@/lib/menu/workspace-presets'
+import { cn } from '@/lib/utils'
+
+const PRESET_OPTIONS: {
+  value: WorkspacePreset
+  label: string
+}[] = [
+  { value: 'full', label: 'Full' },
+  { value: 'dba', label: 'DBA' },
+  { value: 'engineer', label: 'Engineer' },
+  { value: 'sre', label: 'SRE' },
+  { value: 'custom', label: 'Custom' },
+]
+
+const PRESET_HINT: Record<WorkspacePreset, string> = {
+  full: 'Every page the host and deployment already allow. New pages stay visible.',
+  dba: 'Tables, queries, merges, replication, disks, cluster, keeper, security.',
+  engineer:
+    'Overview, queries, SQL/explorer, insights. Less keeper, security, and ops.',
+  sre: 'Overview, health, insights, replication, disks, errors, running queries.',
+  custom:
+    'Starts from a preset. Hide extra pages without a full checkbox wall.',
+}
+
+interface WorkspacePresetPickerProps {
+  preset: WorkspacePreset
+  hiddenMenuHrefs: string[]
+  onChange: (next: {
+    workspacePreset: WorkspacePreset
+    hiddenMenuHrefs: string[]
+  }) => void
+}
+
+export function WorkspacePresetPicker({
+  preset,
+  hiddenMenuHrefs,
+  onChange,
+}: WorkspacePresetPickerProps) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const leaves = useMemo(() => collectMenuLeaves(menuItemsConfig), [])
+  const hiddenSet = useMemo(() => new Set(hiddenMenuHrefs), [hiddenMenuHrefs])
+
+  const applyPreset = (next: WorkspacePreset) => {
+    if (next === 'full') {
+      onChange({ workspacePreset: 'full', hiddenMenuHrefs: [] })
+      return
+    }
+    if (next === 'custom') {
+      if (preset !== 'full' && preset !== 'custom') {
+        onChange({
+          workspacePreset: 'custom',
+          hiddenMenuHrefs: hrefsOutsidePresetGroups(
+            menuItemsConfig,
+            PRESET_GROUP_TITLES[preset]
+          ),
+        })
+        return
+      }
+      onChange({ workspacePreset: 'custom', hiddenMenuHrefs })
+      return
+    }
+    onChange({ workspacePreset: next, hiddenMenuHrefs: [] })
+  }
+
+  const hideHref = (href: string) => {
+    const base =
+      preset === 'full'
+        ? []
+        : preset === 'custom'
+          ? hiddenMenuHrefs
+          : hrefsOutsidePresetGroups(
+              menuItemsConfig,
+              PRESET_GROUP_TITLES[preset]
+            )
+    if (base.includes(href)) {
+      onChange({ workspacePreset: 'custom', hiddenMenuHrefs: base })
+      return
+    }
+    onChange({
+      workspacePreset: 'custom',
+      hiddenMenuHrefs: [...base, href],
+    })
+  }
+
+  const showHref = (href: string) => {
+    const next = hiddenMenuHrefs.filter((item) => item !== href)
+    onChange({ workspacePreset: 'custom', hiddenMenuHrefs: next })
+  }
+
+  const filteredLeaves = leaves.filter((leaf) => {
+    if (!query.trim()) return true
+    const q = query.toLowerCase()
+    return (
+      leaf.title.toLowerCase().includes(q) ||
+      leaf.group.toLowerCase().includes(q) ||
+      leaf.href.toLowerCase().includes(q)
+    )
+  })
+
+  const hiddenLeaves = leaves.filter((leaf) => hiddenSet.has(leaf.href))
+
+  return (
+    <div className="space-y-3">
+      <SegmentedControl
+        ariaLabel="Workspace preset"
+        value={preset}
+        onChange={applyPreset}
+        options={PRESET_OPTIONS}
+      />
+      <WorkspacePreview preset={preset} />
+      <p className="text-xs text-muted-foreground">{PRESET_HINT[preset]}</p>
+
+      {hiddenLeaves.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {hiddenLeaves.length} extra page
+          {hiddenLeaves.length === 1 ? '' : 's'} hidden. Search to restore one.
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 text-xs"
+        onClick={() => setPickerOpen((open) => !open)}
+      >
+        {pickerOpen ? 'Close page list' : 'Hide pages…'}
+      </Button>
+
+      {pickerOpen && (
+        <div className="space-y-2 rounded-lg border border-border p-2">
+          <div className="relative">
+            <Search
+              className="pointer-events-none absolute top-2.5 left-2.5 size-3.5 text-muted-foreground"
+              aria-hidden
+            />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search pages"
+              className="h-8 pl-8 text-[13px]"
+            />
+          </div>
+          <ul className="max-h-48 space-y-0.5 overflow-y-auto">
+            {filteredLeaves.map((leaf) => {
+              const hidden = hiddenSet.has(leaf.href)
+              return (
+                <li key={leaf.href}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      hidden ? showHref(leaf.href) : hideHref(leaf.href)
+                    }
+                    className={cn(
+                      'flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-muted',
+                      hidden && 'text-muted-foreground'
+                    )}
+                  >
+                    <span>
+                      {leaf.title}
+                      <span className="ml-1.5 text-[11px] text-muted-foreground">
+                        {leaf.group}
+                      </span>
+                    </span>
+                    <span className="text-[11px]">
+                      {hidden ? 'Show' : 'Hide'}
+                    </span>
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function WorkspacePreview({ preset }: { preset: WorkspacePreset }) {
+  const rows =
+    preset === 'dba'
+      ? ['Queries', 'Tables', 'Keeper']
+      : preset === 'engineer'
+        ? ['Overview', 'Queries', 'Insights']
+        : preset === 'sre'
+          ? ['Health', 'Insights', 'Errors']
+          : preset === 'custom'
+            ? ['Overview', 'Queries']
+            : ['Overview', 'Queries', 'Tables', 'Keeper']
+
+  return (
+    <div
+      className="flex h-[72px] w-full max-w-[180px] flex-col gap-1 overflow-hidden rounded-lg bg-zinc-100 p-1.5 ring-1 ring-black/10 dark:bg-zinc-900 dark:ring-white/10"
+      aria-hidden="true"
+    >
+      {rows.map((row) => (
+        <div
+          key={row}
+          className="h-3 rounded-sm bg-foreground/15 px-1 text-[9px] leading-3 text-foreground/70"
+        >
+          {row}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -7,6 +7,10 @@ import {
   filterCloudOnly,
   filterMenuItemsByEngine,
 } from '@/lib/menu/visible-items'
+import {
+  applyWorkspaceVisibility,
+  PRESET_GROUP_TITLES,
+} from '@/lib/menu/workspace-presets'
 
 const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
   title: overrides.title ?? 'Item',
@@ -224,5 +228,123 @@ describe('filterMenuItemsByEngine', () => {
     // ClickHouse-only top-level items must not appear.
     expect(pgTitles).not.toContain('Overview')
     expect(pgTitles).not.toContain('Health')
+  })
+})
+
+describe('applyWorkspaceVisibility', () => {
+  const fixture: MenuItem[] = [
+    leaf({ title: 'Overview', href: '/overview' }),
+    {
+      title: 'Queries',
+      href: '',
+      items: [
+        leaf({ title: 'Running', href: '/running-queries' }),
+        leaf({ title: 'Advisor', href: '/advisor' }),
+      ],
+    },
+    {
+      title: 'Keeper',
+      href: '',
+      items: [leaf({ title: 'Keeper Info', href: '/keeper/info' })],
+    },
+    {
+      title: 'Health',
+      href: '',
+      items: [leaf({ title: 'Health', href: '/health' })],
+    },
+    leaf({ title: 'About', href: '/about', section: 'footer' }),
+  ]
+
+  test('Full keeps every item and applies an extra hide list', () => {
+    const full = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'full',
+      hiddenMenuHrefs: [],
+    })
+    expect(full.map((i) => i.title)).toEqual([
+      'Overview',
+      'Queries',
+      'Keeper',
+      'Health',
+      'About',
+    ])
+
+    const hidden = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'full',
+      hiddenMenuHrefs: ['/advisor'],
+    })
+    expect(
+      hidden.find((i) => i.title === 'Queries')?.items?.map((i) => i.href)
+    ).toEqual(['/running-queries'])
+  })
+
+  test('named presets keep a stable group set and never drop the footer', () => {
+    const dba = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'dba',
+      hiddenMenuHrefs: [],
+    })
+    expect(dba.map((i) => i.title)).toEqual([
+      'Overview',
+      'Queries',
+      'Keeper',
+      'About',
+    ])
+
+    const engineer = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'engineer',
+      hiddenMenuHrefs: [],
+    })
+    expect(engineer.map((i) => i.title)).toEqual([
+      'Overview',
+      'Queries',
+      'About',
+    ])
+
+    const sre = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'sre',
+      hiddenMenuHrefs: [],
+    })
+    expect(sre.map((i) => i.title)).toEqual([
+      'Overview',
+      'Queries',
+      'Health',
+      'About',
+    ])
+  })
+
+  test('custom hide-list drops a parent left empty', () => {
+    const result = applyWorkspaceVisibility(fixture, {
+      workspacePreset: 'custom',
+      hiddenMenuHrefs: ['/keeper/info'],
+    })
+    expect(result.map((i) => i.title)).not.toContain('Keeper')
+    expect(result.map((i) => i.title)).toContain('About')
+  })
+
+  test('new fixture groups stay hidden on a named preset and appear on Full', () => {
+    const withNewGroup: MenuItem[] = [
+      ...fixture,
+      {
+        title: 'Brand New',
+        href: '',
+        items: [leaf({ title: 'TTL', href: '/ttl' })],
+      },
+    ]
+    const dba = applyWorkspaceVisibility(withNewGroup, {
+      workspacePreset: 'dba',
+      hiddenMenuHrefs: [],
+    })
+    expect(dba.map((i) => i.title)).not.toContain('Brand New')
+
+    const full = applyWorkspaceVisibility(withNewGroup, {
+      workspacePreset: 'full',
+      hiddenMenuHrefs: [],
+    })
+    expect(full.map((i) => i.title)).toContain('Brand New')
+  })
+
+  test('DBA preset group titles stay the documented set', () => {
+    expect(PRESET_GROUP_TITLES.dba).toContain('Tables')
+    expect(PRESET_GROUP_TITLES.engineer).not.toContain('Keeper')
+    expect(PRESET_GROUP_TITLES.sre).toContain('Health')
   })
 })

--- a/apps/dashboard/src/lib/menu/visible-items.ts
+++ b/apps/dashboard/src/lib/menu/visible-items.ts
@@ -18,6 +18,10 @@ import type { PublicFeaturePermissionConfig } from '@/lib/feature-permissions/ty
 
 import { isCloudModeClient } from '@/lib/cloud/cloud-mode'
 import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
+import {
+  applyWorkspaceVisibility,
+  type WorkspaceVisibility,
+} from '@/lib/menu/workspace-presets'
 
 /**
  * Drop `cloudOnly` items (and any parent left empty by their removal) when the
@@ -80,20 +84,25 @@ export function filterMenuItemsByEngine(
 
 /**
  * The single source of truth for what a CLIENT nav surface may render:
- * `menuItemsConfig` with feature-permission, cloud-only, and engine gates
- * applied. `isCloudModeClient()` is resolved at build time, so this is cheap and
- * stable across renders.
+ * `menuItemsConfig` with feature-permission, cloud-only, engine, and
+ * workspace-preset gates applied. `isCloudModeClient()` is resolved at build
+ * time, so this is cheap and stable across renders.
  *
  * `engine` is the ACTIVE host's source engine (defaults to `'clickhouse'`), so
  * a caller that doesn't thread it — and every ClickHouse host — sees exactly
- * today's menu.
+ * today's menu when the workspace is Full.
+ *
+ * Workspace filtering is last and never replaces the deployment gates.
  */
 export function getVisibleMenuItems(
   config: PublicFeaturePermissionConfig,
-  engine: SourceEngine = 'clickhouse'
+  engine: SourceEngine = 'clickhouse',
+  workspace?: WorkspaceVisibility
 ): MenuItem[] {
   const cloudMode = isCloudModeClient()
   const byPermission = filterMenuItemsByPermissions(menuItemsConfig, config)
   const byCloud = filterCloudOnly(byPermission, cloudMode)
-  return filterMenuItemsByEngine(byCloud, engine)
+  const byEngine = filterMenuItemsByEngine(byCloud, engine)
+  if (!workspace) return byEngine
+  return applyWorkspaceVisibility(byEngine, workspace)
 }

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -1,0 +1,184 @@
+import type { MenuItem } from '@/components/menu/types'
+import type { WorkspacePreset } from '@/lib/types/user-settings'
+
+import {
+  parseHiddenMenuHrefs,
+  parseWorkspacePreset,
+} from '@/lib/types/user-settings'
+
+/**
+ * Role workspace presets (issue #3077). Named presets keep a stable set of
+ * top-level menu groups. Full is the only auto-expand preset: new pages and
+ * groups appear there automatically. Footer rows (About / Organization) are
+ * never hidden — they sit next to the Settings gear and Host switcher.
+ */
+
+export const WORKSPACE_PRESETS = [
+  'full',
+  'dba',
+  'engineer',
+  'sre',
+  'custom',
+] as const
+
+export interface WorkspaceVisibility {
+  workspacePreset: WorkspacePreset
+  hiddenMenuHrefs: readonly string[]
+}
+
+/** Top-level `MenuItem.title` values kept by each named preset. */
+export const PRESET_GROUP_TITLES: Record<
+  Exclude<WorkspacePreset, 'full' | 'custom'>,
+  readonly string[]
+> = {
+  dba: [
+    'Overview',
+    'Queries',
+    'Tables',
+    'Merges',
+    'Metrics',
+    'Keeper',
+    'Security',
+    'Logs',
+    'Cluster',
+    'System',
+  ],
+  engineer: ['Overview', 'Queries', 'Tables', 'Insights', 'AI Agent'],
+  sre: [
+    'Overview',
+    'Health',
+    'Insights',
+    'Queries',
+    'Tables',
+    'System',
+    'Operations',
+    'Metrics',
+    'Logs',
+  ],
+}
+
+function isFooterItem(item: MenuItem): boolean {
+  return item.section === 'footer'
+}
+
+function isHiddenByHref(item: MenuItem, hidden: ReadonlySet<string>): boolean {
+  if (!item.href) return false
+  return hidden.has(item.href)
+}
+
+/**
+ * Drop items whose href is on the hide list (and any parent left empty).
+ * Footer items are never removed. Recursive, same empty-parent rule as
+ * `filterCloudOnly`.
+ */
+export function filterHiddenMenuHrefs(
+  items: readonly MenuItem[],
+  hiddenHrefs: readonly string[]
+): MenuItem[] {
+  if (hiddenHrefs.length === 0) return items.map((item) => ({ ...item }))
+
+  const hidden = new Set(hiddenHrefs)
+  return items.flatMap((item) => {
+    if (isFooterItem(item)) return [{ ...item }]
+    if (isHiddenByHref(item, hidden)) return []
+
+    if (!item.items) return [{ ...item }]
+
+    const childItems = filterHiddenMenuHrefs(item.items, hiddenHrefs)
+    if (childItems.length === 0) return []
+    return [{ ...item, items: childItems }]
+  })
+}
+
+/**
+ * Keep only top-level groups whose title is in `allowedTitles`. Footer rows
+ * always survive. Empty parents after child filtering are dropped.
+ */
+export function filterMenuItemsByGroupTitles(
+  items: readonly MenuItem[],
+  allowedTitles: readonly string[]
+): MenuItem[] {
+  const allowed = new Set(allowedTitles)
+  return items.flatMap((item) => {
+    if (isFooterItem(item)) return [{ ...item }]
+    if (!allowed.has(item.title)) return []
+    return [{ ...item }]
+  })
+}
+
+export function applyWorkspaceVisibility(
+  items: readonly MenuItem[],
+  workspace: WorkspaceVisibility
+): MenuItem[] {
+  const { workspacePreset, hiddenMenuHrefs } = workspace
+
+  if (workspacePreset === 'full') {
+    return filterHiddenMenuHrefs(items, hiddenMenuHrefs)
+  }
+
+  if (workspacePreset === 'custom') {
+    return filterHiddenMenuHrefs(items, hiddenMenuHrefs)
+  }
+
+  const byGroup = filterMenuItemsByGroupTitles(
+    items,
+    PRESET_GROUP_TITLES[workspacePreset]
+  )
+  return filterHiddenMenuHrefs(byGroup, hiddenMenuHrefs)
+}
+
+/** Flatten leaf hrefs for the customize picker (skip empty parent hrefs). */
+export function hrefsOutsidePresetGroups(
+  items: readonly MenuItem[],
+  allowedTitles: readonly string[]
+): string[] {
+  const allowed = new Set(allowedTitles)
+  const hrefs: string[] = []
+  for (const item of items) {
+    if (isFooterItem(item)) continue
+    if (allowed.has(item.title)) continue
+    hrefs.push(...collectMenuHrefs([item]))
+  }
+  return hrefs
+}
+
+export function collectMenuHrefs(items: readonly MenuItem[]): string[] {
+  const hrefs: string[] = []
+  for (const item of items) {
+    if (item.href) hrefs.push(item.href)
+    if (item.items) hrefs.push(...collectMenuHrefs(item.items))
+  }
+  return hrefs
+}
+
+export function collectMenuLeaves(
+  items: readonly MenuItem[]
+): { href: string; title: string; group: string }[] {
+  const leaves: { href: string; title: string; group: string }[] = []
+
+  const walk = (nodes: readonly MenuItem[], group: string) => {
+    for (const item of nodes) {
+      const nextGroup = group || item.title
+      if (item.items?.length) {
+        walk(item.items, nextGroup)
+        continue
+      }
+      if (item.href && !isFooterItem(item)) {
+        leaves.push({ href: item.href, title: item.title, group: nextGroup })
+      }
+    }
+  }
+
+  walk(items, '')
+  return leaves
+}
+
+export function workspaceFromSettings(settings: {
+  workspacePreset?: unknown
+  hiddenMenuHrefs?: unknown
+}): WorkspaceVisibility {
+  return {
+    workspacePreset: parseWorkspacePreset(settings.workspacePreset),
+    hiddenMenuHrefs: parseHiddenMenuHrefs(settings.hiddenMenuHrefs),
+  }
+}

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -19,6 +19,8 @@ describe('mergeUserSettings', () => {
     expect(merged.chartPalette).toBe('default')
     expect(merged.tableDensity).toBe('comfortable')
     expect(merged.defaultTimeRange).toBe('24h')
+    expect(merged.workspacePreset).toBe('full')
+    expect(merged.hiddenMenuHrefs).toEqual([])
   })
 
   test('stored values override the defaults', () => {
@@ -39,6 +41,15 @@ describe('mergeUserSettings', () => {
     expect(mergeUserSettings('junk')).toEqual(DEFAULT_USER_SETTINGS)
     // Must be a copy, not the shared reference.
     expect(mergeUserSettings(null)).not.toBe(DEFAULT_USER_SETTINGS)
+  })
+
+  test('junk workspace keys fall back to Full and an empty hide list', () => {
+    const merged = mergeUserSettings({
+      workspacePreset: 'intern',
+      hiddenMenuHrefs: ['/health', 12, ''],
+    })
+    expect(merged.workspacePreset).toBe('full')
+    expect(merged.hiddenMenuHrefs).toEqual(['/health'])
   })
 
   test('default byteUnit/numberFormat reproduce historical behaviour', () => {

--- a/apps/dashboard/src/lib/types/user-settings.ts
+++ b/apps/dashboard/src/lib/types/user-settings.ts
@@ -3,6 +3,7 @@ export type NumberFormat = 'abbreviated' | 'full'
 export type ChartPalette = 'default' | 'colorblind-safe' | 'monochrome'
 export type TableDensity = 'comfortable' | 'compact'
 export type DefaultTimeRange = '1h' | '6h' | '24h' | '7d' | '30d'
+export type WorkspacePreset = 'full' | 'dba' | 'engineer' | 'sre' | 'custom'
 
 export interface UserSettings {
   timezone: string // IANA timezone identifier (e.g., 'America/New_York')
@@ -23,6 +24,18 @@ export interface UserSettings {
    * true to preserve the long-standing "gray, don't hide" behaviour.
    */
   dimUnavailablePages: boolean
+  /**
+   * Role workspace preset. Full is the default and the only auto-expand
+   * preset (new menu pages stay visible). Named presets keep a stable group
+   * set. Custom uses `hiddenMenuHrefs` as a hide list.
+   */
+  workspacePreset: WorkspacePreset
+  /**
+   * Menu hrefs hidden from sidebar + command palette. Hidden is not
+   * unauthorized — routes stay reachable. Footer / Settings / host switcher
+   * are never filtered here.
+   */
+  hiddenMenuHrefs: string[]
 }
 
 export const DEFAULT_USER_SETTINGS: UserSettings = {
@@ -34,6 +47,8 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   tableDensity: 'comfortable',
   defaultTimeRange: '24h',
   dimUnavailablePages: true,
+  workspacePreset: 'full',
+  hiddenMenuHrefs: [],
 }
 
 export const USER_SETTINGS_STORAGE_KEY = 'clickhouse-monitor-user-settings'
@@ -48,5 +63,29 @@ export function mergeUserSettings(stored: unknown): UserSettings {
   if (!stored || typeof stored !== 'object') {
     return { ...DEFAULT_USER_SETTINGS }
   }
-  return { ...DEFAULT_USER_SETTINGS, ...(stored as Partial<UserSettings>) }
+  const partial = stored as Partial<UserSettings> & Record<string, unknown>
+  const merged = { ...DEFAULT_USER_SETTINGS, ...partial }
+  merged.workspacePreset = parseWorkspacePreset(partial.workspacePreset)
+  merged.hiddenMenuHrefs = parseHiddenMenuHrefs(partial.hiddenMenuHrefs)
+  return merged
+}
+
+export function parseWorkspacePreset(value: unknown): WorkspacePreset {
+  if (
+    value === 'full' ||
+    value === 'dba' ||
+    value === 'engineer' ||
+    value === 'sre' ||
+    value === 'custom'
+  ) {
+    return value
+  }
+  return DEFAULT_USER_SETTINGS.workspacePreset
+}
+
+export function parseHiddenMenuHrefs(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter(
+    (href): href is string => typeof href === 'string' && href.length > 0
+  )
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-17
+updated: 2026-08-18
 tags:
   - design-system
   - ui
@@ -93,7 +93,8 @@ settings store.
 `clickhouse-monitor-user-settings`, merged over `DEFAULT_USER_SETTINGS` via
 `mergeUserSettings` so legacy blobs pick up new keys) carries the
 timezone/theme plus **units** (`byteUnit`, `numberFormat`), **colors**
-(`chartPalette`), and **layout** (`tableDensity`, `defaultTimeRange`). The
+(`chartPalette`), **layout** (`tableDensity`, `defaultTimeRange`), and a
+**workspace** (`workspacePreset`, `hiddenMenuHrefs`). The
 Settings dialog (`components/settings/settings-dialog.tsx` +
 `settings-form.tsx`) uses `rounded-xl border bg-card`, a Settings icon + title
 + "Local to this browser" header, a **stable height**
@@ -103,7 +104,14 @@ Preferences / Display / Workspace, icon + label rows, selected as a muted
 pill, `border-r`) and a content pane whose heading is the active tab.
 Theme (Light / Dark / System, next-themes) is a
 label-left / thumbnails-right row on Appearance only. Navigation
-picks Dim vs Hide with two menu demos (Queries + dimmed/missing Backups).
+leads with a workspace **preset** (`Full` / `DBA` / `Engineer` / `SRE` /
+`Custom`) then Dim vs Hide with two menu demos (Queries + dimmed/missing
+Backups). Hidden pages stay routable; Settings gear and the host switcher
+are never filtered. Workspace visibility is applied last in
+`getVisibleMenuItems` and does not replace permission / cloud / engine
+gates. Named presets keep a stable group set; Full is the only
+auto-expand preset. Custom uses a hide list plus a searchable picker —
+never a 40-checkbox wall.
 Timezone is a searchable combobox
 (`timezone-combobox.tsx`) with the browser local zone pinned under Suggested.
 Chart palette is a three-card picker with a mini bar preview. Unit options
@@ -115,7 +123,7 @@ show a sample on the control (`1.5 GiB` / `1.6 GB`). Integrations lists MCP
 **Invariant: every default reproduces the prior behaviour byte-for-byte** —
 `byteUnit: 'binary'`, `numberFormat: 'abbreviated'`, `chartPalette: 'default'`
 (attribute absent), `tableDensity: 'comfortable'` (attribute absent),
-`defaultTimeRange: '24h'`.
+`defaultTimeRange: '24h'`, `workspacePreset: 'full'`, `hiddenMenuHrefs: []`.
 
 How each applies (all wired by `AppearanceSettingsProvider`,
 `lib/context/appearance-settings.tsx`, mounted at `__root`):


### PR DESCRIPTION
## Summary

Adds local role workspace presets (Full, DBA, Engineer, SRE, Custom) so the sidebar and command palette can be slimmed without 404ing hidden routes. Closes #3077.

## Changes

- Extend `UserSettings` with `workspacePreset` + `hiddenMenuHrefs`; `mergeUserSettings` fills missing keys
- Filter last in `getVisibleMenuItems` (after permission, cloud, engine)
- Settings → Navigation: segmented presets + searchable hide list
- Update product-design skill and knowledge doc

## Test plan

- [x] `pnpm run lint` / pre-push Biome check
- [ ] `pnpm run build` (CI)
- [x] `pnpm run test:unit` (pre-push)
- [ ] Tested manually in local dev
- [x] Unit tests for visibility helper and merge defaults

## Notes for reviewer

Hidden means not in nav. Settings gear and host switcher are not filtered. Deployment gates stay first.

---

Co-Authored-By: duyetbot <bot@duyet.net>