### PR TITLE
refactor(dashboard): share TTL inventory SQL and collapse workspace branches

### DIFF
--- a/apps/dashboard/src/lib/insights/collectors.ts
+++ b/apps/dashboard/src/lib/insights/collectors.ts
@@ -20,10 +20,6 @@ import {
   projectHoursToThreshold,
 } from '../health/parts-pressure'
 import {
-  evaluateTtlPartitionHealth,
-  type TtlPartitionInventoryRow,
-} from '../health/ttl-partition-heuristics'
-import {
   checkDetachedParts,
   checkFailedDictionaries,
   checkLongRunningQuery,
@@ -35,6 +31,7 @@ import {
   selectSchemaOptimizations,
 } from './schema-optimizations'
 import { refitBaselineIfStale, scoreAnomaly } from './statistical-baseline'
+import { collectTtlPartitionHealth } from './ttl-partition-collector'
 
 function extractValue(result: unknown): number | null {
   if (Array.isArray(result) && result.length > 0) {
@@ -419,88 +416,6 @@ async function collectStorage(hostId: number): Promise<InsightCandidate[]> {
   out.push(...(await collectTtlPartitionHealth(hostId)))
 
   return out
-}
-
-/** Worst TTL / partition-inventory findings (no part_log required). */
-async function collectTtlPartitionHealth(
-  hostId: number
-): Promise<InsightCandidate[]> {
-  try {
-    const rows = await readOnlyQuery({
-      query: `
-        SELECT
-          t.database AS database,
-          t.name AS table,
-          t.partition_key AS partition_key,
-          if(
-            positionCaseInsensitive(t.create_table_query, ' TTL ') > 0,
-            trim(BOTH ' ' FROM replaceRegexpOne(
-              substring(
-                t.create_table_query,
-                positionCaseInsensitive(t.create_table_query, ' TTL ') + 5
-              ),
-              '\\\\s+(SETTINGS|COMMENT)\\\\s+.*$',
-              ''
-            )),
-            ''
-          ) AS ttl_expression,
-          uniqExact(p.partition) AS partitions,
-          countIf(p.active) AS active_parts
-        FROM system.tables AS t
-        LEFT JOIN system.parts AS p
-          ON p.database = t.database AND p.table = t.name
-        WHERE t.is_temporary = 0
-          AND t.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
-          AND positionCaseInsensitive(t.engine, 'MergeTree') > 0
-        GROUP BY t.database, t.name, t.partition_key, t.create_table_query
-        ORDER BY partitions DESC
-        LIMIT 50
-      `,
-      hostId,
-    })
-    if (!Array.isArray(rows)) return []
-
-    const flagged: {
-      row: TtlPartitionInventoryRow
-      severity: 'warning' | 'critical'
-    }[] = []
-    for (const raw of rows) {
-      const rec = raw as Record<string, unknown>
-      const row: TtlPartitionInventoryRow = {
-        database: String(rec.database ?? ''),
-        table: String(rec.table ?? ''),
-        partitionKey: String(rec.partition_key ?? ''),
-        ttlExpression: String(rec.ttl_expression ?? ''),
-        partitions: Number(rec.partitions) || 0,
-        activeParts: Number(rec.active_parts) || 0,
-      }
-      const health = evaluateTtlPartitionHealth(row)
-      if (health.severity === 'warning' || health.severity === 'critical') {
-        flagged.push({ row, severity: health.severity })
-      }
-    }
-    if (flagged.length === 0) return []
-
-    flagged.sort((a, b) => b.row.partitions - a.row.partitions)
-    const worst = flagged[0]
-    const fq = `${worst.row.database}.${worst.row.table}`
-    return [
-      {
-        severity: worst.severity,
-        category: 'storage',
-        metric: 'ttl_partition_health',
-        title: `${fq} needs TTL or partition review`,
-        detail: `${fq} has ${worst.row.partitions} partitions (${worst.row.activeParts} active parts). Open TTL & Partitions for the full inventory. This is recommend-only — no ALTER TTL is applied.`,
-        value: worst.row.partitions,
-        action: {
-          label: 'View TTL inventory',
-          href: '/ttl-partition-health',
-        },
-      },
-    ]
-  } catch {
-    return []
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/dashboard/src/lib/insights/ttl-partition-collector.test.ts
+++ b/apps/dashboard/src/lib/insights/ttl-partition-collector.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('../ai/agent/tools/helpers', () => ({
+  readOnlyQuery: async () => [],
+}))
+
+const {
+  insightFromTtlInventoryRows,
+  rowFromTtlInventoryRecord,
+} = await import('./ttl-partition-collector')
+
+describe('rowFromTtlInventoryRecord', () => {
+  test('maps QueryConfig inventory columns', () => {
+    expect(
+      rowFromTtlInventoryRecord({
+        database: 'analytics',
+        name: 'events',
+        table: 'events',
+        partition_key: 'toYYYYMM(ts)',
+        ttl_expression: '',
+        partitions: '1200',
+        active_parts: 2400,
+      })
+    ).toEqual({
+      database: 'analytics',
+      table: 'events',
+      partitionKey: 'toYYYYMM(ts)',
+      ttlExpression: '',
+      partitions: 1200,
+      activeParts: 2400,
+    })
+  })
+})
+
+describe('insightFromTtlInventoryRows', () => {
+  test('returns empty when nothing is flagged', () => {
+    expect(
+      insightFromTtlInventoryRows([
+        {
+          database: 'db',
+          table: 'ok',
+          partition_key: 'tuple()',
+          ttl_expression: '',
+          partitions: 2,
+          active_parts: 2,
+        },
+      ])
+    ).toEqual([])
+  })
+
+  test('emits one insight for the worst flagged table', () => {
+    const out = insightFromTtlInventoryRows([
+      {
+        database: 'a',
+        table: 'mid',
+        partition_key: 'toYYYYMM(ts)',
+        ttl_expression: '',
+        partitions: 600,
+        active_parts: 600,
+      },
+      {
+        database: 'b',
+        table: 'worst',
+        partition_key: 'toYYYYMM(ts)',
+        ttl_expression: '',
+        partitions: 1500,
+        active_parts: 1500,
+      },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0]?.metric).toBe('ttl_partition_health')
+    expect(out[0]?.title).toContain('b.worst')
+    expect(out[0]?.severity).toBe('critical')
+    expect(out[0]?.value).toBe(1500)
+    expect(out[0]?.action).toEqual({
+      label: 'View TTL inventory',
+      href: '/ttl-partition-health',
+    })
+  })
+})

--- a/apps/dashboard/src/lib/insights/ttl-partition-collector.ts
+++ b/apps/dashboard/src/lib/insights/ttl-partition-collector.ts
@@ -1,0 +1,80 @@
+/**
+ * TTL / partition inventory insight collector.
+ *
+ * SQL lives in query-config; this file maps rows to InsightCandidate.
+ */
+
+import type { InsightCandidate } from './types'
+
+import { readOnlyQuery } from '../ai/agent/tools/helpers'
+import {
+  evaluateTtlPartitionHealth,
+  type TtlPartitionInventoryRow,
+} from '../health/ttl-partition-heuristics'
+import { ttlPartitionInventorySql } from '../query-config/system/ttl-partition-health'
+
+export function rowFromTtlInventoryRecord(
+  rec: Record<string, unknown>
+): TtlPartitionInventoryRow {
+  return {
+    database: String(rec.database ?? ''),
+    table: String(rec.table ?? rec.name ?? ''),
+    partitionKey: String(rec.partition_key ?? ''),
+    ttlExpression: String(rec.ttl_expression ?? ''),
+    partitions: Number(rec.partitions) || 0,
+    activeParts: Number(rec.active_parts) || 0,
+  }
+}
+
+/** Worst flagged row → at most one storage insight. */
+export function insightFromTtlInventoryRows(
+  rows: unknown
+): InsightCandidate[] {
+  if (!Array.isArray(rows)) return []
+
+  const flagged: {
+    row: TtlPartitionInventoryRow
+    severity: 'warning' | 'critical'
+  }[] = []
+  for (const raw of rows) {
+    const rec = raw as Record<string, unknown>
+    const row = rowFromTtlInventoryRecord(rec)
+    const health = evaluateTtlPartitionHealth(row)
+    if (health.severity === 'warning' || health.severity === 'critical') {
+      flagged.push({ row, severity: health.severity })
+    }
+  }
+  if (flagged.length === 0) return []
+
+  flagged.sort((a, b) => b.row.partitions - a.row.partitions)
+  const worst = flagged[0]
+  const fq = `${worst.row.database}.${worst.row.table}`
+  return [
+    {
+      severity: worst.severity,
+      category: 'storage',
+      metric: 'ttl_partition_health',
+      title: `${fq} needs TTL or partition review`,
+      detail: `${fq} has ${worst.row.partitions} partitions (${worst.row.activeParts} active parts). Open TTL & Partitions for the full inventory. This is recommend-only — no ALTER TTL is applied.`,
+      value: worst.row.partitions,
+      action: {
+        label: 'View TTL inventory',
+        href: '/ttl-partition-health',
+      },
+    },
+  ]
+}
+
+export async function collectTtlPartitionHealth(
+  hostId: number
+): Promise<InsightCandidate[]> {
+  try {
+    const rows = await readOnlyQuery({
+      query: ttlPartitionInventorySql,
+      hostId,
+    })
+    return insightFromTtlInventoryRows(rows)
+  } catch {
+    return []
+  }
+}

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -112,11 +112,7 @@ export function applyWorkspaceVisibility(
 ): MenuItem[] {
   const { workspacePreset, hiddenMenuHrefs } = workspace
 
-  if (workspacePreset === 'full') {
-    return filterHiddenMenuHrefs(items, hiddenMenuHrefs)
-  }
-
-  if (workspacePreset === 'custom') {
+  if (workspacePreset === 'full' || workspacePreset === 'custom') {
     return filterHiddenMenuHrefs(items, hiddenMenuHrefs)
   }
 

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
@@ -84,6 +84,9 @@ function inventorySql(ttlExpressionSql: string): string {
   `
 }
 
+/** CREATE TABLE parse — works on every supported version; used by Insights. */
+export const ttlPartitionInventorySql = inventorySql(TTL_FROM_CREATE)
+
 export const ttlPartitionHealthConfig: QueryConfig = {
   name: 'ttl-partition-health',
   defaultView: 'auto',
@@ -100,7 +103,7 @@ export const ttlPartitionHealthConfig: QueryConfig = {
     {
       since: '19.1',
       description: 'TTL parsed from CREATE TABLE (no system.tables.ttl)',
-      sql: inventorySql(TTL_FROM_CREATE),
+      sql: ttlPartitionInventorySql,
     },
     {
       since: '21.8',


### PR DESCRIPTION
## Summary
- Collapse identical `full` / `custom` branches in `applyWorkspaceVisibility`.
- Extract TTL partition insight collection to `ttl-partition-collector.ts` and reuse the QueryConfig inventory SQL instead of a second hand-rolled query.
- Cover row mapping and worst-table insight selection with unit tests. Heuristics are unchanged.

## Test plan
- [x] `bun test` on `ttl-partition-collector.test.ts` and `ttl-partition-heuristics.test.ts`
- [ ] Required CI (`unit-tests`, `dashboard`)