### PR TITLE
fix(dashboard): keep What's new notes scrolling above the footer

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   ?host routing + hooks-at-deepest-consumer, file/route organization, and brand.
   Triggers: "new page", "add a chart", "build UI", "design", "component",
   "empty state", "loading", "consistent", "follow-up feature", "match the design",
-  "what's new", "changelog", "settings gear",
+  "what's new", "changelog", "dialog scroll", "settings gear",
   "schema compare", "settings diff", "add host".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
@@ -80,6 +80,14 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   inside `PopoverContent`, closing the popover unmounts the dialog and nothing
   appears. Keep the selected item + dialog in the parent, as a sibling of
   `<Popover>` — see `components/insights/insights-popover.tsx`.
+- **Dialog with sticky header/footer:** `DialogContent` is `flex flex-col
+  overflow-hidden p-0` with `max-h-[min(36rem,85vh)]` (or a stable `h-[…]`).
+  Header and footer are `shrink-0`. The body is `min-h-0 flex-1 overflow-y-auto`
+  — that element is the scroll container. Do not use `ScrollArea` with `flex-1`
+  for this: its viewport is `size-full` and does not constrain unless the root
+  has an explicit height, so notes paint under the footer. Reset
+  `DialogFooter`'s default `-mx-4 -mb-4` to `mx-0 mb-0` when the dialog is
+  `p-0`. See `components/whats-new/whats-new-dialog.tsx`.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).
@@ -263,7 +271,9 @@ What's new is `WhatsNewButton` (`components/whats-new/`, lucide `Newspaper`,
 `UserSettings`). The dialog (`WhatsNewDialog`, sibling of the menu via
 `WhatsNewProvider` in `dashboard-shell.tsx`) lists `vX.Y.Z` GitHub Releases
 newest first; auto-opens **once** per upgrade (sessionStorage), never on every
