### PR TITLE
fix(docs): pad article Copy Markdown and Open to 44px on phones

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -158,9 +158,10 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   labels like "Memory & CPU" scroll instead of clipping.
 - **Responsive chrome:** overview KPIs wrap from `sm` (truncate is `max-sm:`
   only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
-  sidebar sheet is opaque — no heatmap-through-frost. Phone time chips /
+  sidebar sheet is opaque — no heatmap-through-frost.   Phone time chips /
   sidebar rows / toggle / header utility icons (refresh, search, theme) are
-  `min 44×44`. Agent FAB must not cover heatmap
+  `min 44×44`. Docs article Copy Markdown / Open are 44px below `md` (not
+  header search/menu). Agent FAB must not cover heatmap
   "Avg / active day" (`pb-16` + last-card `pr-16`; landscape FAB at `top-16`).
 - **Paired page sections** (e.g. AI-generated vs. plain-statistics content):
   identical-weight header on both — `icon (size-4, muted-foreground) + <h2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test mobile header tap targets
+      - name: Test docs tap targets
         run: pnpm test
 
       - name: Build

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
     "types:check": "fumadocs-mdx && tsc --noEmit",
-    "test": "node --test src/styles/mobile-header.test.mjs",
+    "test": "node --test src/styles/*.test.mjs",
     "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -121,11 +121,18 @@ const clientLoader = browserCollections.docs.createClientLoader({
       <DocsPage toc={toc}>
         <DocsTitle>{frontmatter.title}</DocsTitle>
         <DocsDescription>{frontmatter.description}</DocsDescription>
-        <div className="flex flex-row gap-2 items-center border-b -mt-4 pb-6">
-          <MarkdownCopyButton markdownUrl={markdownUrl} />
+        <div
+          data-article-actions
+          className="flex flex-row flex-wrap items-center gap-2 border-b -mt-4 pb-6"
+        >
+          <MarkdownCopyButton
+            markdownUrl={markdownUrl}
+            className="max-md:min-h-11"
+          />
           <ViewOptionsPopover
             markdownUrl={markdownUrl}
             githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/docs/content/${path}`}
+            className="max-md:min-h-11 max-md:min-w-11"
           />
         </div>
         <DocsBody>

--- a/apps/docs/src/styles/app.css
+++ b/apps/docs/src/styles/app.css
@@ -84,3 +84,20 @@ html > body[data-scroll-locked] {
     flex-shrink: 0;
   }
 }
+
+/*
+ * Article page actions (issue #3111) — not header chrome (#3107).
+ *
+ * Copy Markdown / Open are fumadocs `size: "sm"` buttons (~30px tall from
+ * `py-1.5` + `text-xs` + border). Pad the hit area to WCAG 2.5.5 44px on
+ * phones. Glyph size stays fumadocs `size-3.5`. Unlayered so this beats
+ * Tailwind `py-*`. Open also gets min-width 44px (Copy Markdown is already
+ * wider). flex-wrap on the row avoids overflow-x at 375px.
+ */
+@media (max-width: 768px) {
+  [data-article-actions] button {
+    box-sizing: border-box;
+    min-height: 44px;
+    min-width: 44px;
+  }
+}

