### PR TITLE
feat(dashboard): add Tools sidebar group (#3115)

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -290,7 +290,12 @@ module snapshot in `lib/format-settings.ts`; palette/density →
 
 1. `src/routes/(dashboard)/my-page.tsx` (`'use client'`, uses `useHostId()`).
 2. Add a `QueryConfig` in `src/lib/query-config/` if it needs data.
-3. Register in `src/menu.ts` (with feature gate / `tableCheck` if optional).
+3. Register in `src/menu/` (with feature gate / `tableCheck` if optional).
+   Interactive utilities (SQL, explorer, explain, compare, builder) go in
+   `menu/tools.ts` — not under Queries/Tables/Operations/System. System-table
+   views stay in their domain file. The Tools parent must not set
+   `permission`; copy the child's existing feature onto the leaf. DBA /
+   Engineer / SRE presets include `Tools`.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -294,8 +294,10 @@ module snapshot in `lib/format-settings.ts`; palette/density →
    Interactive utilities (SQL, explorer, explain, compare, builder) go in
    `menu/tools.ts` — not under Queries/Tables/Operations/System. System-table
    views stay in their domain file. The Tools parent must not set
-   `permission`; copy the child's existing feature onto the leaf. DBA /
-   Engineer / SRE presets include `Tools`.
+   `permission`; copy the child's existing feature onto the leaf. Leave
+   `engines` absent so Postgres hosts hide the whole Tools group — do not
+   add `engines: ['postgres']`. DBA / Engineer / SRE presets include
+   `Tools`.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -119,7 +119,7 @@ describe('Sidebar navigation', () => {
       })
   })
 