-navigation. Manual open always works. Extra entry points: `WhatsNewMenuItem`
+navigation. Header and footer stay put; only the notes body
+(`min-h-0 flex-1 overflow-y-auto`) scrolls — see the sticky header/footer
+dialog idiom above. Manual open always works. Extra entry points: `WhatsNewMenuItem`
 next to About in the user dropdown, and a What's new action on `/about`. Do
 **not** add a Settings tab for changelog — Settings stays browser-local prefs.
 `GET /api/v1/releases` loads notes server-side (no browser GitHub calls);

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * What's new dialog: header/footer stay put; the notes body is the
+ * scroll container so a tall list cannot paint under the footer.
+ */
+
+import type { ReactElement } from 'react'
+import type { ReleaseNote } from '@/lib/whats-new/types'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import {
+  GITHUB_RELEASES_PAGE_URL,
+  LANDING_CHANGELOG_URL,
+} from '@/lib/whats-new/constants'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+function tallNote(version: string, bullets: string[]): ReleaseNote {
+  return {
+    version,
+    tag: `v${version}`,
+    publishedAt: '2026-08-01T00:00:00Z',
+    summary: bullets[0] ?? '',
+    markdown: bullets.map((item) => `- ${item}`).join('\n'),
+    highlights: bullets,
+  }
+}
+
+const TALL_RELEASES: ReleaseNote[] = [
+  tallNote('0.3.3', [
+    'fleet overview',
+    'explorer tree',
+    'query insights',
+    'replication lag',
+  ]),
+  tallNote('0.3.2', [
+    'cluster topology',
+    'keeper deep dive',
+    'more fleet notes',
+    'more explorer notes',
+  ]),
+  tallNote('0.3.1', [
+    'AI agent tools',
+    'dashboard charts',
+    'settings workspace',
+    'last fleet bullet',
+    'last explorer bullet',
+  ]),
+]
+
+describe("What's new dialog layout", () => {
+  test('the notes body is the scroll container; footer chrome stays outside it', async () => {
+    const { WhatsNewDialog } = await import('./whats-new-dialog')
+    const onGotIt = mock(() => {})
+
+    const { cleanup } = await renderInto(
+      <WhatsNewDialog
+        open
+        onOpenChange={() => {}}
+        onGotIt={onGotIt}
+        releases={TALL_RELEASES}
+        isLoading={false}
+      />
+    )
+
+    try {
+      const dialog = document.querySelector('[data-testid="whats-new-dialog"]')
+      const body = document.querySelector(
+        '[data-testid="whats-new-dialog-body"]'
+      )
+      const footer = document.querySelector('[data-slot="dialog-footer"]')
+      const header = document.querySelector('[data-slot="dialog-header"]')
+      const gotIt = document.querySelector('[data-testid="whats-new-got-it"]')
+      const versions = [
+        ...document.querySelectorAll('[data-testid="whats-new-version"]'),
+      ]
+
+      expect(dialog).not.toBeNull()
+      expect(body).not.toBeNull()
+      expect(footer).not.toBeNull()
+      expect(header).not.toBeNull()
+      expect(gotIt).not.toBeNull()
+      expect(versions.length).toBe(TALL_RELEASES.length)
+
+      expect(dialog?.className).toContain('flex-col')
+      expect(dialog?.className).toContain('overflow-hidden')
+      expect(body?.className).toContain('min-h-0')
+      expect(body?.className).toContain('flex-1')
+      expect(body?.className).toContain('overflow-y-auto')
+      expect(header?.className).toContain('shrink-0')
+      expect(footer?.className).toContain('shrink-0')
+      expect(footer?.className.split(/\s+/)).not.toContain('-mx-4')
+      expect(footer?.className.split(/\s+/)).not.toContain('-mb-4')
+
+      for (const version of versions) {
+        expect(body?.contains(version)).toBe(true)
+      }
+      expect(body?.contains(gotIt as Node)).toBe(false)
+      expect(body?.contains(footer as Node)).toBe(false)
+      expect(body?.contains(header as Node)).toBe(false)
+      expect(dialog?.contains(body as Node)).toBe(true)
+      expect(dialog?.contains(footer as Node)).toBe(true)
+      expect(body?.textContent).toContain('last explorer bullet')
+
+      const github = [...document.querySelectorAll('a')].find((anchor) =>
+        anchor.textContent?.includes('GitHub Releases')
+      )
+      const changelog = [...document.querySelectorAll('a')].find((anchor) =>
+        anchor.textContent?.includes('Changelog')
+      )
+      expect(github?.getAttribute('href')).toBe(GITHUB_RELEASES_PAGE_URL)
+      expect(changelog?.getAttribute('href')).toBe(LANDING_CHANGELOG_URL)
+      expect(body?.contains(github as Node)).toBe(false)
+      expect(body?.contains(changelog as Node)).toBe(false)
+
+      const { act } = await import('react')
+      await act(async () => {
+        ;(gotIt as HTMLButtonElement).click()
+      })
+      expect(onGotIt).toHaveBeenCalledTimes(1)
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
@@ -13,7 +13,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { EmptyState } from '@/components/ui/empty-state'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   GITHUB_RELEASES_PAGE_URL,
@@ -73,14 +72,17 @@ export function WhatsNewDialog({
         className="flex max-h-[min(36rem,85vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-lg"
         data-testid="whats-new-dialog"
       >
-        <DialogHeader className="border-b border-border px-4 py-3">
+        <DialogHeader className="shrink-0 border-b border-border px-4 py-3">
           <DialogTitle>What's new</DialogTitle>
           <DialogDescription>
             Product changes since your last visit.
           </DialogDescription>
         </DialogHeader>
 
-        <ScrollArea className="min-h-0 flex-1">
+        <div
+          className="min-h-0 flex-1 overflow-y-auto"
+          data-testid="whats-new-dialog-body"
+        >
           <div className="flex flex-col gap-6 px-4 py-4">
             {isLoading ? (
               <div
@@ -124,9 +126,9 @@ export function WhatsNewDialog({
               </section>
             ))}
           </div>
-        </ScrollArea>
+        </div>
 
-        <DialogFooter className="items-center gap-2 sm:justify-between">
+        <DialogFooter className="mx-0 mb-0 shrink-0 items-center gap-2 sm:justify-between">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Button
               variant="link"

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -89,7 +89,13 @@ dialog is owned by `WhatsNewProvider` (sibling of the shell chrome, not inside
 the user menu). The same dialog also opens from a **What's new** item next to
 About in the user dropdown (`WhatsNewMenuItem`) and from an action on
 `/about`. Auto-open once on upgrade; dismiss / Got it writes last-seen.
-Notes come from `GET /api/v1/releases` (server-side GitHub Releases; airgap
+The dialog is a flex column (`max-h-[min(36rem,85vh)] overflow-hidden p-0`):
+header and footer are `shrink-0`; only the notes list
+(`data-testid="whats-new-dialog-body"`, `min-h-0 flex-1 overflow-y-auto`)
+scrolls. Native overflow on that body — not `ScrollArea` + `flex-1` — so a
+tall list cannot paint under GitHub Releases / Changelog / Got it. Footer
+resets the primitive's `-mx-4 -mb-4` (`mx-0 mb-0`) because the dialog is
+`p-0`. Notes come from `GET /api/v1/releases` (server-side GitHub Releases; airgap
 fallback is a **build-time snapshot** of latest `v*` Features, not
 the full CHANGELOG.md). Settings icon is lucide `Settings` (`size-4`, `strokeWidth={1.5}`),
 `aria-label="Open settings"`, `data-testid="nav-settings-button"`, tooltip


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3133

## Summary

The What's new dialog let release notes paint under GitHub Releases / Changelog / Got it. Header and footer now stay put; only the notes list scrolls.

## Changes

- `WhatsNewDialog` is a flex column with a `min-h-0 flex-1 overflow-y-auto` notes body (`data-testid="whats-new-dialog-body"`)
- Header and footer are `shrink-0`; footer resets the primitive `-mx-4 -mb-4` so it no longer overlays the list on a `p-0` dialog
- Replaced `ScrollArea` + `flex-1` (viewport `size-full` does not constrain) with native overflow on the body
- Focused test: tall notes live in the scroll body; footer chrome stays outside it; Got it and footer links still work
- Documented the sticky header/footer dialog idiom in the product-design skill and knowledge doc

Out of scope: GitHub Release body rewrite (#3132), adding a host, #3105, release-please.

## Test plan

- [x] Focused unit test: dialog body is the scroll container; footer does not contain the notes
- [x] `bun test src/components/whats-new/` passes
- [x] `pnpm run type-check:test` passes
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Design skill / knowledge doc updated for the sticky dialog chrome pattern
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

First-visit badge, upgrade auto-open once, newspaper icon left of Settings, Got it closes, and footer links are unchanged.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc964086-4137-4083-b8fe-d56e17727997?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc964086-4137-4083-b8fe-d56e17727997&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

