### PR TITLE
fix(landing): hide Pricing and Always shipping on homepage

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -37,6 +37,9 @@ const forbidden = [
   // Removed rotating slogan surface — do not reintroduce a false match via JS.
   'data-hero-slogan',
   'data-slogans',
+  // Homepage no longer embeds Pricing cards or the changelog band.
+  'Always shipping',
+  'id="pricing"',
 ] as const
 
 let failed = false
@@ -161,7 +164,10 @@ if (html.includes('min-w-[640px]')) {
 const distVs = join(process.cwd(), 'dist/vs-grafana/index.html')
 try {
   const vsHtml = readFileSync(distVs, 'utf8')
-  if (!vsHtml.includes('cmp-matrix') || !vsHtml.includes('data-label="chmonitor"')) {
+  if (
+    !vsHtml.includes('cmp-matrix') ||
+    !vsHtml.includes('data-label="chmonitor"')
+  ) {
     console.error('MISSING stacked-matrix markers on /vs-grafana')
     failed = true
   } else {
@@ -179,10 +185,50 @@ if (html.includes('data-feature-count=')) {
   console.log('OK: no feature-count promo on homepage')
 }
 
+const headerStart = html.indexOf('<header')
+const headerEnd = html.indexOf('</header>')
+const header =
+  headerStart === -1 || headerEnd === -1
+    ? ''
+    : html.slice(headerStart, headerEnd)
+if (/href="\/pricing"/.test(header)) {
+  console.error('FORBIDDEN Pricing link in homepage header nav')
+  failed = true
+} else {
+  console.log('OK: homepage header nav has no Pricing link')
+}
+
+const drawerStart = html.indexOf('id="mobile-menu"')
+const drawerFoot = html.indexOf('nav-drawer-foot')
+const drawer =
+  drawerStart === -1 || drawerFoot === -1
+    ? ''
+    : html.slice(drawerStart, drawerFoot)
+if (/href="\/pricing"/.test(drawer)) {
+  console.error('FORBIDDEN Pricing link in homepage mobile nav')
+  failed = true
+} else {
+  console.log('OK: homepage mobile nav has no Pricing link')
+}
+
+const distPricing = join(process.cwd(), 'dist/pricing/index.html')
+try {
+  const pricingHtml = readFileSync(distPricing, 'utf8')
+  if (!pricingHtml.includes('id="pricing"')) {
+    console.error('MISSING pricing section in dist/pricing/index.html')
+    failed = true
+  } else {
+    console.log('OK: dist/pricing/index.html still has Pricing cards')
+  }
+} catch {
+  console.error('MISSING dist/pricing/index.html — run build first')
+  failed = true
+}
+
 const distChangelog = join(process.cwd(), 'dist/changelog/index.html')
 try {
   const changelogHtml = readFileSync(distChangelog, 'utf8')
-  if (!changelogHtml.includes('Always shipping') && !changelogHtml.includes('changelog')) {
+  if (!changelogHtml.toLowerCase().includes('changelog')) {
     console.error('MISSING changelog content in dist/changelog/index.html')
     failed = true
   } else {

--- a/apps/landing/src/components/Nav.astro
+++ b/apps/landing/src/components/Nav.astro
@@ -56,7 +56,6 @@ const featureIco = (d: string) =>
             <a href="/features/postgres"><span class="nav-ico" set:html={featureIco(featureIcons.postgres)} /><span class="nav-txt"><span class="nav-item-label">Postgres<span class="nav-badge">Beta</span></span><small>Monitor Postgres alongside</small></span></a>
           </div>
         </div>
-        <a href="/pricing">Pricing</a>
         <a href="/customers">Customers</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
         <div class="nav-group">
@@ -126,7 +125,6 @@ const featureIco = (d: string) =>
             <a href="/features/postgres">Postgres<span class="nav-badge">Beta</span></a>
           </div>
         </details>
-        <a href="/pricing">Pricing</a>
         <a href="/customers">Customers</a>
         <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Docs</a>
         <details class="nav-drawer-group">

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
-const landing = join(import.meta.dir, '../..')
+const landing = join(import.meta.dir, '..')
 const read = (rel: string) => readFileSync(join(landing, rel), 'utf8')
 
 const home = read('src/pages/index.astro')

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -5,10 +5,8 @@ import Hero from '../components/Hero.astro'
 import FeatureShowcase from '../components/FeatureShowcase.astro'
 import Capabilities from '../components/Capabilities.astro'
 import Comparison from '../components/Comparison.astro'
-import Pricing from '../components/Pricing.astro'
 import FAQ from '../components/FAQ.astro'
 import FinalCta from '../components/FinalCta.astro'
-import ChangelogBand from '../components/ChangelogBand.astro'
 import Footer from '../components/Footer.astro'
 import UseCaseLinks from '../components/UseCaseLinks.astro'
 import { useCases } from '../data/use-cases'
@@ -21,10 +19,8 @@ import { useCases } from '../data/use-cases'
     <Capabilities />
     <Comparison />
     <UseCaseLinks items={useCases} eyebrow="Use cases" heading="Explore by use case" soft />
-    <Pricing compact />
     <FAQ />
     <FinalCta />
-    <ChangelogBand />
   </main>
   <Footer />
 </Base>

--- a/apps/landing/src/pages/index.test.ts
+++ b/apps/landing/src/pages/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const landing = join(import.meta.dir, '../..')
+const read = (rel: string) => readFileSync(join(landing, rel), 'utf8')
+
+const home = read('src/pages/index.astro')
+const nav = read('src/components/Nav.astro')
+const footer = read('src/components/Footer.astro')
+
+describe('homepage hides Pricing and the Always shipping band', () => {
+  test('does not import or render Pricing or ChangelogBand', () => {
+    expect(home).not.toContain("from '../components/Pricing.astro'")
+    expect(home).not.toContain("from '../components/ChangelogBand.astro'")
+    expect(home).not.toMatch(/<Pricing\b/)
+    expect(home).not.toMatch(/<ChangelogBand\b/)
+  })
+
+  test('keeps FAQ and the dedicated pages/components', () => {
+    expect(home).toContain('<FAQ />')
+    expect(existsSync(join(landing, 'src/pages/pricing.astro'))).toBe(true)
+    expect(existsSync(join(landing, 'src/pages/changelog.astro'))).toBe(true)
+    expect(existsSync(join(landing, 'src/components/Pricing.astro'))).toBe(true)
+    expect(
+      existsSync(join(landing, 'src/components/ChangelogBand.astro'))
+    ).toBe(true)
+  })
+})
+
+describe('header nav does not advertise Pricing', () => {
+  test('desktop and mobile chrome have no /pricing item', () => {
+    expect(nav).not.toContain('href="/pricing"')
+    expect(nav).not.toMatch(/>Pricing</)
+  })
+
+  test('Changelog still links to /changelog', () => {
+    expect(nav).toContain('href="/changelog"')
+  })
+
+  test('footer still links to /pricing', () => {
+    expect(footer).toContain('href="/pricing"')
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hide the Pricing cards and the Changelog “Always shipping” band on the chmonitor.dev homepage. `/pricing` and `/changelog` stay as dedicated pages. Closes #3135.

## Changes

- Remove `<Pricing compact />` and `<ChangelogBand />` (and their unused imports) from `apps/landing/src/pages/index.astro`
- Remove desktop and mobile header Nav **Pricing** links in `apps/landing/src/components/Nav.astro`; Changelog stays under Resources (`/changelog`)
- Leave footer `/pricing` and FAQ (self-host vs cloud still mentions commercial licenses)
- Keep `Pricing.astro`, `ChangelogBand.astro`, and pricing data files
- Assert the homepage no longer contains those sections in `src/homepage.test.ts` (kept out of `src/pages` so Astro does not treat it as a route) and `scripts/verify-landing-structure.ts`; `/pricing` and `/changelog` still build

## Test plan

- [x] `cd apps/landing && bun test` passes (64 tests)
- [x] `cd apps/landing && pnpm run build && bun scripts/verify-landing-structure.ts` passes
- [x] Built `/` has no Pricing cards, no “Always shipping”, no header/mobile Pricing links
- [x] Built `/pricing` still has Pricing cards; `/changelog` still builds
- [x] Local preview: `/`, `/pricing/`, `/changelog/` all 200
- [x] Docs unchanged (`docs/content/` / `ai-agent.mdx` not applicable)

![Homepage header with no Pricing nav item](https://cursor.com/artifacts/c/art-284b94f4-17a4-4242-bf2f-b75983a3bc47)
![Homepage FAQ then CTA with no Pricing cards or Always shipping band](https://cursor.com/artifacts/c/art-d10868a9-7a5e-4db4-afa9-ceab1acf624b)
![Resources dropdown still lists Changelog](https://cursor.com/artifacts/c/art-463b8486-ef1a-4460-aa74-2b54f6830a84)
![/pricing page still renders license cards](https://cursor.com/artifacts/c/art-73bc9488-664e-4706-a21a-0be4fc1c96a6)
![/changelog page still renders release notes](https://cursor.com/artifacts/c/art-e56e48d7-ad74-4a2b-96bb-d1c4a66862c1)
<a href="https://cursor.com/agents/bc-6b67af7c-76bc-41bf-86d3-f7be1675737a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hide_pricing_changelog_demo.mp4"><img src="https://cursor.com/artifacts/c/art-bf91109e-9a80-47c5-8d4f-362759f695c8" alt="homepage_hide_pricing_changelog_demo.mp4" /></a>

## Notes for reviewer

Out of scope: no extra host, #3105 stays, no release-please merge, no #3132 / #3133 / #3134.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b67af7c-76bc-41bf-86d3-f7be1675737a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b67af7c-76bc-41bf-86d3-f7be1675737a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

