### PR TITLE
feat(dashboard): TTL and partition health inventory

### DIFF
--- a/apps/dashboard/src/lib/health/ttl-partition-heuristics.test.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-heuristics.test.ts
@@ -1,0 +1,130 @@
+import {
+  evaluateTtlPartitionHealth,
+  hasTtlExpression,
+  isTimeBasedPartitionKey,
+  PARTITION_COUNT_CRITICAL,
+  PARTITION_COUNT_WARNING,
+  ttlPartitionRowClassName,
+} from './ttl-partition-heuristics'
+import { describe, expect, test } from 'bun:test'
+
+describe('isTimeBasedPartitionKey', () => {
+  test('flags toYYYYMMDD and related helpers', () => {
+    expect(isTimeBasedPartitionKey('toYYYYMMDD(event_time)')).toBe(true)
+    expect(isTimeBasedPartitionKey('toYYYYMM(created_at)')).toBe(true)
+    expect(isTimeBasedPartitionKey('toStartOfDay(ts)')).toBe(true)
+    expect(isTimeBasedPartitionKey('toMonday(ts)')).toBe(true)
+  })
+
+  test('does not flag city or hash keys', () => {
+    expect(isTimeBasedPartitionKey('city_id')).toBe(false)
+    expect(isTimeBasedPartitionKey('sipHash64(user_id)')).toBe(false)
+    expect(isTimeBasedPartitionKey('')).toBe(false)
+  })
+})
+
+describe('hasTtlExpression', () => {
+  test('empty and whitespace are missing', () => {
+    expect(hasTtlExpression('')).toBe(false)
+    expect(hasTtlExpression('   ')).toBe(false)
+    expect(hasTtlExpression(null)).toBe(false)
+  })
+
+  test('any expression counts', () => {
+    expect(hasTtlExpression('event_time + INTERVAL 30 DAY')).toBe(true)
+  })
+})
+
+describe('evaluateTtlPartitionHealth', () => {
+  test('toYYYYMMDD with 500+ partitions flags high count', () => {
+    const result = evaluateTtlPartitionHealth({
+      database: 'logs',
+      table: 'events',
+      partitionKey: 'toYYYYMMDD(event_time)',
+      ttlExpression: 'event_time + INTERVAL 90 DAY',
+      partitions: PARTITION_COUNT_WARNING,
+      activeParts: PARTITION_COUNT_WARNING,
+    })
+    expect(result.flags).toContain('high_partition_count')
+    expect(result.severity).toBe('warning')
+  })
+
+  test('1000+ partitions is critical', () => {
+    const result = evaluateTtlPartitionHealth({
+      database: 'logs',
+      table: 'events',
+      partitionKey: 'toYYYYMMDD(event_time)',
+      ttlExpression: 'event_time + INTERVAL 90 DAY',
+      partitions: PARTITION_COUNT_CRITICAL,
+      activeParts: PARTITION_COUNT_CRITICAL,
+    })
+    expect(result.flags).toContain('too_many_partitions')
+    expect(result.severity).toBe('critical')
+  })
+
+  test('time-based partition key with no TTL still appears as missing_ttl', () => {
+    const result = evaluateTtlPartitionHealth({
+      database: 'logs',
+      table: 'events',
+      partitionKey: 'toYYYYMMDD(event_time)',
+      ttlExpression: '',
+      partitions: 12,
+      activeParts: 12,
+    })
+    expect(result.flags).toContain('missing_ttl')
+    expect(result.severity).toBe('warning')
+  })
+
+  test('tables with no TTL and a non-time key are ok', () => {
+    const result = evaluateTtlPartitionHealth({
+      database: 'dim',
+      table: 'users',
+      partitionKey: 'city_id',
+      ttlExpression: '',
+      partitions: 8,
+      activeParts: 16,
+    })
+    expect(result.flags).toEqual([])
+    expect(result.severity).toBe('ok')
+  })
+
+  test('high parts per partition is info when nothing else is wrong', () => {
+    const result = evaluateTtlPartitionHealth({
+      database: 'dim',
+      table: 'users',
+      partitionKey: 'city_id',
+      ttlExpression: '',
+      partitions: 2,
+      activeParts: 40,
+    })
+    expect(result.flags).toContain('high_parts_per_partition')
+    expect(result.severity).toBe('info')
+  })
+})
+
+describe('ttlPartitionRowClassName', () => {
+  test('highlights warning rows from query-shaped objects', () => {
+    const cls = ttlPartitionRowClassName({
+      database: 'logs',
+      table: 'events',
+      partition_key: 'toYYYYMMDD(ts)',
+      ttl_expression: '',
+      partitions: 10,
+      active_parts: 10,
+    })
+    expect(cls).toContain('amber')
+  })
+
+  test('leaves healthy rows unstyled', () => {
+    expect(
+      ttlPartitionRowClassName({
+        database: 'dim',
+        table: 'users',
+        partition_key: 'id',
+        ttl_expression: '',
+        partitions: 1,
+        active_parts: 1,
+      })
+    ).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/health/ttl-partition-heuristics.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-heuristics.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure TTL / partition inventory health checks.
+ *
+ * No I/O. Used by the /ttl-partition-health page (row styling) and the
+ * optional Insights collector. Thresholds match the schema-design skill
+ * (~500–1000 partitions/table) and issue #3074 acceptance.
+ */
+
+export const PARTITION_COUNT_WARNING = 500
+export const PARTITION_COUNT_CRITICAL = 1000
+export const PARTS_PER_PARTITION_WARNING = 10
+
+/** ClickHouse date/time partition helpers — a table using these looks time-series. */
+const TIME_BASED_PARTITION_RE =
+  /toYYYYMM(DD(hhmmss)?)?|toStartOf(Day|Hour|Minute|Month|Week|Quarter|Year|Interval)|toDate(Time)?(\(|$)|toMonday|toYearWeek|toISOWeek|toStartOfISOYear/i
+
+export type TtlPartitionSeverity = 'ok' | 'info' | 'warning' | 'critical'
+
+export type TtlPartitionFlag =
+  | 'too_many_partitions'
+  | 'high_partition_count'
+  | 'missing_ttl'
+  | 'high_parts_per_partition'
+
+export interface TtlPartitionInventoryRow {
+  database: string
+  table: string
+  partitionKey: string
+  ttlExpression: string
+  partitions: number
+  activeParts: number
+}
+
+export interface TtlPartitionHealth {
+  flags: TtlPartitionFlag[]
+  severity: TtlPartitionSeverity
+}
+
+export function isTimeBasedPartitionKey(partitionKey: string): boolean {
+  const key = partitionKey.trim()
+  if (!key) return false
+  return TIME_BASED_PARTITION_RE.test(key)
+}
+
+export function hasTtlExpression(
+  ttlExpression: string | null | undefined
+): boolean {
+  return Boolean(ttlExpression && ttlExpression.trim().length > 0)
+}
+
+export function evaluateTtlPartitionHealth(
+  row: TtlPartitionInventoryRow
+): TtlPartitionHealth {
+  const flags: TtlPartitionFlag[] = []
+
+  if (row.partitions >= PARTITION_COUNT_CRITICAL) {
+    flags.push('too_many_partitions')
+  } else if (row.partitions >= PARTITION_COUNT_WARNING) {
+    flags.push('high_partition_count')
+  }
+
+  const partsPerPartition =
+    row.partitions > 0 ? row.activeParts / row.partitions : 0
+  if (partsPerPartition >= PARTS_PER_PARTITION_WARNING) {
+    flags.push('high_parts_per_partition')
+  }
+
+  if (
+    isTimeBasedPartitionKey(row.partitionKey) &&
+    !hasTtlExpression(row.ttlExpression)
+  ) {
+    flags.push('missing_ttl')
+  }
+
+  return { flags, severity: severityFromFlags(flags) }
+}
+
+function severityFromFlags(flags: TtlPartitionFlag[]): TtlPartitionSeverity {
+  if (flags.includes('too_many_partitions')) return 'critical'
+  if (flags.includes('high_partition_count') || flags.includes('missing_ttl')) {
+    return 'warning'
+  }
+  if (flags.includes('high_parts_per_partition')) return 'info'
+  return 'ok'
+}
+
+export function ttlPartitionRowClassName(
+  row: Record<string, unknown>
+): string | undefined {
+  const health = evaluateTtlPartitionHealth(inventoryRowFromQuery(row))
+  if (health.severity === 'critical') {
+    return 'bg-red-50 dark:bg-red-950/20'
+  }
+  if (health.severity === 'warning') {
+    return 'bg-amber-50 dark:bg-amber-950/15'
+  }
+  return undefined
+}
+
+export function inventoryRowFromQuery(
+  row: Record<string, unknown>
+): TtlPartitionInventoryRow {
+  return {
+    database: String(row.database ?? row._database ?? ''),
+    table: String(row.table ?? row._table ?? ''),
+    partitionKey: String(row.partition_key ?? ''),
+    ttlExpression: String(row.ttl_expression ?? ''),
+    partitions: Number(row.partitions) || 0,
+    activeParts: Number(row.active_parts) || 0,
+  }
+}

--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -20,6 +20,10 @@ import {
   projectHoursToThreshold,
 } from '../health/parts-pressure'
 import {
+  evaluateTtlPartitionHealth,
+  type TtlPartitionInventoryRow,
+} from '../health/ttl-partition-heuristics'
+import {
   checkDetachedParts,
   checkFailedDictionaries,
   checkLongRunningQuery,
@@ -412,7 +416,91 @@ async function collectStorage(hostId: number): Promise<InsightCandidate[]> {
     }
   }
 
+  out.push(...(await collectTtlPartitionHealth(hostId)))
+
   return out
+}
+
+/** Worst TTL / partition-inventory findings (no part_log required). */
+async function collectTtlPartitionHealth(
+  hostId: number
+): Promise<InsightCandidate[]> {
+  try {
+    const rows = await readOnlyQuery({
+      query: `
+        SELECT
+          t.database AS database,
+          t.name AS table,
+          t.partition_key AS partition_key,
+          if(
+            positionCaseInsensitive(t.create_table_query, ' TTL ') > 0,
+            trim(BOTH ' ' FROM replaceRegexpOne(
+              substring(
+                t.create_table_query,
+                positionCaseInsensitive(t.create_table_query, ' TTL ') + 5
+              ),
+              '\\\\s+(SETTINGS|COMMENT)\\\\s+.*$',
+              ''
+            )),
+            ''
+          ) AS ttl_expression,
+          uniqExact(p.partition) AS partitions,
+          countIf(p.active) AS active_parts
+        FROM system.tables AS t
+        LEFT JOIN system.parts AS p
+          ON p.database = t.database AND p.table = t.name
+        WHERE t.is_temporary = 0
+          AND t.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+          AND positionCaseInsensitive(t.engine, 'MergeTree') > 0
+        GROUP BY t.database, t.name, t.partition_key, t.create_table_query
+        ORDER BY partitions DESC
+        LIMIT 50
+      `,
+      hostId,
+    })
+    if (!Array.isArray(rows)) return []
+
+    const flagged: {
+      row: TtlPartitionInventoryRow
+      severity: 'warning' | 'critical'
+    }[] = []
+    for (const raw of rows) {
+      const rec = raw as Record<string, unknown>
+      const row: TtlPartitionInventoryRow = {
+        database: String(rec.database ?? ''),
+        table: String(rec.table ?? ''),
+        partitionKey: String(rec.partition_key ?? ''),
+        ttlExpression: String(rec.ttl_expression ?? ''),
+        partitions: Number(rec.partitions) || 0,
+        activeParts: Number(rec.active_parts) || 0,
+      }
+      const health = evaluateTtlPartitionHealth(row)
+      if (health.severity === 'warning' || health.severity === 'critical') {
+        flagged.push({ row, severity: health.severity })
+      }
+    }
+    if (flagged.length === 0) return []
+
+    flagged.sort((a, b) => b.row.partitions - a.row.partitions)
+    const worst = flagged[0]
+    const fq = `${worst.row.database}.${worst.row.table}`
+    return [
+      {
+        severity: worst.severity,
+        category: 'storage',
+        metric: 'ttl_partition_health',
+        title: `${fq} needs TTL or partition review`,
+        detail: `${fq} has ${worst.row.partitions} partitions (${worst.row.activeParts} active parts). Open TTL & Partitions for the full inventory. This is recommend-only — no ALTER TTL is applied.`,
+        value: worst.row.partitions,
+        action: {
+          label: 'View TTL inventory',
+          href: '/ttl-partition-health',
+        },
+      },
+    ]
+  } catch {
+    return []
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/lib/insights/insight-charts.test.ts
+++ b/apps/dashboard/src/lib/insights/insight-charts.test.ts
@@ -87,6 +87,7 @@ describe('insightChartNames', () => {
       { category: 'storage', metric: 'max_active_parts' },
       { category: 'storage', metric: 'detached_parts' },
       { category: 'storage', metric: 'worst_compression_ratio' },
+      { category: 'storage', metric: 'ttl_partition_health' },
       { category: 'reliability', metric: 'readonly_replicas' },
       { category: 'reliability', metric: 'max_replication_delay' },
       { category: 'reliability', metric: 'stuck_mutations' },

--- a/apps/dashboard/src/lib/insights/insight-charts.ts
+++ b/apps/dashboard/src/lib/insights/insight-charts.ts
@@ -34,6 +34,7 @@ const METRIC_CHARTS: Record<string, readonly string[]> = {
   max_active_parts: ['parts-per-table', 'merge-count'],
   detached_parts: ['parts-per-table', 'new-parts-created'],
   worst_compression_ratio: ['top-table-size', 'disk-usage-by-database'],
+  ttl_partition_health: ['partition-part-health', 'parts-per-table'],
   // Reliability collectors
   readonly_replicas: ['readonly-replica', 'replication-summary-table'],
   max_replication_delay: [

--- a/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
+++ b/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
@@ -568,6 +568,12 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
   },
   {
     "depth": 1,
+    "href": "/ttl-partition-health",
+    "section": undefined,
+    "title": "TTL & Partitions",
+  },
+  {
+    "depth": 1,
     "href": "/warnings",
     "section": undefined,
     "title": "Warnings",

--- a/apps/dashboard/src/lib/og.ts
+++ b/apps/dashboard/src/lib/og.ts
@@ -81,6 +81,12 @@ export const OG_PAGES: Record<string, OgPage> = {
     description:
       'Compression ratios, tier utilization and TTL moves to track storage cost and efficiency.',
   },
+  'ttl-partition-health': {
+    eyebrow: 'STORAGE',
+    title: 'TTL & Partition Health',
+    description:
+      'Inventory of table TTL, PARTITION BY, and partition counts — without applying ALTER TTL.',
+  },
   'query-condition-cache': {
     eyebrow: 'CACHE',
     title: 'Query Condition Cache',

--- a/apps/dashboard/src/lib/query-config/index.ts
+++ b/apps/dashboard/src/lib/query-config/index.ts
@@ -121,6 +121,7 @@ import {
   storagePoliciesConfig,
   ttlStorageMovesConfig,
 } from './system/storage-economics'
+import { ttlPartitionHealthConfig } from './system/ttl-partition-health'
 import { warningsConfig } from './system/warnings'
 import { workloadsConfig } from './system/workloads'
 import { detachedPartsConfig } from './tables/detached-parts'
@@ -251,6 +252,7 @@ export const queries: Array<QueryConfig> = [
   storageCompressionConfig,
   storagePoliciesConfig,
   ttlStorageMovesConfig,
+  ttlPartitionHealthConfig,
   histogramMetricsConfig,
   latencyLogConfig,
   workloadsConfig,

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
@@ -1,0 +1,33 @@
+import { ttlPartitionHealthConfig } from './ttl-partition-health'
+import { describe, expect, test } from 'bun:test'
+import { getAllSqlStrings } from '@chm/sql-builder'
+import { getQueryConfigByName } from '@/lib/query-config'
+
+describe('ttlPartitionHealthConfig', () => {
+  test('is registered by name', () => {
+    expect(getQueryConfigByName('ttl-partition-health')?.name).toBe(
+      'ttl-partition-health'
+    )
+  })
+
+  test('is version-aware and never queries part_log', () => {
+    const variants = getAllSqlStrings(ttlPartitionHealthConfig.sql)
+    expect(variants.length).toBe(2)
+    for (const sql of variants) {
+      expect(sql).toContain('system.tables')
+      expect(sql).toContain('system.parts')
+      expect(sql).not.toContain('system.part_log')
+    }
+  })
+
+  test('older variant parses TTL from CREATE TABLE', () => {
+    const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[0]
+    expect(sql).toContain('create_table_query')
+    expect(sql).not.toMatch(/\bt\.ttl\b/)
+  })
+
+  test('newer variant reads system.tables.ttl', () => {
+    const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[1]
+    expect(sql).toContain('t.ttl')
+  })
+})

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
@@ -1,0 +1,140 @@
+import type { QueryConfig } from '@/types/query-config'
+
+import { ttlPartitionRowClassName } from '@/lib/health/ttl-partition-heuristics'
+import { ColumnFormat } from '@/types/column-format'
+
+/**
+ * Inventory of MergeTree TTL + PARTITION BY + live part counts.
+ *
+ * Reads system.tables + system.parts only — does not need system.part_log.
+ * Older ClickHouse builds have no `system.tables.ttl`; those variants parse
+ * `create_table_query` instead. Tables with no TTL still appear.
+ */
+
+const TTL_FROM_CREATE = `
+      if(
+        positionCaseInsensitive(t.create_table_query, ' TTL ') > 0,
+        trim(BOTH ' ' FROM replaceRegexpOne(
+          substring(
+            t.create_table_query,
+            positionCaseInsensitive(t.create_table_query, ' TTL ') + 5
+          ),
+          '\\\\s+(SETTINGS|COMMENT)\\\\s+.*$',
+          ''
+        )),
+        ''
+      )`
+
+const TTL_FROM_COLUMN = `ifNull(nullIf(t.ttl, ''), ${TTL_FROM_CREATE})`
+
+function inventorySql(ttlExpressionSql: string): string {
+  return `
+    WITH part_stats AS (
+      SELECT
+        database,
+        table,
+        uniqExact(partition) AS partitions,
+        count() AS active_parts,
+        if(
+          uniqExact(partition) = 0,
+          0,
+          round(count() / uniqExact(partition), 2)
+        ) AS parts_per_partition,
+        sum(bytes_on_disk) AS bytes_on_disk
+      FROM system.parts
+      WHERE active
+      GROUP BY database, table
+    )
+    SELECT
+      t.database,
+      t.name AS table,
+      concat(t.database, '.', t.name) AS full_table,
+      t.database AS _database,
+      t.name AS _table,
+      t.engine,
+      t.partition_key,
+      ${ttlExpressionSql} AS ttl_expression,
+      ifNull(p.partitions, 0) AS partitions,
+      ifNull(p.active_parts, 0) AS active_parts,
+      ifNull(p.parts_per_partition, 0) AS parts_per_partition,
+      ifNull(p.bytes_on_disk, 0) AS bytes_on_disk,
+      formatReadableSize(ifNull(p.bytes_on_disk, 0)) AS readable_bytes_on_disk,
+      round(
+        ifNull(p.bytes_on_disk, 0) * 100.0
+          / nullIf(max(ifNull(p.bytes_on_disk, 0)) OVER (), 0),
+        2
+      ) AS pct_bytes_on_disk,
+      round(
+        ifNull(p.partitions, 0) * 100.0
+          / nullIf(max(ifNull(p.partitions, 0)) OVER (), 0),
+        2
+      ) AS pct_partitions,
+      round(
+        ifNull(p.active_parts, 0) * 100.0
+          / nullIf(max(ifNull(p.active_parts, 0)) OVER (), 0),
+        2
+      ) AS pct_active_parts
+    FROM system.tables AS t
+    LEFT JOIN part_stats AS p
+      ON p.database = t.database AND p.table = t.name
+    WHERE t.is_temporary = 0
+      AND t.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
+      AND positionCaseInsensitive(t.engine, 'MergeTree') > 0
+    ORDER BY partitions DESC, bytes_on_disk DESC
+  `
+}
+
+export const ttlPartitionHealthConfig: QueryConfig = {
+  name: 'ttl-partition-health',
+  defaultView: 'auto',
+  card: {
+    primary: 'full_table',
+    badges: ['engine'],
+    metrics: ['partitions', 'active_parts', 'readable_bytes_on_disk'],
+  },
+  description:
+    'TTL expression, PARTITION BY, and partition/part counts per MergeTree table. Does not apply ALTER TTL or DROP PARTITION.',
+  docs: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl',
+  tableCheck: 'system.parts',
+  sql: [
+    {
+      since: '19.1',
+      description: 'TTL parsed from CREATE TABLE (no system.tables.ttl)',
+      sql: inventorySql(TTL_FROM_CREATE),
+    },
+    {
+      since: '21.8',
+      description: 'Prefer system.tables.ttl; fall back to CREATE TABLE',
+      sql: inventorySql(TTL_FROM_COLUMN),
+    },
+  ],
+  columns: [
+    'full_table',
+    'engine',
+    'partition_key',
+    'ttl_expression',
+    'partitions',
+    'active_parts',
+    'parts_per_partition',
+    'readable_bytes_on_disk',
+  ],
+  columnFormats: {
+    full_table: [
+      ColumnFormat.Link,
+      {
+        href: '/table?host=[ctx.hostId]&database=[_database]&table=[_table]',
+      },
+    ],
+    engine: ColumnFormat.ColoredBadge,
+    partition_key: ColumnFormat.Code,
+    ttl_expression: ColumnFormat.Code,
+    partitions: ColumnFormat.BackgroundBar,
+    active_parts: ColumnFormat.BackgroundBar,
+    readable_bytes_on_disk: ColumnFormat.BackgroundBar,
+  },
+  relatedCharts: [
+    ['partition-part-health', { title: 'Part health' }],
+    ['parts-per-table', { title: 'Parts per table' }],
+  ],
+  rowClassName: ttlPartitionRowClassName,
+}

--- a/apps/dashboard/src/menu/system.ts
+++ b/apps/dashboard/src/menu/system.ts
@@ -79,6 +79,16 @@ export const systemItems: MenuItem[] = [
         tableCheck: 'system.parts',
       },
       {
+        title: 'TTL & Partitions',
+        href: '/ttl-partition-health',
+        description:
+          'TTL expression, PARTITION BY, and partition counts per table',
+        icon: HardDriveIcon,
+        isNew: true,
+        docs: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl',
+        tableCheck: 'system.parts',
+      },
+      {
         title: 'Warnings',
         href: '/warnings',
         description:

--- a/apps/dashboard/src/routes/(dashboard)/ttl-partition-health.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/ttl-partition-health.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Suspense } from 'react'
+import { PageLayout } from '@/components/layout/query-page'
+import { PageSkeleton } from '@/components/skeletons'
+import { pageOgHead } from '@/lib/og'
+import { ttlPartitionHealthConfig } from '@/lib/query-config/system/ttl-partition-health'
+
+function TtlPartitionHealthPageContent() {
+  return (
+    <PageLayout
+      queryConfig={ttlPartitionHealthConfig}
+      title="TTL & Partition Health"
+      description="Inventory of MergeTree TTL and PARTITION BY, with partition and part counts. Tables without TTL still appear. Highlighted rows have too many partitions or a time-based partition key with no TTL. Recommend-only — this page does not run ALTER TTL or DROP PARTITION. Related: Storage Economics and the disk-capacity forecast in the agent."
+    />
+  )
+}
+
+function TtlPartitionHealthPage() {
+  return (
+    <Suspense fallback={<PageSkeleton />}>
+      <TtlPartitionHealthPageContent />
+    </Suspense>
+  )
+}
+
+export const Route = createFileRoute('/(dashboard)/ttl-partition-health')({
+  component: TtlPartitionHealthPage,
+  head: () => pageOgHead('ttl-partition-health'),
+})


### PR DESCRIPTION
## Summary

Adds a fleet inventory of MergeTree TTL, `PARTITION BY`, and partition/part counts so DBAs can catch partition bloat and missing retention. Closes #3074.

## Changes

- Version-aware QueryConfig over `system.tables` + `system.parts` (no `part_log`). Older ClickHouse parses TTL from `CREATE TABLE`; 21.8+ prefers `system.tables.ttl`.
- Pure heuristics + unit tests: 500+ partitions, 1000+ critical, missing TTL on time-based keys, high parts-per-partition.
- Page `/ttl-partition-health` (PageLayout + existing part-health charts) and System menu item. Rows link to Explorer.
- Optional Insights collector for the worst flagged table.
- Recommend-only: no `ALTER TTL` / `DROP PARTITION`.

## Test plan

- [x] Heuristic unit tests
- [x] Query-config + shipped SQL validator
- [x] Menu snapshot + href→route
- [x] Pre-push `biome check` + dashboard unit tests
- [ ] CI required checks (`unit-tests`, `dashboard`)

## Notes for reviewer

Tables with no TTL still appear. Inventory works without `part_log`. Capacity-forecaster is unchanged (linked from the page copy).

---

Co-Authored-By: duyetbot <bot@duyet.net>