### PR TITLE
fix(dashboard): enlarge header utility icons to 44px on phones

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -159,7 +159,8 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
 - **Responsive chrome:** overview KPIs wrap from `sm` (truncate is `max-sm:`
   only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
   sidebar sheet is opaque — no heatmap-through-frost. Phone time chips /
-  sidebar rows / toggle are `min 44×44`. Agent FAB must not cover heatmap
+  sidebar rows / toggle / header utility icons (refresh, search, theme) are
+  `min 44×44`. Agent FAB must not cover heatmap
   "Avg / active day" (`pb-16` + last-card `pr-16`; landscape FAB at `top-16`).
 - **Paired page sections** (e.g. AI-generated vs. plain-statistics content):
   identical-weight header on both — `icon (size-4, muted-foreground) + <h2

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -42,13 +42,13 @@ export function CommandPaletteTrigger({ onOpen }: { onOpen: () => void }) {
         icon={<Search className="size-4" />}
         onClick={onOpen}
         tooltip="Search"
-        className="md:hidden"
+        className="min-h-11 min-w-11 md:hidden lg:min-h-8 lg:min-w-8"
       />
 
       <button
         type="button"
         onClick={onOpen}
-        className="relative hidden h-8 w-30 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 md:inline-flex md:w-40"
+        className="relative hidden h-8 min-h-11 w-30 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 md:inline-flex md:w-40 lg:h-8 lg:min-h-8"
       >
         <Search aria-hidden="true" className="size-3.5 text-muted-foreground" />
         <span className="text-muted-foreground">Search…</span>

--- a/apps/dashboard/src/components/header/header-actions.tsx
+++ b/apps/dashboard/src/components/header/header-actions.tsx
@@ -70,14 +70,14 @@ export const HeaderActions = function HeaderActions({
           }
           icon={resolvedTheme === 'light' ? <Moon /> : <Sun />}
           onClick={toggleTheme}
-          className="inline-flex"
+          className="inline-flex min-h-11 min-w-11 lg:min-h-8 lg:min-w-8"
           suppressHydrationWarning
         />
       ) : (
         <Button
           variant="ghost"
           size="icon"
-          className="inline-flex"
+          className="inline-flex min-h-11 min-w-11 lg:min-h-8 lg:min-w-8"
           aria-label="Toggle theme"
         >
           <Sun className="size-4" />

--- a/apps/dashboard/src/components/header/header-utility-icons.test.tsx
+++ b/apps/dashboard/src/components/header/header-utility-icons.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Persistent header utility icons (refresh, search, theme) must be 44×44
+ * below lg. Glyph stays 16–20px. Time chips and the sidebar toggle are
+ * covered by time-range-picker.test.tsx / responsive-chrome.test.ts.
+ */
+
+import type { ReactElement } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+function expectPhoneTapTarget(el: Element) {
+  expect(el.className).toContain('min-h-11')
+  expect(el.className).toContain('min-w-11')
+  expect(el.className).toContain('lg:min-h-8')
+  expect(el.className).toContain('lg:min-w-8')
+}
+
+describe('header utility icons', () => {
+  test('auto-refresh is a 44px tap target below lg', async () => {
+    const { AppProvider } = await import('@/lib/context/app-context')
+    const { RefreshCountdown } = await import('./refresh-countdown')
+    const { container, cleanup } = await renderInto(
+      <AppProvider>
+        <RefreshCountdown />
+      </AppProvider>
+    )
+
+    const button = container.querySelector('button[aria-label^="Auto refresh"]')
+    expect(button).not.toBeNull()
+    expectPhoneTapTarget(button as Element)
+    expect(button?.innerHTML).toContain('h-3.5')
+
+    await cleanup()
+  })
+
+  test('search icon is a 44px tap target below lg', async () => {
+    const { CommandPaletteTrigger } = await import(
+      '@/components/controls/command-palette/command-palette-items'
+    )
+    const { TooltipProvider } = await import('@/components/ui/tooltip')
+    const { container, cleanup } = await renderInto(
+      <TooltipProvider>
+        <CommandPaletteTrigger onOpen={() => {}} />
+      </TooltipProvider>
+    )
+
+    const button = container.querySelector('button[aria-label="Search"]')
+    expect(button).not.toBeNull()
+    expectPhoneTapTarget(button as Element)
+    expect(button?.className).toContain('md:hidden')
+    expect(button?.innerHTML).toContain('size-4')
+
+    await cleanup()
+  })
+})

--- a/apps/dashboard/src/components/header/refresh-countdown.tsx
+++ b/apps/dashboard/src/components/header/refresh-countdown.tsx
@@ -52,7 +52,7 @@ export const RefreshCountdown = function RefreshCountdown() {
             variant="ghost"
             size="sm"
             className={cn(
-              'h-8 shrink-0 gap-1.5 px-2 text-xs font-normal',
+              'h-8 min-h-11 min-w-11 shrink-0 gap-1.5 px-2 text-xs font-normal lg:min-h-8 lg:min-w-8',
               isRefreshing && 'animate-pulse'
             )}
             aria-label={`Auto refresh ${reloadInterval ? `in ${formatReadableSecondDuration(remaining)}` : 'disabled'}. Click to change.`}

--- a/apps/dashboard/src/components/layout/responsive-chrome.test.ts
+++ b/apps/dashboard/src/components/layout/responsive-chrome.test.ts
@@ -62,6 +62,27 @@ describe('responsive chrome', () => {
     expect(src('components/layout/dashboard-shell.tsx')).toContain('pb-16')
   })
 
+  test('header utility icons are 44px below lg', () => {
+    const tap = 'min-h-11 min-w-11'
+    const desktop = 'lg:min-h-8 lg:min-w-8'
+    expect(src('components/header/refresh-countdown.tsx')).toContain(tap)
+    expect(src('components/header/refresh-countdown.tsx')).toContain(desktop)
+    expect(src('components/header/header-actions.tsx')).toContain(tap)
+    expect(src('components/header/header-actions.tsx')).toContain(desktop)
+    expect(
+      src('components/controls/command-palette/command-palette-items.tsx')
+    ).toContain(tap)
+    expect(
+      src('components/controls/command-palette/command-palette-items.tsx')
+    ).toContain(desktop)
+    expect(src('components/header/time-range-picker.tsx')).toContain(
+      'sm:min-h-0 sm:min-w-0'
+    )
+    expect(src('components/layout/dashboard-shell.tsx')).toContain(
+      'size-11 lg:size-7'
+    )
+  })
+
   test('heatmap last stat card clears the FAB on small screens', () => {
     const heatmap = src('components/charts/query/query-count-heatmap.tsx')
     expect(heatmap).toContain('max-lg:col-span-2 max-lg:pr-16')

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -535,7 +535,8 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   FAB moves to `top-16`.
 - **Phone tap targets are 44×44.** Time chips (`min-h-11 min-w-11` until
   `sm`), sidebar rows (`h-11` until `lg`), sidebar trigger (`size-11` until
-  `lg`). Compact sizes return at the desktop rail.
+  `lg`), header utility icons — refresh, search, theme (`min-h-11 min-w-11`
+  until `lg`). Glyph stays 16–20px. Compact sizes return at the desktop rail.
 
 ## UX conventions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3108. Auto-refresh, Search, and theme in the dashboard header were still 32×32 after #3103. Those persistent icon buttons are now a 44×44 tap target below `lg`. Glyph size is unchanged (16–20px). Time chips and Toggle Sidebar stay as shipped in #3103.

## Changes

- `RefreshCountdown` — `min-h-11 min-w-11` below `lg` (compact `h-8` from the desktop rail)
- Command palette Search icon — same 44×44 box on phones; Search… bar is at least 44px tall below `lg`
- Theme toggle (and the hydration placeholder) — `min-h-11 min-w-11` below `lg`
- Tests: source contract in `responsive-chrome.test.ts` plus render checks for refresh and search
- Product-design skill + knowledge doc: header utility icons are part of the 44px phone chrome

## Test plan

- [x] `pnpm run lint` passes with no errors (Biome check on touched files)
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [x] Targeted unit tests pass (`responsive-chrome`, `header-utility-icons`, `time-range-picker` — 11/11)
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

Please check https://dash.chmonitor.dev/overview at 375:

- Auto-refresh, Search, and Switch to dark mode `getBoundingClientRect` ≥ 44×44
- Time chips and Toggle Sidebar stay 44
- No document `overflow-x`

## Notes for reviewer

Do not merge. Apps/dashboard only. AnyRouter is untouched.

Fixes #3108
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dcdc3ca-931c-4471-9b64-3efe229b78aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dcdc3ca-931c-4471-9b64-3efe229b78aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

