### PR TITLE
fix(landing): show full self-host claim on 320px hero pill

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -51,7 +51,9 @@ for (const marker of required) {
 }
 
 const ossIdx = html.indexOf('data-hero-oss')
-const ossChunk = ossIdx === -1 ? '' : html.slice(ossIdx, ossIdx + 900)
+const ossEnd = ossIdx === -1 ? -1 : html.indexOf('</a>', ossIdx)
+const ossChunk =
+  ossIdx === -1 || ossEnd === -1 ? '' : html.slice(ossIdx, ossEnd)
 if (!ossChunk.includes('self-host free')) {
   console.error('MISSING self-host free claim in [data-hero-oss]')
   failed = true

--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -50,6 +50,20 @@ for (const marker of required) {
   }
 }
 
+const ossIdx = html.indexOf('data-hero-oss')
+const ossChunk = ossIdx === -1 ? '' : html.slice(ossIdx, ossIdx + 900)
+if (!ossChunk.includes('self-host free')) {
+  console.error('MISSING self-host free claim in [data-hero-oss]')
+  failed = true
+} else if (/\btruncate\b/.test(ossChunk)) {
+  console.error(
+    'FORBIDDEN truncate on hero OSS pill (clips SELF-HOST FREE at 320px)'
+  )
+  failed = true
+} else {
+  console.log('OK: hero OSS pill keeps the full self-host claim (no truncate)')
+}
+
 for (const text of forbidden) {
   if (html.includes(text)) {
     console.error(`FORBIDDEN on homepage: ${text}`)

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -77,9 +77,13 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
         class="inline-flex max-w-full"
         data-hero-oss
       >
-        <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors hover:bg-[var(--hairline-strong)]">
+        {/* Wrap below ~360px so 320px shows the full self-host claim. 375+
+            stays one line. Do not truncate, and do not shrink below 12px. */}
+        <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-semibold uppercase tracking-[0.06em] sm:tracking-[0.08em] leading-snug transition-colors hover:bg-[var(--hairline-strong)] max-[359px]:py-1.5">
           <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
-          <span class="truncate">Open source · GPL-3.0 · self-host free</span>
+          <span class="min-w-0 text-center min-[360px]:whitespace-nowrap">
+            Open source · GPL-3.0 ·<br class="min-[360px]:hidden" /> self-host free
+          </span>
         </span>
       </a>
 

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -78,7 +78,7 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
         data-hero-oss
       >
         {/* Wrap below ~360px so 320px shows the full self-host claim. 375+
-            stays one line. Do not truncate, and do not shrink below 12px. */}
+            stays one line. Type stays at 12px — no smaller squeeze. */}
         <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-semibold uppercase tracking-[0.06em] sm:tracking-[0.08em] leading-snug transition-colors hover:bg-[var(--hairline-strong)] max-[359px]:py-1.5">
           <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
           <span class="min-w-0 text-center min-[360px]:whitespace-nowrap">

--- a/apps/landing/src/layouts/mobile-landing.test.ts
+++ b/apps/landing/src/layouts/mobile-landing.test.ts
@@ -99,7 +99,7 @@ describe('hero OSS pill: 320px shows the full self-host claim', () => {
     const oss = hero.split('data-hero-oss')[1] ?? ''
     const pill = oss.slice(0, oss.indexOf('</a>'))
     expect(pill).toContain('self-host free')
-    expect(pill).not.toContain('truncate')
+    expect(pill).not.toMatch(/class="[^"]*\btruncate\b/)
     expect(pill).toContain('min-[360px]:whitespace-nowrap')
     expect(pill).toContain('<br class="min-[360px]:hidden"')
   })

--- a/apps/landing/src/layouts/mobile-landing.test.ts
+++ b/apps/landing/src/layouts/mobile-landing.test.ts
@@ -7,6 +7,7 @@ const read = (rel: string) => readFileSync(join(landing, rel), 'utf8')
 
 const base = read('src/layouts/Base.astro')
 const nav = read('src/components/Nav.astro')
+const hero = read('src/components/Hero.astro')
 const homeCmp = read('src/components/Comparison.astro')
 const vsCmp = read('src/components/ComparisonTable.astro')
 const dbCmp = read('src/components/DbComparisonTable.astro')
@@ -90,6 +91,24 @@ describe('mobile nav: open menu shows X + dim, tap targets ≥44px', () => {
       /@media \(max-width:1024px\)[\s\S]*?\.nav-drawer-close,\.theme-toggle\{width:44px;height:44px\}/
     )
     expect(extra).toContain('.nav-drawer-group-body a{min-height:44px}')
+  })
+})
+
+describe('hero OSS pill: 320px shows the full self-host claim', () => {
+  test('does not truncate; wraps below 360px; 375+ stays one line', () => {
+    const oss = hero.split('data-hero-oss')[1] ?? ''
+    const pill = oss.slice(0, oss.indexOf('</a>'))
+    expect(pill).toContain('self-host free')
+    expect(pill).not.toContain('truncate')
+    expect(pill).toContain('min-[360px]:whitespace-nowrap')
+    expect(pill).toContain('<br class="min-[360px]:hidden"')
+  })
+
+  test('type is at least 12px (text-xs), not a squeeze below that', () => {
+    const oss = hero.split('data-hero-oss')[1] ?? ''
+    const pill = oss.slice(0, oss.indexOf('</a>'))
+    expect(pill).toContain('text-xs')
+    expect(pill).not.toMatch(/text-\[(?:9|10|11)px\]/)
   })
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes leftover clipping on the homepage hero OSS chip at 320px (`SELF-HOST …` ellipsis). The full self-host claim stays readable; 375 and 1280 stay one line. This is not a redo of #3104 (nav/header).

Closes #3106.

## Changes

- `apps/landing/src/components/Hero.astro`: drop `truncate` on the leftover hero chip; wrap to two lines below 360px (`<br class="min-[360px]:hidden" />`) so `SELF-HOST FREE` is fully visible at 320px; `whitespace-nowrap` from 360px up; bump type to `text-xs` (12px) instead of shrinking further.
- `apps/landing/src/layouts/mobile-landing.test.ts`: source assertions for no truncate class, wrap breakpoint, and ≥12px type.
- `apps/landing/scripts/verify-landing-structure.ts`: built HTML must keep `self-host free` on `[data-hero-oss]` and must not reintroduce `truncate`.

## Test plan

- [x] `cd apps/landing && bun test src/layouts/mobile-landing.test.ts` — 13 pass
- [x] Visual (headless Chrome): 320×568 two lines, full `SELF-HOST FREE`; 375 and 1280 one line; `scrollWidth === clientWidth` (no overflow-x); computed font-size 12px
- [x] `cd apps/landing && pnpm run build` + `bun scripts/verify-landing-structure.ts` — pass
- [x] Docs unchanged (marketing chip only)

## Screenshots

320px (wraps; full self-host claim):

![Hero pill at 320px](https://cursor.com/artifacts/c/art-f802fb41-a375-42cc-9288-d56b94032d2a)

375px (one line):

![Hero pill at 375px](https://cursor.com/artifacts/c/art-069959a9-ec3a-4a97-829c-5fafd477f8b9)

1280px (one line):

![Hero pill at 1280px](https://cursor.com/artifacts/c/art-acc1b23e-5e45-41eb-b1aa-089bf3cfc8f3)

## Notes for reviewer

Please do not merge until you are happy with the 320 wrap. Header/nav from #3104 is untouched.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deae65ff-3052-4778-b8ef-a0395c4bd186?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deae65ff-3052-4778-b8ef-a0395c4bd186&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

