### PR TITLE
feat(dashboard): hide sidebar pages from the menu with undo toast

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -242,7 +242,9 @@ Synthetic column ids `__expand`, `select`, `action` are non-data — skip them i
 filter/search/sort/card wiring.
 
 Favorites in the sidebar can be drag-reordered; order is the localStorage pin
-list (`chm-pinned-favorites`).
+list (`chm-pinned-favorites`). Leaf sidebar rows also reveal Hide (EyeOff)
+beside the pin; that writes `hiddenMenuHrefs` and toasts Undo + Open
+Navigation (Settings → Workspace → Navigation).
 
 ## User appearance settings
 

--- a/apps/dashboard/src/components/header/header-actions.tsx
+++ b/apps/dashboard/src/components/header/header-actions.tsx
@@ -8,7 +8,7 @@ import { RefreshCountdown } from '@/components/header/refresh-countdown'
 import { GlobalTimeRangePicker } from '@/components/header/time-range-picker'
 import { InsightsPopover } from '@/components/insights/insights-popover'
 import { NotificationsPopover } from '@/components/notifications/notifications-popover'
-import { SettingsDialog } from '@/components/settings'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
 import { Button } from '@/components/ui/button'
 import { IconButton } from '@/components/ui/icon-button'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
@@ -25,7 +25,7 @@ export const HeaderActions = function HeaderActions({
   const { setTheme, resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  const openSettings = useOpenSettings()
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
   const pathname = useLocation({ select: (l) => l.pathname })
@@ -55,9 +55,7 @@ export const HeaderActions = function HeaderActions({
       <CommandPalette
         open={commandPaletteOpen}
         onOpenChange={setCommandPaletteOpen}
-        onOpenSettings={
-          canUseSettings ? () => setSettingsOpen(true) : undefined
-        }
+        onOpenSettings={canUseSettings ? () => openSettings() : undefined}
       />
 
       {/* Theme toggle - visible on all viewports */}
@@ -88,12 +86,6 @@ export const HeaderActions = function HeaderActions({
       <InsightsPopover />
       <NotificationsPopover />
       {menuComponent}
-
-      {canUseSettings && (
-        <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-          <div />
-        </SettingsDialog>
-      )}
     </div>
   )
 }

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -5,6 +5,7 @@ import { KeyboardShortcuts } from '@/components/controls/keyboard-shortcuts'
 import { HeaderActions } from '@/components/header/header-actions'
 import { Breadcrumb } from '@/components/navigation/breadcrumb'
 import { ResizableSidebarProvider } from '@/components/resizable-sidebar-provider'
+import { SettingsDialogProvider } from '@/components/settings/settings-dialog-provider'
 import { DynamicTitle } from '@/components/status/dynamic-title'
 import { NetworkStatusBanner } from '@/components/status/network-status-banner'
 import { Separator } from '@/components/ui/separator'
@@ -26,7 +27,7 @@ import { Toaster } from '@/components/ui/sonner'
  */
 export function DashboardShell({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <SettingsDialogProvider>
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -68,6 +69,6 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       </ResizableSidebarProvider>
       <GlobalAssistantModal />
       <Toaster />
-    </>
+    </SettingsDialogProvider>
   )
 }

--- a/apps/dashboard/src/components/nav-user.tsx
+++ b/apps/dashboard/src/components/nav-user.tsx
@@ -7,12 +7,10 @@ import {
 } from 'lucide-react'
 
 import { ClerkNavWrapper as ClerkNavWrapperImpl } from './nav-user/clerk-nav'
-import { useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { NavUserFooterRow } from '@/components/nav-user/nav-settings-button'
 import { useAuthIdentity } from '@/components/nav-user/use-auth-identity'
-import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
-import { SettingsDialog } from '@/components/settings'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   DropdownMenu,
@@ -54,7 +52,7 @@ export function NavUser({
   }
 }) {
   const { isMobile } = useSidebar()
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  const openSettingsDialog = useOpenSettings()
   // Under reverse-proxy auth (`trusted`/`proxy`), show the forwarded identity
   // instead of the static guest user. No-op for other providers.
   const proxyIdentity = useAuthIdentity()
@@ -68,9 +66,8 @@ export function NavUser({
     : undefined
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
   const openSettings = () => {
-    if (canUseSettings) setSettingsOpen(true)
+    if (canUseSettings) openSettingsDialog()
   }
-  useSettingsShortcut(openSettings, canUseSettings)
 
   // If Clerk is enabled, use Clerk navigation
   if (isClerkEnabled() && ClerkNavWrapper) {
@@ -174,7 +171,7 @@ export function NavUser({
                   <DropdownMenuItem
                     className="flex items-center gap-2"
                     onClick={() => {
-                      setSettingsOpen(true)
+                      openSettings()
                     }}
                     data-testid="nav-user-settings"
                   >
@@ -190,9 +187,6 @@ export function NavUser({
           </DropdownMenu>
         </ClientOnly>
       </NavUserFooterRow>
-      {canUseSettings && (
-        <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-      )}
     </>
   )
 }

--- a/apps/dashboard/src/components/nav-user/clerk-nav.tsx
+++ b/apps/dashboard/src/components/nav-user/clerk-nav.tsx
@@ -15,10 +15,8 @@ import {
   useOrganization,
   useUser,
 } from '@clerk/tanstack-react-start'
-import { useState } from 'react'
 import { NavUserFooterRow } from '@/components/nav-user/nav-settings-button'
-import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
-import { SettingsDialog } from '@/components/settings'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import {
   DropdownMenu,
@@ -49,13 +47,12 @@ export function ClerkNavWrapper() {
   const { organization } = useOrganization()
   const queryClient = useQueryClient()
   const { isMobile } = useSidebar()
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  const openSettingsDialog = useOpenSettings()
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
   const openSettings = () => {
-    if (canUseSettings) setSettingsOpen(true)
+    if (canUseSettings) openSettingsDialog()
   }
-  useSettingsShortcut(openSettings, canUseSettings)
 
   // Loading state - show skeleton. Gear stays visible so local settings
   // remain reachable while Clerk loads (no account required).
@@ -68,9 +65,6 @@ export function ClerkNavWrapper() {
         >
           <UserSkeletonButton />
         </NavUserFooterRow>
-        {canUseSettings && (
-          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-        )}
       </>
     )
   }
@@ -217,7 +211,7 @@ export function ClerkNavWrapper() {
                   <DropdownMenuItem
                     className="flex items-center gap-2"
                     onClick={() => {
-                      setSettingsOpen(true)
+                      openSettings()
                     }}
                     data-testid="nav-user-settings"
                   >
@@ -249,9 +243,6 @@ export function ClerkNavWrapper() {
           </DropdownMenu>
         )}
       </NavUserFooterRow>
-      {canUseSettings && (
-        <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-      )}
     </>
   )
 }

--- a/apps/dashboard/src/components/navigation/nav-main/hide-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/hide-button.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Hover-hide control: type=button, does not navigate, 44px mobile hit area.
+ * happy-dom + react-dom/client — same harness as nav-settings-button.test.tsx.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type { ReactElement } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('HideButton', () => {
+  test('is a button, does not follow a wrapping link, and has a 44px hit area', async () => {
+    const { HideButton } = await import('./hide-button')
+    const { SidebarProvider, SidebarMenu, SidebarMenuItem } = await import(
+      '@/components/ui/sidebar'
+    )
+    const { USER_SETTINGS_QUERY_KEY } = await import(
+      '@/lib/hooks/use-user-settings'
+    )
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
+
+    let linkClicked = false
+
+    const { container, cleanup } = await renderInto(
+      <QueryClientProvider client={queryClient}>
+        <SidebarProvider>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <a
+                href="/overview"
+                onClick={() => {
+                  linkClicked = true
+                }}
+              >
+                Overview
+                <HideButton href="/overview" title="Overview" />
+              </a>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarProvider>
+      </QueryClientProvider>
+    )
+
+    try {
+      const button = container.querySelector(
+        '[data-testid="hide-menu-item"]'
+      ) as HTMLButtonElement | null
+      expect(button).not.toBeNull()
+      expect(button?.tagName).toBe('BUTTON')
+      expect(button?.getAttribute('aria-label')).toBe('Hide Overview from menu')
+      expect(button?.className).toContain('after:-inset-3')
+
+      const { act } = await import('react')
+      await act(async () => {
+        button?.click()
+      })
+      expect(linkClicked).toBe(false)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/navigation/nav-main/hide-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/hide-button.tsx
@@ -1,0 +1,115 @@
+import { EyeOff } from 'lucide-react'
+
+import { useCallback, useRef } from 'react'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import { SidebarMenuAction } from '@/components/ui/sidebar'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import {
+  persistHideMenuHref,
+  persistShowMenuHref,
+  showHiddenMenuToast,
+} from '@/lib/menu/hide-menu-item'
+import { cn } from '@/lib/utils'
+
+function useHideMenuItem(): (href: string, title: string) => void {
+  const { settings, updateSettings } = useUserSettings()
+  const openSettings = useOpenSettings()
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+
+  return useCallback(
+    (href: string, title: string) => {
+      const hidden = persistHideMenuHref(settingsRef.current, href)
+      updateSettings(hidden)
+      settingsRef.current = { ...settingsRef.current, ...hidden }
+
+      showHiddenMenuToast({
+        title,
+        onUndo: () => {
+          const shown = persistShowMenuHref(settingsRef.current, href)
+          updateSettings(shown)
+          settingsRef.current = { ...settingsRef.current, ...shown }
+        },
+        onOpenNavigation: () => openSettings('navigation'),
+      })
+    },
+    [openSettings, updateSettings]
+  )
+}
+
+interface HideButtonProps {
+  href: string
+  title: string
+  /**
+   * Shift left of the pin, which itself shifts left of the `isNew`/count
+   * badge — all three share the same absolute right-hand corner.
+   */
+  hasBadge?: boolean
+}
+
+/**
+ * Hover-revealed hide control for a top-level sidebar leaf. Sibling of the
+ * link (via `SidebarMenuAction`) so the click never navigates. Same reveal as
+ * `PinButton`. `after:-inset-3` on the 20px control is a 44px mobile hit area;
+ * `md:after:hidden` keeps desktop hover-only.
+ */
+export function HideButton({ href, title, hasBadge }: HideButtonProps) {
+  const hideMenuItem = useHideMenuItem()
+
+  if (!href) return null
+
+  return (
+    <SidebarMenuAction
+      type="button"
+      showOnHover
+      data-testid="hide-menu-item"
+      className={cn(
+        'right-7 after:-inset-3 [&>svg]:size-3',
+        hasBadge && 'right-12'
+      )}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault()
+        event.stopPropagation()
+        hideMenuItem(href, title)
+      }}
+      aria-label={`Hide ${title} from menu`}
+    >
+      <EyeOff />
+    </SidebarMenuAction>
+  )
+}
+
+interface SubHideButtonProps {
+  href: string
+  title: string
+  hasBadge?: boolean
+}
+
+/**
+ * Hover-revealed hide control for a sidebar sub-item. Matches `SubPinButton`
+ * (standalone absolute sibling on `group/menu-sub-item`).
+ */
+export function SubHideButton({ href, title, hasBadge }: SubHideButtonProps) {
+  const hideMenuItem = useHideMenuItem()
+
+  if (!href) return null
+
+  return (
+    <button
+      type="button"
+      data-testid="hide-menu-item"
+      onClick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        hideMenuItem(href, title)
+      }}
+      aria-label={`Hide ${title} from menu`}
+      className={cn(
+        'absolute top-1/2 right-7 flex aspect-square size-5 -translate-y-1/2 items-center justify-center rounded-md p-0 text-sidebar-foreground opacity-0 outline-hidden transition-opacity after:absolute after:-inset-3 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 group-data-[collapsible=icon]:hidden md:after:hidden',
+        hasBadge && 'right-12'
+      )}
+    >
+      <EyeOff className="size-3" />
+    </button>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -5,6 +5,7 @@ import type { MenuItem as MenuItemType } from '@/components/menu/types'
 import type { MenuItemActiveState, MenuItemProps } from './types'
 
 import { CollapsedSubmenu } from './collapsed-submenu'
+import { HideButton, SubHideButton } from './hide-button'
 import { PinButton, SubPinButton } from './pin-button'
 import { lazy, Suspense } from 'react'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
@@ -143,10 +144,18 @@ const SingleMenuItem = function SingleMenuItem({
         }
       >
         {item.icon && <item.icon className="size-4 shrink-0" />}
-        <span className="group-data-[state=collapsed]/sidebar:hidden">
+        <span
+          className={cn(
+            'min-w-0 truncate group-data-[state=collapsed]/sidebar:hidden',
+            hasBadge ? 'pr-16' : 'pr-12'
+          )}
+        >
           {item.title}
         </span>
       </SidebarMenuButton>
+      {item.href ? (
+        <HideButton href={item.href} title={item.title} hasBadge={hasBadge} />
+      ) : null}
       <PinButton href={item.href} title={item.title} hasBadge={hasBadge} />
       {item.isNew && (
         <SidebarMenuBadge className={badgeHiddenClasses}>
@@ -208,8 +217,8 @@ const SubMenuItem = function SubMenuItem({
           pathname
         )}
         className={cn(
-          'h-11 min-h-11 w-full cursor-pointer pr-7 lg:h-7 lg:min-h-7',
-          hasBadge && 'pr-12',
+          'h-11 min-h-11 w-full cursor-pointer pr-12 lg:h-7 lg:min-h-7',
+          hasBadge && 'pr-16',
           available ? '' : 'opacity-50 text-muted-foreground/50'
         )}
         render={
@@ -243,6 +252,13 @@ const SubMenuItem = function SubMenuItem({
           </span>
         )}
       </SidebarMenuSubButton>
+      {subItem.href ? (
+        <SubHideButton
+          href={subItem.href}
+          title={subItem.title}
+          hasBadge={hasBadge}
+        />
+      ) : null}
       <SubPinButton
         href={subItem.href}
         title={subItem.title}

--- a/apps/dashboard/src/components/settings/index.ts
+++ b/apps/dashboard/src/components/settings/index.ts
@@ -1,2 +1,6 @@
 export { SettingsDialog } from './settings-dialog'
+export {
+  SettingsDialogProvider,
+  useOpenSettings,
+} from './settings-dialog-provider'
 export { SettingsForm } from './settings-form'

--- a/apps/dashboard/src/components/settings/settings-dialog-provider.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog-provider.tsx
@@ -1,0 +1,69 @@
+import type { SettingsTab } from '@/lib/settings-tab'
+
+import { SettingsDialog } from './settings-dialog'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+import { useSettingsShortcut } from '@/components/nav-user/use-settings-shortcut'
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
+
+type OpenSettings = (tab?: SettingsTab) => void
+
+const SettingsDialogContext = createContext<OpenSettings | null>(null)
+
+/**
+ * One Settings dialog for the shell (gear, ⌘,, command palette, hide-page
+ * toast). Passing a tab opens that pane; omitting it opens General.
+ */
+export function SettingsDialogProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(false)
+  const [initialTab, setInitialTab] = useState<SettingsTab>('general')
+  const { config } = useFeaturePermissions()
+  const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
+
+  const openSettings = useCallback<OpenSettings>(
+    (tab = 'general') => {
+      if (!canUseSettings) return
+      setInitialTab(tab)
+      setOpen(true)
+    },
+    [canUseSettings]
+  )
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next)
+    if (!next) setInitialTab('general')
+  }, [])
+
+  useSettingsShortcut(openSettings, canUseSettings)
+
+  const value = useMemo(() => openSettings, [openSettings])
+
+  return (
+    <SettingsDialogContext.Provider value={value}>
+      {children}
+      {canUseSettings ? (
+        <SettingsDialog
+          open={open}
+          onOpenChange={handleOpenChange}
+          initialTab={initialTab}
+        />
+      ) : null}
+    </SettingsDialogContext.Provider>
+  )
+}
+
+/** No-op outside the provider so isolated tests keep working. */
+export function useOpenSettings(): OpenSettings {
+  return useContext(SettingsDialogContext) ?? (() => {})
+}

--- a/apps/dashboard/src/components/settings/settings-dialog.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog.tsx
@@ -1,5 +1,7 @@
 import { Settings } from 'lucide-react'
 
+import type { SettingsTab } from '@/lib/settings-tab'
+
 import { SettingsForm } from './settings-form'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
@@ -17,12 +19,14 @@ interface SettingsDialogProps {
   children?: React.ReactElement
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  initialTab?: SettingsTab
 }
 
 export function SettingsDialog({
   children,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
+  initialTab = 'general',
 }: SettingsDialogProps) {
   const [internalOpen, setInternalOpen] = useState(false)
   const { settings, updateSettings } = useUserSettings()
@@ -59,6 +63,7 @@ export function SettingsDialog({
           settings={settings}
           onUpdate={updateSettings}
           onClose={() => onOpenChange(false)}
+          initialTab={initialTab}
         />
       </DialogContent>
     </Dialog>

--- a/apps/dashboard/src/components/settings/settings-form-initial-tab.test.tsx
+++ b/apps/dashboard/src/components/settings/settings-form-initial-tab.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * SettingsForm initialTab: Open Navigation lands on the Navigation pane.
+ * happy-dom + react-dom/client — same harness as workspace-preset-picker.test.tsx.
+ */
+
+import type { ReactElement } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { DEFAULT_SOURCE_ENGINE } from '@chm/types'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+mock.module('next-themes', () => ({
+  useTheme: () => ({ setTheme: () => {}, theme: 'system' }),
+}))
+
+mock.module('@/lib/hooks/use-active-pg-connection', () => ({
+  useActiveHostEngine: () => DEFAULT_SOURCE_ENGINE,
+  useActivePgConnection: () => null,
+  PG_HOST_PARAM: 'pg',
+}))
+
+mock.module('@/lib/swr/api-fetch', () => ({
+  apiFetch: async () => ({ ok: false }),
+}))
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('SettingsForm initialTab', () => {
+  test('defaults to General (Navigation tree is not shown)', async () => {
+    const { SettingsForm } = await import('./settings-form')
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+
+    const { container, cleanup } = await renderInto(
+      <SettingsForm
+        settings={DEFAULT_USER_SETTINGS}
+        onUpdate={() => {}}
+        onClose={() => {}}
+      />
+    )
+
+    try {
+      expect(
+        container.querySelector('[data-testid="workspace-menu-tree"]')
+      ).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('initialTab=navigation opens the Navigation pane', async () => {
+    const { SettingsForm } = await import('./settings-form')
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+
+    const { container, cleanup } = await renderInto(
+      <SettingsForm
+        settings={DEFAULT_USER_SETTINGS}
+        onUpdate={() => {}}
+        onClose={() => {}}
+        initialTab="navigation"
+      />
+    )
+
+    try {
+      expect(
+        container.querySelector('[data-testid="workspace-menu-tree"]')
+      ).toBeTruthy()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -12,6 +12,7 @@ import {
   Settings,
 } from 'lucide-react'
 
+import type { SettingsTab } from '@/lib/settings-tab'
 import type {
   ByteUnit,
   ChartPalette,
@@ -51,6 +52,8 @@ interface SettingsFormProps {
   settings: UserSettings
   onUpdate: (updates: Partial<UserSettings>) => void
   onClose: () => void
+  /** Opens this pane. Defaults to General. */
+  initialTab?: SettingsTab
 }
 
 const themeOptions = [
@@ -439,6 +442,7 @@ export function SettingsForm({
   settings,
   onUpdate,
   onClose,
+  initialTab = 'general',
 }: SettingsFormProps) {
   const { setTheme } = useTheme()
   const engine = useActiveHostEngine()
@@ -533,7 +537,10 @@ export function SettingsForm({
     },
   ]
 
-  const [activeTab, setActiveTab] = useState('general')
+  const [activeTab, setActiveTab] = useState(initialTab)
+  useEffect(() => {
+    setActiveTab(initialTab)
+  }, [initialTab])
   const activeLabel =
     navGroups
       .flatMap((group) => group.items)

--- a/apps/dashboard/src/lib/menu/hide-menu-item.test.ts
+++ b/apps/dashboard/src/lib/menu/hide-menu-item.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import {
+  DEFAULT_USER_SETTINGS,
+  type UserSettings,
+} from '@/lib/types/user-settings'
+
+const toastMock = mock((_title: string, _opts?: unknown) => ({ id: 'toast' }))
+
+mock.module('sonner', () => ({
+  toast: toastMock,
+}))
+
+const {
+  consumeHideToastDuration,
+  FIRST_HIDE_TOAST_MS,
+  HIDE_TOAST_MS,
+  persistHideMenuHref,
+  persistShowMenuHref,
+  resetHideMenuToastState,
+  showHiddenMenuToast,
+} = await import('./hide-menu-item')
+
+afterEach(() => {
+  resetHideMenuToastState()
+  toastMock.mockClear()
+})
+
+describe('persistHideMenuHref / persistShowMenuHref', () => {
+  test('hiding a leaf switches to Custom and records the href', () => {
+    const next = persistHideMenuHref(DEFAULT_USER_SETTINGS, '/overview')
+    expect(next.workspacePreset).toBe('custom')
+    expect(next.hiddenMenuHrefs).toContain('/overview')
+  })
+
+  test('showing a hidden leaf drops that href', () => {
+    const hidden: UserSettings = {
+      ...DEFAULT_USER_SETTINGS,
+      workspacePreset: 'custom',
+      hiddenMenuHrefs: ['/overview', '/queries'],
+    }
+    const next = persistShowMenuHref(hidden, '/overview')
+    expect(next.workspacePreset).toBe('custom')
+    expect(next.hiddenMenuHrefs).not.toContain('/overview')
+    expect(next.hiddenMenuHrefs).toContain('/queries')
+  })
+})
+
+describe('hide-page toast', () => {
+  test('first hide uses a longer duration; later hides use the default', () => {
+    expect(consumeHideToastDuration()).toBe(FIRST_HIDE_TOAST_MS)
+    expect(consumeHideToastDuration()).toBe(HIDE_TOAST_MS)
+    expect(consumeHideToastDuration()).toBe(HIDE_TOAST_MS)
+  })
+
+  test('copy includes Undo and Open Navigation actions', () => {
+    const onUndo = mock(() => {})
+    const onOpenNavigation = mock(() => {})
+    showHiddenMenuToast({
+      title: 'Overview',
+      onUndo,
+      onOpenNavigation,
+    })
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    const [title, opts] = toastMock.mock.calls[0] as [
+      string,
+      {
+        description: string
+        duration: number
+        action: { label: string; onClick: () => void }
+        cancel: { label: string; onClick: () => void }
+      },
+    ]
+    expect(title).toBe('Overview hidden from the menu')
+    expect(opts.description).toBe(
+      'Bring it back in Settings → Workspace → Navigation.'
+    )
+    expect(opts.duration).toBe(FIRST_HIDE_TOAST_MS)
+    expect(opts.action.label).toBe('Undo')
+    expect(opts.cancel.label).toBe('Open Navigation')
+    opts.action.onClick()
+    opts.cancel.onClick()
+    expect(onUndo).toHaveBeenCalledTimes(1)
+    expect(onOpenNavigation).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/dashboard/src/lib/menu/hide-menu-item.ts
+++ b/apps/dashboard/src/lib/menu/hide-menu-item.ts
@@ -1,0 +1,76 @@
+import { toast } from 'sonner'
+import { menuItemsConfig } from '@/menu'
+
+import type { UserSettings } from '@/lib/types/user-settings'
+
+import {
+  hideMenuHref,
+  showMenuHref,
+  workspaceFromSettings,
+} from '@/lib/menu/workspace-presets'
+
+export const FIRST_HIDE_TOAST_MS = 8_000
+export const HIDE_TOAST_MS = 4_000
+
+let isFirstHideToast = true
+
+export function resetHideMenuToastState(): void {
+  isFirstHideToast = true
+}
+
+export function consumeHideToastDuration(): number {
+  if (isFirstHideToast) {
+    isFirstHideToast = false
+    return FIRST_HIDE_TOAST_MS
+  }
+  return HIDE_TOAST_MS
+}
+
+export function persistHideMenuHref(
+  settings: UserSettings,
+  href: string
+): Pick<UserSettings, 'workspacePreset' | 'hiddenMenuHrefs'> {
+  const next = hideMenuHref(
+    menuItemsConfig,
+    workspaceFromSettings(settings),
+    href
+  )
+  return {
+    workspacePreset: next.workspacePreset,
+    hiddenMenuHrefs: [...next.hiddenMenuHrefs],
+  }
+}
+
+export function persistShowMenuHref(
+  settings: UserSettings,
+  href: string
+): Pick<UserSettings, 'workspacePreset' | 'hiddenMenuHrefs'> {
+  const next = showMenuHref(
+    menuItemsConfig,
+    workspaceFromSettings(settings),
+    href
+  )
+  return {
+    workspacePreset: next.workspacePreset,
+    hiddenMenuHrefs: [...next.hiddenMenuHrefs],
+  }
+}
+
+export function showHiddenMenuToast(options: {
+  title: string
+  onUndo: () => void
+  onOpenNavigation: () => void
+}): void {
+  toast(`${options.title} hidden from the menu`, {
+    description: 'Bring it back in Settings → Workspace → Navigation.',
+    duration: consumeHideToastDuration(),
+    action: {
+      label: 'Undo',
+      onClick: options.onUndo,
+    },
+    cancel: {
+      label: 'Open Navigation',
+      onClick: options.onOpenNavigation,
+    },
+  })
+}

--- a/apps/dashboard/src/lib/settings-tab.test.ts
+++ b/apps/dashboard/src/lib/settings-tab.test.ts
@@ -1,0 +1,14 @@
+import { isSettingsTab, SETTINGS_TABS } from './settings-tab'
+import { describe, expect, test } from 'bun:test'
+
+describe('isSettingsTab', () => {
+  test('accepts the Navigation pane id', () => {
+    expect(isSettingsTab('navigation')).toBe(true)
+    expect(SETTINGS_TABS).toContain('navigation')
+  })
+
+  test('rejects unknown ids', () => {
+    expect(isSettingsTab('general')).toBe(true)
+    expect(isSettingsTab('not-a-tab')).toBe(false)
+  })
+})

--- a/apps/dashboard/src/lib/settings-tab.ts
+++ b/apps/dashboard/src/lib/settings-tab.ts
@@ -1,0 +1,14 @@
+export const SETTINGS_TABS = [
+  'general',
+  'appearance',
+  'units',
+  'layout',
+  'navigation',
+  'integrations',
+] as const
+
+export type SettingsTab = (typeof SETTINGS_TABS)[number]
+
+export function isSettingsTab(value: string): value is SettingsTab {
+  return (SETTINGS_TABS as readonly string[]).includes(value)
+}

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -289,6 +289,9 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   is hover-only on that row (never always-on). Favorites also show a grip
   handle on hover; drag it to reorder (`nav-favorites.tsx`). Order is the
   `chm-pinned-favorites` localStorage pin list (`lib/menu/favorites-store.ts`).
+  Leaf rows also reveal Hide (EyeOff) beside the pin; that writes
+  `hiddenMenuHrefs` via `hideMenuHref` and toasts Undo + Open Navigation
+  (Settings → Workspace → Navigation). Footer About is not hideable this way.
 
 - **Dashboard widget grid** (plan 57, `components/dashboard/`): `grid.tsx`
   lays out `DashboardWidget[]` (chart/table/stat/text, `@/types/dashboard-layout`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds hover-hide on leaf sidebar pages, persists via the existing workspace hide list, and toasts Undo plus Open Navigation so pages can be restored from Settings → Workspace → Navigation. Closes #3123.

## Changes

- Leaf sidebar rows reveal Hide (EyeOff) beside Pin, with the same hover reveal, `type="button"`, and a 44px mobile hit area. Footer About is not hideable this way. Labels truncate before the new controls.
- Hide uses existing `hideMenuHref` / `showMenuHref`, persists user settings immediately, and lands on Custom.
- Toast copy: `{title} hidden from the menu` / `Bring it back in Settings → Workspace → Navigation.` Actions: Undo and Open Navigation.
- One shell-level `SettingsDialogProvider` so gear, ⌘,, command palette, and the toast share a single dialog. `initialTab` opens Navigation; ⌘, still opens General.
- Settings > Navigation still uses `useActiveHostEngine` (Postgres hosts do not see ClickHouse-only items).
- Product-design docs one-liner. Unit tests for hide control, settings tab, hide persist + toast, and the existing Postgres navigation-tree invariant.

## Test plan

- [x] `pnpm run type-check` passes (`tsc --noEmit`)
- [x] `pnpm run type-check:test` passes
- [x] Targeted `bun test` passes: hide-button, hide-menu-item, settings-tab, settings-form initialTab, workspace-preset-picker (including Postgres engine), nav-settings-button
- [ ] `pnpm run lint` passes with no errors (Biome check on changed files passed)
- [ ] `pnpm run build` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Docs updated in product-design knowledge + skill
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed (not applicable)

## Notes for reviewer

Smallest settings-open path is a single provider in `DashboardShell`. Isolated tests keep working because `useOpenSettings` is a no-op outside the provider, and `nav-settings-button.test.tsx` still mounts its own `SettingsDialog`.

Do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d95e310c-2ae5-4502-8a14-60ced5335069?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d95e310c-2ae5-4502-8a14-60ced5335069&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

