### PR TITLE
fix(dashboard): load TTL partition inventory without missing ttl column

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -224,7 +224,9 @@ chart in `components/charts/` as the template — don't reinvent the wiring.
 - **Empty:** `EmptyState` (`components/ui/empty-state.tsx`) with the right
   `variant` (`no-data | no-results | error | table-missing | timeout |
   filtered-empty | offline | loading`), `icon`, `title`, `description`, optional
-  `action`/`onRefresh`.
+  `action`/`onRefresh`. Table query failures use the full (non-compact)
+  EmptyState so timeout / missing-column copy is visible — never hourglass +
+  Retry with no description.
 - **Error (graceful):** initial error (`error && !hasData`) → full `ChartError`
   with retry. Revalidation error (`staleError`) → KEEP showing data + subtle
   amber `ChartStaleIndicator` (hover-revealed), auto-clears on next success.

--- a/apps/dashboard/src/components/tables/table-client.tsx
+++ b/apps/dashboard/src/components/tables/table-client.tsx
@@ -426,8 +426,10 @@ export const TableClient = function TableClient({
       )
     }
 
-    // Fall back to generic error handling for other error types
-    const errorTitle = getCardErrorTitle(variant, title)
+    // Fall back to generic error handling for other error types.
+    // Do not pass the table title as the error heading — that hid
+    // "Request timed out" / "Failed to load" behind the page name (#3121).
+    const errorTitle = getCardErrorTitle(variant)
     const errorClassName = getCardErrorClassName(variant)
     const errorDescription = getCardErrorDescription(
       error as CardError,
@@ -452,7 +454,6 @@ export const TableClient = function TableClient({
             variant={variant}
             title={errorTitle}
             description={errorDescription}
-            compact={true}
             action={
               showRetry
                 ? {

--- a/apps/dashboard/src/lib/__tests__/card-error-utils.test.ts
+++ b/apps/dashboard/src/lib/__tests__/card-error-utils.test.ts
@@ -176,6 +176,21 @@ describe('detectCardErrorVariant — HTTP status codes', () => {
     )
   })
 
+  test('unknown identifier / missing columns stay errors even on HTTP 500', () => {
+    expect(
+      detectCardErrorVariant({
+        message: "Unknown identifier: 'ttl'",
+        status: 500,
+      } as any)
+    ).toBe('error')
+    expect(
+      detectCardErrorVariant({
+        message: 'Missing columns: ttl',
+        status: 500,
+      } as any)
+    ).toBe('error')
+  })
+
   test('503 returns offline', () => {
     expect(detectCardErrorVariant({ message: '', status: 503 } as any)).toBe(
       'offline'

--- a/apps/dashboard/src/lib/card-error-utils.test.ts
+++ b/apps/dashboard/src/lib/card-error-utils.test.ts
@@ -212,6 +212,20 @@ describe('detectCardErrorVariant', () => {
     ).toBe('timeout')
   })
 
+  it('returns error for unknown identifier even when status is 500', () => {
+    expect(
+      detectCardErrorVariant(
+        makeError("Unknown identifier: 'ttl'", { status: 500 })
+      )
+    ).toBe('error')
+  })
+
+  it('returns error for missing columns even when status is 500', () => {
+    expect(
+      detectCardErrorVariant(makeError('Missing columns: ttl', { status: 500 }))
+    ).toBe('error')
+  })
+
   it('returns offline for status 503', () => {
     expect(
       detectCardErrorVariant(makeError('Service Unavailable', { status: 503 }))

--- a/apps/dashboard/src/lib/card-error-utils.ts
+++ b/apps/dashboard/src/lib/card-error-utils.ts
@@ -147,6 +147,17 @@ export function detectCardErrorVariant(error: CardError): CardErrorVariant {
     return 'timeout'
   }
 
+  // 2a. SQL identifier / missing-column errors are not timeouts. The table
+  // API returns HTTP 500 for any query_error, which would otherwise become
+  // a silent hourglass (#3121: unknown `system.tables.ttl`).
+  if (
+    message.includes('unknown identifier') ||
+    message.includes('unknown column') ||
+    message.includes('missing columns')
+  ) {
+    return 'error'
+  }
+
   // 2b. Server / resource errors (HTTP 5xx, e.g. a Cloudflare Worker that
   // exceeded CPU/memory limits) are retryable and best surfaced as a "too
   // heavy" timeout-style error rather than a generic failure.

--- a/apps/dashboard/src/lib/health/ttl-partition-heuristics.test.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-heuristics.test.ts
@@ -4,6 +4,7 @@ import {
   isTimeBasedPartitionKey,
   PARTITION_COUNT_CRITICAL,
   PARTITION_COUNT_WARNING,
+  ttlPartitionFlagsLabel,
   ttlPartitionRowClassName,
 } from './ttl-partition-heuristics'
 import { describe, expect, test } from 'bun:test'
@@ -126,5 +127,33 @@ describe('ttlPartitionRowClassName', () => {
         active_parts: 1,
       })
     ).toBeUndefined()
+  })
+})
+
+describe('ttlPartitionFlagsLabel', () => {
+  test('joins flags for a time-based table with no TTL', () => {
+    expect(
+      ttlPartitionFlagsLabel({
+        database: 'logs',
+        table: 'events',
+        partition_key: 'toYYYYMMDD(ts)',
+        ttl_expression: '',
+        partitions: 10,
+        active_parts: 10,
+      })
+    ).toBe('missing_ttl')
+  })
+
+  test('is empty for healthy rows', () => {
+    expect(
+      ttlPartitionFlagsLabel({
+        database: 'dim',
+        table: 'users',
+        partition_key: 'id',
+        ttl_expression: '',
+        partitions: 1,
+        active_parts: 1,
+      })
+    ).toBe('')
   })
 })

--- a/apps/dashboard/src/lib/health/ttl-partition-heuristics.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-heuristics.ts
@@ -97,6 +97,11 @@ export function ttlPartitionRowClassName(
   return undefined
 }
 
+/** Human-readable flag list for inventory rows (empty when healthy). */
+export function ttlPartitionFlagsLabel(row: Record<string, unknown>): string {
+  return evaluateTtlPartitionHealth(inventoryRowFromQuery(row)).flags.join(', ')
+}
+
 export function inventoryRowFromQuery(
   row: Record<string, unknown>
 ): TtlPartitionInventoryRow {

--- a/apps/dashboard/src/lib/insights/ttl-partition-collector.test.ts
+++ b/apps/dashboard/src/lib/insights/ttl-partition-collector.test.ts
@@ -4,10 +4,9 @@ mock.module('../ai/agent/tools/helpers', () => ({
   readOnlyQuery: async () => [],
 }))
 
-const {
-  insightFromTtlInventoryRows,
-  rowFromTtlInventoryRecord,
-} = await import('./ttl-partition-collector')
+const { insightFromTtlInventoryRows, rowFromTtlInventoryRecord } = await import(
+  './ttl-partition-collector'
+)
 
 describe('rowFromTtlInventoryRecord', () => {
   test('maps QueryConfig inventory columns', () => {
@@ -72,6 +71,8 @@ describe('insightFromTtlInventoryRows', () => {
     expect(out[0]?.title).toContain('b.worst')
     expect(out[0]?.severity).toBe('critical')
     expect(out[0]?.value).toBe(1500)
+    expect(out[0]?.detail).toContain('too_many_partitions')
+    expect(out[0]?.detail).toContain('recommend-only')
     expect(out[0]?.action).toEqual({
       label: 'View TTL inventory',
       href: '/ttl-partition-health',

--- a/apps/dashboard/src/lib/insights/ttl-partition-collector.ts
+++ b/apps/dashboard/src/lib/insights/ttl-partition-collector.ts
@@ -10,6 +10,7 @@ import { readOnlyQuery } from '../ai/agent/tools/helpers'
 import {
   evaluateTtlPartitionHealth,
   type TtlPartitionInventoryRow,
+  ttlPartitionFlagsLabel,
 } from '../health/ttl-partition-heuristics'
 import { ttlPartitionInventorySql } from '../query-config/system/ttl-partition-health'
 
@@ -27,21 +28,24 @@ export function rowFromTtlInventoryRecord(
 }
 
 /** Worst flagged row → at most one storage insight. */
-export function insightFromTtlInventoryRows(
-  rows: unknown
-): InsightCandidate[] {
+export function insightFromTtlInventoryRows(rows: unknown): InsightCandidate[] {
   if (!Array.isArray(rows)) return []
 
   const flagged: {
     row: TtlPartitionInventoryRow
     severity: 'warning' | 'critical'
+    flags: string
   }[] = []
   for (const raw of rows) {
     const rec = raw as Record<string, unknown>
     const row = rowFromTtlInventoryRecord(rec)
     const health = evaluateTtlPartitionHealth(row)
     if (health.severity === 'warning' || health.severity === 'critical') {
-      flagged.push({ row, severity: health.severity })
+      flagged.push({
+        row,
+        severity: health.severity,
+        flags: ttlPartitionFlagsLabel(rec),
+      })
     }
   }
   if (flagged.length === 0) return []
@@ -55,7 +59,7 @@ export function insightFromTtlInventoryRows(
       category: 'storage',
       metric: 'ttl_partition_health',
       title: `${fq} needs TTL or partition review`,
-      detail: `${fq} has ${worst.row.partitions} partitions (${worst.row.activeParts} active parts). Open TTL & Partitions for the full inventory. This is recommend-only — no ALTER TTL is applied.`,
+      detail: `${fq} has ${worst.row.partitions} partitions (${worst.row.activeParts} active parts); ${worst.flags}. Open TTL & Partitions for the full inventory. This is recommend-only — no ALTER TTL is applied.`,
       value: worst.row.partitions,
       action: {
         label: 'View TTL inventory',

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
@@ -10,24 +10,49 @@ describe('ttlPartitionHealthConfig', () => {
     )
   })
 
-  test('is version-aware and never queries part_log', () => {
+  test('never queries part_log, create_table_query, or a fictional tables.ttl', () => {
     const variants = getAllSqlStrings(ttlPartitionHealthConfig.sql)
-    expect(variants.length).toBe(2)
+    expect(variants.length).toBeGreaterThanOrEqual(1)
     for (const sql of variants) {
       expect(sql).toContain('system.tables')
       expect(sql).toContain('system.parts')
+      expect(sql).toContain('engine_full')
+      expect(sql).toContain('mergetree_tables')
       expect(sql).not.toContain('system.part_log')
+      expect(sql).not.toContain('create_table_query')
+      expect(sql).not.toMatch(/\bt\.ttl\b/)
     }
   })
 
-  test('older variant parses TTL from CREATE TABLE', () => {
+  test('parses table TTL from engine_full before SETTINGS', () => {
     const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[0]
-    expect(sql).toContain('create_table_query')
-    expect(sql).not.toMatch(/\bt\.ttl\b/)
+    expect(sql).toContain("positionCaseInsensitive(t.engine_full, ' TTL ')")
+    expect(sql).toContain('SETTINGS')
   })
 
-  test('newer variant reads system.tables.ttl', () => {
-    const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[1]
-    expect(sql).toContain('t.ttl')
+  test('filters system databases on both tables and parts', () => {
+    const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[0]
+    const systemFilter =
+      "database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')"
+    expect(sql).toContain(systemFilter)
+    expect(sql.split(systemFilter).length - 1).toBeGreaterThanOrEqual(2)
+  })
+
+  test('caps execution under the Worker wall-clock', () => {
+    const sql = getAllSqlStrings(ttlPartitionHealthConfig.sql)[0]
+    expect(sql).toContain('SETTINGS max_execution_time = 25')
+  })
+
+  test('keeps inventory columns used by row highlighting', () => {
+    for (const col of [
+      'full_table',
+      'partition_key',
+      'ttl_expression',
+      'partitions',
+      'active_parts',
+    ]) {
+      expect(ttlPartitionHealthConfig.columns).toContain(col)
+    }
+    expect(ttlPartitionHealthConfig.rowClassName).toBeDefined()
   })
 })

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
@@ -7,29 +7,52 @@ import { ColumnFormat } from '@/types/column-format'
  * Inventory of MergeTree TTL + PARTITION BY + live part counts.
  *
  * Reads system.tables + system.parts only — does not need system.part_log.
- * Older ClickHouse builds have no `system.tables.ttl`; those variants parse
- * `create_table_query` instead. Tables with no TTL still appear.
+ * Table-level TTL is parsed from `engine_full` (the engine clause), not
+ * `create_table_query` (full CREATE TEXT, too heavy on the cloud demo) and
+ * not `system.tables.ttl` (that column does not exist — #3121).
+ * Tables with no TTL still appear.
  */
 
-const TTL_FROM_CREATE = `
+const SYSTEM_DATABASES = `'system', 'INFORMATION_SCHEMA', 'information_schema'`
+
+/**
+ * Table TTL is the clause after ` TTL ` in engine_full, before SETTINGS.
+ * engine_full is far cheaper than create_table_query (no column list).
+ */
+const TTL_FROM_ENGINE_FULL = `
       if(
-        positionCaseInsensitive(t.create_table_query, ' TTL ') > 0,
+        positionCaseInsensitive(t.engine_full, ' TTL ') > 0,
         trim(BOTH ' ' FROM replaceRegexpOne(
           substring(
-            t.create_table_query,
-            positionCaseInsensitive(t.create_table_query, ' TTL ') + 5
+            t.engine_full,
+            positionCaseInsensitive(t.engine_full, ' TTL ') + 5
           ),
-          '\\\\s+(SETTINGS|COMMENT)\\\\s+.*$',
+          '\\\\s+SETTINGS\\\\s+.*$',
           ''
         )),
         ''
       )`
 
-const TTL_FROM_COLUMN = `ifNull(nullIf(t.ttl, ''), ${TTL_FROM_CREATE})`
-
-function inventorySql(ttlExpressionSql: string): string {
-  return `
-    WITH part_stats AS (
+/**
+ * Filter MergeTree tables first (cheap columns + engine_full), aggregate
+ * parts separately, then join. Avoids scanning create_table_query and
+ * avoids a missing `t.ttl` identifier that 500'd the table API as a
+ * silent hourglass (#3121).
+ */
+export const ttlPartitionInventorySql = `
+    WITH mergetree_tables AS (
+      SELECT
+        database,
+        name,
+        engine,
+        partition_key,
+        engine_full
+      FROM system.tables
+      WHERE is_temporary = 0
+        AND database NOT IN (${SYSTEM_DATABASES})
+        AND positionCaseInsensitive(engine, 'MergeTree') > 0
+    ),
+    part_stats AS (
       SELECT
         database,
         table,
@@ -43,6 +66,7 @@ function inventorySql(ttlExpressionSql: string): string {
         sum(bytes_on_disk) AS bytes_on_disk
       FROM system.parts
       WHERE active
+        AND database NOT IN (${SYSTEM_DATABASES})
       GROUP BY database, table
     )
     SELECT
@@ -53,7 +77,7 @@ function inventorySql(ttlExpressionSql: string): string {
       t.name AS _table,
       t.engine,
       t.partition_key,
-      ${ttlExpressionSql} AS ttl_expression,
+      ${TTL_FROM_ENGINE_FULL} AS ttl_expression,
       ifNull(p.partitions, 0) AS partitions,
       ifNull(p.active_parts, 0) AS active_parts,
       ifNull(p.parts_per_partition, 0) AS parts_per_partition,
@@ -74,18 +98,12 @@ function inventorySql(ttlExpressionSql: string): string {
           / nullIf(max(ifNull(p.active_parts, 0)) OVER (), 0),
         2
       ) AS pct_active_parts
-    FROM system.tables AS t
+    FROM mergetree_tables AS t
     LEFT JOIN part_stats AS p
       ON p.database = t.database AND p.table = t.name
-    WHERE t.is_temporary = 0
-      AND t.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
-      AND positionCaseInsensitive(t.engine, 'MergeTree') > 0
     ORDER BY partitions DESC, bytes_on_disk DESC
+    SETTINGS max_execution_time = 25
   `
-}
-
-/** CREATE TABLE parse — works on every supported version; used by Insights. */
-export const ttlPartitionInventorySql = inventorySql(TTL_FROM_CREATE)
 
 export const ttlPartitionHealthConfig: QueryConfig = {
   name: 'ttl-partition-health',
@@ -99,18 +117,7 @@ export const ttlPartitionHealthConfig: QueryConfig = {
     'TTL expression, PARTITION BY, and partition/part counts per MergeTree table. Does not apply ALTER TTL or DROP PARTITION.',
   docs: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl',
   tableCheck: 'system.parts',
-  sql: [
-    {
-      since: '19.1',
-      description: 'TTL parsed from CREATE TABLE (no system.tables.ttl)',
-      sql: ttlPartitionInventorySql,
-    },
-    {
-      since: '21.8',
-      description: 'Prefer system.tables.ttl; fall back to CREATE TABLE',
-      sql: inventorySql(TTL_FROM_COLUMN),
-    },
-  ],
+  sql: ttlPartitionInventorySql,
   columns: [
     'full_table',
     'engine',
@@ -121,6 +128,15 @@ export const ttlPartitionHealthConfig: QueryConfig = {
     'parts_per_partition',
     'readable_bytes_on_disk',
   ],
+  columnDescriptions: {
+    ttl_expression:
+      'Table-level TTL from engine_full. Empty means no table TTL.',
+    partition_key: 'PARTITION BY expression.',
+    partitions:
+      'Active partition count. Highlighted rows have 500+ partitions or a time-based key with no TTL.',
+    parts_per_partition:
+      'Active parts divided by partitions. High values mean merge backlog.',
+  },
   columnFormats: {
     full_table: [
       ColumnFormat.Link,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-18
+updated: 2026-08-19
 tags:
   - design-system
   - ui
@@ -265,7 +265,9 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   (`components/illustrations/empty-state-illustration.tsx`) inside the shared
   circle frame — differentiate the illustration, not the chrome. `ChartError`
   routes its detected cause through `toEmptyStateVariant` → `EmptyState`, so a
-  chart failure automatically gets the matching illustration.
+  chart failure automatically gets the matching illustration. Table query
+  failures (`TableClient`) use the full EmptyState, not `compact`, so timeout
+  and missing-column copy stays visible.
 - **Illustrations:** bespoke, theme-aware, token-driven, motion-safe inline SVGs
   in `components/illustrations/` — prefer over a lone lucide glyph for
   high-impact moments. `WelcomeIllustration` (first-run hero),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The live TTL & Partition Health inventory table never loaded because the 21.8 SQL variant selected `system.tables.ttl`, which is not a real column. The table API returned HTTP 500; compact EmptyState classified that as a timeout and showed only an hourglass plus Retry.

This change parses table-level TTL from `engine_full` (cheap, real column), joins filtered MergeTree tables to `system.parts` aggregates, and surfaces identifier / missing-column errors as real copy instead of a silent Retry.

Closes #3121.

## Changes

- Rewrite `ttl-partition-health` inventory SQL: no `t.ttl`, no `create_table_query`; TTL from `engine_full`; `mergetree_tables` CTE + parts stats join; `SETTINGS max_execution_time = 25`
- Table error EmptyState uses the full (non-compact) layout and the variant title (`Failed to load` / `Request timed out`), not the page name
- HTTP 500 with `unknown identifier` / `missing columns` is classified as an error, not a timeout
- Insights detail includes bloat flags; row highlighting unchanged (recommend-only)
- Unit tests for query config, heuristics, collector, and error classification

## Test plan

- [x] `bun test` for TTL query-config, heuristics, collector, card-error-utils, and shipped-sql validator (404 pass)
- [x] Biome check on changed files
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Docs updated in `docs/knowledge/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

`system.tables` has no `ttl` column (confirmed against current docs). Charts on this page were already cheap `system.parts` aggregations, so they kept working while the table 500'd.

Advisor is unchanged and still recommend-only.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3138366b-08fa-4c0a-8a67-5bbf85336554?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3138366b-08fa-4c0a-8a67-5bbf85336554&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

