### PR TITLE
fix(docs): pad mobile header search and menu to 44px

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test mobile header tap targets
+        run: pnpm test
+
       - name: Build
         run: pnpm run build
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
     "types:check": "fumadocs-mdx && tsc --noEmit",
+    "test": "node --test src/styles/mobile-header.test.mjs",
     "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -64,3 +64,23 @@ html > body[data-scroll-locked] {
 :root {
   --fd-layout-width: 1400px;
 }
+
+/*
+ * Mobile header tap targets (issue #3107).
+ *
+ * Fumadocs home hamburger is `lg` (1024px); docs-page header is `md` (768px).
+ * Both icon buttons render at 34×34: search is `p-2` + `size-4.5` svg, menu is
+ * `p-1.5` + `size-5.5` svg. Pad the hit area to WCAG 2.5.5 44×44 and keep the
+ * glyph size. Unlayered so this beats Tailwind `p-*` utilities.
+ */
+@media (max-width: 1024px) {
+  #nd-nav [data-search],
+  #nd-nav [aria-label='Toggle Menu'],
+  #nd-subnav [data-search],
+  #nd-subnav [aria-label='Open Sidebar'] {
+    box-sizing: border-box;
+    min-width: 44px;
+    min-height: 44px;
+    flex-shrink: 0;
+  }
+}

--- a/apps/docs/src/styles/mobile-header.test.mjs
+++ b/apps/docs/src/styles/mobile-header.test.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+
+const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'app.css'), 'utf8')
+
+/** Unlayered rules after the last `:root { ... }` — beats Tailwind utilities. */
+function unlayeredCss(src) {
+  const marker = src.lastIndexOf('--fd-layout-width:')
+  assert.ok(marker > -1, 'expected --fd-layout-width in app.css')
+  const blockEnd = src.indexOf('}', marker)
+  assert.ok(blockEnd > -1, 'expected closing brace after --fd-layout-width')
+  return src.slice(blockEnd + 1)
+}
+
+describe('docs mobile header: search and menu tap targets ≥44px', () => {
+  test('pads header icon buttons at the hamburger breakpoint', () => {
+    const extra = unlayeredCss(css)
+    assert.match(
+      extra,
+      /@media \(max-width:\s*1024px\)[\s\S]*?#nd-nav \[data-search\]/
+    )
+    assert.ok(extra.includes("#nd-nav [aria-label='Toggle Menu']"))
+    assert.ok(extra.includes('#nd-subnav [data-search]'))
+    assert.ok(extra.includes("#nd-subnav [aria-label='Open Sidebar']"))
+    assert.ok(extra.includes('min-width: 44px'))
+    assert.ok(extra.includes('min-height: 44px'))
+  })
+
+  test('keeps the visual glyph size (no svg width/height override)', () => {
+    const extra = unlayeredCss(css)
+    assert.doesNotMatch(extra, /svg[\s\S]{0,80}(width|height|font-size)/)
+    assert.ok(!extra.includes('[&_svg]'))
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3107. On phone widths, the docs header **Open Search** and **Toggle Menu** buttons were 34×34. They are now padded to a 44×44 hit area. Glyph size is unchanged.

## Changes

- `apps/docs/src/styles/app.css` — at the hamburger breakpoint (`max-width: 1024px`), set `min-width` / `min-height: 44px` on the Fumadocs home (`#nd-nav`) search + menu buttons and the docs-page (`#nd-subnav`) search + sidebar trigger. Unlayered CSS so it beats Tailwind `p-*`.
- `apps/docs/src/styles/mobile-header.test.mjs` — asserts the 44px pad is present and that svg size is not overridden.
- `apps/docs/package.json` + `.github/workflows/docs.yml` — run that test in the docs CI job.

Apps/dashboard, apps/landing, and AnyRouter are untouched.

## Test plan

- [x] `cd apps/docs && pnpm test` (source-level CSS contract)
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed
- [ ] Open https://docs.chmonitor.dev/ at 375: search and menu `getBoundingClientRect` are ≥44×44; `scrollWidth === 375` (no overflow-x)

## Notes for reviewer

Do not merge from this PR. Inner doc pages get the same pad on `#nd-subnav` (Open Search / Open Sidebar).

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e44e20d6-a3c4-4ce2-a891-b1d536989a44?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e44e20d6-a3c4-4ce2-a891-b1d536989a44&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

