### PR TITLE
fix(dashboard): publish real public OpenAPI spec

### DIFF
--- a/apps/dashboard/src/__tests__/agent-discovery.test.ts
+++ b/apps/dashboard/src/__tests__/agent-discovery.test.ts
@@ -249,11 +249,15 @@ describe('Agent Discovery Metadata Endpoints & Content Negotiation', () => {
     expect(res.headers.get('Content-Type')).toContain(OPENAPI_CONTENT_TYPE)
 
     const data = (await res.json()) as OpenAPIResponse
-    expect(data.openapi).toBe('3.0.0')
+    expect(data.openapi).toMatch(/^3\.0\.\d+$/)
     expect(data.info.title).toBe('chmonitor API')
     expect(data.paths).toBeDefined()
     expect(data.paths['/api/health']).toBeDefined()
     expect(data.paths[OPENAPI_SPEC_PATH]).toBeDefined()
+    expect(data.paths['/api/v1/hosts']).toBeDefined()
+    expect(data.paths['/api/v1/charts/{name}']).toBeDefined()
+    expect(data.paths['/api/v1/tables/{name}']).toBeDefined()
+    expect(Object.keys(data.paths).length).toBeGreaterThan(2)
     expect(buildOpenApiDocument().externalDocs.url).toBe(API_SERVICE_DOC_HREF)
   })
 