--- a/apps/docs/src/styles/article-actions.test.mjs
+++ b/apps/docs/src/styles/article-actions.test.mjs
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(join(here, 'app.css'), 'utf8')
+const page = readFileSync(join(here, '../routes/$.tsx'), 'utf8')
+
+/** Unlayered rules after the last `:root { ... }` — beats Tailwind utilities. */
+function unlayeredCss(src) {
+  const marker = src.lastIndexOf('--fd-layout-width:')
+  assert.ok(marker > -1, 'expected --fd-layout-width in app.css')
+  const blockEnd = src.indexOf('}', marker)
+  assert.ok(blockEnd > -1, 'expected closing brace after --fd-layout-width')
+  return src.slice(blockEnd + 1)
+}
+
+describe('docs article actions: Copy Markdown and Open tap targets ≥44px', () => {
+  test('marks the article action row (not header chrome)', () => {
+    assert.match(page, /data-article-actions/)
+    assert.match(page, /MarkdownCopyButton/)
+    assert.match(page, /ViewOptionsPopover/)
+    assert.match(page, /className="max-md:min-h-11"/)
+    assert.match(page, /className="max-md:min-h-11 max-md:min-w-11"/)
+    assert.doesNotMatch(page, /#nd-nav|#nd-subnav|data-search/)
+  })
+
+  test('pads article action buttons at the md breakpoint', () => {
+    const extra = unlayeredCss(css)
+    const article = extra.match(
+      /@media \(max-width:\s*768px\)\s*\{[\s\S]*?\[data-article-actions\] button[\s\S]*?\n\}/
+    )
+    assert.ok(article, 'expected 768px [data-article-actions] rule')
+    assert.ok(article[0].includes('min-height: 44px'))
+    assert.ok(article[0].includes('min-width: 44px'))
+    assert.doesNotMatch(article[0], /#nd-nav|#nd-subnav/)
+  })
+
+  test('keeps the visual glyph size (no svg width/height override)', () => {
+    const extra = unlayeredCss(css)
+    assert.doesNotMatch(extra, /svg[\s\S]{0,80}(width|height|font-size)/)
+    assert.ok(!extra.includes('[&_svg]'))
+  })
+})

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -543,6 +543,9 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   `sm`), sidebar rows (`h-11` until `lg`), sidebar trigger (`size-11` until
   `lg`), header utility icons — refresh, search, theme (`min-h-11 min-w-11`
   until `lg`). Glyph stays 16–20px. Compact sizes return at the desktop rail.
+  Docs article **Copy Markdown** / **Open** (`[data-article-actions]`, below
+  `md`) are the same 44px floor; docs header search/menu is a separate control
+  (`#nd-nav` / `#nd-subnav`).
 
 ## UX conventions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3111. On phone widths, the docs article **Copy Markdown** and **Open** buttons were ~30px tall. They are now padded to a 44px hit area (Open also `min-width: 44px`). Glyph size is unchanged.

Rebased onto `main` after #3112 (`dfcdccf`) landed. Header search/menu (#3107) stay on the existing `#nd-nav` / `#nd-subnav` rules. This PR only adds `[data-article-actions]`.

## Changes

- `apps/docs/src/routes/$.tsx` — mark the article action row with `data-article-actions`; `max-md:min-h-11` on Copy Markdown, plus `max-md:min-w-11` on Open; `flex-wrap` so the row cannot overflow-x at 375px.
- `apps/docs/src/styles/app.css` — at `max-width: 768px`, unlayered `min-height` / `min-width: 44px` on `[data-article-actions] button`. Does not change `#nd-nav` / `#nd-subnav`.
- `apps/docs/src/styles/article-actions.test.mjs` — asserts the 44px pad is present and scoped to article actions (header selectors stay in their own 1024px rule).
- `apps/docs/package.json` — `pnpm test` runs `src/styles/*.test.mjs` (header + article).
- `.github/workflows/docs.yml` — one tap-target test step covering both files.

Apps/dashboard, apps/landing, and AnyRouter are untouched.

## Test plan

- [x] `cd apps/docs && pnpm test` (header + article CSS/JSX contracts, 5 passing)
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed
- [ ] Open https://docs.chmonitor.dev/guide/getting-started/ at 375: Copy Markdown and Open `getBoundingClientRect` height ≥44; Open width ≥44; no overflow-x. Header search/menu remain the #3107 / #3112 pad.

## Notes for reviewer

Do not merge from this agent. Header chrome is intentionally unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b538a68-cc4a-4b73-949b-9eeddaa8600a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b538a68-cc4a-4b73-949b-9eeddaa8600a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

