### PR TITLE
fix(dashboard): left-align Navigation tree and collapse on role select

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -270,10 +270,15 @@ divider. Content pane shows the active tab title. Theme (Light / Dark /
 System) is a settings row (label left, three window thumbnails right)
 on Appearance only. Navigation leads with a `SegmentedControl` workspace
 preset (Full / DBA / Engineer / SRE / Custom) plus an in-page sidebar-like
-menu tree (same groups, icons, nested children as `nav-main`). Click a
-leaf to hide or show it — hidden rows stay visible but muted, like Dim
-unavailable pages. Search filters the tree. Never a 40-checkbox wall or a
-separate Hide-pages drawer. Then the Dim / Hide unavailable-page demos.
+menu tree (same groups, icons, nested children as `nav-main`). Groups
+default collapsed; picking a role remounts them closed. Nested children
+are left-aligned with Hide/Show on the right (local row classes — do
+not use `SidebarMenuSubButton` here). Click a leaf to hide or show it —
+hidden rows stay visible but muted, like Dim unavailable pages.
+Expand/collapse does not write Custom; Hide/Show of a leaf does when
+the hide list leaves the role. Search filters the tree. Never a
+40-checkbox wall or a separate Hide-pages drawer. Then the Dim / Hide
+unavailable-page demos.
 Hidden pages stay routable. Filter through
 `getVisibleMenuItems` so sidebar, ⌘K, and the Settings > Navigation
 tree match the **active host engine** (`useActiveHostEngine` —

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -272,14 +272,15 @@ on Appearance only. Navigation leads with a `SegmentedControl` workspace
 preset (Full / DBA / Engineer / SRE / Custom) plus an in-page sidebar-like
 menu tree (same groups, icons, nested children as `nav-main`). Groups
 default collapsed; picking a role remounts them closed. Parent rows are
-chevron-only. Nested children use local `w-full justify-start text-left`
-with Hide `ml-auto` (settings tree is not a real Sidebar). Click a leaf
-to hide or show it — hidden rows stay visible but muted, like Dim
-unavailable pages. Expand/collapse does not write settings. Hide of an
-already-hidden-by-preset leaf stays on the role; Custom only when the
-hide list leaves `hideListForPreset`. Search filters the tree. Never a
-40-checkbox wall or a separate Hide-pages drawer. Then the Dim / Hide
-unavailable-page demos.
+chevron-only. Nested children use `SidebarMenuSubButton` (`text-left`,
+same as the parent button) so a `<button>` row is not UA-centered; Hide
+stays `shrink-0` on the right. Click a leaf to hide or show it — hidden
+rows stay visible but muted, like Dim unavailable pages.
+Expand/collapse does not write settings. Hide of an already-hidden-by-
+preset leaf stays on the role; Custom only when the hide list leaves
+`hideListForPreset`. Search filters the tree. Never a 40-checkbox wall
+or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
+demos.
 Hidden pages stay routable. Filter through
 `getVisibleMenuItems` so sidebar, ⌘K, and the Settings > Navigation
 tree match the **active host engine** (`useActiveHostEngine` —

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -271,12 +271,13 @@ System) is a settings row (label left, three window thumbnails right)
 on Appearance only. Navigation leads with a `SegmentedControl` workspace
 preset (Full / DBA / Engineer / SRE / Custom) plus an in-page sidebar-like
 menu tree (same groups, icons, nested children as `nav-main`). Groups
-default collapsed; picking a role remounts them closed. Nested children
-are left-aligned with Hide/Show on the right (local row classes — do
-not use `SidebarMenuSubButton` here). Click a leaf to hide or show it —
-hidden rows stay visible but muted, like Dim unavailable pages.
-Expand/collapse does not write Custom; Hide/Show of a leaf does when
-the hide list leaves the role. Search filters the tree. Never a
+default collapsed; picking a role remounts them closed. Parent rows are
+chevron-only. Nested children use local `w-full justify-start text-left`
+with Hide `ml-auto` (settings tree is not a real Sidebar). Click a leaf
+to hide or show it — hidden rows stay visible but muted, like Dim
+unavailable pages. Expand/collapse does not write settings. Hide of an
+already-hidden-by-preset leaf stays on the role; Custom only when the
+hide list leaves `hideListForPreset`. Search filters the tree. Never a
 40-checkbox wall or a separate Hide-pages drawer. Then the Dim / Hide
 unavailable-page demos.
 Hidden pages stay routable. Filter through

--- a/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
+++ b/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
@@ -14,7 +14,6 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuSub,
-  SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from '@/components/ui/sidebar'
 import { menuItemIsHidden } from '@/lib/menu/workspace-presets'
@@ -28,12 +27,18 @@ const SECTION_LABELS: Record<Exclude<MenuSection, 'footer'>, string> = {
 const SECTIONS: Exclude<MenuSection, 'footer'>[] = ['main', 'others']
 
 const menuButtonClass =
-  'flex h-8 w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0'
+  'flex h-8 w-full items-center justify-start gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0'
+
+/** Local row — do not use SidebarMenuSubButton (icon-mode center leaks here). */
+const subLeafButtonClass =
+  'flex h-7 w-full min-w-0 items-center justify-start gap-2 overflow-hidden rounded-md px-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2'
 
 interface WorkspaceMenuTreeProps {
   items: readonly MenuItem[]
   hiddenHrefs: ReadonlySet<string>
   query: string
+  /** Remount groups collapsed when the role pill changes. */
+  resetKey?: string
   onToggle: (href: string, hidden: boolean) => void
 }
 
@@ -41,6 +46,7 @@ export function WorkspaceMenuTree({
   items,
   hiddenHrefs,
   query,
+  resetKey = '',
   onToggle,
 }: WorkspaceMenuTreeProps) {
   const filtered = useMemo(() => filterMenuTree(items, query), [items, query])
@@ -65,10 +71,11 @@ export function WorkspaceMenuTree({
             <SidebarMenu>
               {sectionItems.map((item) => (
                 <TreeNode
-                  key={item.title}
+                  key={`${resetKey}:${item.title}`}
                   item={item}
                   hiddenHrefs={hiddenHrefs}
                   forceOpen={searching}
+                  resetKey={resetKey}
                   onToggle={onToggle}
                 />
               ))}
@@ -84,11 +91,13 @@ function TreeNode({
   item,
   hiddenHrefs,
   forceOpen,
+  resetKey,
   onToggle,
 }: {
   item: MenuItem
   hiddenHrefs: ReadonlySet<string>
   forceOpen: boolean
+  resetKey: string
   onToggle: (href: string, hidden: boolean) => void
 }) {
   const hasChildren = Boolean(item.items?.length)
@@ -100,21 +109,22 @@ function TreeNode({
 
   return (
     <Collapsible
-      key={forceOpen ? `${item.title}-search` : item.title}
-      defaultOpen
+      key={forceOpen ? `${item.title}-search` : `${resetKey}:${item.title}`}
+      defaultOpen={forceOpen}
       className="group/collapsible"
       render={<SidebarMenuItem />}
     >
       <CollapsibleTrigger
         className={cn(menuButtonClass, hidden && mutedItemClass)}
+        data-testid={`workspace-menu-group-${item.title}`}
         data-hidden={hidden ? 'true' : 'false'}
       >
         {item.icon && <item.icon className="size-4 shrink-0" />}
-        <span className="min-w-0 flex-1 truncate">{item.title}</span>
+        <span className="min-w-0 flex-1 truncate text-left">{item.title}</span>
         <ChevronRight className="ml-auto size-4 shrink-0 transition-transform duration-200 group-data-open/collapsible:rotate-90" />
       </CollapsibleTrigger>
-      <CollapsibleContent>
-        <SidebarMenuSub>
+      <CollapsibleContent keepMounted={forceOpen}>
+        <SidebarMenuSub className="w-full">
           {item.items?.map((child) => (
             <SubLeafRow
               key={child.href || child.title}
@@ -154,8 +164,8 @@ function LeafRow({
         className={cn(menuButtonClass, hidden && mutedItemClass)}
       >
         {item.icon && <item.icon className="size-4 shrink-0" />}
-        <span className="min-w-0 flex-1 truncate">{item.title}</span>
-        <span className="shrink-0 text-[11px] text-muted-foreground">
+        <span className="min-w-0 flex-1 truncate text-left">{item.title}</span>
+        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
           {hidden ? 'Show' : 'Hide'}
         </span>
       </button>
@@ -174,11 +184,11 @@ function SubLeafRow({
 }) {
   if (item.items?.length) {
     return (
-      <SidebarMenuSubItem>
-        <div className="px-2 py-1 text-[11px] font-medium text-muted-foreground">
+      <SidebarMenuSubItem className="w-full">
+        <div className="px-2 py-1 text-left text-[11px] font-medium text-muted-foreground">
           {item.title}
         </div>
-        <SidebarMenuSub>
+        <SidebarMenuSub className="w-full">
           {item.items.map((child) => (
             <SubLeafRow
               key={child.href || child.title}
@@ -195,24 +205,24 @@ function SubLeafRow({
   const hidden = menuItemIsHidden(item, hiddenHrefs)
 
   return (
-    <SidebarMenuSubItem>
-      <SidebarMenuSubButton
+    <SidebarMenuSubItem className="w-full">
+      <button
+        type="button"
         data-testid={`workspace-menu-leaf-${item.href}`}
         data-hidden={hidden ? 'true' : 'false'}
+        data-align="start"
         aria-pressed={!hidden}
         aria-label={
           hidden ? `Show ${item.title} in the sidebar` : `Hide ${item.title}`
         }
-        className={cn('cursor-pointer', hidden && mutedItemClass)}
-        render={
-          <button type="button" onClick={() => onToggle(item.href, hidden)} />
-        }
+        onClick={() => onToggle(item.href, hidden)}
+        className={cn(subLeafButtonClass, hidden && mutedItemClass)}
       >
-        <span className="min-w-0 flex-1 truncate">{item.title}</span>
-        <span className="shrink-0 text-[11px] text-muted-foreground">
+        <span className="min-w-0 flex-1 truncate text-left">{item.title}</span>
+        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
           {hidden ? 'Show' : 'Hide'}
         </span>
-      </SidebarMenuSubButton>
+      </button>
     </SidebarMenuSubItem>
   )
 }

--- a/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
+++ b/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
@@ -14,6 +14,7 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuSub,
+  SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from '@/components/ui/sidebar'
 import { menuItemIsHidden } from '@/lib/menu/workspace-presets'
@@ -28,14 +29,6 @@ const SECTIONS: Exclude<MenuSection, 'footer'>[] = ['main', 'others']
 
 const menuButtonClass =
   'flex h-8 w-full items-center justify-start gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0'
-
-/**
- * Settings tree sits outside a real Sidebar, so SidebarMenuSubButton's
- * `w-full` / `pr-7` do not stretch the row. Local classes: full width,
- * left-aligned label, Hide on the right. Do not change the live sidebar.
- */
-const subLeafButtonClass =
-  'flex h-7 w-full min-w-0 items-center justify-start gap-2 overflow-hidden rounded-md px-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2'
 
 interface WorkspaceMenuTreeProps {
   items: readonly MenuItem[]
@@ -128,7 +121,7 @@ function TreeNode({
         <ChevronRight className="ml-auto size-4 shrink-0 transition-transform duration-200 group-data-open/collapsible:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent keepMounted={forceOpen}>
-        <SidebarMenuSub className="w-full">
+        <SidebarMenuSub>
           {item.items?.map((child) => (
             <SubLeafRow
               key={child.href || child.title}
@@ -188,11 +181,11 @@ function SubLeafRow({
 }) {
   if (item.items?.length) {
     return (
-      <SidebarMenuSubItem className="w-full">
+      <SidebarMenuSubItem>
         <div className="px-2 py-1 text-left text-[11px] font-medium text-muted-foreground">
           {item.title}
         </div>
-        <SidebarMenuSub className="w-full">
+        <SidebarMenuSub>
           {item.items.map((child) => (
             <SubLeafRow
               key={child.href || child.title}
@@ -209,24 +202,24 @@ function SubLeafRow({
   const hidden = menuItemIsHidden(item, hiddenHrefs)
 
   return (
-    <SidebarMenuSubItem className="w-full">
-      <button
-        type="button"
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton
         data-testid={`workspace-menu-leaf-${item.href}`}
         data-hidden={hidden ? 'true' : 'false'}
-        data-align="start"
         aria-pressed={!hidden}
         aria-label={
           hidden ? `Show ${item.title} in the sidebar` : `Hide ${item.title}`
         }
-        onClick={() => onToggle(item.href, hidden)}
-        className={cn(subLeafButtonClass, hidden && mutedItemClass)}
+        className={cn('cursor-pointer text-left', hidden && mutedItemClass)}
+        render={
+          <button type="button" onClick={() => onToggle(item.href, hidden)} />
+        }
       >
-        <span className="min-w-0 flex-1 truncate text-left">{item.title}</span>
-        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+        <span className="min-w-0 flex-1 truncate">{item.title}</span>
+        <span className="shrink-0 text-[11px] text-muted-foreground">
           {hidden ? 'Show' : 'Hide'}
         </span>
-      </button>
+      </SidebarMenuSubButton>
     </SidebarMenuSubItem>
   )
 }

--- a/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
+++ b/apps/dashboard/src/components/settings/workspace-menu-tree.tsx
@@ -29,7 +29,11 @@ const SECTIONS: Exclude<MenuSection, 'footer'>[] = ['main', 'others']
 const menuButtonClass =
   'flex h-8 w-full items-center justify-start gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0'
 
-/** Local row — do not use SidebarMenuSubButton (icon-mode center leaks here). */
+/**
+ * Settings tree sits outside a real Sidebar, so SidebarMenuSubButton's
+ * `w-full` / `pr-7` do not stretch the row. Local classes: full width,
+ * left-aligned label, Hide on the right. Do not change the live sidebar.
+ */
 const subLeafButtonClass =
   'flex h-7 w-full min-w-0 items-center justify-start gap-2 overflow-hidden rounded-md px-2 text-left text-sm ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2'
 

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
@@ -339,10 +339,8 @@ describe('WorkspacePresetPicker', () => {
         '[data-testid="workspace-menu-leaf-/agents"]'
       )
       expect(chat).toBeTruthy()
-      expect(chat?.getAttribute('data-align')).toBe('start')
       expect(chat?.className).toMatch(/\btext-left\b/)
-      expect(chat?.className).toMatch(/\bjustify-start\b/)
-      expect(chat?.className).toMatch(/\bw-full\b/)
+      expect(chat?.className).toMatch(/\bitems-center\b/)
       expect(chat?.textContent).toContain('Chat')
       expect(chat?.textContent).toMatch(/Hide$/)
     } finally {

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
@@ -72,6 +72,36 @@ async function renderInto(
   }
 }
 
+function selectedPreset(container: HTMLElement): string {
+  return (
+    container.querySelector('[role="radio"][aria-checked="true"]')
+      ?.textContent ?? ''
+  )
+}
+
+async function clickPreset(container: HTMLElement, label: string) {
+  const { act } = await import('react')
+  const option = Array.from(container.querySelectorAll('[role="radio"]')).find(
+    (node) => node.textContent?.includes(label)
+  )
+  expect(option).toBeTruthy()
+  await act(async () => {
+    option?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+async function expandGroup(container: HTMLElement, title: string) {
+  const { act } = await import('react')
+  const trigger = container.querySelector(
+    `[data-testid="workspace-menu-group-${title}"]`
+  )
+  expect(trigger).toBeTruthy()
+  if (trigger?.getAttribute('aria-expanded') === 'true') return
+  await act(async () => {
+    trigger?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
 describe('WorkspacePresetPicker', () => {
   test('renders the sidebar tree and hides a leaf into Custom', async () => {
     const { useState } = await import('react')
@@ -178,6 +208,12 @@ describe('WorkspacePresetPicker', () => {
         engineer?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
       })
 
+      const keeperGroup = container.querySelector(
+        '[data-testid="workspace-menu-group-Keeper"]'
+      )
+      expect(keeperGroup).toBeTruthy()
+      await expandGroup(container, 'Keeper')
+
       const keeper = container.querySelector(
         '[data-testid="workspace-menu-leaf-/keeper/info"]'
       )
@@ -266,11 +302,13 @@ describe('WorkspacePresetPicker', () => {
       expect(
         container.querySelector('[data-testid="workspace-menu-leaf-/overview"]')
       ).toBeTruthy()
+      await expandGroup(container, 'Queries')
       expect(
         container.querySelector(
           '[data-testid="workspace-menu-leaf-/running-queries"]'
         )
       ).toBeTruthy()
+      await expandGroup(container, 'Tools')
       expect(
         container.querySelector('[data-testid="workspace-menu-leaf-/sql"]')
       ).toBeTruthy()
@@ -279,6 +317,152 @@ describe('WorkspacePresetPicker', () => {
           '[data-testid="workspace-menu-leaf-/postgres/queries"]'
         )
       ).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('submenu rows are left-aligned with Hide on the right', async () => {
+    const { WorkspacePresetPicker } = await import('./workspace-preset-picker')
+
+    const { container, cleanup } = await renderInto(
+      <WorkspacePresetPicker
+        preset="full"
+        hiddenMenuHrefs={[]}
+        onChange={() => {}}
+      />
+    )
+
+    try {
+      await expandGroup(container, 'AI Agent')
+      const chat = container.querySelector(
+        '[data-testid="workspace-menu-leaf-/agents"]'
+      )
+      expect(chat).toBeTruthy()
+      expect(chat?.getAttribute('data-align')).toBe('start')
+      expect(chat?.className).toMatch(/\btext-left\b/)
+      expect(chat?.className).toMatch(/\bjustify-start\b/)
+      expect(chat?.className).toMatch(/\bw-full\b/)
+      expect(chat?.textContent).toContain('Chat')
+      expect(chat?.textContent).toMatch(/Hide$/)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('role pills remount groups collapsed', async () => {
+    const { useState } = await import('react')
+    const { WorkspacePresetPicker } = await import('./workspace-preset-picker')
+
+    function Harness() {
+      const [state, setState] = useState<{
+        workspacePreset: WorkspacePreset
+        hiddenMenuHrefs: string[]
+      }>({ workspacePreset: 'full', hiddenMenuHrefs: [] })
+      return (
+        <WorkspacePresetPicker
+          preset={state.workspacePreset}
+          hiddenMenuHrefs={state.hiddenMenuHrefs}
+          onChange={setState}
+        />
+      )
+    }
+
+    const { container, cleanup } = await renderInto(<Harness />)
+
+    try {
+      const queries = () =>
+        container.querySelector('[data-testid="workspace-menu-group-Queries"]')
+      expect(queries()?.getAttribute('aria-expanded')).toBe('false')
+
+      await expandGroup(container, 'Queries')
+      expect(queries()?.getAttribute('aria-expanded')).toBe('true')
+
+      await clickPreset(container, 'Engineer')
+      expect(selectedPreset(container)).toContain('Engineer')
+      expect(queries()?.getAttribute('aria-expanded')).toBe('false')
+
+      await clickPreset(container, 'Full')
+      expect(queries()?.getAttribute('aria-expanded')).toBe('false')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('expanding a group does not switch the preset to Custom', async () => {
+    const { useState } = await import('react')
+    const { WorkspacePresetPicker } = await import('./workspace-preset-picker')
+
+    function Harness() {
+      const [state, setState] = useState<{
+        workspacePreset: WorkspacePreset
+        hiddenMenuHrefs: string[]
+      }>({ workspacePreset: 'full', hiddenMenuHrefs: [] })
+      return (
+        <WorkspacePresetPicker
+          preset={state.workspacePreset}
+          hiddenMenuHrefs={state.hiddenMenuHrefs}
+          onChange={setState}
+        />
+      )
+    }
+
+    const { container, cleanup } = await renderInto(<Harness />)
+
+    try {
+      expect(selectedPreset(container)).toContain('Full')
+      await expandGroup(container, 'Queries')
+      expect(selectedPreset(container)).toContain('Full')
+      expect(selectedPreset(container)).not.toContain('Custom')
+
+      const queries = container.querySelector(
+        '[data-testid="workspace-menu-group-Queries"]'
+      )
+      const { act } = await import('react')
+      await act(async () => {
+        queries?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      })
+      expect(queries?.getAttribute('aria-expanded')).toBe('false')
+      expect(selectedPreset(container)).toContain('Full')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('hiding a leaf still switches the preset to Custom', async () => {
+    const { useState } = await import('react')
+    const { WorkspacePresetPicker } = await import('./workspace-preset-picker')
+
+    function Harness() {
+      const [state, setState] = useState<{
+        workspacePreset: WorkspacePreset
+        hiddenMenuHrefs: string[]
+      }>({ workspacePreset: 'engineer', hiddenMenuHrefs: [] })
+      return (
+        <WorkspacePresetPicker
+          preset={state.workspacePreset}
+          hiddenMenuHrefs={state.hiddenMenuHrefs}
+          onChange={setState}
+        />
+      )
+    }
+
+    const { container, cleanup } = await renderInto(<Harness />)
+
+    try {
+      expect(selectedPreset(container)).toContain('Engineer')
+      await expandGroup(container, 'Queries')
+      expect(selectedPreset(container)).toContain('Engineer')
+
+      const running = container.querySelector(
+        '[data-testid="workspace-menu-leaf-/running-queries"]'
+      )
+      expect(running).toBeTruthy()
+      const { act } = await import('react')
+      await act(async () => {
+        running?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      })
+      expect(selectedPreset(container)).toContain('Custom')
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -131,6 +131,7 @@ export function WorkspacePresetPicker({
         items={treeItems}
         hiddenHrefs={hiddenSet}
         query={query}
+        resetKey={preset}
         onToggle={toggleHref}
       />
     </div>

--- a/apps/dashboard/src/components/ui/sidebar.tsx
+++ b/apps/dashboard/src/components/ui/sidebar.tsx
@@ -683,7 +683,7 @@ function SidebarMenuSubButton({
     props: mergeProps<'a'>(
       {
         className: cn(
-          'flex h-7 w-full min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 pr-7 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+          'flex h-7 w-full min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 pr-7 text-left text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
           className
         ),
       },

--- a/apps/dashboard/src/lib/menu/workspace-presets.test.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.test.ts
@@ -27,16 +27,6 @@ const fixture: MenuItem[] = [
     ],
   },
   {
-    title: 'Tables',
-    href: '/tables',
-    items: [leaf({ title: 'Tables Overview', href: '/tables-overview' })],
-  },
-  {
-    title: 'Merges',
-    href: '/merges',
-    items: [leaf({ title: 'Merges', href: '/merges' })],
-  },
-  {
     title: 'Keeper',
     href: '',
     items: [leaf({ title: 'Keeper Info', href: '/keeper/info' })],
@@ -150,27 +140,7 @@ describe('hideMenuHref / showMenuHref', () => {
     expect(next.hiddenMenuHrefs).toContain('/insights')
   })
 
-  test('hiding a parent folder href does not switch to Custom', () => {
-    expect(
-      hideMenuHref(
-        fixture,
-        { workspacePreset: 'full', hiddenMenuHrefs: [] },
-        '/tables'
-      )
-    ).toEqual({ workspacePreset: 'full', hiddenMenuHrefs: [] })
-  })
-
-  test('showing a parent folder href does not switch to Custom', () => {
-    expect(
-      showMenuHref(
-        fixture,
-        { workspacePreset: 'dba', hiddenMenuHrefs: [] },
-        '/tables'
-      )
-    ).toEqual({ workspacePreset: 'dba', hiddenMenuHrefs: [] })
-  })
-
-  test('hiding a leaf that is already muted by the role stays on that role', () => {
+  test('hiding a leaf already in the preset hide list stays on that role', () => {
     expect(
       hideMenuHref(
         fixture,
@@ -188,19 +158,6 @@ describe('hideMenuHref / showMenuHref', () => {
         '/overview'
       )
     ).toEqual({ workspacePreset: 'full', hiddenMenuHrefs: [] })
-  })
-
-  test('hiding a leaf that shares a parent href still switches to Custom', () => {
-    expect(
-      hideMenuHref(
-        fixture,
-        { workspacePreset: 'full', hiddenMenuHrefs: [] },
-        '/merges'
-      )
-    ).toEqual({
-      workspacePreset: 'custom',
-      hiddenMenuHrefs: ['/merges'],
-    })
   })
 })
 

--- a/apps/dashboard/src/lib/menu/workspace-presets.test.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.test.ts
@@ -27,6 +27,16 @@ const fixture: MenuItem[] = [
     ],
   },
   {
+    title: 'Tables',
+    href: '/tables',
+    items: [leaf({ title: 'Tables Overview', href: '/tables-overview' })],
+  },
+  {
+    title: 'Merges',
+    href: '/merges',
+    items: [leaf({ title: 'Merges', href: '/merges' })],
+  },
+  {
     title: 'Keeper',
     href: '',
     items: [leaf({ title: 'Keeper Info', href: '/keeper/info' })],
@@ -138,6 +148,59 @@ describe('hideMenuHref / showMenuHref', () => {
     expect(next.workspacePreset).toBe('custom')
     expect(next.hiddenMenuHrefs).not.toContain('/health')
     expect(next.hiddenMenuHrefs).toContain('/insights')
+  })
+
+  test('hiding a parent folder href does not switch to Custom', () => {
+    expect(
+      hideMenuHref(
+        fixture,
+        { workspacePreset: 'full', hiddenMenuHrefs: [] },
+        '/tables'
+      )
+    ).toEqual({ workspacePreset: 'full', hiddenMenuHrefs: [] })
+  })
+
+  test('showing a parent folder href does not switch to Custom', () => {
+    expect(
+      showMenuHref(
+        fixture,
+        { workspacePreset: 'dba', hiddenMenuHrefs: [] },
+        '/tables'
+      )
+    ).toEqual({ workspacePreset: 'dba', hiddenMenuHrefs: [] })
+  })
+
+  test('hiding a leaf that is already muted by the role stays on that role', () => {
+    expect(
+      hideMenuHref(
+        fixture,
+        { workspacePreset: 'dba', hiddenMenuHrefs: [] },
+        '/health'
+      )
+    ).toEqual({ workspacePreset: 'dba', hiddenMenuHrefs: [] })
+  })
+
+  test('showing a visible Full leaf is a no-op', () => {
+    expect(
+      showMenuHref(
+        fixture,
+        { workspacePreset: 'full', hiddenMenuHrefs: [] },
+        '/overview'
+      )
+    ).toEqual({ workspacePreset: 'full', hiddenMenuHrefs: [] })
+  })
+
+  test('hiding a leaf that shares a parent href still switches to Custom', () => {
+    expect(
+      hideMenuHref(
+        fixture,
+        { workspacePreset: 'full', hiddenMenuHrefs: [] },
+        '/merges'
+      )
+    ).toEqual({
+      workspacePreset: 'custom',
+      hiddenMenuHrefs: ['/merges'],
+    })
   })
 })
 

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -247,29 +247,66 @@ export function applyWorkspacePreset(
   return { workspacePreset: next, hiddenMenuHrefs: [] }
 }
 
-/** Hide a leaf. Always lands on Custom so the hide list is the source of truth. */
+/** True when `href` is a page with no children. Folder-only hrefs are not. */
+function isLeafMenuHref(items: readonly MenuItem[], href: string): boolean {
+  if (!href) return false
+  for (const item of items) {
+    if (!item.items?.length && item.href === href) return true
+    if (item.items?.length && isLeafMenuHref(item.items, href)) return true
+  }
+  return false
+}
+
+function sameHrefSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  const seen = new Set(a)
+  return b.every((href) => seen.has(href))
+}
+
+/**
+ * Custom only when the hide list actually diverges from the selected role.
+ * Expand/collapse is UI-only; folder hrefs are not hide targets.
+ */
+function materializeIfDiverged(
+  items: readonly MenuItem[],
+  current: WorkspaceVisibility,
+  nextHidden: readonly string[]
+): WorkspaceVisibility {
+  if (current.workspacePreset === 'custom') {
+    return { workspacePreset: 'custom', hiddenMenuHrefs: [...nextHidden] }
+  }
+  const roleHidden = hideListForPreset(items, current)
+  if (sameHrefSet(roleHidden, nextHidden)) {
+    return current
+  }
+  return { workspacePreset: 'custom', hiddenMenuHrefs: [...nextHidden] }
+}
+
+/** Hide a leaf. Lands on Custom only when the hide list leaves the role. */
 export function hideMenuHref(
   items: readonly MenuItem[],
   current: WorkspaceVisibility,
   href: string
 ): WorkspaceVisibility {
+  if (!isLeafMenuHref(items, href)) return current
+
   const base = hideListForPreset(items, current)
-  if (base.includes(href)) {
-    return { workspacePreset: 'custom', hiddenMenuHrefs: base }
-  }
-  return { workspacePreset: 'custom', hiddenMenuHrefs: [...base, href] }
+  const nextHidden = base.includes(href) ? base : [...base, href]
+  return materializeIfDiverged(items, current, nextHidden)
 }
 
-/** Show a leaf. Materializes the effective hide list, then drops this href. */
+/** Show a leaf. Materializes Custom only when the hide list leaves the role. */
 export function showMenuHref(
   items: readonly MenuItem[],
   current: WorkspaceVisibility,
   href: string
 ): WorkspaceVisibility {
+  if (!isLeafMenuHref(items, href)) return current
+
   const next = effectiveHiddenMenuHrefs(items, current).filter(
     (item) => item !== href
   )
-  return { workspacePreset: 'custom', hiddenMenuHrefs: next }
+  return materializeIfDiverged(items, current, next)
 }
 
 /** A parent is hidden when every descendant leaf is on the hide list. */

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -247,16 +247,6 @@ export function applyWorkspacePreset(
   return { workspacePreset: next, hiddenMenuHrefs: [] }
 }
 
-/** True when `href` is a page with no children. Folder-only hrefs are not. */
-function isLeafMenuHref(items: readonly MenuItem[], href: string): boolean {
-  if (!href) return false
-  for (const item of items) {
-    if (!item.items?.length && item.href === href) return true
-    if (item.items?.length && isLeafMenuHref(item.items, href)) return true
-  }
-  return false
-}
-
 function sameHrefSet(a: readonly string[], b: readonly string[]): boolean {
   if (a.length !== b.length) return false
   const seen = new Set(a)
@@ -264,8 +254,9 @@ function sameHrefSet(a: readonly string[], b: readonly string[]): boolean {
 }
 
 /**
- * Custom only when the hide list actually diverges from the selected role.
- * Expand/collapse is UI-only; folder hrefs are not hide targets.
+ * Custom only when `nextHidden` diverges from `hideListForPreset`.
+ * Used by show: a no-op Show on a visible leaf stays on the named role.
+ * Expand/collapse never calls these helpers.
  */
 function materializeIfDiverged(
   items: readonly MenuItem[],
@@ -282,27 +273,25 @@ function materializeIfDiverged(
   return { workspacePreset: 'custom', hiddenMenuHrefs: [...nextHidden] }
 }
 
-/** Hide a leaf. Lands on Custom only when the hide list leaves the role. */
+/** Hide a leaf. Custom only when the hide list leaves the current role. */
 export function hideMenuHref(
   items: readonly MenuItem[],
   current: WorkspaceVisibility,
   href: string
 ): WorkspaceVisibility {
-  if (!isLeafMenuHref(items, href)) return current
-
   const base = hideListForPreset(items, current)
-  const nextHidden = base.includes(href) ? base : [...base, href]
-  return materializeIfDiverged(items, current, nextHidden)
+  if (base.includes(href)) {
+    return current
+  }
+  return { workspacePreset: 'custom', hiddenMenuHrefs: [...base, href] }
 }
 
-/** Show a leaf. Materializes Custom only when the hide list leaves the role. */
+/** Show a leaf. Custom only when the hide list leaves the current role. */
 export function showMenuHref(
   items: readonly MenuItem[],
   current: WorkspaceVisibility,
   href: string
 ): WorkspaceVisibility {
-  if (!isLeafMenuHref(items, href)) return current
-
   const next = effectiveHiddenMenuHrefs(items, current).filter(
     (item) => item !== href
   )

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -108,26 +108,26 @@ leads with a workspace **preset** (`Full` / `DBA` / `Engineer` / `SRE` /
 `Custom`) plus an in-page sidebar-like menu tree (same Main/Others
 groups, chevrons, and leaf icons as `nav-main` / `app-sidebar`). Groups
 default **collapsed**; picking a role remounts them closed. Parent rows
-are chevron-only (not hideable). Nested child rows are local
-`w-full justify-start text-left` with Hide `ml-auto` — the settings
-tree is outside a real Sidebar, so `SidebarMenuSubButton`'s `w-full` /
-`pr-7` do not stretch. Do not change the live sidebar. Click a leaf to
-hide or show it; hidden rows stay visible but muted (same idea as Dim
-unavailable pages). Expand/collapse is UI-only. `hideMenuHref` /
-`showMenuHref` stay on the named preset when the hide list already
-matches `hideListForPreset` (hide of an already-hidden-by-preset leaf
-is a no-op); they switch to Custom only when the list diverges. Search
-filters the tree — no Hide-pages drawer and never a 40-checkbox wall.
-Then Dim vs Hide with two menu demos (Queries + dimmed/missing
-Backups). Hidden pages stay routable; Settings gear and the host
-switcher are never filtered. Workspace visibility is applied last in
-`getVisibleMenuItems` and does not replace permission / cloud / engine
-gates. The Settings > Navigation tree uses the same engine filter as
-the sidebar (`getSettingsNavMenuItems` / `useActiveHostEngine`): a
-Postgres host customizes Postgres pages; the default source engine keeps
-today's Queries/Cluster tree. Named presets keep a stable group set;
-Full is the only auto-expand preset. Custom uses `hiddenMenuHrefs` as
-the hide list.
+are chevron-only (not hideable). Nested child rows use
+`SidebarMenuSubButton`, which includes `text-left` (same as
+`SidebarMenuButton`) so a settings-tree `<button>` is not centered by
+the UA `button { text-align: center }` default; Hide stays `shrink-0`
+on the right. Click a leaf to hide or show it; hidden rows stay visible
+but muted (same idea as Dim unavailable pages). Expand/collapse is
+UI-only. `hideMenuHref` / `showMenuHref` stay on the named preset when
+the hide list already matches `hideListForPreset` (hide of an
+already-hidden-by-preset leaf is a no-op); they switch to Custom only
+when the list diverges. Search filters the tree — no Hide-pages drawer
+and never a 40-checkbox wall. Then Dim vs Hide with two menu demos
+(Queries + dimmed/missing Backups). Hidden pages stay routable; Settings
+gear and the host switcher are never filtered. Workspace visibility is
+applied last in `getVisibleMenuItems` and does not replace permission /
+cloud / engine gates. The Settings > Navigation tree uses the same
+engine filter as the sidebar (`getSettingsNavMenuItems` /
+`useActiveHostEngine`): a Postgres host customizes Postgres pages; the
+default source engine keeps today's Queries/Cluster tree. Named presets
+keep a stable group set; Full is the only auto-expand preset. Custom
+uses `hiddenMenuHrefs` as the hide list.
 Timezone is a searchable combobox
 (`timezone-combobox.tsx`) with the browser local zone pinned under Suggested.
 Chart palette is a three-card picker with a mini bar preview. Unit options

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -106,18 +106,27 @@ Theme (Light / Dark / System, next-themes) is a
 label-left / thumbnails-right row on Appearance only. Navigation
 leads with a workspace **preset** (`Full` / `DBA` / `Engineer` / `SRE` /
 `Custom`) plus an in-page sidebar-like menu tree (same Main/Others
-groups, chevrons, and leaf icons as `nav-main` / `app-sidebar`). Click a
-leaf to hide or show it; hidden rows stay visible but muted (same idea as
-Dim unavailable pages). Search filters the tree — no Hide-pages drawer
-and never a 40-checkbox wall. Then Dim vs Hide with two menu demos
-(Queries + dimmed/missing Backups). Hidden pages stay routable; Settings
-gear and the host switcher are never filtered. Workspace visibility is
-applied last in `getVisibleMenuItems` and does not replace permission /
-cloud / engine gates. The Settings > Navigation tree uses the same
-engine filter as the sidebar (`getSettingsNavMenuItems` /
-`useActiveHostEngine`): a Postgres host customizes Postgres pages; the
-default source engine keeps today's Queries/Cluster tree. Named presets keep a stable group set; Full is the
-only auto-expand preset. Custom uses `hiddenMenuHrefs` as the hide list.
+groups, chevrons, and leaf icons as `nav-main` / `app-sidebar`). Groups
+default **collapsed**; picking a role remounts them closed. Nested child
+rows are left-aligned (`text-left justify-start w-full`) with the
+indent + connector; Hide/Show sits on the right — a local settings-tree
+row, not `SidebarMenuSubButton` (its icon-collapsed centering must not
+leak here). Click a leaf to hide or show it; hidden rows stay visible
+but muted (same idea as Dim unavailable pages). Expand/collapse is
+UI-only. `hideMenuHref` / `showMenuHref` switch to Custom only when a
+**leaf** Hide/Show makes the hide list diverge from the selected role —
+not when expanding a parent, and not when the href is a folder. Search
+filters the tree — no Hide-pages drawer and never a 40-checkbox wall.
+Then Dim vs Hide with two menu demos (Queries + dimmed/missing
+Backups). Hidden pages stay routable; Settings gear and the host
+switcher are never filtered. Workspace visibility is applied last in
+`getVisibleMenuItems` and does not replace permission / cloud / engine
+gates. The Settings > Navigation tree uses the same engine filter as
+the sidebar (`getSettingsNavMenuItems` / `useActiveHostEngine`): a
+Postgres host customizes Postgres pages; the default source engine keeps
+today's Queries/Cluster tree. Named presets keep a stable group set;
+Full is the only auto-expand preset. Custom uses `hiddenMenuHrefs` as
+the hide list.
 Timezone is a searchable combobox
 (`timezone-combobox.tsx`) with the browser local zone pinned under Suggested.
 Chart palette is a three-card picker with a mini bar preview. Unit options

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -107,15 +107,16 @@ label-left / thumbnails-right row on Appearance only. Navigation
 leads with a workspace **preset** (`Full` / `DBA` / `Engineer` / `SRE` /
 `Custom`) plus an in-page sidebar-like menu tree (same Main/Others
 groups, chevrons, and leaf icons as `nav-main` / `app-sidebar`). Groups
-default **collapsed**; picking a role remounts them closed. Nested child
-rows are left-aligned (`text-left justify-start w-full`) with the
-indent + connector; Hide/Show sits on the right — a local settings-tree
-row, not `SidebarMenuSubButton` (its icon-collapsed centering must not
-leak here). Click a leaf to hide or show it; hidden rows stay visible
-but muted (same idea as Dim unavailable pages). Expand/collapse is
-UI-only. `hideMenuHref` / `showMenuHref` switch to Custom only when a
-**leaf** Hide/Show makes the hide list diverge from the selected role —
-not when expanding a parent, and not when the href is a folder. Search
+default **collapsed**; picking a role remounts them closed. Parent rows
+are chevron-only (not hideable). Nested child rows are local
+`w-full justify-start text-left` with Hide `ml-auto` — the settings
+tree is outside a real Sidebar, so `SidebarMenuSubButton`'s `w-full` /
+`pr-7` do not stretch. Do not change the live sidebar. Click a leaf to
+hide or show it; hidden rows stay visible but muted (same idea as Dim
+unavailable pages). Expand/collapse is UI-only. `hideMenuHref` /
+`showMenuHref` stay on the named preset when the hide list already
+matches `hideListForPreset` (hide of an already-hidden-by-preset leaf
+is a no-op); they switch to Custom only when the list diverges. Search
 filters the tree — no Hide-pages drawer and never a 40-checkbox wall.
 Then Dim vs Hide with two menu demos (Queries + dimmed/missing
 Backups). Hidden pages stay routable; Settings gear and the host


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Settings → Workspace → Navigation: nested labels were centered, groups opened on every role pick, and hide/show flipped to Custom even when the hide list did not change.

Closes #3127

## Changes

- `SidebarMenuSubButton` was missing `text-left` that `SidebarMenuButton` already has. Nested settings leaves render as a `<button>`, so UA `button { text-align: center }` centered the title while Hide stayed `shrink-0` on the right. Added `text-left` on the primitive (`items-center` kept) so live-nav sub items match. Settings `SubLeafRow` also passes `className={cn('cursor-pointer text-left', ...)}`.
- Parent rows stay chevron-only. Groups default collapsed; picking Full / DBA / Engineer / SRE / Custom remounts them closed. Expand/collapse is UI-only.
- `hideMenuHref` stays on the named preset when `hideListForPreset` already contains the href. `showMenuHref` switches to Custom only when the hide list diverges from `hideListForPreset`.

## Test plan

- [x] Submenu row has `text-left` (and `items-center`)
- [x] Preset change → groups collapsed
- [x] Expand/collapse does not set Custom
- [x] Leaf Hide/Show that changes the hide list does set Custom
- [x] Hide of an already-hidden-by-preset leaf stays on the named role
- [x] Existing workspace-preset-picker tests stay green (25 pass / 0 fail)

## Notes for reviewer

- Root cause is missing `text-left` on `SidebarMenuSubButton`, not `justify-center` and not a width/`pr-7` stretch miss.
- Parents are not hideable; the Custom bug was the no-op hide path in `hideMenuHref`.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1f2ba17-0eea-4048-98cc-19f13c9a5969?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1f2ba17-0eea-4048-98cc-19f13c9a5969&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