--- a/apps/dashboard/src/lib/api/__tests__/openapi-spec.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/openapi-spec.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Public OpenAPI contract.
+ *
+ * Guards the #3088 follow-up: GET /api/v1/openapi.json must document the real
+ * public HTTP API (hosts, charts, tables, …), not a 2-path stub of /api/health
+ * + itself. Also asserts every advertised path exists on the TanStack route
+ * tree so we do not invent endpoints.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { getAvailableCharts } from '@/lib/api/chart-registry'
+import {
+  buildOpenApiDocument,
+  OPENAPI_CONTENT_TYPE,
+  OPENAPI_SPEC_PATH,
+  OPENAPI_VERSION,
+  openApiResponse,
+} from '@/lib/api/openapi-spec'
+import {
+  listPublicOpenApiPaths,
+  MIN_PUBLIC_API_PATHS,
+  PUBLIC_API_ROUTES,
+  REQUIRED_PUBLIC_API_PATHS,
+  tanstackPathToOpenApiPath,
+} from '@/lib/api/public-api'
+import { getAvailableTables } from '@/lib/api/table-registry'
+
+const HTTP_METHODS = [
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'options',
+] as const
+
+function parseTanstackApiPaths(source: string): Set<string> {
+  const paths = new Set<string>()
+  const re = /fullPath: '(\/api[^']*)'/g
+  let match: RegExpExecArray | null = re.exec(source)
+  while (match) {
+    paths.add(match[1])
+    match = re.exec(source)
+  }
+  return paths
+}
+
+function isOpenApi30(doc: { openapi: string }): boolean {
+  return /^3\.0\.\d+$/.test(doc.openapi)
+}
+
+describe('public OpenAPI spec', () => {
+  const spec = buildOpenApiDocument()
+  const pathKeys = Object.keys(spec.paths)
+
+  test('is OpenAPI 3.0 JSON with info and paths', () => {
+    expect(isOpenApi30(spec)).toBe(true)
+    expect(spec.openapi).toBe(OPENAPI_VERSION)
+    expect(spec.info.title).toBe('chmonitor API')
+    expect(spec.info.version).toBeTruthy()
+    expect(spec.info.description).toContain('public')
+    expect(spec.externalDocs.url).toContain('/reference/api')
+    expect(spec.components.securitySchemes.bearerAuth).toBeDefined()
+  })
+
+  test('lists more than two paths (not a health+self stub)', () => {
+    expect(pathKeys.length).toBeGreaterThan(2)
+    expect(pathKeys.length).toBeGreaterThanOrEqual(MIN_PUBLIC_API_PATHS)
+    expect(pathKeys.length).toBe(PUBLIC_API_ROUTES.length)
+  })
+
+  test('includes the stable public surface', () => {
+    for (const path of REQUIRED_PUBLIC_API_PATHS) {
+      expect(spec.paths[path]).toBeDefined()
+    }
+    expect(spec.paths['/api/v1/hosts']?.get).toBeDefined()
+    expect(spec.paths['/api/v1/charts/{name}']?.get).toBeDefined()
+    expect(spec.paths['/api/v1/tables/{name}']?.get).toBeDefined()
+    expect(spec.paths['/api/v1/tables']?.get).toBeDefined()
+    expect(spec.paths['/api/v1/findings']?.get).toBeDefined()
+    expect(spec.paths['/api/v1/agent']?.post).toBeDefined()
+    expect(spec.paths['/api/mcp']?.post).toBeDefined()
+    expect(spec.paths['/api/v1/auth/api-key']?.post).toBeDefined()
+  })
+
+  test('paths match the public-api catalog exactly', () => {
+    expect(pathKeys.sort()).toEqual([...listPublicOpenApiPaths()].sort())
+  })
+
+  test('every path item has at least one HTTP method and responses', () => {
+    for (const [path, item] of Object.entries(spec.paths)) {
+      const methods = HTTP_METHODS.filter((method) => item[method] != null)
+      expect(methods.length, `${path} has no HTTP methods`).toBeGreaterThan(0)
+      for (const method of methods) {
+        const operation = item[method] as {
+          responses?: Record<string, unknown>
+        }
+        expect(
+          operation.responses,
+          `${method.toUpperCase()} ${path}`
+        ).toBeDefined()
+        expect(Object.keys(operation.responses ?? {}).length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test('does not advertise internal surfaces', () => {
+    const advertised = pathKeys.join('\n')
+    expect(advertised).not.toContain('/explorer')
+    expect(advertised).not.toContain('/billing')
+    expect(advertised).not.toContain('/webhooks')
+    expect(advertised).not.toContain('/cron')
+    expect(advertised).not.toContain('/menu-counts')
+    expect(advertised).not.toContain('/conversations')
+    expect(advertised).not.toContain('/user-connections')
+  })
+
+  test('chart and table path params use the live registries', () => {
+    const charts = [...getAvailableCharts()].sort()
+    const tables = getAvailableTables()
+    expect(charts.length).toBeGreaterThanOrEqual(100)
+    expect(tables.length).toBeGreaterThanOrEqual(50)
+
+    const chartParam = (
+      spec.paths['/api/v1/charts/{name}']?.get as {
+        parameters: Array<{ name: string; schema: { enum?: string[] } }>
+      }
+    ).parameters.find((p) => p.name === 'name')
+    const tableParam = (
+      spec.paths['/api/v1/tables/{name}']?.get as {
+        parameters: Array<{ name: string; schema: { enum?: string[] } }>
+      }
+    ).parameters.find((p) => p.name === 'name')
+
+    expect(chartParam?.schema.enum).toEqual(charts)
+    expect(tableParam?.schema.enum).toEqual(tables)
+    expect(chartParam?.schema.enum).toContain('query-count')
+    expect(tableParam?.schema.enum).toContain('running-queries')
+  })
+
+  test('every catalog path exists on the TanStack route tree', () => {
+    const routeTreePath = fileURLToPath(
+      new URL('../../../routeTree.gen.ts', import.meta.url)
+    )
+    const source = readFileSync(routeTreePath, 'utf8')
+    const live = parseTanstackApiPaths(source)
+    expect(live.size).toBeGreaterThan(MIN_PUBLIC_API_PATHS)
+
+    for (const route of PUBLIC_API_ROUTES) {
+      expect(live.has(route.tanstackPath), route.tanstackPath).toBe(true)
+      expect(tanstackPathToOpenApiPath(route.tanstackPath)).toBe(
+        route.openapiPath
+      )
+      expect(spec.paths[route.openapiPath]?.['x-tanstack-path']).toBe(
+        route.tanstackPath
+      )
+    }
+  })
+
+  test('openApiResponse is 200 application/openapi+json', async () => {
+    const res = openApiResponse()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe(OPENAPI_CONTENT_TYPE)
+    const body = (await res.json()) as {
+      openapi: string
+      paths: Record<string, unknown>
+    }
+    expect(isOpenApi30(body)).toBe(true)
+    expect(Object.keys(body.paths).length).toBeGreaterThan(2)
+    expect(body.paths[OPENAPI_SPEC_PATH]).toBeDefined()
+    expect(body.paths['/api/v1/hosts']).toBeDefined()
+  })
+})

--- a/apps/dashboard/src/lib/api/__tests__/openapi-spec.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/openapi-spec.test.ts
@@ -3,11 +3,13 @@
  *
  * Guards the #3088 follow-up: GET /api/v1/openapi.json must document the real
  * public HTTP API (hosts, charts, tables, …), not a 2-path stub of /api/health
- * + itself. Also asserts every advertised path exists on the TanStack route
- * tree so we do not invent endpoints.
+ * + itself. Also asserts every advertised path has a committed route module
+ * under src/routes/api/ so we do not invent endpoints. Do not read
+ * routeTree.gen.ts — that file is generated and absent from the CI unit-test job.
  */
 import { describe, expect, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { getAvailableCharts } from '@/lib/api/chart-registry'
 import {
@@ -35,14 +37,31 @@ const HTTP_METHODS = [
   'options',
 ] as const
 
-function parseTanstackApiPaths(source: string): Set<string> {
+/** Collect createFileRoute('/api/...') paths from committed route modules. */
+function collectApiFileRoutes(dir: string): Set<string> {
   const paths = new Set<string>()
-  const re = /fullPath: '(\/api[^']*)'/g
-  let match: RegExpExecArray | null = re.exec(source)
-  while (match) {
-    paths.add(match[1])
-    match = re.exec(source)
+
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue
+        walk(full)
+        continue
+      }
+      if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.tsx')) continue
+      if (entry.name.includes('.test.')) continue
+      const source = readFileSync(full, 'utf8')
+      const routeRe = /createFileRoute\('(\/api[^']*)'\)/g
+      let match: RegExpExecArray | null = routeRe.exec(source)
+      while (match) {
+        paths.add(match[1])
+        match = routeRe.exec(source)
+      }
+    }
   }
+
+  walk(dir)
   return paths
 }
 
@@ -139,12 +158,11 @@ describe('public OpenAPI spec', () => {
     expect(tableParam?.schema.enum).toContain('running-queries')
   })
 
-  test('every catalog path exists on the TanStack route tree', () => {
-    const routeTreePath = fileURLToPath(
-      new URL('../../../routeTree.gen.ts', import.meta.url)
+  test('every catalog path exists as a committed API route module', () => {
+    const routesDir = fileURLToPath(
+      new URL('../../../routes/api', import.meta.url)
     )
-    const source = readFileSync(routeTreePath, 'utf8')
-    const live = parseTanstackApiPaths(source)
+    const live = collectApiFileRoutes(routesDir)
     expect(live.size).toBeGreaterThan(MIN_PUBLIC_API_PATHS)
 
     for (const route of PUBLIC_API_ROUTES) {

--- a/apps/dashboard/src/lib/api/openapi-spec.ts
+++ b/apps/dashboard/src/lib/api/openapi-spec.ts
@@ -4,13 +4,66 @@
  * Served at GET /api/v1/openapi.json as a real file route (not middleware)
  * so anonymous callers get 200 application/openapi+json instead of a 500
  * from the dashboard shell when no /api/v1 route matches.
+ *
+ * Paths are assembled from {@link PUBLIC_API_ROUTES} (the live TanStack
+ * routes that form the public contract) plus the chart/table registries for
+ * `{name}` enums. Internal routes are not listed.
  */
+
+import { getAvailableCharts } from '@/lib/api/chart-registry'
+import {
+  MIN_PUBLIC_API_PATHS,
+  PUBLIC_API_ROUTES,
+  type PublicHttpMethod,
+} from '@/lib/api/public-api'
+import { VALID_INTERVALS } from '@/lib/api/query-executor'
+import { getAvailableTables } from '@/lib/api/table-registry'
 
 export const API_SERVICE_DOC_HREF = 'https://docs.chmonitor.dev/reference/api'
 
 export const OPENAPI_CONTENT_TYPE = 'application/openapi+json'
 
 export const OPENAPI_SPEC_PATH = '/api/v1/openapi.json'
+
+export const OPENAPI_VERSION = '3.0.3'
+
+type JsonSchema = Record<string, unknown>
+
+interface OpenApiParameter {
+  name: string
+  in: 'query' | 'path' | 'header'
+  required?: boolean
+  description?: string
+  schema: JsonSchema
+}
+
+interface OpenApiMedia {
+  schema: JsonSchema
+}
+
+interface OpenApiResponse {
+  description: string
+  content?: Record<string, OpenApiMedia>
+}
+
+interface OpenApiOperation {
+  tags: string[]
+  summary: string
+  description: string
+  operationId: string
+  security?: Array<Record<string, string[]>>
+  parameters?: OpenApiParameter[]
+  requestBody?: {
+    required?: boolean
+    content: Record<string, OpenApiMedia>
+  }
+  responses: Record<string, OpenApiResponse>
+}
+
+interface OpenApiPathItem {
+  'x-tanstack-path': string
+  [method: string]: unknown
+}
 
 export interface OpenApiDocument {
   openapi: string
@@ -23,42 +76,855 @@ export interface OpenApiDocument {
     description: string
     url: string
   }
-  paths: Record<string, unknown>
+  servers: Array<{ url: string; description: string }>
+  tags: Array<{ name: string; description: string }>
+  paths: Record<string, OpenApiPathItem>
+  components: {
+    securitySchemes: Record<string, JsonSchema>
+    schemas: Record<string, JsonSchema>
+  }
+}
+
+const OPTIONAL_AUTH: Array<Record<string, string[]>> = [{}, { bearerAuth: [] }]
+const REQUIRED_AUTH: Array<Record<string, string[]>> = [{ bearerAuth: [] }]
+
+const ref = (name: string): JsonSchema => ({
+  $ref: `#/components/schemas/${name}`,
+})
+
+function hostIdParam(required: boolean): OpenApiParameter {
+  return {
+    name: 'hostId',
+    in: 'query',
+    required,
+    description:
+      'Zero-based index into the configured host list. Defaults to 0 when omitted (except host-status and overview, which require it).',
+    schema: { type: 'integer', minimum: 0, default: 0 },
+  }
+}
+
+function jsonContent(schema: JsonSchema): Record<string, OpenApiMedia> {
+  return { 'application/json': { schema } }
+}
+
+function errorResponses(
+  extra: Record<string, OpenApiResponse> = {}
+): Record<string, OpenApiResponse> {
+  return {
+    '400': {
+      description: 'Validation error',
+      content: jsonContent(ref('ErrorBody')),
+    },
+    '401': {
+      description:
+        'Authentication required (when the deployment is not fully open)',
+      content: jsonContent(ref('ErrorBody')),
+    },
+    '429': {
+      description: 'Rate limited. Retry-After may be set.',
+      content: jsonContent(ref('ErrorBody')),
+    },
+    '500': {
+      description: 'Server or query error',
+      content: jsonContent(ref('ErrorBody')),
+    },
+    '503': {
+      description: 'Upstream database unreachable or not configured',
+      content: jsonContent(ref('ErrorBody')),
+    },
+    ...extra,
+  }
+}
+
+function buildOperations(
+  chartNames: string[],
+  tableNames: string[]
+): Record<string, Partial<Record<PublicHttpMethod, OpenApiOperation>>> {
+  return {
+    '/api/health': {
+      get: {
+        tags: ['Discovery'],
+        summary: 'Liveness',
+        description:
+          'Anonymous callers receive `{status, timestamp}` only — no deployment metadata. Authenticated callers also receive a `deployment` object (git SHA, auth provider).',
+        operationId: 'getHealth',
+        security: OPTIONAL_AUTH,
+        responses: {
+          '200': {
+            description: 'Process is up',
+            content: jsonContent(ref('HealthResponse')),
+          },
+        },
+      },
+    },
+    [OPENAPI_SPEC_PATH]: {
+      get: {
+        tags: ['Discovery'],
+        summary: 'OpenAPI descriptor',
+        description:
+          'This document. Public discovery (RFC 9727 service-desc); exempt from the `/api/v1` auth gate so a client can read the contract before it has credentials.',
+        operationId: 'getOpenApiSpec',
+        security: [{}],
+        responses: {
+          '200': {
+            description: 'OpenAPI 3.0 document',
+            content: {
+              [OPENAPI_CONTENT_TYPE]: {
+                schema: { type: 'object' },
+              },
+              'application/json': {
+                schema: { type: 'object' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/v1/hosts': {
+      get: {
+        tags: ['Hosts'],
+        summary: 'List configured hosts',
+        description:
+          'Sanitized hosts from the dashboard host env (name + URL). Passwords and query strings are stripped. In cloud mode the list is narrowed to the public demo allowlist.',
+        operationId: 'listHosts',
+        security: OPTIONAL_AUTH,
+        responses: {
+          '200': {
+            description: 'Host list',
+            content: jsonContent(ref('HostListResponse')),
+          },
+          '503': {
+            description: 'No hosts configured',
+            content: jsonContent(ref('ErrorBody')),
+          },
+        },
+      },
+    },
+    '/api/v1/host-status': {
+      get: {
+        tags: ['Hosts'],
+        summary: 'Probe one host',
+        description:
+          'Cheap liveness probe: version, uptime, hostname. Pass `fleet=1` (or the original `counts=1`) to include the optional Fleet metric bundle (counts, live resources, replication, sparkline).',
+        operationId: 'getHostStatus',
+        security: OPTIONAL_AUTH,
+        parameters: [
+          hostIdParam(true),
+          {
+            name: 'fleet',
+            in: 'query',
+            required: false,
+            description: 'Set to `1` to include the Fleet metric bundle.',
+            schema: { type: 'string', enum: ['1'] },
+          },
+          {
+            name: 'counts',
+            in: 'query',
+            required: false,
+            description:
+              'Original name of the Fleet bundle; treated as `fleet=1`.',
+            schema: { type: 'string', enum: ['1'] },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Host status',
+            content: jsonContent(ref('HostStatusResponse')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/overview': {
+      get: {
+        tags: ['Hosts'],
+        summary: 'Overview metrics batch',
+        description:
+          'Single request for the overview page: running/today query counts, database/table counts, disk usage, and host info.',
+        operationId: 'getOverview',
+        security: OPTIONAL_AUTH,
+        parameters: [hostIdParam(true)],
+        responses: {
+          '200': {
+            description: 'Overview metrics',
+            content: jsonContent(ref('OverviewResponse')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/charts/{name}': {
+      get: {
+        tags: ['Charts'],
+        summary: 'Chart series',
+        description:
+          'Named chart from the dashboard chart registry. Unknown names return 404 with `availableCharts`. Optional charts whose backing table is missing return 200 with empty data and `metadata.unavailable`.',
+        operationId: 'getChart',
+        security: OPTIONAL_AUTH,
+        parameters: [
+          {
+            name: 'name',
+            in: 'path',
+            required: true,
+            description: 'Registered chart name.',
+            schema:
+              chartNames.length > 0
+                ? { type: 'string', enum: chartNames }
+                : { type: 'string' },
+          },
+          hostIdParam(false),
+          {
+            name: 'interval',
+            in: 'query',
+            required: false,
+            description:
+              'Time-bucket function (toStartOf*). Invalid values are ignored.',
+            schema: { type: 'string', enum: [...VALID_INTERVALS] },
+          },
+          {
+            name: 'lastHours',
+            in: 'query',
+            required: false,
+            description:
+              'Lookback window in hours. Capped at 8760 (one year), matching the widest built-in chart.',
+            schema: { type: 'integer', minimum: 1, maximum: 8760 },
+          },
+          {
+            name: 'params',
+            in: 'query',
+            required: false,
+            description: 'JSON object of extra chart builder params.',
+            schema: { type: 'string' },
+          },
+          {
+            name: 'timezone',
+            in: 'query',
+            required: false,
+            description:
+              'IANA timezone for the query session. Invalid values are ignored.',
+            schema: { type: 'string', example: 'UTC' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Chart data (`{success, data, metadata}`)',
+            content: jsonContent(ref('ApiEnvelope')),
+          },
+          '404': {
+            description: 'Chart name is not in the registry',
+            content: jsonContent(ref('ApiEnvelope')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/tables': {
+      get: {
+        tags: ['Tables'],
+        summary: 'List tables (autocomplete)',
+        description:
+          'Lightweight list of non-system, non-temporary tables for autocomplete. Ordered by size. Not the query-config registry — use GET /api/v1/tables/{name} for named dashboard tables.',
+        operationId: 'listTables',
+        security: OPTIONAL_AUTH,
+        parameters: [
+          hostIdParam(false),
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            description: 'Max rows (default 500, max 1000).',
+            schema: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 1000,
+              default: 500,
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Table list',
+            content: jsonContent(ref('ApiEnvelope')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/tables/{name}': {
+      get: {
+        tags: ['Tables'],
+        summary: 'Named table page',
+        description:
+          'Runs a registered QueryConfig. Extra search params (filters, `page`, `limit`, `sortBy`, `sortOrder`, `pageSize`) are forwarded into the config. Unknown names return 404 with `availableTables`. Optional configs whose backing table is missing return 200 with empty data and `metadata.unavailable`.',
+        operationId: 'getTable',
+        security: OPTIONAL_AUTH,
+        parameters: [
+          {
+            name: 'name',
+            in: 'path',
+            required: true,
+            description:
+              'Registered query-config name (e.g. `running-queries`).',
+            schema:
+              tableNames.length > 0
+                ? { type: 'string', enum: tableNames }
+                : { type: 'string' },
+          },
+          hostIdParam(false),
+          {
+            name: 'page',
+            in: 'query',
+            required: false,
+            description: 'Page number forwarded to the query config.',
+            schema: { type: 'integer', minimum: 1 },
+          },
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            description: 'Page size forwarded to the query config.',
+            schema: { type: 'integer', minimum: 1 },
+          },
+          {
+            name: 'pageSize',
+            in: 'query',
+            required: false,
+            description:
+              'Alias used by the Rust CLI; forwarded like other search params.',
+            schema: { type: 'integer', minimum: 1 },
+          },
+          {
+            name: 'sortBy',
+            in: 'query',
+            required: false,
+            description: 'Column to sort by, forwarded to the query config.',
+            schema: { type: 'string' },
+          },
+          {
+            name: 'sortOrder',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['asc', 'desc'] },
+          },
+          {
+            name: 'search',
+            in: 'query',
+            required: false,
+            description: 'Free-text search forwarded to the query config.',
+            schema: { type: 'string' },
+          },
+          {
+            name: 'timezone',
+            in: 'query',
+            required: false,
+            description:
+              'IANA timezone for the query session. Invalid values are ignored.',
+            schema: { type: 'string', example: 'UTC' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Table rows (`{success, data, metadata}`)',
+            content: jsonContent(ref('ApiEnvelope')),
+          },
+          '404': {
+            description: 'Table config is not in the registry',
+            content: jsonContent(ref('ApiEnvelope')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/findings': {
+      get: {
+        tags: ['Insights'],
+        summary: 'Recent findings',
+        description:
+          'Recently recorded findings for a host (newest first). Produced by health-sweep cron and the agent `record_finding` tool. Note the host query param is `host`, not `hostId`. Response shape is `{findings, count}`, not the `{success, data}` envelope.',
+        operationId: 'listFindings',
+        security: OPTIONAL_AUTH,
+        parameters: [
+          {
+            name: 'host',
+            in: 'query',
+            required: false,
+            description:
+              'Host id (default 0). Same index space as `hostId` on other routes.',
+            schema: { type: 'integer', minimum: 0, default: 0 },
+          },
+          {
+            name: 'severity',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['info', 'warning', 'critical'] },
+          },
+          {
+            name: 'since',
+            in: 'query',
+            required: false,
+            description:
+              'Lower time bound as an interval expression, e.g. `24 HOUR` or `7 DAY`.',
+            schema: { type: 'string', example: '24 HOUR' },
+          },
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            description: 'Max findings (default 100, max 1000).',
+            schema: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 1000,
+              default: 100,
+            },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Findings list',
+            content: jsonContent(ref('FindingsResponse')),
+          },
+          ...errorResponses(),
+        },
+      },
+    },
+    '/api/v1/agent': {
+      post: {
+        tags: ['Agent'],
+        summary: 'Streaming AI agent',
+        description:
+          'Natural-language agent over the connected host. Streams UI-message events (Vercel AI SDK). On cloud this is an authenticated feature; self-hosted with `CHM_AUTH_PROVIDER=none` is open. Guest/cloud usage may be metered.',
+        operationId: 'runAgent',
+        security: REQUIRED_AUTH,
+        requestBody: {
+          required: true,
+          content: jsonContent(ref('AgentRequest')),
+        },
+        responses: {
+          '200': {
+            description: 'UI message stream',
+            content: {
+              'text/event-stream': { schema: { type: 'string' } },
+            },
+          },
+          '400': {
+            description: 'Invalid JSON, empty messages, or payload too large',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '401': {
+            description: 'Authentication required',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '413': {
+            description: 'Request body exceeds the 128 KiB limit',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '429': {
+            description: 'Rate limited',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '503': {
+            description: 'Model provider is not configured',
+            content: jsonContent(ref('ErrorBody')),
+          },
+        },
+      },
+    },
+    '/api/mcp': {
+      get: {
+        tags: ['MCP'],
+        summary: 'MCP Streamable HTTP (GET)',
+        description:
+          'Model Context Protocol endpoint (streamable HTTP). Plan-gated by `api_mcp_access` on cloud; self-hosted is never gated. See the MCP server docs.',
+        operationId: 'mcpGet',
+        security: OPTIONAL_AUTH,
+        responses: {
+          '200': {
+            description: 'MCP session / SSE',
+          },
+          '401': { description: 'Authentication required' },
+          '429': { description: 'Rate limited' },
+        },
+      },
+      post: {
+        tags: ['MCP'],
+        summary: 'MCP Streamable HTTP (POST)',
+        description:
+          'JSON-RPC MCP messages (initialize, tools/list, tools/call, …). Same auth and plan gate as GET.',
+        operationId: 'mcpPost',
+        security: OPTIONAL_AUTH,
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { type: 'object' } },
+          },
+        },
+        responses: {
+          '200': { description: 'MCP JSON-RPC response or stream' },
+          '401': { description: 'Authentication required' },
+          '429': { description: 'Rate limited' },
+        },
+      },
+      delete: {
+        tags: ['MCP'],
+        summary: 'MCP session delete',
+        description: 'Ends an MCP Streamable HTTP session.',
+        operationId: 'mcpDelete',
+        security: OPTIONAL_AUTH,
+        responses: {
+          '200': { description: 'Session ended' },
+          '429': { description: 'Rate limited' },
+        },
+      },
+      options: {
+        tags: ['MCP'],
+        summary: 'CORS preflight',
+        description:
+          'CORS preflight so cross-origin MCP clients can call this route.',
+        operationId: 'mcpOptions',
+        security: [{}],
+        responses: {
+          '204': { description: 'CORS headers' },
+        },
+      },
+    },
+    '/api/v1/auth/api-key': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Issue an API key',
+        description:
+          'Mints a signed `chm_` API key. Authorize with `Authorization: Bearer` set to `CHM_API_KEY_SECRET` (the issuance secret, not an existing key). Returns 503 when the secret is unset.',
+        operationId: 'issueApiKey',
+        security: REQUIRED_AUTH,
+        requestBody: {
+          required: false,
+          content: jsonContent(ref('IssueApiKeyRequest')),
+        },
+        responses: {
+          '200': {
+            description: 'Minted key',
+            content: jsonContent(ref('IssueApiKeyResponse')),
+          },
+          '400': {
+            description: 'Invalid JSON or `days` out of range',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '401': {
+            description: 'Bearer token is not CHM_API_KEY_SECRET',
+            content: jsonContent(ref('ErrorBody')),
+          },
+          '503': {
+            description: 'CHM_API_KEY_SECRET is not configured',
+            content: jsonContent(ref('ErrorBody')),
+          },
+        },
+      },
+    },
+  }
+}
+
+const SCHEMAS: Record<string, JsonSchema> = {
+  ErrorBody: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      error: {
+        oneOf: [
+          { type: 'string' },
+          {
+            type: 'object',
+            properties: {
+              type: { type: 'string' },
+              message: { type: 'string' },
+              details: { type: 'object', additionalProperties: true },
+            },
+          },
+        ],
+      },
+      metadata: { $ref: '#/components/schemas/ApiMetadata' },
+    },
+  },
+  ApiMetadata: {
+    type: 'object',
+    properties: {
+      queryId: { type: 'string' },
+      duration: { type: 'number' },
+      rows: { type: 'number' },
+      host: { type: 'string' },
+      sql: { type: 'string' },
+      clickhouseVersion: { type: 'string' }, // pragma: allowlist secret
+      timezone: { type: 'string' },
+      unavailable: {
+        description:
+          'Present when an optional backing table is missing or a demo host is hidden.',
+        oneOf: [
+          { type: 'boolean' },
+          {
+            type: 'object',
+            properties: {
+              reason: { type: 'string' },
+              message: { type: 'string' },
+              missingTables: { type: 'array', items: { type: 'string' } },
+            },
+          },
+        ],
+      },
+    },
+  },
+  ApiEnvelope: {
+    type: 'object',
+    required: ['success'],
+    properties: {
+      success: { type: 'boolean' },
+      data: {},
+      metadata: { $ref: '#/components/schemas/ApiMetadata' },
+      error: {
+        type: 'object',
+        properties: {
+          type: { type: 'string' },
+          message: { type: 'string' },
+        },
+      },
+    },
+  },
+  HealthResponse: {
+    type: 'object',
+    required: ['status', 'timestamp'],
+    properties: {
+      status: { type: 'string', enum: ['ok', 'error'] },
+      timestamp: { type: 'string', format: 'date-time' },
+      deployment: {
+        type: 'object',
+        description: 'Only present for authenticated callers.',
+        additionalProperties: true,
+      },
+    },
+  },
+  Host: {
+    type: 'object',
+    required: ['id', 'name', 'host'],
+    properties: {
+      id: { type: 'integer', minimum: 0 },
+      name: { type: 'string' },
+      host: { type: 'string', description: 'Sanitized host (no password).' },
+    },
+  },
+  HostListResponse: {
+    type: 'object',
+    required: ['success', 'data'],
+    properties: {
+      success: { type: 'boolean', enum: [true] },
+      data: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/Host' },
+      },
+    },
+  },
+  HostStatusResponse: {
+    type: 'object',
+    required: ['success'],
+    properties: {
+      success: { type: 'boolean' },
+      data: {
+        type: 'object',
+        properties: {
+          version: { type: 'string' },
+          uptime: { type: 'string' },
+          hostname: { type: 'string' },
+          databases: { type: 'number' },
+          tables: { type: 'number' },
+          clusterNodes: { type: 'number' },
+          runningQueries: { type: 'number' },
+        },
+        additionalProperties: true,
+      },
+      error: { type: 'string' },
+      metadata: { $ref: '#/components/schemas/ApiMetadata' },
+    },
+  },
+  OverviewResponse: {
+    type: 'object',
+    required: ['success'],
+    properties: {
+      success: { type: 'boolean' },
+      data: {
+        type: 'object',
+        properties: {
+          runningQueries: { type: 'number' },
+          todayQueries: { type: 'number' },
+          databaseCount: { type: 'number' },
+          tableCount: { type: 'number' },
+          diskUsage: { type: 'object', additionalProperties: true },
+          hostInfo: { type: 'object', additionalProperties: true },
+        },
+      },
+      metadata: { type: 'object', additionalProperties: true },
+      error: { type: 'string' },
+    },
+  },
+  Finding: {
+    type: 'object',
+    properties: {
+      event_time: { type: 'string' },
+      host_id: { type: 'string' },
+      severity: { type: 'string', enum: ['info', 'warning', 'critical'] },
+      category: { type: 'string' },
+      source: { type: 'string' },
+      title: { type: 'string' },
+      detail: { type: 'string' },
+      metric: { type: 'string' },
+      value: { type: 'number' },
+    },
+  },
+  FindingsResponse: {
+    type: 'object',
+    required: ['findings', 'count'],
+    properties: {
+      findings: {
+        type: 'array',
+        items: { $ref: '#/components/schemas/Finding' },
+      },
+      count: { type: 'integer' },
+      unavailable: { type: 'object', additionalProperties: true },
+    },
+  },
+  AgentRequest: {
+    type: 'object',
+    properties: {
+      message: { type: 'string', description: 'Single-turn user message.' },
+      messages: {
+        type: 'array',
+        description: 'UI-message history (max 64).',
+        items: { type: 'object', additionalProperties: true },
+      },
+      hostId: { type: 'integer', minimum: 0, default: 0 },
+      model: { type: 'string' },
+      apiKey: {
+        type: 'string',
+        description: 'BYOK model-provider key. Never persisted.',
+      },
+      disabledTools: { type: 'array', items: { type: 'string' } },
+      sessionId: { type: 'string' },
+      pageContext: {
+        type: 'object',
+        properties: {
+          route: { type: 'string' },
+          label: { type: 'string' },
+        },
+      },
+    },
+  },
+  IssueApiKeyRequest: {
+    type: 'object',
+    properties: {
+      label: { type: 'string', default: 'cli' },
+      days: {
+        type: 'integer',
+        minimum: 1,
+        maximum: 365,
+        default: 30,
+        description: 'Key lifetime in days.',
+      },
+    },
+  },
+  IssueApiKeyResponse: {
+    type: 'object',
+    required: ['data'],
+    properties: {
+      data: {
+        type: 'object',
+        required: ['apiKey'],
+        properties: {
+          apiKey: { type: 'string' },
+        },
+      },
+    },
+  },
 }
 
 export function buildOpenApiDocument(): OpenApiDocument {
+  const chartNames = [...getAvailableCharts()].sort()
+  const tableNames = getAvailableTables()
+  const operations = buildOperations(chartNames, tableNames)
+
+  const paths: Record<string, OpenApiPathItem> = {}
+  for (const route of PUBLIC_API_ROUTES) {
+    const byMethod = operations[route.openapiPath]
+    if (!byMethod) {
+      throw new Error(
+        `OpenAPI operation map is missing path ${route.openapiPath}`
+      )
+    }
+    const item: OpenApiPathItem = {
+      'x-tanstack-path': route.tanstackPath,
+    }
+    for (const method of route.methods) {
+      const operation = byMethod[method]
+      if (!operation) {
+        throw new Error(
+          `OpenAPI operation map is missing ${method.toUpperCase()} ${route.openapiPath}`
+        )
+      }
+      item[method] = operation
+    }
+    paths[route.openapiPath] = item
+  }
+
+  if (Object.keys(paths).length < MIN_PUBLIC_API_PATHS) {
+    throw new Error(
+      `Public OpenAPI spec has ${Object.keys(paths).length} paths; minimum is ${MIN_PUBLIC_API_PATHS}`
+    )
+  }
+
   return {
-    openapi: '3.0.0',
+    openapi: OPENAPI_VERSION,
     info: {
       title: 'chmonitor API',
       version: '1.0.0',
-      description: 'API endpoints for ClickHouse monitoring dashboard.',
+      description:
+        'Public HTTP API for the chmonitor dashboard. This document is the RFC 9727 service-desc at GET /api/v1/openapi.json.\n\nIt lists the stable public contract assembled from the live TanStack Start routes: liveness, host list and status, chart series, table pages, overview, findings, the streaming agent, MCP, and API-key issuance. Internal surfaces (explorer, conversations, billing, webhooks, cron, menu-counts, Slack, health-alert admin, per-user connections) are omitted on purpose.',
     },
     externalDocs: {
       description: 'HTTP API reference',
       url: API_SERVICE_DOC_HREF,
     },
-    paths: {
-      '/api/health': {
-        get: {
-          summary: 'Health Check',
-          responses: {
-            '200': {
-              description: 'Success',
-            },
-          },
+    servers: [
+      {
+        url: '/',
+        description: 'Same origin as the dashboard',
+      },
+    ],
+    tags: [
+      { name: 'Discovery', description: 'Catalog, OpenAPI, liveness' },
+      {
+        name: 'Hosts',
+        description: 'Configured hosts and overview',
+      },
+      {
+        name: 'Charts',
+        description: 'Named chart series from the chart registry',
+      },
+      {
+        name: 'Tables',
+        description: 'Named QueryConfig tables and autocomplete',
+      },
+      { name: 'Insights', description: 'Persisted findings' },
+      { name: 'Agent', description: 'Streaming AI agent' },
+      { name: 'MCP', description: 'Model Context Protocol' },
+      { name: 'Auth', description: 'API-key issuance' },
+    ],
+    paths,
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'chm_',
+          description:
+            'Signed `chm_` API key (`Authorization: Bearer chm_…`) or a Clerk session on cloud. Self-hosted with CHM_AUTH_PROVIDER=none and no CHM_API_KEY_SECRET is fully open.',
         },
       },
-      [OPENAPI_SPEC_PATH]: {
-        get: {
-          summary: 'OpenAPI descriptor',
-          responses: {
-            '200': {
-              description: 'OpenAPI 3.0 document',
-            },
-          },
-        },
-      },
+      schemas: SCHEMAS,
     },
   }
 }

--- a/apps/dashboard/src/lib/api/public-api.ts
+++ b/apps/dashboard/src/lib/api/public-api.ts
@@ -6,9 +6,9 @@
  * surfaces (explorer/*, conversations/*, billing/*, webhooks/*, cron/*,
  * menu-counts/*, Slack, health-alert admin, user-connections) stay out.
  *
- * Each entry maps an OpenAPI path to the file-route `fullPath` in
- * `src/routeTree.gen.ts`. Tests fail if a catalog path is missing from the
- * route tree, or if the published spec shrinks back to a 2-path stub.
+ * Each entry maps an OpenAPI path to a committed `createFileRoute(...)` under
+ * `src/routes/api/`. Tests fail if a catalog path has no matching route
+ * module, or if the published spec shrinks back to a 2-path stub.
  */
 
 export type PublicHttpMethod =

--- a/apps/dashboard/src/lib/api/public-api.ts
+++ b/apps/dashboard/src/lib/api/public-api.ts
@@ -1,0 +1,129 @@
+/**
+ * Stable public HTTP API surface.
+ *
+ * This is the contract advertised by GET /api/v1/openapi.json — assembled from
+ * the TanStack Start routes that already exist, not invented. Internal
+ * surfaces (explorer/*, conversations/*, billing/*, webhooks/*, cron/*,
+ * menu-counts/*, Slack, health-alert admin, user-connections) stay out.
+ *
+ * Each entry maps an OpenAPI path to the file-route `fullPath` in
+ * `src/routeTree.gen.ts`. Tests fail if a catalog path is missing from the
+ * route tree, or if the published spec shrinks back to a 2-path stub.
+ */
+
+export type PublicHttpMethod =
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'patch'
+  | 'delete'
+  | 'options'
+
+export interface PublicApiRoute {
+  /** Path as advertised in OpenAPI (brace params, no trailing slash). */
+  readonly openapiPath: string
+  /** Path registered on the TanStack file route (`$name`, trailing slash ok). */
+  readonly tanstackPath: string
+  readonly methods: readonly PublicHttpMethod[]
+}
+
+/**
+ * Convert a TanStack file-route path to the OpenAPI form:
+ * `$name` → `{name}`, trailing slash stripped.
+ */
+export function tanstackPathToOpenApiPath(tanstackPath: string): string {
+  const braced = tanstackPath.replace(/\$([A-Za-z0-9_]+)/g, '{$1}')
+  if (braced.length > 1 && braced.endsWith('/')) {
+    return braced.slice(0, -1)
+  }
+  return braced
+}
+
+/**
+ * The public contract. Order is the order paths appear in the OpenAPI
+ * document. Keep this list in sync with the operation map in openapi-spec.ts.
+ */
+export const PUBLIC_API_ROUTES = [
+  {
+    openapiPath: '/api/health',
+    tanstackPath: '/api/health',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/openapi.json',
+    tanstackPath: '/api/v1/openapi.json',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/hosts',
+    tanstackPath: '/api/v1/hosts',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/host-status',
+    tanstackPath: '/api/v1/host-status',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/overview',
+    tanstackPath: '/api/v1/overview',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/charts/{name}',
+    tanstackPath: '/api/v1/charts/$name',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/tables',
+    tanstackPath: '/api/v1/tables/',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/tables/{name}',
+    tanstackPath: '/api/v1/tables/$name',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/findings',
+    tanstackPath: '/api/v1/findings',
+    methods: ['get'],
+  },
+  {
+    openapiPath: '/api/v1/agent',
+    tanstackPath: '/api/v1/agent',
+    methods: ['post'],
+  },
+  {
+    openapiPath: '/api/mcp',
+    tanstackPath: '/api/mcp',
+    methods: ['get', 'post', 'delete', 'options'],
+  },
+  {
+    openapiPath: '/api/v1/auth/api-key',
+    tanstackPath: '/api/v1/auth/api-key',
+    methods: ['post'],
+  },
+] as const satisfies readonly PublicApiRoute[]
+
+/** Hard floor so GET /api/v1/openapi.json cannot silently become a 2-path stub. */
+export const MIN_PUBLIC_API_PATHS = 10
+
+/** Paths every published spec must include (subset of PUBLIC_API_ROUTES). */
+export const REQUIRED_PUBLIC_API_PATHS = [
+  '/api/health',
+  '/api/v1/openapi.json',
+  '/api/v1/hosts',
+  '/api/v1/charts/{name}',
+  '/api/v1/tables/{name}',
+  '/api/v1/host-status',
+  '/api/v1/overview',
+] as const
+
+export function listPublicOpenApiPaths(): string[] {
+  return PUBLIC_API_ROUTES.map((route) => route.openapiPath)
+}
+
+export function listPublicTanstackPaths(): string[] {
+  return PUBLIC_API_ROUTES.map((route) => route.tanstackPath)
+}

--- a/apps/dashboard/src/routes/api/v1/__tests__/openapi-contract.test.ts
+++ b/apps/dashboard/src/routes/api/v1/__tests__/openapi-contract.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Route-level OpenAPI contract (roadmap 17).
+ *
+ * Delegates to lib/api/__tests__/openapi-spec.test.ts for the full suite;
+ * this file keeps a route-adjacent assertion that the published document
+ * cannot collapse to the two-path stub that shipped with #3101.
+ */
+import { describe, expect, test } from 'bun:test'
+import { buildOpenApiDocument } from '@/lib/api/openapi-spec'
+import {
+  MIN_PUBLIC_API_PATHS,
+  REQUIRED_PUBLIC_API_PATHS,
+} from '@/lib/api/public-api'
+
+describe('GET /api/v1/openapi.json contract', () => {
+  test('documents the real public API, not a 2-path stub', () => {
+    const spec = buildOpenApiDocument()
+    const paths = Object.keys(spec.paths)
+    expect(paths.length).toBeGreaterThan(2)
+    expect(paths.length).toBeGreaterThanOrEqual(MIN_PUBLIC_API_PATHS)
+    for (const path of REQUIRED_PUBLIC_API_PATHS) {
+      expect(spec.paths[path]).toBeDefined()
+    }
+  })
+})

--- a/docs/content/reference/api.mdx
+++ b/docs/content/reference/api.mdx
@@ -22,7 +22,7 @@ curl -sS https://dash.example.com/.well-known/api-catalog
 curl -sS https://dash.example.com/api/v1/openapi.json
 ```
 
-`GET /api/v1/openapi.json` is public. It returns **200** with `openapi`, `info`, and `paths` for anonymous callers — it does not require a session or API key.
+`GET /api/v1/openapi.json` is public. It returns **200** with `openapi`, `info`, and `paths` for anonymous callers — it does not require a session or API key. The document is the stable public contract (health, hosts, charts, tables, overview, findings, agent, MCP, API-key issuance), assembled from the live dashboard routes — not a two-path stub of `/api/health` and itself.
 
 Neighboring discovery URLs (same origin):
 
@@ -50,13 +50,21 @@ The OpenAPI document is the machine-readable list. These are the endpoints most 
 | Method | Path | Notes |
 |---|---|---|
 | `GET` | `/api/health` | Liveness only. Anonymous response is `{status, timestamp}` — no deployment metadata ([#1768](https://github.com/chmonitor/chmonitor/issues/1768)). |
-| `GET` | `/api/v1/openapi.json` | This spec. Public. |
+| `GET` | `/api/v1/openapi.json` | This spec. Public. Chart and table `{name}` enums come from the live registries. |
 | `GET` | `/api/v1/hosts` | Configured ClickHouse hosts (sanitized; no passwords). |
-| `GET` | `/api/v1/charts/:name` | Chart series. Requires `hostId`. |
-| `GET` | `/api/v1/tables/:name` | Table pages. Requires `hostId`. |
+| `GET` | `/api/v1/host-status` | Version / uptime / hostname. Requires `hostId`. Pass `fleet=1` for the metric bundle. |
+| `GET` | `/api/v1/overview` | Overview KPI batch. Requires `hostId`. |
+| `GET` | `/api/v1/charts/{name}` | Chart series. `hostId` defaults to `0`. |
+| `GET` | `/api/v1/tables` | Autocomplete list of non-system tables. |
+| `GET` | `/api/v1/tables/{name}` | Named QueryConfig page. `hostId` defaults to `0`. |
+| `GET` | `/api/v1/findings` | Recent findings. Host query param is `host` (not `hostId`). |
+| `POST` | `/api/v1/agent` | Streaming AI agent. Authenticated on cloud. |
 | `POST` | `/api/mcp` | Model Context Protocol server — see [MCP server](/reference/mcp-server). |
+| `POST` | `/api/v1/auth/api-key` | Mint a `chm_` key. Bearer must be `CHM_API_KEY_SECRET`. |
 
-Most data routes take `hostId` (query param, default `0`) to select a host from `CLICKHOUSE_HOST`.
+Most data routes take `hostId` (query param, default `0`) to select a host from the configured host list.
+
+The OpenAPI document is the machine-readable list; this table is the short start set.
 
 ## Related
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3088 / #3101. `GET /api/v1/openapi.json` now documents the real public HTTP API (hosts, charts, tables, overview, findings, agent, MCP, API-key issuance), not a two-path stub of `/api/health` and itself.

## Changes

- Assemble the OpenAPI 3.0 document from the live TanStack public routes (`lib/api/public-api.ts`) plus chart/table registry names for `{name}` enums.
- Internal surfaces (explorer, conversations, billing, webhooks, cron, menu-counts, Slack, health-alert admin, per-user connections) are omitted on purpose.
- Contract tests fail if the spec has ≤2 paths, drops below 10 paths, or advertises a path that is not a committed `createFileRoute` under `src/routes/api/` (does not read generated `routeTree.gen.ts`, which is absent in the CI unit-test job).
- Docs `/reference/api` (already live) lists the same public start set.

## Test plan

- [x] `bun test src/lib/api/__tests__/openapi-spec.test.ts src/routes/api/v1/__tests__/openapi-contract.test.ts src/__tests__/agent-discovery.test.ts --isolate` — 30 pass, 0 fail
- [x] Catalog assertion walks committed API route modules, not `routeTree.gen.ts`
- [x] Built spec is OpenAPI 3.0.3 with 12 paths; stub-size guards remain
- [x] `pnpm exec biome check` on touched files
- [ ] After deploy: anonymous `GET https://dash.chmonitor.dev/api/v1/openapi.json` is 200 OpenAPI 3 JSON with hosts/charts/tables paths
- [x] `https://docs.chmonitor.dev/reference/api` is already a real docs page

## Notes for reviewer

#3088 was closed when #3101 made the route return 200. QA is right that a 2-path stub is not a public spec. This PR does not reopen #3088 and does not merge.

Do not merge. Do not merge release-please.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e006f9b-13bb-493e-890f-cfbbd39fbc9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e006f9b-13bb-493e-890f-cfbbd39fbc9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