-  test('navigates to running-queries via sidebar', () => {
+  it('navigates to running-queries via sidebar', () => {
     cy.get(SIDEBAR).should('be.visible')
     expandGroup('Queries', '/running-queries')
     clickHref('/running-queries')

--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -61,7 +61,9 @@ function ensureDesktopRailExpanded() {
 function expandGroup(groupLabel: string, hrefPart: string) {
   const labelRe = new RegExp(`^${groupLabel}(\\s|$)`)
   cy.get(`${SIDEBAR} [data-slot="collapsible-trigger"]`)
-    .filter((_, el) => labelRe.test((el.innerText || '').replace(/\s+/g, ' ').trim()))
+    .filter((_, el) =>
+      labelRe.test((el.innerText || '').replace(/\s+/g, ' ').trim())
+    )
     .should('have.length.at.least', 1)
     .first()
     .scrollIntoView()
@@ -71,7 +73,9 @@ function expandGroup(groupLabel: string, hrefPart: string) {
     if ($body.find(`a[href*="${hrefPart}"]`).length === 0) {
       // First click collapsed an already-open group — toggle back.
       cy.get(`${SIDEBAR} [data-slot="collapsible-trigger"]`)
-        .filter((_, el) => labelRe.test((el.innerText || '').replace(/\s+/g, ' ').trim()))
+        .filter((_, el) =>
+          labelRe.test((el.innerText || '').replace(/\s+/g, ' ').trim())
+        )
         .first()
         .click({ force: true })
     }
@@ -115,11 +119,20 @@ describe('Sidebar navigation', () => {
       })
   })
 
-  it('navigates to running-queries via sidebar', () => {
+  test('navigates to running-queries via sidebar', () => {
     cy.get(SIDEBAR).should('be.visible')
     expandGroup('Queries', '/running-queries')
     clickHref('/running-queries')
     cy.url().should('include', '/running-queries')
+    cy.url().should('include', 'host=0')
+    cy.get('body').should('exist')
+  })
+
+  it('navigates to sql console via Tools sidebar group', () => {
+    cy.get(SIDEBAR).should('be.visible')
+    expandGroup('Tools', '/sql')
+    clickHref('/sql')
+    cy.url().should('include', '/sql')
     cy.url().should('include', 'host=0')
     cy.get('body').should('exist')
   })

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
@@ -100,6 +100,7 @@ describe('WorkspacePresetPicker', () => {
       ).toBeTruthy()
       expect(container.textContent).toContain('Overview')
       expect(container.textContent).toContain('Queries')
+      expect(container.textContent).toContain('Tools')
       expect(container.textContent).toContain('Main')
 
       const overview = container.querySelector(
@@ -225,6 +226,7 @@ describe('WorkspacePresetPicker', () => {
         container.querySelector('[data-testid="workspace-menu-leaf-/clusters"]')
       ).toBeNull()
       expect(container.textContent).not.toContain('Cluster')
+      expect(container.textContent).not.toContain('Tools')
     } finally {
       await cleanup()
     }
@@ -253,6 +255,9 @@ describe('WorkspacePresetPicker', () => {
         container.querySelector(
           '[data-testid="workspace-menu-leaf-/running-queries"]'
         )
+      ).toBeTruthy()
+      expect(
+        container.querySelector('[data-testid="workspace-menu-leaf-/sql"]')
       ).toBeTruthy()
       expect(
         container.querySelector(

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
@@ -225,6 +225,12 @@ describe('WorkspacePresetPicker', () => {
       expect(
         container.querySelector('[data-testid="workspace-menu-leaf-/clusters"]')
       ).toBeNull()
+      expect(
+        container.querySelector('[data-testid="workspace-menu-leaf-/sql"]')
+      ).toBeNull()
+      expect(
+        container.querySelector('[data-testid="workspace-menu-leaf-/explorer"]')
+      ).toBeNull()
       expect(container.textContent).not.toContain('Cluster')
       expect(container.textContent).not.toContain('Tools')
     } finally {

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -30,10 +30,10 @@ const PRESET_OPTIONS: {
 
 const PRESET_HINT: Record<WorkspacePreset, string> = {
   full: 'Every page the host and deployment already allow. New pages stay visible.',
-  dba: 'Tables, queries, merges, replication, disks, cluster, keeper, security.',
+  dba: 'Tables, queries, SQL tools, merges, replication, disks, cluster, keeper, security.',
   engineer:
-    'Overview, queries, SQL/explorer, insights. Less keeper, security, and ops.',
-  sre: 'Overview, health, insights, replication, disks, errors, running queries.',
+    'Overview, SQL/explorer, queries, insights. Less keeper, security, and ops.',
+  sre: 'Overview, health, insights, SQL tools, replication, disks, errors, running queries.',
   custom:
     'Starts from a preset. Hide extra pages without a full checkbox wall.',
 }

--- a/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
+++ b/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
@@ -24,6 +24,54 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
     "depth": 0,
     "href": "",
     "section": "main",
+    "title": "Tools",
+  },
+  {
+    "depth": 1,
+    "href": "/sql",
+    "section": undefined,
+    "title": "SQL Console",
+  },
+  {
+    "depth": 1,
+    "href": "/explorer",
+    "section": undefined,
+    "title": "Data Explorer",
+  },
+  {
+    "depth": 1,
+    "href": "/explain",
+    "section": undefined,
+    "title": "Explain",
+  },
+  {
+    "depth": 1,
+    "href": "/advisor",
+    "section": undefined,
+    "title": "Advisor",
+  },
+  {
+    "depth": 1,
+    "href": "/dashboard",
+    "section": undefined,
+    "title": "Chart Builder",
+  },
+  {
+    "depth": 1,
+    "href": "/schema-diff",
+    "section": undefined,
+    "title": "Schema Compare",
+  },
+  {
+    "depth": 1,
+    "href": "/settings-diff",
+    "section": undefined,
+    "title": "Settings Diff",
+  },
+  {
+    "depth": 0,
+    "href": "",
+    "section": "main",
     "title": "AI Agent",
   },
   {
@@ -160,18 +208,6 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
   },
   {
     "depth": 1,
-    "href": "/explain",
-    "section": undefined,
-    "title": "Explain",
-  },
-  {
-    "depth": 1,
-    "href": "/advisor",
-    "section": undefined,
-    "title": "Advisor",
-  },
-  {
-    "depth": 1,
     "href": "/query-views-log",
     "section": undefined,
     "title": "Query Views Log",
@@ -211,18 +247,6 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
     "href": "/tables",
     "section": "main",
     "title": "Tables",
-  },
-  {
-    "depth": 1,
-    "href": "/explorer",
-    "section": undefined,
-    "title": "Data Explorer",
-  },
-  {
-    "depth": 1,
-    "href": "/sql",
-    "section": undefined,
-    "title": "SQL Console",
   },
   {
     "depth": 1,
@@ -544,18 +568,6 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
   },
   {
     "depth": 1,
-    "href": "/settings-diff",
-    "section": undefined,
-    "title": "Settings Diff",
-  },
-  {
-    "depth": 1,
-    "href": "/schema-diff",
-    "section": undefined,
-    "title": "Schema Compare",
-  },
-  {
-    "depth": 1,
     "href": "/disks",
     "section": undefined,
     "title": "Disks",
@@ -625,12 +637,6 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
     "href": "",
     "section": "others",
     "title": "Operations",
-  },
-  {
-    "depth": 1,
-    "href": "/dashboard",
-    "section": undefined,
-    "title": "Chart Builder",
   },
   {
     "depth": 1,

--- a/apps/dashboard/src/lib/menu/__tests__/breadcrumb.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/breadcrumb.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  getBreadcrumbPath,
   isMenuItemActive,
   isMenuItemActiveAmongSiblings,
 } from '@/lib/menu/breadcrumb'
@@ -58,5 +59,28 @@ describe('isMenuItemActiveAmongSiblings', () => {
     expect(
       isMenuItemActiveAmongSiblings('/agents', siblingHrefs, '/agents')
     ).toBe(true)
+  })
+})
+
+describe('getBreadcrumbPath (Tools regroup)', () => {
+  test('SQL Console breadcrumbs go through Tools, not Tables', () => {
+    expect(getBreadcrumbPath('/sql')).toEqual([
+      { title: 'Tools', href: '' },
+      { title: 'SQL Console', href: '/sql' },
+    ])
+  })
+
+  test('Explain breadcrumbs go through Tools, not Queries', () => {
+    expect(getBreadcrumbPath('/explain')).toEqual([
+      { title: 'Tools', href: '' },
+      { title: 'Explain', href: '/explain' },
+    ])
+  })
+
+  test('Chart Builder breadcrumbs go through Tools, not Operations', () => {
+    expect(getBreadcrumbPath('/dashboard')).toEqual([
+      { title: 'Tools', href: '' },
+      { title: 'Chart Builder', href: '/dashboard' },
+    ])
   })
 })

--- a/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
@@ -167,10 +167,14 @@ describe('Tools group (interactive utilities)', () => {
     expect(byHref['/settings-diff']).toBe('settings')
   })
 
-  test('has no engines tag so Postgres hosts hide the group (#3105)', () => {
+  test('has no engines tag so Postgres hosts hide the whole group (#3105 / #3115)', () => {
+    // Absent engines = default source-engine family. Do not add
+    // engines: ['postgres'] — that would show CH-only tools on Postgres.
     expect(tools?.engines).toBeUndefined()
+    expect(tools?.engines?.includes('postgres') ?? false).toBe(false)
     for (const item of tools?.items ?? []) {
       expect(item.engines, item.href).toBeUndefined()
+      expect(item.engines?.includes('postgres') ?? false, item.href).toBe(false)
     }
   })
 

--- a/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
@@ -128,3 +128,57 @@ describe('menu.ts hrefs resolve to a real route file', () => {
     expect(offenders).toEqual([])
   })
 })
+
+describe('Tools group (interactive utilities)', () => {
+  const tools = menuItemsConfig.find((item) => item.title === 'Tools')
+
+  test('is a top-level main group after Overview/Postgres and before AI Agent', () => {
+    const titles = menuItemsConfig.map((item) => item.title)
+    const toolsAt = titles.indexOf('Tools')
+    expect(toolsAt).toBeGreaterThan(titles.indexOf('Overview'))
+    expect(toolsAt).toBeGreaterThan(titles.indexOf('Running Queries'))
+    expect(toolsAt).toBeLessThan(titles.indexOf('AI Agent'))
+    expect(tools?.section).toBe('main')
+  })
+
+  test('lists daily-use utilities in most-used-first order', () => {
+    expect(tools?.items?.map((item) => item.href)).toEqual([
+      '/sql',
+      '/explorer',
+      '/explain',
+      '/advisor',
+      '/dashboard',
+      '/schema-diff',
+      '/settings-diff',
+    ])
+  })
+
+  test('parent does not over-gate children; each child keeps its feature', () => {
+    expect(tools?.permission).toBeUndefined()
+    const byHref = Object.fromEntries(
+      (tools?.items ?? []).map((item) => [item.href, item.permission?.feature])
+    )
+    expect(byHref['/sql']).toBe('tables')
+    expect(byHref['/explorer']).toBe('tables')
+    expect(byHref['/explain']).toBe('queries')
+    expect(byHref['/advisor']).toBe('queries')
+    expect(byHref['/dashboard']).toBe('dashboard')
+    expect(byHref['/schema-diff']).toBe('settings')
+    expect(byHref['/settings-diff']).toBe('settings')
+  })
+
+  test('moved pages are gone from their old groups', () => {
+    const hrefsOf = (title: string) =>
+      menuItemsConfig
+        .find((item) => item.title === title)
+        ?.items?.map((item) => item.href) ?? []
+
+    expect(hrefsOf('Tables')).not.toContain('/sql')
+    expect(hrefsOf('Tables')).not.toContain('/explorer')
+    expect(hrefsOf('Queries')).not.toContain('/explain')
+    expect(hrefsOf('Queries')).not.toContain('/advisor')
+    expect(hrefsOf('Operations')).not.toContain('/dashboard')
+    expect(hrefsOf('System')).not.toContain('/schema-diff')
+    expect(hrefsOf('System')).not.toContain('/settings-diff')
+  })
+})

--- a/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
@@ -167,6 +167,13 @@ describe('Tools group (interactive utilities)', () => {
     expect(byHref['/settings-diff']).toBe('settings')
   })
 
+  test('has no engines tag so Postgres hosts hide the group (#3105)', () => {
+    expect(tools?.engines).toBeUndefined()
+    for (const item of tools?.items ?? []) {
+      expect(item.engines, item.href).toBeUndefined()
+    }
+  })
+
   test('moved pages are gone from their old groups', () => {
     const hrefsOf = (title: string) =>
       menuItemsConfig

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -217,6 +217,26 @@ describe('filterMenuItemsByEngine', () => {
     // ClickHouse-only top-level items must not appear.
     expect(pgTitles).not.toContain('Overview')
     expect(pgTitles).not.toContain('Health')
+    // #3115: the whole Tools group is hidden, not an empty parent.
+    expect(pgTitles).not.toContain('Tools')
+  })
+
+  test('Postgres host does not see the Tools group at all (#3115)', () => {
+    // Absent `engines` on the Tools parent fails itemMatchesEngine for
+    // postgres, so the group is dropped before children are considered.
+    const pg = filterMenuItemsByEngine(menuItemsConfig, 'postgres')
+    expect(pg.map((i) => i.title)).not.toContain('Tools')
+    for (const href of [
+      '/sql',
+      '/explorer',
+      '/explain',
+      '/advisor',
+      '/dashboard',
+      '/schema-diff',
+      '/settings-diff',
+    ]) {
+      expect(collectMenuHrefs(pg)).not.toContain(href)
+    }
   })
 })
 

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/menu/visible-items'
 import {
   applyWorkspaceVisibility,
+  collectMenuHrefs,
   PRESET_GROUP_TITLES,
 } from '@/lib/menu/workspace-presets'
 
@@ -241,6 +242,21 @@ describe('getSettingsNavMenuItems', () => {
     expect(titles).not.toContain('Cluster')
     expect(titles).not.toContain('Overview')
     expect(titles).not.toContain('About')
+  })
+
+  test('Postgres Settings tree does not include Tools leaves (#3105)', () => {
+    const hrefs = collectMenuHrefs(getSettingsNavMenuItems('postgres'))
+    for (const href of [
+      '/sql',
+      '/explorer',
+      '/explain',
+      '/advisor',
+      '/dashboard',
+      '/schema-diff',
+      '/settings-diff',
+    ]) {
+      expect(hrefs).not.toContain(href)
+    }
   })
 })
 

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -226,6 +226,7 @@ describe('getSettingsNavMenuItems', () => {
       getSettingsNavMenuItems(DEFAULT_SOURCE_ENGINE).map((i) => i.title)
     )
     expect(titles).toContain('Queries')
+    expect(titles).toContain('Tools')
     expect(titles).toContain('Cluster')
     expect(titles).not.toContain('Query Insights')
     expect(titles).not.toContain('About')
@@ -236,6 +237,7 @@ describe('getSettingsNavMenuItems', () => {
     expect(titles).toContain('Query Insights')
     expect(titles).toContain('Running Queries')
     expect(titles).not.toContain('Queries')
+    expect(titles).not.toContain('Tools')
     expect(titles).not.toContain('Cluster')
     expect(titles).not.toContain('Overview')
     expect(titles).not.toContain('About')
@@ -355,7 +357,10 @@ describe('applyWorkspaceVisibility', () => {
 
   test('DBA preset group titles stay the documented set', () => {
     expect(PRESET_GROUP_TITLES.dba).toContain('Tables')
+    expect(PRESET_GROUP_TITLES.dba).toContain('Tools')
+    expect(PRESET_GROUP_TITLES.engineer).toContain('Tools')
     expect(PRESET_GROUP_TITLES.engineer).not.toContain('Keeper')
     expect(PRESET_GROUP_TITLES.sre).toContain('Health')
+    expect(PRESET_GROUP_TITLES.sre).toContain('Tools')
   })
 })

--- a/apps/dashboard/src/lib/menu/workspace-presets.test.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.test.ts
@@ -6,6 +6,7 @@ import {
   effectiveHiddenMenuHrefs,
   hideMenuHref,
   menuItemIsHidden,
+  PRESET_GROUP_TITLES,
   showMenuHref,
 } from '@/lib/menu/workspace-presets'
 
@@ -168,5 +169,13 @@ describe('effectiveHiddenMenuHrefs / menuItemIsHidden', () => {
         new Set(['/advisor', '/running-queries'])
       )
     ).toBe(true)
+  })
+})
+
+describe('PRESET_GROUP_TITLES', () => {
+  test('DBA, Engineer, and SRE all include Tools', () => {
+    expect(PRESET_GROUP_TITLES.dba).toContain('Tools')
+    expect(PRESET_GROUP_TITLES.engineer).toContain('Tools')
+    expect(PRESET_GROUP_TITLES.sre).toContain('Tools')
   })
 })

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -33,6 +33,7 @@ export const PRESET_GROUP_TITLES: Record<
 > = {
   dba: [
     'Overview',
+    'Tools',
     'Queries',
     'Tables',
     'Merges',
@@ -43,9 +44,10 @@ export const PRESET_GROUP_TITLES: Record<
     'Cluster',
     'System',
   ],
-  engineer: ['Overview', 'Queries', 'Tables', 'Insights', 'AI Agent'],
+  engineer: ['Overview', 'Tools', 'Queries', 'Tables', 'Insights', 'AI Agent'],
   sre: [
     'Overview',
+    'Tools',
     'Health',
     'Insights',
     'Queries',

--- a/apps/dashboard/src/menu/index.ts
+++ b/apps/dashboard/src/menu/index.ts
@@ -18,13 +18,16 @@ import { queriesItems } from './queries'
 import { securityItems } from './security'
 import { systemItems } from './system'
 import { tablesItems } from './tables'
+import { toolsItems } from './tools'
 
-// Composed in the exact original menu.ts order — see each section file for
+// Composed in sidebar / command-palette order — see each section file for
 // the top-level group it holds. Keep this order when adding/removing
-// sections: it drives the sidebar and command palette listing order.
+// sections. Tools sits after Overview + Postgres and before AI Agent so
+// daily actions (SQL Console, Data Explorer) are near the top.
 export const menuItemsConfig: MenuItem[] = [
   ...overviewItems,
   ...postgresItems,
+  ...toolsItems,
   ...aiAgentItems,
   ...insightsItems,
   ...healthItems,

--- a/apps/dashboard/src/menu/operations.ts
+++ b/apps/dashboard/src/menu/operations.ts
@@ -1,4 +1,4 @@
-import { ArchiveIcon, BarChartIcon, DashboardIcon } from '@radix-ui/react-icons'
+import { ArchiveIcon, BarChartIcon } from '@radix-ui/react-icons'
 import { CloudIcon, ShieldAlertIcon } from 'lucide-react'
 
 import type { MenuItem } from '@/components/menu/types'
@@ -13,13 +13,6 @@ export const operationsItems: MenuItem[] = [
     section: 'others',
     permission: { feature: 'operations' },
     items: [
-      {
-        title: 'Chart Builder',
-        href: '/dashboard',
-        description: 'Build custom monitoring dashboards with charts',
-        icon: DashboardIcon,
-        permission: { feature: 'dashboard' },
-      },
       {
         title: 'Backups',
         href: '/backups',

--- a/apps/dashboard/src/menu/queries.ts
+++ b/apps/dashboard/src/menu/queries.ts
@@ -1,7 +1,6 @@
 import {
   CounterClockwiseClockIcon,
   CrossCircledIcon,
-  InfoCircledIcon,
   LightningBoltIcon,
   MixIcon,
 } from '@radix-ui/react-icons'
@@ -12,7 +11,6 @@ import {
   GaugeIcon,
   LayersIcon,
   UsersIcon,
-  WandSparklesIcon,
 } from 'lucide-react'
 
 import type { MenuItem } from '@/components/menu/types'
@@ -100,21 +98,6 @@ export const queriesItems: MenuItem[] = [
         icon: LayersIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/query_log',
         tableCheck: 'system.query_log',
-      },
-      {
-        title: 'Explain',
-        href: '/explain',
-        description: 'Query execution plan analysis for performance tuning',
-        icon: InfoCircledIcon,
-        docs: 'https://clickhouse.com/docs/en/sql-reference/statements/explain',
-      },
-      {
-        title: 'Advisor',
-        href: '/advisor',
-        description:
-          'Ranked skip-index, projection, partition-key, and PREWHERE recommendations for a slow query (recommend-only)',
-        icon: WandSparklesIcon,
-        isNew: true,
       },
       {
         title: 'Query Views Log',

--- a/apps/dashboard/src/menu/system.ts
+++ b/apps/dashboard/src/menu/system.ts
@@ -3,7 +3,6 @@ import {
   AlertTriangleIcon,
   CircleDollarSignIcon,
   GaugeIcon,
-  GitCompareArrowsIcon,
   HardDriveIcon,
   SlidersHorizontalIcon,
   WorkflowIcon,
@@ -48,25 +47,6 @@ export const systemItems: MenuItem[] = [
         icon: SlidersHorizontalIcon,
         docs: 'https://clickhouse.com/docs/en/operations/system-tables/replicated_merge_tree_settings',
         tableCheck: 'system.replicated_merge_tree_settings',
-      },
-      {
-        title: 'Settings Diff',
-        href: '/settings-diff',
-        description:
-          'Compare system.settings and merge_tree_settings across all configured hosts',
-        icon: GitCompareArrowsIcon,
-        isNew: true,
-        permission: { feature: 'settings' },
-      },
-      {
-        title: 'Schema Compare',
-        href: '/schema-diff',
-        description:
-          'Compare table schemas across hosts and copy a recommend-only change plan',
-        icon: GitCompareArrowsIcon,
-        isNew: true,
-        permission: { feature: 'settings' },
-        tableCheck: 'system.tables',
       },
       {
         title: 'Disks',

--- a/apps/dashboard/src/menu/tables.ts
+++ b/apps/dashboard/src/menu/tables.ts
@@ -11,7 +11,6 @@ import {
   Grid2x2CheckIcon,
   LayersIcon,
   RssIcon,
-  TerminalIcon,
   Trash2Icon,
   UnplugIcon,
 } from 'lucide-react'
@@ -26,24 +25,6 @@ export const tablesItems: MenuItem[] = [
     section: 'main',
     permission: { feature: 'tables' },
     items: [
-      {
-        title: 'Data Explorer',
-        href: '/explorer',
-        description: 'Interactive database schema browser with metadata',
-        countKey: 'tables-explorer',
-        countLabel: 'tables',
-        icon: TableIcon,
-        docs: 'https://clickhouse.com/docs/en/operations/system-tables/databases',
-        tableCheck: ['system.databases', 'system.tables'],
-      },
-      {
-        title: 'SQL Console',
-        href: '/sql',
-        description:
-          'Run read-only SQL with history, EXPLAIN, query log and scan analysis',
-        icon: TerminalIcon,
-        docs: 'https://clickhouse.com/docs/en/sql-reference/statements/select',
-      },
       {
         title: 'Tables Overview',
         href: '/tables-overview',

--- a/apps/dashboard/src/menu/tools.ts
+++ b/apps/dashboard/src/menu/tools.ts
@@ -17,11 +17,13 @@ export const toolsItems: MenuItem[] = [
     // old groups (`tables`, `queries`, `dashboard`, `settings`) so the
     // group is not over-gated.
     //
-    // No `engines` on the parent or children (#3105): absent already means
-    // the default source-engine family, so filterMenuItemsByEngine hides
-    // Tools on a Postgres host. Do not tag these items — Settings >
-    // Navigation uses the same getSettingsNavMenuItems(engine) path as the
-    // sidebar.
+    // No `engines` on the parent or children (#3105 / #3115): absent already
+    // means the default source-engine family. filterMenuItemsByEngine drops
+    // the parent when itemMatchesEngine fails, so a Postgres host does not
+    // see the Tools group at all — not an empty heading, not CH-only
+    // children. Do NOT add `engines: ['postgres']` (that would show these
+    // pages on a Postgres host). Settings > Navigation uses the same
+    // getSettingsNavMenuItems(engine) path as the sidebar.
     title: 'Tools',
     href: '',
     icon: WrenchIcon,

--- a/apps/dashboard/src/menu/tools.ts
+++ b/apps/dashboard/src/menu/tools.ts
@@ -1,0 +1,89 @@
+import { DashboardIcon, InfoCircledIcon } from '@radix-ui/react-icons'
+import {
+  GitCompareArrowsIcon,
+  TableIcon,
+  TerminalIcon,
+  WandSparklesIcon,
+  WrenchIcon,
+} from 'lucide-react'
+
+import type { MenuItem } from '@/components/menu/types'
+
+export const toolsItems: MenuItem[] = [
+  {
+    // Interactive utilities (run SQL, explore schema, explain, compare,
+    // build charts) — not system-table monitors. No `permission` on the
+    // parent: children keep the feature gates they inherited from their
+    // old groups (`tables`, `queries`, `dashboard`, `settings`) so the
+    // group is not over-gated.
+    title: 'Tools',
+    href: '',
+    icon: WrenchIcon,
+    section: 'main',
+    items: [
+      {
+        title: 'SQL Console',
+        href: '/sql',
+        description:
+          'Run read-only SQL with history, EXPLAIN, query log and scan analysis',
+        icon: TerminalIcon,
+        docs: 'https://clickhouse.com/docs/en/sql-reference/statements/select', // pragma: allowlist secret
+        permission: { feature: 'tables' },
+      },
+      {
+        title: 'Data Explorer',
+        href: '/explorer',
+        description: 'Interactive database schema browser with metadata',
+        countKey: 'tables-explorer',
+        countLabel: 'tables',
+        icon: TableIcon,
+        docs: 'https://clickhouse.com/docs/en/operations/system-tables/databases', // pragma: allowlist secret
+        tableCheck: ['system.databases', 'system.tables'],
+        permission: { feature: 'tables' },
+      },
+      {
+        title: 'Explain',
+        href: '/explain',
+        description: 'Query execution plan analysis for performance tuning',
+        icon: InfoCircledIcon,
+        docs: 'https://clickhouse.com/docs/en/sql-reference/statements/explain', // pragma: allowlist secret
+        permission: { feature: 'queries' },
+      },
+      {
+        title: 'Advisor',
+        href: '/advisor',
+        description:
+          'Ranked skip-index, projection, partition-key, and PREWHERE recommendations for a slow query (recommend-only)',
+        icon: WandSparklesIcon,
+        isNew: true,
+        permission: { feature: 'queries' },
+      },
+      {
+        title: 'Chart Builder',
+        href: '/dashboard',
+        description: 'Build custom monitoring dashboards with charts', // pragma: allowlist secret
+        icon: DashboardIcon,
+        permission: { feature: 'dashboard' },
+      },
+      {
+        title: 'Schema Compare',
+        href: '/schema-diff',
+        description:
+          'Compare table schemas across hosts and copy a recommend-only change plan',
+        icon: GitCompareArrowsIcon,
+        isNew: true,
+        permission: { feature: 'settings' },
+        tableCheck: 'system.tables',
+      },
+      {
+        title: 'Settings Diff',
+        href: '/settings-diff',
+        description:
+          'Compare system.settings and merge_tree_settings across all configured hosts',
+        icon: GitCompareArrowsIcon,
+        isNew: true,
+        permission: { feature: 'settings' },
+      },
+    ],
+  },
+]

--- a/apps/dashboard/src/menu/tools.ts
+++ b/apps/dashboard/src/menu/tools.ts
@@ -16,6 +16,12 @@ export const toolsItems: MenuItem[] = [
     // parent: children keep the feature gates they inherited from their
     // old groups (`tables`, `queries`, `dashboard`, `settings`) so the
     // group is not over-gated.
+    //
+    // No `engines` on the parent or children (#3105): absent already means
+    // the default source-engine family, so filterMenuItemsByEngine hides
+    // Tools on a Postgres host. Do not tag these items — Settings >
+    // Navigation uses the same getSettingsNavMenuItems(engine) path as the
+    // sidebar.
     title: 'Tools',
     href: '',
     icon: WrenchIcon,

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -3,7 +3,7 @@ id: conventions
 title: Development Conventions
 type: workflow
 status: active
-updated: 2026-06-02
+updated: 2026-08-18
 tags:
   - conventions
   - patterns
@@ -26,7 +26,9 @@ related:
 - Root route: `src/routes/__root.tsx`
 - Dashboard pages: File-based routes under `src/routes/(dashboard)/`
 - API routes: Server-side API endpoints under `src/routes/api/`
-- Navigation config: Defined in `src/menu.ts`
+- Navigation config: Per-section files under `src/menu/` composed by
+  `src/menu/index.ts` (re-exported from `src/menu.ts`). Interactive utilities
+  live in `menu/tools.ts`; system-table views stay in their domain file.
 - Styles: Main Tailwind v4 stylesheet at `src/styles.css`
 - Test files co-located with components or in cypress/ directory (`.cy.tsx` / `.cy.ts`)
 

--- a/docs/knowledge/conventions.md
+++ b/docs/knowledge/conventions.md
@@ -29,6 +29,8 @@ related:
 - Navigation config: Per-section files under `src/menu/` composed by
   `src/menu/index.ts` (re-exported from `src/menu.ts`). Interactive utilities
   live in `menu/tools.ts`; system-table views stay in their domain file.
+  Leave `engines` absent on Tools so Postgres hosts hide the whole group
+  (`filterMenuItemsByEngine`); do not add `engines: ['postgres']`.
 - Styles: Main Tailwind v4 stylesheet at `src/styles.css`
 - Test files co-located with components or in cypress/ directory (`.cy.tsx` / `.cy.ts`)
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -287,6 +287,7 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   is hover-only on that row (never always-on). Favorites also show a grip
   handle on hover; drag it to reorder (`nav-favorites.tsx`). Order is the
   `chm-pinned-favorites` localStorage pin list (`lib/menu/favorites-store.ts`).
+
 - **Dashboard widget grid** (plan 57, `components/dashboard/`): `grid.tsx`
   lays out `DashboardWidget[]` (chart/table/stat/text, `@/types/dashboard-layout`)
   on a fixed 12-column CSS grid; view mode is plain positioned `div`s, arrange
@@ -631,9 +632,41 @@ lettermark (first letter, provider's existing accent color) rather than
 inventing a low-quality logo — see `ProviderMark` in
 `components/agents/settings/provider-models-tab.tsx`.
 
+
+## Sidebar navigation groups
+
+The dashboard sidebar (and Settings > Navigation, ⌘K, breadcrumbs) is composed
+from `apps/dashboard/src/menu/*.ts` via `menu/index.ts` (re-exported as
+`src/menu.ts`). Order in `menuItemsConfig` is the sidebar order.
+
+**Main** (near the top): Overview, Postgres (engine-gated), **Tools**, AI Agent,
+Insights, Health, Queries, Tables, Merges, Metrics, Keeper, PeerDB.
+
+**Others**: Inbound Events, Security, Logs, System, Cluster, Operations.
+
+**Footer**: About (next to the Settings gear; never hidden by a workspace
+preset).
+
+**Tools** is the interactive-utility group — pages where you *do* something
+(run SQL, explore schema, explain a query, compare hosts, build charts) rather
+than watch a system-table monitor. Current leaves, most-used first: SQL Console
+(`/sql`), Data Explorer (`/explorer`), Explain (`/explain`), Advisor
+(`/advisor`, recommend-only), Chart Builder (`/dashboard`), Schema Compare
+(`/schema-diff`), Settings Diff (`/settings-diff`). AI Agent stays its own
+flagship group. Postgres-only items stay engine-gated and are not moved here.
+
+The Tools parent must **not** over-gate children: leave `permission` off the
+group and copy each child's existing feature (`tables`, `queries`,
+`dashboard`, `settings`) onto the leaf. DBA, Engineer, and SRE presets all
+include `Tools` (`PRESET_GROUP_TITLES`); Full auto-includes new groups.
+
+When adding a page: interactive utility → `menu/tools.ts`; system-table view →
+the matching domain file (`queries.ts`, `tables.ts`, …).
+
 ## File / naming
 
 kebab-case files; PascalCase components; `use*` hooks; `'use client'` on
 interactive client components; shared types in `src/types/` or
 `src/lib/api/types.ts`; route pages under `src/routes/(dashboard)/`; nav in
-`src/menu.ts`. See `conventions.md`.
+`src/menu/` (composed by `menu/index.ts`, re-exported from `src/menu.ts`).
+See `conventions.md`.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -655,6 +655,12 @@ than watch a system-table monitor. Current leaves, most-used first: SQL Console
 (`/schema-diff`), Settings Diff (`/settings-diff`). AI Agent stays its own
 flagship group. Postgres-only items stay engine-gated and are not moved here.
 
+Leave `engines` **absent** on the Tools parent and children. Absent already
+means the default source-engine family, so `filterMenuItemsByEngine` drops
+the **whole group** on a Postgres host (not an empty heading). Do not add
+`engines: ['postgres']`. Settings > Navigation uses the same engine filter
+(`useActiveHostEngine` → `getSettingsNavMenuItems(engine)`).
+
 The Tools parent must **not** over-gate children: leave `permission` off the
 group and copy each child's existing feature (`tables`, `queries`,
 `dashboard`, `settings`) onto the leaf. DBA, Engineer, and SRE presets all


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3115

## Summary

Adds a top-level **Tools** sidebar group and moves interactive utilities out of Tables, Queries, Operations, and System so daily actions (SQL Console, Data Explorer) sit near the top of the nav.

This PR is only the Tools nav regroup. Advisor stays recommend-only. No route or page-behavior changes. Does not touch release-please, #3042, #3005, or Renovate #14.

Please squash-merge when you are ready — do not use auto-merge.

## Proposed tree

New group **Tools** (after Overview + Postgres, before AI Agent). Locked to exactly these seven items, in this order:

- SQL Console (`/sql`) — from Tables
- Data Explorer (`/explorer`) — from Tables
- Explain (`/explain`) — from Queries
- Advisor (`/advisor`) — from Queries (recommend-only, unchanged)
- Chart Builder (`/dashboard`) — from Operations
- Schema Compare (`/schema-diff`) — from System
- Settings Diff (`/settings-diff`) — from System

**Not moved:** AI Agent stays its own top-level group. Queries, Cluster, Insights, Health, and other monitoring groups stay where they are. RBAC Management stays under Security; Index & Projection Analytics stays under Tables.

## #3105 / Postgres

Settings > Navigation and the sidebar still use the active host engine (`useActiveHostEngine` → `getSettingsNavMenuItems(engine)` / `getVisibleMenuItems(..., engine)`).

Tools parent and children have **no** `engines` tag (absent = default source-engine family). `filterMenuItemsByEngine` therefore drops the **whole Tools group** on a Postgres host — not an empty heading, not CH-only children only. Do not add `engines: ['postgres']`. No host, env, or hardcoded engine string was added to the Settings picker.

## Test plan

- [x] Menu unit tests + snapshot (Tools is exactly the seven hrefs above)
- [x] `filterMenuItemsByEngine(..., 'postgres')` does not contain the Tools group
- [x] Workspace preset picker: default engine shows `/sql`; Postgres engine hides Tools
- [x] Invariant: Tools items have no `engines` tag (never `engines: ['postgres']`)
- [x] Biome check on changed files
- [x] Required CI: `unit-tests` and `dashboard` (re-running on this commit)

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-531e55d2-9dd0-44be-b47c-91fe5a0f868f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-531e55d2-9dd0-44be-b47c-91fe5a0f868f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

