### PR TITLE
feat(dashboard): add friendly What's new notes for dialog and changelog

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -276,9 +276,11 @@ navigation. Header and footer stay put; only the notes body
 dialog idiom above. Manual open always works. Extra entry points: `WhatsNewMenuItem`
 next to About in the user dropdown, and a What's new action on `/about`. Do
 **not** add a Settings tab for changelog — Settings stays browser-local prefs.
-`GET /api/v1/releases` loads notes server-side (no browser GitHub calls);
-airgap fallback is the committed `airgap-snapshot.json` (latest `v*` Features),
-never a runtime fetch of CHANGELOG.md. Use `NavSettingsButton` /
+`GET /api/v1/releases` loads notes server-side (no browser GitHub calls).
+Copy comes from `docs/whats-new/vX.Y.Z.md` when present (same files as landing
+`/changelog`); otherwise the GitHub body is stripped to Features. Airgap
+fallback is the committed `airgap-snapshot.json` (friendly notes overlaid on
+latest `v*` Features), never a runtime fetch of CHANGELOG.md. Use `NavSettingsButton` /
 `NavUserFooterRow` (`components/nav-user/nav-settings-button.tsx`): lucide
 `Settings`, `size-4`, `strokeWidth={1.5}`, `aria-label="Open settings"`,
 `data-testid="nav-settings-button"`, tooltip "Settings". Hide when

--- a/.github/release-notes-prompt.md
+++ b/.github/release-notes-prompt.md
@@ -37,6 +37,9 @@ dashboard; lead with user impact, not implementation detail.
   link, or agent shoutout — the workflow appends those **below** your notes.
   Ignore the recap numbers for the opening Highlights unless a figure is
   genuinely user-facing (it almost never is).
+- The dashboard What's new file (`docs/whats-new/vX.Y.Z.md`) is generated in a
+  later step from these notes. Do not try to replace the GitHub Release body
+  with that short file.
 
 ## Release
 

--- a/.github/whats-new-prompt.md
+++ b/.github/whats-new-prompt.md
@@ -1,0 +1,48 @@
+You are writing the **friendly What's new note** for chmonitor (dashboard +
+landing /changelog). This is a short, natural, human-readable note. It is NOT
+the GitHub Release body.
+
+The GitHub Release already has the detailed changelog (recap stats, Docker,
+full commit list). Do not copy that dump. Do not include recap numbers, agent
+shoutouts, Docker pull blocks, commit SHAs, or PR-number walls.
+
+## Output
+
+Return ONLY a markdown file with YAML frontmatter, in this shape:
+
+```md
+---
+version: 0.3.4
+date: 2026-08-19
+summary: One sentence of what users can now do.
+screenshots:
+  - src: /assets/whats-new/v0.3.4-nav.png
+    alt: Short alt
+---
+
+- User-facing bullet.
+- Another bullet.
+```
+
+Rules:
+- `version` must match the release tag without the leading `v`.
+- `summary` is one sentence.
+- Body is 4–8 short bullets. Imperative or present tense is fine; keep them
+  natural ("Drag to reorder pinned favorites"), not `**scope:** commit title`.
+- Copy screenshot markdown from Unreleased Highlights into `screenshots` when
+  present. Never invent image paths.
+- Omit the `screenshots` key when there are none.
+- Skip refactors, CI, chores, tests, and other internal-only work.
+
+## Release
+
+Release tag: {{RELEASE_TAG}}
+Date: {{DATE}}
+
+## Unreleased Highlights (from CHANGELOG.md — prefer these)
+
+{{HIGHLIGHTS}}
+
+## Detailed release notes (source material — do not paste wholesale)
+
+{{RELEASE_NOTES}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,3 +352,98 @@ jobs:
             "clickhouse-monitor-${TAG}-cloudflare.tar.gz" \
             SHA256SUMS \
             --clobber
+
+  # Friendly What's new file for the dashboard dialog + landing /changelog.
+  # Does not replace the GitHub Release body (already published above).
+  whats-new:
+    name: whats-new
+    needs: [assets]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: write
+      models: read
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Download release notes
+        uses: actions/download-artifact@v7
+        with:
+          name: release-assets-${{ needs.assets.outputs.tag }}
+          path: /tmp/release-assets
+
+      - name: Build What's new prompt
+        id: prompt
+        env:
+          RELEASE_TAG: ${{ needs.assets.outputs.tag }}
+        run: |
+          set -euo pipefail
+          DATE="$(date -u +%F)"
+          bun scripts/build-whats-new-prompt.ts \
+            --tag "$RELEASE_TAG" \
+            --date "$DATE" \
+            --release-notes /tmp/release-assets/release-notes.md \
+            --out whats-new-prompt.txt
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Friendly notes (GitHub Copilot)
+        id: ai_copilot
+        continue-on-error: true
+        uses: actions/ai-inference@v2
+        with:
+          provider: copilot
+          model: openai/gpt-4o
+          prompt-file: whats-new-prompt.txt
+
+      - name: Friendly notes (GitHub Models)
+        id: ai_models
+        if: ${{ steps.ai_copilot.outputs.response == '' }}
+        continue-on-error: true
+        uses: actions/ai-inference@v2
+        with:
+          provider: github-models
+          model: openai/gpt-4o
+          prompt-file: whats-new-prompt.txt
+
+      - name: Write docs/whats-new file
+        env:
+          RELEASE_TAG: ${{ needs.assets.outputs.tag }}
+          COPILOT_FILE: ${{ steps.ai_copilot.outputs.response-file }}
+          MODELS_FILE: ${{ steps.ai_models.outputs.response-file }}
+          DATE: ${{ steps.prompt.outputs.date }}
+        run: |
+          set -euo pipefail
+          AI=""
+          if [ -n "${COPILOT_FILE:-}" ] && [ -s "$COPILOT_FILE" ]; then AI="$COPILOT_FILE"
+          elif [ -n "${MODELS_FILE:-}" ] && [ -s "$MODELS_FILE" ]; then AI="$MODELS_FILE"
+          fi
+          ARGS=(--tag "$RELEASE_TAG" --date "$DATE" --release-notes /tmp/release-assets/release-notes.md)
+          if [ -n "$AI" ]; then ARGS+=(--ai-file "$AI"); fi
+          bun scripts/write-whats-new.ts "${ARGS[@]}"
+
+      - name: Commit friendly notes to main
+        env:
+          TAG: ${{ needs.assets.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add docs/whats-new/*.md
+          if git diff --cached --quiet; then
+            echo "No What's new changes"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(dashboard): add What's new notes for ${TAG}
+
+          Co-Authored-By: duyetbot <bot@duyet.net>"
+          git pull --rebase origin main
+          git push origin HEAD:main
+

--- a/apps/dashboard/.gitignore
+++ b/apps/dashboard/.gitignore
@@ -6,5 +6,6 @@ dist
 .turbo
 src/routeTree.gen.ts
 src/lib/whats-new/airgap-snapshot.generated.json
+src/lib/whats-new/friendly-notes.generated.json
 worker-configuration.d.ts
 *.tsbuildinfo

--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -74,15 +74,44 @@ function clickGroupTrigger(groupLabel: string) {
 }
 
 /**
- * Groups default collapsed (#3130). Click once, then wait for the href.
- * Nested group links can render in a Popover portal outside
- * `[data-sidebar="sidebar"]`, so search the document — do not scope to
- * SIDEBAR. Do not sync-read `$body.find` and click again (that closes a
- * group whose submenu has not mounted yet).
+ * Groups default collapsed (#3130). Nested group links can render in a
+ * Popover portal outside `[data-sidebar="sidebar"]`, so search the document.
+ *
+ * One click can close an already-open group. Click once, wait up to ~2s for
+ * the href on the live document, and only then click again to re-open. Do
+ * not sync-read `$body.find` immediately after click (that races the
+ * submenu mount and a second click closes a group that was still opening).
  */
+function waitForHrefOnDocument(hrefPart: string, timeoutMs: number) {
+  const hrefSel = `a[href*="${hrefPart}"]`
+  return cy
+    .document({ log: false })
+    .then({ timeout: timeoutMs + 250 }, (doc) => {
+      const deadline = Date.now() + timeoutMs
+      return new Cypress.Promise<boolean>((resolve) => {
+        const tick = () => {
+          if (doc.querySelector(hrefSel)) {
+            resolve(true)
+            return
+          }
+          if (Date.now() >= deadline) {
+            resolve(false)
+            return
+          }
+          setTimeout(tick, 50)
+        }
+        tick()
+      })
+    })
+}
+
 function expandGroup(groupLabel: string, hrefPart: string) {
+  const hrefSel = `a[href*="${hrefPart}"]`
   clickGroupTrigger(groupLabel)
-  cy.get(`a[href*="${hrefPart}"]`, { timeout: 10000 }).should('exist')
+  waitForHrefOnDocument(hrefPart, 2000).then((found) => {
+    if (!found) clickGroupTrigger(groupLabel)
+  })
+  cy.get(hrefSel, { timeout: 10000 }).should('exist')
 }
 
 function clickHref(hrefPart: string) {

--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -73,29 +73,20 @@ function clickGroupTrigger(groupLabel: string) {
     .click({ force: true })
 }
 
-function sidebarHref(hrefPart: string) {
-  return `${SIDEBAR} a[href*="${hrefPart}"]`
-}
-
 /**
- * Groups default collapsed (#3130). Do not sync-read `$body.find` right after
- * click — that races the submenu mount and a second click closes the group.
- * If the href is already in the sidebar, skip the toggle (already open).
+ * Groups default collapsed (#3130). Click once, then wait for the href.
+ * Nested group links can render in a Popover portal outside
+ * `[data-sidebar="sidebar"]`, so search the document — do not scope to
+ * SIDEBAR. Do not sync-read `$body.find` and click again (that closes a
+ * group whose submenu has not mounted yet).
  */
 function expandGroup(groupLabel: string, hrefPart: string) {
-  const linkSel = sidebarHref(hrefPart)
-
-  cy.get(SIDEBAR).then(($sidebar) => {
-    const alreadyOpen = $sidebar.find(`a[href*="${hrefPart}"]`).length > 0
-    if (alreadyOpen) return
-    clickGroupTrigger(groupLabel)
-  })
-
-  cy.get(linkSel, { timeout: 10000 }).should('exist')
+  clickGroupTrigger(groupLabel)
+  cy.get(`a[href*="${hrefPart}"]`, { timeout: 10000 }).should('exist')
 }
 
 function clickHref(hrefPart: string) {
-  cy.get(sidebarHref(hrefPart)).first().click({ force: true })
+  cy.get(`a[href*="${hrefPart}"]`).first().click({ force: true })
 }
 
 describe('Sidebar navigation', () => {

--- a/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
+++ b/apps/dashboard/cypress/e2e/sidebar-navigation.cy.ts
@@ -26,6 +26,9 @@ const SIDEBAR_GROUP = '[data-slot="sidebar"]'
 
 const USER_SETTINGS_STORAGE_KEY = 'clickhouse-monitor-user-settings'
 const E2E_USER_SETTINGS = {
+  // Dim (true) keeps tableCheck-gated leaves in the menu when e2e healthz /
+  // host probes fail. Hide (false) removes them — Running Queries uses
+  // tableCheck `system.processes`, so Hide would drop `a[href*="/running-queries"]`.
   dimUnavailablePages: true,
   workspacePreset: 'full',
   hiddenMenuHrefs: [] as string[],
@@ -58,7 +61,7 @@ function ensureDesktopRailExpanded() {
   cy.get(SIDEBAR_GROUP).should('have.attr', 'data-state', 'expanded')
 }
 
-function expandGroup(groupLabel: string, hrefPart: string) {
+function clickGroupTrigger(groupLabel: string) {
   const labelRe = new RegExp(`^${groupLabel}(\\s|$)`)
   cy.get(`${SIDEBAR} [data-slot="collapsible-trigger"]`)
     .filter((_, el) =>
@@ -68,24 +71,31 @@ function expandGroup(groupLabel: string, hrefPart: string) {
     .first()
     .scrollIntoView()
     .click({ force: true })
+}
 
-  cy.get('body').then(($body) => {
-    if ($body.find(`a[href*="${hrefPart}"]`).length === 0) {
-      // First click collapsed an already-open group — toggle back.
-      cy.get(`${SIDEBAR} [data-slot="collapsible-trigger"]`)
-        .filter((_, el) =>
-          labelRe.test((el.innerText || '').replace(/\s+/g, ' ').trim())
-        )
-        .first()
-        .click({ force: true })
-    }
+function sidebarHref(hrefPart: string) {
+  return `${SIDEBAR} a[href*="${hrefPart}"]`
+}
+
+/**
+ * Groups default collapsed (#3130). Do not sync-read `$body.find` right after
+ * click — that races the submenu mount and a second click closes the group.
+ * If the href is already in the sidebar, skip the toggle (already open).
+ */
+function expandGroup(groupLabel: string, hrefPart: string) {
+  const linkSel = sidebarHref(hrefPart)
+
+  cy.get(SIDEBAR).then(($sidebar) => {
+    const alreadyOpen = $sidebar.find(`a[href*="${hrefPart}"]`).length > 0
+    if (alreadyOpen) return
+    clickGroupTrigger(groupLabel)
   })
 
-  cy.get(`a[href*="${hrefPart}"]`, { timeout: 10000 }).should('exist')
+  cy.get(linkSel, { timeout: 10000 }).should('exist')
 }
 
 function clickHref(hrefPart: string) {
-  cy.get(`a[href*="${hrefPart}"]`).first().click({ force: true })
+  cy.get(sidebarHref(hrefPart)).first().click({ force: true })
 }
 
 describe('Sidebar navigation', () => {

--- a/apps/dashboard/scripts/build-whats-new-snapshot.ts
+++ b/apps/dashboard/scripts/build-whats-new-snapshot.ts
@@ -1,43 +1,71 @@
 #!/usr/bin/env bun
 
 /**
- * Bake the latest `v*` product notes from repo-root CHANGELOG.md into a small
- * JSON snapshot. Used as the airgap fallback for GET /api/v1/releases.
+ * Bake latest `v*` product notes (friendly files first, then CHANGELOG
+ * Features) into gitignored JSON used by GET /api/v1/releases.
  *
  *   bun scripts/build-whats-new-snapshot.ts
  */
 
 import { serializeAirgapSnapshot } from '../src/lib/whats-new/airgap-snapshot'
+import { loadFriendlyNotesFromDir } from '../src/lib/whats-new/load-friendly-notes'
 import { buildAirgapSnapshot } from '../src/lib/whats-new/parse-changelog'
+import { serializeFriendlyNotesJson } from '../src/lib/whats-new/parse-friendly-note'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
 const DASHBOARD_ROOT = dirname(SCRIPT_DIR)
+const REPO_ROOT = join(DASHBOARD_ROOT, '../..')
 const CHANGELOG_CANDIDATES = [
-  join(DASHBOARD_ROOT, '../../CHANGELOG.md'),
+  join(REPO_ROOT, 'CHANGELOG.md'),
   join(DASHBOARD_ROOT, '../CHANGELOG.md'),
 ]
 const CHANGELOG_PATH =
   CHANGELOG_CANDIDATES.find((path) => existsSync(path)) ??
   CHANGELOG_CANDIDATES[0]!
-const OUTPUT_PATH = join(
+const WHATS_NEW_DIR = join(REPO_ROOT, 'docs/whats-new')
+const SNAPSHOT_PATH = join(
   DASHBOARD_ROOT,
   'src/lib/whats-new/airgap-snapshot.generated.json'
 )
+const FRIENDLY_PATH = join(
+  DASHBOARD_ROOT,
+  'src/lib/whats-new/friendly-notes.generated.json'
+)
+const FRIENDLY_FIXTURE_PATH = join(
+  DASHBOARD_ROOT,
+  'src/lib/whats-new/friendly-notes.json'
+)
+
+function writeIfChanged(path: string, next: string): boolean {
+  const prev = existsSync(path) ? readFileSync(path, 'utf8') : ''
+  if (prev === next) return false
+  writeFileSync(path, next)
+  return true
+}
 
 export function writeWhatsNewAirgapSnapshot(
   changelogPath = CHANGELOG_PATH,
-  outputPath = OUTPUT_PATH
+  snapshotPath = SNAPSHOT_PATH,
+  whatsNewDir = WHATS_NEW_DIR,
+  friendlyPath = FRIENDLY_PATH,
+  friendlyFixturePath = FRIENDLY_FIXTURE_PATH
 ): boolean {
-  if (!existsSync(changelogPath)) return false
-  const notes = buildAirgapSnapshot(readFileSync(changelogPath, 'utf8'))
-  const next = serializeAirgapSnapshot(notes)
-  const prev = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : ''
-  if (prev === next) return false
-  writeFileSync(outputPath, next)
-  return true
+  const friendly = existsSync(whatsNewDir)
+    ? loadFriendlyNotesFromDir(whatsNewDir)
+    : []
+  const friendlyJson = serializeFriendlyNotesJson(friendly)
+  let wrote = writeIfChanged(friendlyPath, friendlyJson)
+  wrote = writeIfChanged(friendlyFixturePath, friendlyJson) || wrote
+  if (!existsSync(changelogPath)) return wrote
+  const notes = buildAirgapSnapshot(
+    readFileSync(changelogPath, 'utf8'),
+    undefined,
+    friendly
+  )
+  return writeIfChanged(snapshotPath, serializeAirgapSnapshot(notes)) || wrote
 }
 
 const isDirectRun = import.meta.main === true
@@ -49,6 +77,8 @@ if (isDirectRun) {
     process.exit(1)
   }
   console.log(
-    wrote ? `Wrote ${OUTPUT_PATH}` : `Snapshot unchanged at ${OUTPUT_PATH}`
+    wrote
+      ? `Wrote ${SNAPSHOT_PATH} and friendly notes`
+      : `Snapshot unchanged at ${SNAPSHOT_PATH}`
   )
 }

--- a/apps/dashboard/src/lib/whats-new/constants.ts
+++ b/apps/dashboard/src/lib/whats-new/constants.ts
@@ -5,7 +5,12 @@ export const GITHUB_RELEASES_API_URL =
 export const GITHUB_RELEASES_PAGE_URL =
   'https://github.com/chmonitor/chmonitor/releases'
 
-export const LANDING_CHANGELOG_URL = 'https://chmonitor.dev/changelog'
+export const LANDING_ORIGIN = 'https://chmonitor.dev'
+
+export const LANDING_CHANGELOG_URL = `${LANDING_ORIGIN}/changelog`
+
+/** Site-root screenshot paths (`/assets/…`) resolve here in the dashboard dialog. */
+export const WHATS_NEW_ASSET_ORIGIN = LANDING_ORIGIN
 
 export const RELEASES_CACHE_TTL_MS = 60 * 60 * 1000
 

--- a/apps/dashboard/src/lib/whats-new/draft-friendly-note.ts
+++ b/apps/dashboard/src/lib/whats-new/draft-friendly-note.ts
@@ -1,0 +1,191 @@
+import type { FriendlyNote, ReleaseNoteScreenshot } from './types'
+
+import { extractMarkdownImages, IMAGE_RE } from './images'
+import {
+  parseFriendlyNoteMarkdown,
+  serializeFriendlyNoteMarkdown,
+} from './parse-friendly-note'
+import { stripToProductNotes } from './parse-release-body'
+import { normalizeVersion } from './version'
+
+const MAX_FRIENDLY_BULLETS = 8
+const MIN_FRIENDLY_BULLETS = 4
+
+const UNRELEASED_RE =
+  /^## \[Unreleased\](?:\([^)]+\))?(?:\s+\(([^)]+)\))?[ \t]*$/im
+const VERSION_HEADING_RE = /^## \[/m
+
+export function extractUnreleasedHighlights(changelogMarkdown: string): {
+  bullets: string[]
+  screenshots: ReleaseNoteScreenshot[]
+} {
+  const text = changelogMarkdown.replace(/\r\n/g, '\n')
+  const startMatch = text.match(UNRELEASED_RE)
+  if (!startMatch || startMatch.index == null) {
+    return { bullets: [], screenshots: [] }
+  }
+  const after = text.slice(startMatch.index + startMatch[0].length)
+  const next = after.search(VERSION_HEADING_RE)
+  const section = next >= 0 ? after.slice(0, next) : after
+  const highlightsMatch = section.match(
+    /(?:^|\n)#{2,3}\s+[^\n]*highlights?[^\n]*\n([\s\S]*?)(?=\n#{2,3}\s|$)/i
+  )
+  const body = highlightsMatch ? highlightsMatch[1]! : section
+  const bullets: string[] = []
+  for (const line of body.split('\n')) {
+    const match = line.match(/^\s*[-*+]\s+(.+)$/)
+    if (!match) continue
+    const item = match[1]!.trim()
+    if (IMAGE_RE.test(item) || IMAGE_RE.test(line)) continue
+    bullets.push(stripNoise(item))
+  }
+  const screenshots = extractMarkdownImages(body).map((image) => ({
+    src: image.url,
+    alt: image.alt,
+  }))
+  return { bullets: bullets.filter(Boolean), screenshots }
+}
+
+/** Strip PR links, SHAs, and `**scope:**` prefixes from a changelog bullet. */
+export function stripNoise(raw: string): string {
+  return raw
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\(\[#\d+\]\([^)]+\)\)/g, '')
+    .replace(/\[#\d+\]\([^)]+\)/g, '')
+    .replace(/\(\[[a-f0-9]+\]\([^)]+\)\)/gi, '')
+    .replace(/\(#\d+\)/g, '')
+    .replace(/\b[a-f0-9]{7,40}\b/gi, '')
+    .replace(/^\*\*([^:*]+):\*\*\s*/i, '')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/[.,;:\s]+$/g, '')
+    .trim()
+}
+
+function toSentence(raw: string): string {
+  const cleaned = stripNoise(raw)
+  if (!cleaned) return ''
+  const capped = cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
+  return /[.!?]$/.test(capped) ? capped : `${capped}.`
+}
+
+function uniqueSentences(items: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const item of items) {
+    const sentence = toSentence(item)
+    const key = sentence.toLowerCase()
+    if (!sentence || seen.has(key)) continue
+    seen.add(key)
+    out.push(sentence)
+  }
+  return out
+}
+
+function isRecapish(text: string): boolean {
+  return (
+    /\bshoutout\b/i.test(text) ||
+    /\b\d[\d,]*\s+commits?\b/i.test(text) ||
+    /\bdocker\s+pull\b/i.test(text)
+  )
+}
+
+function uncap(text: string): string {
+  if (!text) return text
+  return text.charAt(0).toLowerCase() + text.slice(1)
+}
+
+function composeSummary(bullets: string[]): string {
+  const leads = bullets
+    .slice(0, 3)
+    .map((bullet) => bullet.replace(/[.!?]$/, ''))
+  if (leads.length === 0) return "What's new in this release"
+  if (leads.length === 1) return leads[0]!
+  if (leads.length === 2) return `${leads[0]} and ${uncap(leads[1]!)}`
+  return `${leads[0]}, ${uncap(leads[1]!)}, and ${uncap(leads[2]!)}`
+}
+
+/**
+ * Draft a friendly note from a detailed GitHub Release body plus optional
+ * CHANGELOG Unreleased Highlights. Never invent screenshots.
+ */
+export function draftFriendlyNote(input: {
+  version: string
+  date: string
+  releaseBody: string
+  changelogMarkdown?: string
+}): FriendlyNote {
+  const version = normalizeVersion(input.version)
+  const unreleased = input.changelogMarkdown
+    ? extractUnreleasedHighlights(input.changelogMarkdown)
+    : { bullets: [], screenshots: [] }
+  const product = stripToProductNotes(input.releaseBody, [
+    'highlights',
+    'features',
+  ])
+  const featureBullets: string[] = []
+  for (const line of product.markdown.split('\n')) {
+    const match = line.match(/^\s*[-*+]\s+(.+)$/)
+    if (match) featureBullets.push(match[1]!.trim())
+  }
+
+  const bullets = uniqueSentences([
+    ...unreleased.bullets,
+    ...product.highlights.filter((item) => !isRecapish(item)),
+    ...featureBullets,
+  ]).slice(0, MAX_FRIENDLY_BULLETS)
+
+  const filled =
+    bullets.length >= MIN_FRIENDLY_BULLETS
+      ? bullets
+      : uniqueSentences([...bullets, ...featureBullets]).slice(
+          0,
+          MAX_FRIENDLY_BULLETS
+        )
+
+  const summary =
+    unreleased.bullets[0] && !isRecapish(unreleased.bullets[0])
+      ? toSentence(unreleased.bullets[0]).replace(/[.!?]$/, '')
+      : composeSummary(filled)
+
+  return {
+    version,
+    date: input.date,
+    summary,
+    bullets: filled,
+    screenshots: unreleased.screenshots,
+  }
+}
+
+export function draftFriendlyNoteMarkdown(input: {
+  version: string
+  date: string
+  releaseBody: string
+  changelogMarkdown?: string
+}): string {
+  return serializeFriendlyNoteMarkdown(draftFriendlyNote(input))
+}
+
+/**
+ * Accept an LLM draft when it parses as a friendly note for this version and
+ * does not smuggle recap/Docker/SHA noise. Otherwise keep the deterministic
+ * draft.
+ */
+export function pickFriendlyNoteMarkdown(
+  deterministic: string,
+  aiMarkdown: string | null | undefined,
+  version: string
+): string {
+  if (!aiMarkdown?.trim()) return deterministic
+  const parsed = parseFriendlyNoteMarkdown(aiMarkdown)
+  if (!parsed) return deterministic
+  if (normalizeVersion(parsed.version) !== normalizeVersion(version)) {
+    return deterministic
+  }
+  const blob = `${parsed.summary}\n${parsed.bullets.join('\n')}`
+  if (/\(#\d+\)/.test(blob) || isRecapish(blob)) {
+    return deterministic
+  }
+  if (parsed.bullets.length === 0 && !parsed.summary) return deterministic
+  return serializeFriendlyNoteMarkdown(parsed)
+}

--- a/apps/dashboard/src/lib/whats-new/fetch-releases.test.ts
+++ b/apps/dashboard/src/lib/whats-new/fetch-releases.test.ts
@@ -1,3 +1,5 @@
+import { parseAirgapSnapshot } from './airgap-snapshot'
+import bundledSnapshot from './airgap-snapshot.json'
 import { GITHUB_RELEASES_API_URL } from './constants'
 import {
   loadReleases,
@@ -30,12 +32,15 @@ const GITHUB_JSON = JSON.stringify([
   },
 ])
 
+const originalFetch = globalThis.fetch
+
 afterEach(() => {
   resetReleasesCacheForTests()
   globalThis.fetch = originalFetch
 })
 
-const originalFetch = globalThis.fetch
+const snapshotNotes = parseAirgapSnapshot(bundledSnapshot)
+const noFriendly: [] = []
 
 function mockFetch(
   impl: (
@@ -71,10 +76,34 @@ describe('loadReleases', () => {
       throw new Error(`unexpected fetch ${url}`)
     })
 
-    const payload = await loadReleases()
+    const payload = await loadReleases(Date.now(), snapshotNotes, noFriendly)
     expect(payload.success).toBe(true)
     expect(payload.source).toBe('github')
     expect(payload.data[0]?.version).toBe('0.3.3')
+    expect(payload.data[0]?.markdown).toContain('Features')
+  })
+
+  test('overlays friendly notes over a GitHub recap dump', async () => {
+    mockFetch(async (url) => {
+      if (url.startsWith(GITHUB_RELEASES_API_URL.split('?')[0]!)) {
+        return { ok: true, status: 200, text: async () => GITHUB_JSON }
+      }
+      throw new Error(`unexpected fetch ${url}`)
+    })
+
+    const payload = await loadReleases(Date.now(), snapshotNotes, [
+      {
+        version: '0.3.3',
+        date: '2026-08-16',
+        summary: 'Guest AI caps and simpler alerts.',
+        bullets: ['Cap guest AI usage on Cloud.'],
+        screenshots: [],
+      },
+    ])
+    expect(payload.data[0]?.kind).toBe('friendly')
+    expect(payload.data[0]?.summary).toContain('Guest AI caps')
+    expect(payload.data[0]?.markdown).not.toContain('shoutout')
+    expect(payload.data[0]?.markdown).toContain('Cap guest AI usage')
   })
 
   test('falls back to the bundled snapshot when GitHub is down', async () => {
@@ -84,7 +113,7 @@ describe('loadReleases', () => {
       return { ok: false, status: 503, text: async () => 'down' }
     })
 
-    const payload = await loadReleases()
+    const payload = await loadReleases(Date.now(), snapshotNotes, noFriendly)
     expect(payload.success).toBe(true)
     expect(payload.source).toBe('snapshot')
     expect(payload.data.length).toBeGreaterThan(0)
@@ -98,7 +127,7 @@ describe('loadReleases', () => {
   test('returns a quiet failure when GitHub is down and the snapshot is empty', async () => {
     mockFetch(async () => ({ ok: false, status: 500, text: async () => '' }))
 
-    const payload = await loadReleases(Date.now(), [])
+    const payload = await loadReleases(Date.now(), [], noFriendly)
     expect(payload.success).toBe(false)
     expect(payload.source).toBe('none')
     expect(payload.data).toEqual([])

--- a/apps/dashboard/src/lib/whats-new/fetch-releases.ts
+++ b/apps/dashboard/src/lib/whats-new/fetch-releases.ts
@@ -1,4 +1,4 @@
-import type { ReleaseNote, ReleasesPayload } from './types'
+import type { FriendlyNote, ReleaseNote, ReleasesPayload } from './types'
 
 import { parseAirgapSnapshot } from './airgap-snapshot'
 import bundledSnapshot from './airgap-snapshot.json'
@@ -8,6 +8,11 @@ import {
   RELEASES_CACHE_TTL_MS,
   RELEASES_FETCH_TIMEOUT_MS,
 } from './constants'
+import bundledFriendly from './friendly-notes.json'
+import {
+  overlayFriendlyNotes,
+  parseFriendlyNotesJson,
+} from './parse-friendly-note'
 import { buildReleaseNote } from './parse-release-body'
 import { isProductVersionTag } from './version'
 
@@ -27,6 +32,8 @@ interface CacheEntry {
 let memoryCache: CacheEntry | null = null
 
 const bundledSnapshotNotes: ReleaseNote[] = parseAirgapSnapshot(bundledSnapshot)
+const bundledFriendlyNotes: FriendlyNote[] =
+  parseFriendlyNotesJson(bundledFriendly)
 
 export function resetReleasesCacheForTests(): void {
   memoryCache = null
@@ -92,21 +99,22 @@ function snapshotPayload(
 
 /**
  * Load product release notes: GitHub Releases first, then the build-time
- * airgap snapshot. Never fetches CHANGELOG.md (too large for the client or
- * a runtime fallback). Cached in memory for ~1 hour. Public repo only.
+ * airgap snapshot. Per-version friendly files overlay the stripped GitHub
+ * body when present. Never fetches CHANGELOG.md. Cached ~1 hour.
  *
  * Server-only — do not import this module from client components.
  */
 export async function loadReleases(
   now = Date.now(),
-  snapshot: readonly ReleaseNote[] = bundledSnapshotNotes
+  snapshot: readonly ReleaseNote[] = bundledSnapshotNotes,
+  friendly: readonly FriendlyNote[] = bundledFriendlyNotes
 ): Promise<ReleasesPayload> {
   if (memoryCache && memoryCache.expiresAt > now) {
     return memoryCache.payload
   }
 
   try {
-    const data = await fetchGithubReleases()
+    const data = overlayFriendlyNotes(await fetchGithubReleases(), friendly)
     if (data.length > 0) {
       const payload: ReleasesPayload = {
         success: true,
@@ -120,7 +128,7 @@ export async function loadReleases(
     // Fall through to the bundled snapshot.
   }
 
-  const fallback = snapshotPayload(snapshot)
+  const fallback = snapshotPayload(overlayFriendlyNotes(snapshot, friendly))
   if (fallback) {
     memoryCache = { expiresAt: now + RELEASES_CACHE_TTL_MS, payload: fallback }
     return fallback

--- a/apps/dashboard/src/lib/whats-new/friendly-notes.json
+++ b/apps/dashboard/src/lib/whats-new/friendly-notes.json
@@ -1,0 +1,68 @@
+{
+  "notes": [
+    {
+      "version": "0.3.3",
+      "date": "2026-08-16",
+      "summary": "Guest AI caps, simpler alerts, and pinned favorites you can drag.",
+      "bullets": [
+        "Cap and track guest AI usage on Cloud.",
+        "Pick models dynamically, including AnyRouter presets and a custom model field.",
+        "Alert settings use templates and presets instead of a wall of forms.",
+        "See recently completed merges when none are running.",
+        "Drag to reorder pinned favorites in the sidebar.",
+        "Open Settings from the icon next to Sign in."
+      ],
+      "screenshots": []
+    },
+    {
+      "version": "0.3.2",
+      "date": "2026-08-12",
+      "summary": "A denser fleet view, a live MCP playground, and alert channels that start from what you already configured.",
+      "bullets": [
+        "Alert channels show as a configured-first card grid.",
+        "The query-activity heatmap picks a month window that fits the screen.",
+        "Table Overview in Explorer is denser and engine-aware, with SQL highlighting for DDL.",
+        "Fleet summary strip with richer host metrics and sparklines.",
+        "MCP Playground talks to a live client and covers the 2026-07-28 spec gaps."
+      ],
+      "screenshots": []
+    },
+    {
+      "version": "0.3.1",
+      "date": "2026-08-11",
+      "summary": "Interactive cluster topology and smarter model picking for the agent.",
+      "bullets": [
+        "Drag and inspect cluster topology with glass glyphs.",
+        "Auto-pick AnyRouter models by real usage, not a static list.",
+        "Surface why parts were postponed on 26.2+.",
+        "Keep the Cloudflare Worker under the free 3 MiB limit."
+      ],
+      "screenshots": [
+        {
+          "src": "/assets/screenshots/cluster-topology-dark.png",
+          "alt": "Cluster topology"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "date": "2026-08-06",
+      "summary": "The TanStack Start release — Cloud, Postgres, alerting, and AI on a new runtime.",
+      "bullets": [
+        "Dashboard runs on TanStack Start and Vite; Docker and Cloudflare Workers come from the same app.",
+        "Hosted Cloud at dash.chmonitor.dev with a public demo and per-user connections.",
+        "Monitor Postgres (beta) and PeerDB CDC next to your existing clusters.",
+        "Alerting engine with templates, channels, and health reports.",
+        "AI agent, Insights, advisors, and MCP at /api/mcp.",
+        "Pluggable auth: none, Clerk, proxy, or trusted.",
+        "Helm chart and one-click deploys; connection vars stay the same."
+      ],
+      "screenshots": [
+        {
+          "src": "/assets/screenshots/overview-dark-with-bg.jpeg",
+          "alt": "Overview with cluster status, storage, and query activity heatmap"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/dashboard/src/lib/whats-new/load-friendly-notes.ts
+++ b/apps/dashboard/src/lib/whats-new/load-friendly-notes.ts
@@ -1,0 +1,45 @@
+import type { FriendlyNote } from './types'
+
+import { parseFriendlyNoteMarkdown } from './parse-friendly-note'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const FILE_RE = /^v\d+\.\d+\.\d+\.md$/
+
+function defaultSearchDirs(fromDir: string): string[] {
+  return [
+    join(fromDir, '../../../docs/whats-new'),
+    join(fromDir, '../../../../docs/whats-new'),
+    join(fromDir, '../../../../../docs/whats-new'),
+    join(process.cwd(), 'docs/whats-new'),
+    join(process.cwd(), '../../docs/whats-new'),
+  ]
+}
+
+export function resolveWhatsNewDir(
+  fromDir = dirname(fileURLToPath(import.meta.url))
+): string | null {
+  for (const dir of defaultSearchDirs(fromDir)) {
+    if (existsSync(dir)) return dir
+  }
+  return null
+}
+
+/**
+ * Node-only loader for `docs/whats-new/vX.Y.Z.md`. Not imported by the
+ * Worker `fetch-releases` module (no filesystem there).
+ */
+export function loadFriendlyNotesFromDir(dir?: string): FriendlyNote[] {
+  const resolved = dir ?? resolveWhatsNewDir()
+  if (!resolved || !existsSync(resolved)) return []
+
+  const notes: FriendlyNote[] = []
+  for (const name of readdirSync(resolved).sort().reverse()) {
+    if (!FILE_RE.test(name)) continue
+    const markdown = readFileSync(join(resolved, name), 'utf8')
+    const parsed = parseFriendlyNoteMarkdown(markdown, name)
+    if (parsed) notes.push(parsed)
+  }
+  return notes
+}

--- a/apps/dashboard/src/lib/whats-new/parse-changelog.ts
+++ b/apps/dashboard/src/lib/whats-new/parse-changelog.ts
@@ -1,6 +1,7 @@
-import type { ReleaseNote } from './types'
+import type { FriendlyNote, ReleaseNote } from './types'
 
 import { AIRGAP_SNAPSHOT_LIMIT } from './constants'
+import { overlayFriendlyNotes } from './parse-friendly-note'
 import { buildReleaseNote, stripToProductNotes } from './parse-release-body'
 import { isProductVersionTag, parseSemver, toProductTag } from './version'
 
@@ -63,24 +64,28 @@ export function parseChangelogMarkdown(markdown: string): ReleaseNote[] {
 }
 
 /**
- * Small airgap payload: latest `vX.Y.Z` Features only (Fixes / Perf /
- * Highlights stay on the live GitHub body). Unreleased is omitted.
+ * Small airgap payload: latest `vX.Y.Z` notes. Friendly files win; otherwise
+ * Features only (Fixes / Perf stay on the live GitHub body). Unreleased is omitted.
  */
 export function buildAirgapSnapshot(
   changelogMarkdown: string,
-  limit = AIRGAP_SNAPSHOT_LIMIT
+  limit = AIRGAP_SNAPSHOT_LIMIT,
+  friendly: readonly FriendlyNote[] = []
 ): ReleaseNote[] {
-  return parseChangelogMarkdown(changelogMarkdown)
-    .filter(
-      (note) => note.version !== 'unreleased' && isProductVersionTag(note.tag)
-    )
+  const released = parseChangelogMarkdown(changelogMarkdown).filter(
+    (note) => note.version !== 'unreleased' && isProductVersionTag(note.tag)
+  )
+  const overlaid = overlayFriendlyNotes(released, friendly)
+  return overlaid
     .map((note) => {
+      if (note.kind === 'friendly') return note
       const features = stripToProductNotes(note.markdown, ['features'])
       return {
         ...note,
         markdown: features.markdown,
         summary: features.summary,
         highlights: features.highlights,
+        kind: 'stripped' as const,
       }
     })
     .filter((note) => note.markdown.trim().length > 0)

--- a/apps/dashboard/src/lib/whats-new/parse-friendly-note.test.ts
+++ b/apps/dashboard/src/lib/whats-new/parse-friendly-note.test.ts
@@ -1,0 +1,257 @@
+import {
+  draftFriendlyNote,
+  extractUnreleasedHighlights,
+  pickFriendlyNoteMarkdown,
+  stripNoise,
+} from './draft-friendly-note'
+import friendlyNotesJson from './friendly-notes.json'
+import { loadFriendlyNotesFromDir } from './load-friendly-notes'
+import {
+  friendlyNoteToReleaseNote,
+  overlayFriendlyNotes,
+  parseFriendlyNoteMarkdown,
+  parseFriendlyNotesJson,
+} from './parse-friendly-note'
+import {
+  buildReleaseNote,
+  isRecapLikeText,
+  stripToProductNotes,
+} from './parse-release-body'
+import { describe, expect, test } from 'bun:test'
+
+const FRIENDLY_V033 = `---
+version: 0.3.3
+date: 2026-08-16
+summary: Guest AI caps, simpler alerts, and pinned favorites you can drag.
+screenshots:
+  - src: /assets/whats-new/v0.3.3-nav.png
+    alt: Favorites
+---
+
+- Cap and track guest AI usage on Cloud.
+- Drag to reorder pinned favorites.
+`
+
+const RECAP_DUMP_033 = `## 📊 Release recap
+
+- 📦 **50 commits** across **50 pull requests**
+- 🏆 Shoutout to **@github-actions[bot]**
+
+## 🐳 Docker image
+
+\`\`\`bash
+docker pull ghcr.io/chmonitor/chmonitor:0.3.3
+\`\`\`
+
+### ✨ Features
+
+* **nav:** drag to reorder pinned favorites ([#3026](https://example/3026)) (f5c5fb1)
+* **ui:** add settings icon
+`
+
+const V0216_BODY = `> In this exciting release of **chmonitor**, we’ve celebrated the contributions of 3 dedicated agents over 13 days, resulting in a remarkable 63 commits and 62 pull requests — averaging nearly 5 changes per day! Our night owls made 37 commits under the stars while our daytime contributors added 26. A special shoutout goes to @github-actions[bot], who kept the momentum going with 37 insightful comments.
+
+## ✨ Features
+- Introduce outage escalation and error spike alerts for improved incident response.
+- Add DAU/MAU tracking and weekly report generation to enhance user engagement analysis.
+
+## 📊 Release recap
+
+- 📦 **63 commits** across **62 pull requests**
+- 🏆 Shoutout to **@github-actions[bot]**
+
+## 🐳 Docker image
+
+\`\`\`bash
+docker pull ghcr.io/chmonitor/chmonitor:0.2.16
+\`\`\`
+`
+
+describe('parseFriendlyNoteMarkdown', () => {
+  test('reads version, summary, bullets, and screenshots', () => {
+    const note = parseFriendlyNoteMarkdown(FRIENDLY_V033, 'v0.3.3.md')
+    expect(note?.version).toBe('0.3.3')
+    expect(note?.summary).toContain('Guest AI caps')
+    expect(note?.bullets).toHaveLength(2)
+    expect(note?.screenshots[0]?.src).toBe('/assets/whats-new/v0.3.3-nav.png')
+  })
+
+  test('rejects a file whose name does not match version', () => {
+    expect(parseFriendlyNoteMarkdown(FRIENDLY_V033, 'v0.3.2.md')).toBeNull()
+  })
+})
+
+describe('overlayFriendlyNotes', () => {
+  test('friendly notes win over a recap dump', () => {
+    const stripped = buildReleaseNote({
+      version: '0.3.3',
+      publishedAt: '2026-08-16T12:00:00Z',
+      markdown: RECAP_DUMP_033,
+    })
+    expect(stripped.markdown).toContain('Features')
+    const friendly = parseFriendlyNoteMarkdown(FRIENDLY_V033)
+    expect(friendly).not.toBeNull()
+    const [overlaid] = overlayFriendlyNotes([stripped], [friendly!])
+    expect(overlaid?.kind).toBe('friendly')
+    expect(overlaid?.summary).toBe(
+      'Guest AI caps, simpler alerts, and pinned favorites you can drag.'
+    )
+    expect(overlaid?.markdown).toContain('Cap and track guest AI usage')
+    expect(overlaid?.markdown).not.toContain('50 commits')
+    expect(overlaid?.markdown).not.toContain('Shoutout')
+    expect(overlaid?.markdown).not.toContain('docker pull')
+    expect(overlaid?.markdown).not.toContain('f5c5fb1')
+    expect(overlaid?.screenshots?.[0]?.src).toContain(
+      '/assets/whats-new/v0.3.3-nav.png'
+    )
+  })
+
+  test('versions without a file keep the stripped Features fallback', () => {
+    const stripped = buildReleaseNote({
+      version: '0.2.16',
+      markdown: V0216_BODY,
+    })
+    const friendly = parseFriendlyNoteMarkdown(FRIENDLY_V033)!
+    const [overlaid] = overlayFriendlyNotes([stripped], [friendly])
+    expect(overlaid?.kind).toBe('stripped')
+    expect(overlaid?.markdown).toContain('outage escalation')
+    expect(overlaid?.markdown).not.toContain('63 commits')
+  })
+})
+
+describe('isRecapLikeText + 0.2.x preface', () => {
+  test('detects recap shoutout copy', () => {
+    expect(
+      isRecapLikeText(
+        '63 commits and 62 pull requests. A special shoutout goes to @github-actions[bot]'
+      )
+    ).toBe(true)
+    expect(
+      isRecapLikeText('Compact settings rail and a faster agent widget.')
+    ).toBe(false)
+  })
+
+  test('stripToProductNotes drops 0.2.x recap blockquote and Docker', () => {
+    const result = stripToProductNotes(V0216_BODY)
+    expect(result.markdown).toContain('outage escalation')
+    expect(result.markdown).toContain('Features')
+    expect(result.markdown).not.toContain('63 commits')
+    expect(result.markdown).not.toContain('Shoutout')
+    expect(result.markdown).not.toContain('docker pull')
+    expect(result.summary).not.toContain('63 commits')
+  })
+})
+
+describe('docs/whats-new catalog', () => {
+  test('seeded 0.3.x files parse as friendly notes', () => {
+    const notes = loadFriendlyNotesFromDir()
+    const versions = notes.map((note) => note.version).sort()
+    expect(versions).toEqual(['0.3.0', '0.3.1', '0.3.2', '0.3.3'])
+    for (const note of notes) {
+      expect(note.summary.length).toBeGreaterThan(10)
+      expect(note.bullets.length).toBeGreaterThanOrEqual(4)
+      expect(note.bullets.length).toBeLessThanOrEqual(8)
+      const blob = `${note.summary}\n${note.bullets.join('\n')}`
+      expect(blob).not.toMatch(/shoutout/i)
+      expect(blob).not.toMatch(/docker pull/i)
+      expect(blob).not.toMatch(/\(#\d+\)/)
+    }
+  })
+
+  test('bundled friendly-notes.json matches docs/whats-new', () => {
+    const fromDisk = loadFriendlyNotesFromDir()
+      .map((note) => note.version)
+      .sort()
+    const bundled = parseFriendlyNotesJson(friendlyNotesJson)
+      .map((note) => note.version)
+      .sort()
+    expect(bundled).toEqual(fromDisk)
+  })
+})
+
+describe('draftFriendlyNote', () => {
+  test('rewrites Features into friendly copy and copies Unreleased Highlights', () => {
+    const changelog = `## [Unreleased]
+
+### Highlights
+
+- Upcoming guest AI caps
+- ![Nav](/assets/whats-new/v0.3.3-nav.png)
+
+## [0.3.3](https://example) (2026-08-15)
+`
+    const note = draftFriendlyNote({
+      version: '0.3.3',
+      date: '2026-08-16',
+      releaseBody: RECAP_DUMP_033,
+      changelogMarkdown: changelog,
+    })
+    expect(note.version).toBe('0.3.3')
+    expect(note.bullets[0]).toContain('Upcoming guest AI caps')
+    expect(note.bullets.some((b) => /pinned favorites/i.test(b))).toBe(true)
+    expect(note.screenshots[0]?.src).toBe('/assets/whats-new/v0.3.3-nav.png')
+    expect(note.summary).not.toMatch(/50 commits/)
+  })
+
+  test('pickFriendlyNoteMarkdown rejects recap-tainted AI output', () => {
+    const good = parseFriendlyNoteMarkdown(FRIENDLY_V033)!
+    const deterministic = `---
+version: 0.3.3
+date: 2026-08-16
+summary: Deterministic summary.
+---
+
+- Deterministic bullet.
+`
+    const dirty = `---
+version: 0.3.3
+date: 2026-08-16
+summary: 50 commits and a shoutout.
+---
+
+- docker pull ghcr.io/chmonitor/chmonitor:0.3.3
+`
+    expect(pickFriendlyNoteMarkdown(deterministic, dirty, '0.3.3')).toBe(
+      deterministic
+    )
+    expect(
+      pickFriendlyNoteMarkdown(deterministic, FRIENDLY_V033, '0.3.3')
+    ).toContain(good.summary)
+  })
+
+  test('stripNoise drops SHAs, PRs, and scope prefixes', () => {
+    expect(
+      stripNoise(
+        '**nav:** drag to reorder pinned favorites ([#3026](https://example/3026)) (f5c5fb1)'
+      )
+    ).toBe('drag to reorder pinned favorites')
+  })
+
+  test('extractUnreleasedHighlights reads bullets and images', () => {
+    const extracted = extractUnreleasedHighlights(`## [Unreleased]
+
+### Highlights
+
+- One
+- ![Shot](/assets/screenshots/overview-dark-with-bg.jpeg)
+
+### ✨ Features
+
+* **ui:** ignored
+`)
+    expect(extracted.bullets).toEqual(['One'])
+    expect(extracted.screenshots[0]?.src).toContain(
+      'overview-dark-with-bg.jpeg'
+    )
+  })
+})
+
+describe('friendlyNoteToReleaseNote', () => {
+  test('rewrites /assets paths to the landing origin', () => {
+    const note = parseFriendlyNoteMarkdown(FRIENDLY_V033)!
+    const release = friendlyNoteToReleaseNote(note)
+    expect(release.screenshots?.[0]?.src).toBe(
+      'https://chmonitor.dev/assets/whats-new/v0.3.3-nav.png'
+    )
+  })
+})

--- a/apps/dashboard/src/lib/whats-new/parse-friendly-note.ts
+++ b/apps/dashboard/src/lib/whats-new/parse-friendly-note.ts
@@ -1,0 +1,293 @@
+import type { FriendlyNote, ReleaseNote, ReleaseNoteScreenshot } from './types'
+
+import { LANDING_ORIGIN } from './constants'
+import { normalizeVersion, toProductTag } from './version'
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+
+export function resolveWhatsNewAssetUrl(
+  src: string,
+  origin = LANDING_ORIGIN
+): string {
+  const trimmed = src.trim()
+  if (!trimmed) return trimmed
+  if (/^https?:\/\//i.test(trimmed)) return trimmed
+  const path = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return `${origin}${path}`
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim()
+  const match = trimmed.match(/^["'](.*)["']$/)
+  return (match ? match[1] : trimmed).trim()
+}
+
+function parseScalar(value: string): string {
+  return unquote(value.replace(/#.*$/, ''))
+}
+
+/**
+ * Minimal YAML subset for What's new frontmatter: `key: value`, a
+ * `screenshots` list of strings or `{ src, alt }` maps. Not a general parser.
+ */
+export function parseFriendlyFrontmatter(raw: string): {
+  version?: string
+  date?: string
+  summary?: string
+  screenshots: ReleaseNoteScreenshot[]
+} {
+  const screenshots: ReleaseNoteScreenshot[] = []
+  let version: string | undefined
+  let date: string | undefined
+  let summary: string | undefined
+  let inScreenshots = false
+  let pending: { src?: string; alt?: string } | null = null
+
+  const flushPending = () => {
+    if (pending?.src) {
+      screenshots.push({
+        src: pending.src,
+        alt: pending.alt ?? '',
+      })
+    }
+    pending = null
+  }
+
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.replace(/\t/g, '  ')
+    if (!line.trim()) continue
+
+    if (inScreenshots) {
+      const mapItem = line.match(/^\s+-\s+src:\s*(.+)$/)
+      if (mapItem) {
+        flushPending()
+        pending = { src: parseScalar(mapItem[1] ?? '') }
+        continue
+      }
+      const altItem = line.match(/^\s+alt:\s*(.+)$/)
+      if (altItem && pending) {
+        pending.alt = parseScalar(altItem[1] ?? '')
+        continue
+      }
+      const stringItem = line.match(/^\s+-\s+(.+)$/)
+      if (stringItem) {
+        flushPending()
+        const src = parseScalar(stringItem[1] ?? '')
+        if (src) screenshots.push({ src, alt: '' })
+        continue
+      }
+      if (/^\S/.test(line)) {
+        flushPending()
+        inScreenshots = false
+      } else {
+        continue
+      }
+    }
+
+    if (/^screenshots:\s*$/.test(line.trimEnd())) {
+      inScreenshots = true
+      continue
+    }
+
+    const keyed = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/)
+    if (!keyed) continue
+    const key = keyed[1]
+    const value = parseScalar(keyed[2] ?? '')
+    if (key === 'version') version = value
+    else if (key === 'date') date = value
+    else if (key === 'summary') summary = value
+  }
+  flushPending()
+
+  return { version, date, summary, screenshots }
+}
+
+function parseBullets(body: string): string[] {
+  const bullets: string[] = []
+  for (const line of body.split('\n')) {
+    const match = line.match(/^\s*[-*+]\s+(.+)$/)
+    if (match) bullets.push(match[1]!.trim())
+  }
+  return bullets
+}
+
+export function parseFriendlyNoteMarkdown(
+  markdown: string,
+  fileHint?: string
+): FriendlyNote | null {
+  const match = markdown.replace(/\r\n/g, '\n').match(FRONTMATTER_RE)
+  if (!match) return null
+  const parsed = parseFriendlyFrontmatter(match[1] ?? '')
+  const versionRaw = parsed.version?.trim()
+  if (!versionRaw) return null
+  const version = normalizeVersion(versionRaw)
+  if (fileHint) {
+    const hinted = normalizeVersion(fileHint.replace(/\.md$/i, ''))
+    if (hinted && hinted !== version) return null
+  }
+  const body = (match[2] ?? '').trim()
+  const summary = parsed.summary?.trim() ?? ''
+  const bullets = parseBullets(body)
+  if (!summary && bullets.length === 0) return null
+  const date = parsed.date?.trim() || null
+  return {
+    version,
+    date,
+    summary,
+    bullets,
+    screenshots: parsed.screenshots.filter((shot) => shot.src),
+  }
+}
+
+export function friendlyNoteToMarkdown(
+  note: FriendlyNote,
+  options?: { absoluteScreenshots?: boolean; origin?: string }
+): string {
+  const parts: string[] = []
+  if (note.summary) parts.push(note.summary)
+  if (note.bullets.length > 0) {
+    parts.push(note.bullets.map((bullet) => `- ${bullet}`).join('\n'))
+  }
+  if (note.screenshots.length > 0) {
+    const origin = options?.origin
+    const absolute = options?.absoluteScreenshots !== false
+    parts.push(
+      note.screenshots
+        .map((shot) => {
+          const src =
+            absolute && origin
+              ? resolveWhatsNewAssetUrl(shot.src, origin)
+              : shot.src
+          const alt = shot.alt || 'Release screenshot'
+          return `![${alt}](${src})`
+        })
+        .join('\n')
+    )
+  }
+  return parts.join('\n\n').trim()
+}
+
+export function serializeFriendlyNoteMarkdown(note: FriendlyNote): string {
+  const lines = [
+    '---',
+    `version: ${note.version}`,
+    ...(note.date ? [`date: ${note.date}`] : []),
+    `summary: ${note.summary}`,
+  ]
+  if (note.screenshots.length > 0) {
+    lines.push('screenshots:')
+    for (const shot of note.screenshots) {
+      if (shot.alt) {
+        lines.push(`  - src: ${shot.src}`, `    alt: ${shot.alt}`)
+      } else {
+        lines.push(`  - ${shot.src}`)
+      }
+    }
+  }
+  lines.push('---', '')
+  for (const bullet of note.bullets) {
+    lines.push(`- ${bullet}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function parseFriendlyDate(date: string | null): string | null {
+  if (!date) return null
+  if (/^\d{4}-\d{2}-\d{2}$/.test(date)) return `${date}T00:00:00.000Z`
+  const parsed = new Date(date)
+  if (Number.isNaN(parsed.getTime())) return null
+  return parsed.toISOString()
+}
+
+export function friendlyNoteToReleaseNote(
+  note: FriendlyNote,
+  options?: { publishedAt?: string | null; origin?: string }
+): ReleaseNote {
+  const origin = options?.origin ?? LANDING_ORIGIN
+  const screenshots = note.screenshots.map((shot) => ({
+    src: resolveWhatsNewAssetUrl(shot.src, origin),
+    alt: shot.alt || 'Release screenshot',
+  }))
+  return {
+    version: note.version,
+    tag: toProductTag(note.version),
+    publishedAt: options?.publishedAt ?? parseFriendlyDate(note.date),
+    summary: note.summary,
+    markdown: friendlyNoteToMarkdown(
+      { ...note, screenshots },
+      { absoluteScreenshots: false }
+    ),
+    highlights: note.bullets,
+    kind: 'friendly',
+    screenshots,
+  }
+}
+
+export function indexFriendlyNotes(
+  notes: readonly FriendlyNote[]
+): Map<string, FriendlyNote> {
+  const map = new Map<string, FriendlyNote>()
+  for (const note of notes) {
+    map.set(note.version, note)
+    map.set(toProductTag(note.version), note)
+  }
+  return map
+}
+
+/**
+ * Prefer a per-version friendly file over a stripped GitHub / CHANGELOG body.
+ */
+export function overlayFriendlyNotes(
+  notes: readonly ReleaseNote[],
+  friendly: readonly FriendlyNote[]
+): ReleaseNote[] {
+  if (friendly.length === 0) return [...notes]
+  const map = indexFriendlyNotes(friendly)
+  return notes.map((note) => {
+    const match = map.get(note.version) ?? map.get(note.tag)
+    if (!match) return note
+    return friendlyNoteToReleaseNote(match, {
+      publishedAt: note.publishedAt ?? parseFriendlyDate(match.date),
+    })
+  })
+}
+
+export function parseFriendlyNotesJson(raw: unknown): FriendlyNote[] {
+  if (!raw || typeof raw !== 'object') return []
+  const notes = (raw as { notes?: unknown }).notes
+  if (!Array.isArray(notes)) return []
+  const parsed: FriendlyNote[] = []
+  for (const item of notes) {
+    if (!item || typeof item !== 'object') continue
+    const note = item as Partial<FriendlyNote>
+    if (typeof note.version !== 'string' || typeof note.summary !== 'string') {
+      continue
+    }
+    if (!Array.isArray(note.bullets)) continue
+    parsed.push({
+      version: normalizeVersion(note.version),
+      date: typeof note.date === 'string' ? note.date : null,
+      summary: note.summary,
+      bullets: note.bullets.filter(
+        (bullet): bullet is string => typeof bullet === 'string'
+      ),
+      screenshots: Array.isArray(note.screenshots)
+        ? note.screenshots.filter((shot): shot is ReleaseNoteScreenshot =>
+            Boolean(
+              shot &&
+                typeof shot === 'object' &&
+                typeof (shot as ReleaseNoteScreenshot).src === 'string'
+            )
+          )
+        : [],
+    })
+  }
+  return parsed
+}
+
+export function serializeFriendlyNotesJson(
+  notes: readonly FriendlyNote[]
+): string {
+  return `${JSON.stringify({ notes }, null, 2)}\n`
+}

--- a/apps/dashboard/src/lib/whats-new/parse-release-body.test.ts
+++ b/apps/dashboard/src/lib/whats-new/parse-release-body.test.ts
@@ -102,6 +102,28 @@ describe('stripToProductNotes', () => {
       { alt: 'Overview', url: 'https://example.com/overview.png' },
     ])
   })
+
+  test('drops 0.2.x recap blockquote, shoutout, and Docker even with old headings', () => {
+    const body = `> In this exciting release of **chmonitor**, we’ve celebrated 3 agents over 13 days, resulting in 63 commits and 62 pull requests. A special shoutout goes to @github-actions[bot].
+
+## ✨ Features
+- Introduce outage escalation and error spike alerts.
+
+## 📊 Release recap
+- 📦 **63 commits** across **62 pull requests**
+
+## 🐳 Docker image
+
+\`\`\`bash
+docker pull ghcr.io/chmonitor/chmonitor:0.2.16
+\`\`\`
+`
+    const result = stripToProductNotes(body)
+    expect(result.markdown).toContain('outage escalation')
+    expect(result.markdown).not.toContain('63 commits')
+    expect(result.markdown).not.toContain('shoutout')
+    expect(result.markdown).not.toContain('docker pull')
+  })
 })
 
 describe('parseChangelogMarkdown', () => {
@@ -200,5 +222,29 @@ describe('parseChangelogMarkdown', () => {
     expect(buildAirgapSnapshot(changelog, 1).map((n) => n.tag)).toEqual([
       'v0.3.3',
     ])
+  })
+
+  test('buildAirgapSnapshot overlays friendly notes when present', () => {
+    const changelog = `# Changelog
+
+## [0.3.3](https://example) (2026-08-15)
+
+### ✨ Features
+
+* **ui:** recap dump leftover
+`
+    const notes = buildAirgapSnapshot(changelog, 5, [
+      {
+        version: '0.3.3',
+        date: '2026-08-16',
+        summary: 'Human summary.',
+        bullets: ['Human bullet.'],
+        screenshots: [],
+      },
+    ])
+    expect(notes[0]?.kind).toBe('friendly')
+    expect(notes[0]?.markdown).toContain('Human summary')
+    expect(notes[0]?.markdown).toContain('Human bullet')
+    expect(notes[0]?.markdown).not.toContain('recap dump leftover')
   })
 })

--- a/apps/dashboard/src/lib/whats-new/parse-release-body.ts
+++ b/apps/dashboard/src/lib/whats-new/parse-release-body.ts
@@ -110,6 +110,33 @@ function extractBlockquoteSummary(text: string): string[] {
   return lines
 }
 
+/**
+ * Recap / shoutout / Docker copy that older 0.2.x GitHub Release bodies put
+ * in a leading blockquote (before any heading) or as list items.
+ */
+export function isRecapLikeText(text: string): boolean {
+  const value = text.toLowerCase()
+  if (!value.trim()) return false
+  if (/\bshoutout\b/.test(value)) return true
+  if (/\bdocker\s+pull\b/.test(value)) return true
+  if (
+    /\b\d[\d,]*\s+commits?\b/.test(value) &&
+    /\bpull requests?\b/.test(value)
+  ) {
+    return true
+  }
+  if (
+    /\b\d[\d,]*\s+commits?\b/.test(value) &&
+    /\b(agents?|daytime|night-?time|night owls?)\b/.test(value)
+  ) {
+    return true
+  }
+  if (/\b\d[\d,]*\s+commits?\b/.test(value) && /\bacross\b/.test(value)) {
+    return true
+  }
+  return false
+}
+
 function extractListItems(text: string): string[] {
   const items: string[] = []
   for (const line of text.split('\n')) {
@@ -151,7 +178,14 @@ export function stripToProductNotes(
   const keepPreface = keep.has('highlights')
   const prefaceQuotes = extractBlockquoteSummary(preface)
   const prefaceImages = extractMarkdownImages(preface)
-  if (keepPreface && (prefaceQuotes.length > 0 || prefaceImages.length > 0)) {
+  const prefaceIsRecap = isRecapLikeText(prefaceQuotes.join(' '))
+  if (keepPreface && prefaceIsRecap) {
+    const imageLines = preface.split('\n').filter((line) => IMAGE_RE.test(line))
+    if (imageLines.length > 0) kept.push(imageLines.join('\n'))
+  } else if (
+    keepPreface &&
+    (prefaceQuotes.length > 0 || prefaceImages.length > 0)
+  ) {
     kept.push(trimSection(preface))
     highlights.push(...prefaceQuotes)
   }
@@ -193,5 +227,6 @@ export function buildReleaseNote(input: {
     summary: stripped.summary,
     markdown: stripped.markdown,
     highlights: stripped.highlights,
+    kind: 'stripped',
   }
 }

--- a/apps/dashboard/src/lib/whats-new/types.ts
+++ b/apps/dashboard/src/lib/whats-new/types.ts
@@ -1,5 +1,13 @@
 export type ReleaseSource = 'github' | 'snapshot' | 'none'
 
+/** How this version's copy was produced. */
+export type ReleaseNoteKind = 'friendly' | 'stripped'
+
+export interface ReleaseNoteScreenshot {
+  src: string
+  alt: string
+}
+
 export interface ReleaseNote {
   version: string
   tag: string
@@ -7,6 +15,16 @@ export interface ReleaseNote {
   summary: string
   markdown: string
   highlights: string[]
+  kind?: ReleaseNoteKind
+  screenshots?: ReleaseNoteScreenshot[]
+}
+
+export interface FriendlyNote {
+  version: string
+  date: string | null
+  summary: string
+  bullets: string[]
+  screenshots: ReleaseNoteScreenshot[]
 }
 
 export interface ReleasesPayload {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,5 +1,7 @@
 import { serializeAirgapSnapshot } from './src/lib/whats-new/airgap-snapshot'
+import { loadFriendlyNotesFromDir } from './src/lib/whats-new/load-friendly-notes'
 import { buildAirgapSnapshot } from './src/lib/whats-new/parse-changelog'
+import { serializeFriendlyNotesJson } from './src/lib/whats-new/parse-friendly-note'
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -622,17 +624,32 @@ const startConfig = {
   spa: { enabled: true },
 }
 
-/** Bake latest v* Features into a gitignored JSON used by the Worker bundle. */
+/** Bake friendly notes + latest v* Features into gitignored JSON for the Worker. */
 function whatsNewSnapshotPlugin(): PluginOption {
-  const generatedPath = r('./src/lib/whats-new/airgap-snapshot.generated.json')
+  const generatedSnapshotPath = r(
+    './src/lib/whats-new/airgap-snapshot.generated.json'
+  )
+  const generatedFriendlyPath = r(
+    './src/lib/whats-new/friendly-notes.generated.json'
+  )
+  const whatsNewDir = [r('../../docs/whats-new'), r('../docs/whats-new')].find(
+    (path) => existsSync(path)
+  )
 
   const writeGenerated = () => {
+    const friendly = whatsNewDir ? loadFriendlyNotesFromDir(whatsNewDir) : []
+    writeFileSync(generatedFriendlyPath, serializeFriendlyNotesJson(friendly))
+
     const changelogPath = [r('../../CHANGELOG.md'), r('../CHANGELOG.md')].find(
       (path) => existsSync(path)
     )
     if (!changelogPath) return
-    const notes = buildAirgapSnapshot(readFileSync(changelogPath, 'utf8'))
-    writeFileSync(generatedPath, serializeAirgapSnapshot(notes))
+    const notes = buildAirgapSnapshot(
+      readFileSync(changelogPath, 'utf8'),
+      undefined,
+      friendly
+    )
+    writeFileSync(generatedSnapshotPath, serializeAirgapSnapshot(notes))
   }
 
   return {
@@ -642,13 +659,20 @@ function whatsNewSnapshotPlugin(): PluginOption {
       writeGenerated()
     },
     resolveId(id, importer) {
+      if (!importer?.includes('fetch-releases')) return
       if (
         id.endsWith('airgap-snapshot.json') &&
         !id.endsWith('airgap-snapshot.generated.json') &&
-        importer?.includes('fetch-releases') &&
-        existsSync(generatedPath)
+        existsSync(generatedSnapshotPath)
       ) {
-        return generatedPath
+        return generatedSnapshotPath
+      }
+      if (
+        id.endsWith('friendly-notes.json') &&
+        !id.endsWith('friendly-notes.generated.json') &&
+        existsSync(generatedFriendlyPath)
+      ) {
+        return generatedFriendlyPath
       }
     },
   }

--- a/apps/landing/src/lib/load-friendly-notes.test.ts
+++ b/apps/landing/src/lib/load-friendly-notes.test.ts
@@ -1,0 +1,19 @@
+import {
+  friendlyNoteToHtml,
+  loadLandingFriendlyNotes,
+} from './load-friendly-notes'
+import { describe, expect, test } from 'bun:test'
+
+describe('loadLandingFriendlyNotes', () => {
+  test('loads seeded 0.3.x notes from docs/whats-new', () => {
+    const notes = loadLandingFriendlyNotes()
+    const v033 = notes.get('v0.3.3') ?? notes.get('0.3.3')
+    expect(v033?.summary).toMatch(/guest AI|favorites/i)
+    expect(v033?.bullets.length).toBeGreaterThanOrEqual(4)
+    const html = friendlyNoteToHtml(v033!)
+    expect(html).toContain('<p>')
+    expect(html).toContain('<li>')
+    expect(html).not.toContain('50 commits')
+    expect(html).not.toContain('shoutout')
+  })
+})

--- a/apps/landing/src/lib/load-friendly-notes.ts
+++ b/apps/landing/src/lib/load-friendly-notes.ts
@@ -1,14 +1,140 @@
-import type { FriendlyNote } from '../../../dashboard/src/lib/whats-new/types'
-
-import { loadFriendlyNotesFromDir } from '../../../dashboard/src/lib/whats-new/load-friendly-notes'
-import { indexFriendlyNotes } from '../../../dashboard/src/lib/whats-new/parse-friendly-note'
 import {
   formatInline,
   type ReleaseNoteImage,
 } from './parse-github-release-notes'
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+/**
+ * Landing-local copy of the dashboard friendly-note shape. The shared source
+ * is `docs/whats-new/vX.Y.Z.md` — do not import apps/dashboard (depcruise
+ * `no-cross-app-imports`).
+ */
+export type FriendlyNote = {
+  version: string
+  date: string | null
+  summary: string
+  bullets: string[]
+  screenshots: { src: string; alt: string }[]
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/
+const FILE_RE = /^v\d+\.\d+\.\d+\.md$/
+
+export function stripVersionPrefix(value: string): string {
+  return value.trim().replace(/^v/i, '')
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim()
+  const match = trimmed.match(/^["'](.*)["']$/)
+  return (match ? match[1] : trimmed).trim()
+}
+
+function parseScalar(value: string): string {
+  return unquote(value.replace(/#.*$/, ''))
+}
+
+function parseFrontmatter(raw: string): {
+  version?: string
+  date?: string
+  summary?: string
+  screenshots: FriendlyNote['screenshots']
+} {
+  const screenshots: FriendlyNote['screenshots'] = []
+  let version: string | undefined
+  let date: string | undefined
+  let summary: string | undefined
+  let inScreenshots = false
+  let pending: { src?: string; alt?: string } | null = null
+
+  const flushPending = () => {
+    if (pending?.src) {
+      screenshots.push({ src: pending.src, alt: pending.alt ?? '' })
+    }
+    pending = null
+  }
+
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.replace(/\t/g, '  ')
+    if (!line.trim()) continue
+
+    if (inScreenshots) {
+      const mapItem = line.match(/^\s+-\s+src:\s*(.+)$/)
+      if (mapItem) {
+        flushPending()
+        pending = { src: parseScalar(mapItem[1] ?? '') }
+        continue
+      }
+      const altItem = line.match(/^\s+alt:\s*(.+)$/)
+      if (altItem && pending) {
+        pending.alt = parseScalar(altItem[1] ?? '')
+        continue
+      }
+      const stringItem = line.match(/^\s+-\s+(.+)$/)
+      if (stringItem) {
+        flushPending()
+        const src = parseScalar(stringItem[1] ?? '')
+        if (src) screenshots.push({ src, alt: '' })
+        continue
+      }
+      if (/^\S/.test(line)) {
+        flushPending()
+        inScreenshots = false
+      } else {
+        continue
+      }
+    }
+
+    if (/^screenshots:\s*$/.test(line.trimEnd())) {
+      inScreenshots = true
+      continue
+    }
+
+    const keyed = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/)
+    if (!keyed) continue
+    const key = keyed[1]
+    const value = parseScalar(keyed[2] ?? '')
+    if (key === 'version') version = value
+    else if (key === 'date') date = value
+    else if (key === 'summary') summary = value
+  }
+  flushPending()
+
+  return { version, date, summary, screenshots }
+}
+
+export function parseFriendlyNoteMarkdown(
+  markdown: string,
+  fileHint?: string
+): FriendlyNote | null {
+  const match = markdown.replace(/\r\n/g, '\n').match(FRONTMATTER_RE)
+  if (!match) return null
+  const parsed = parseFrontmatter(match[1] ?? '')
+  const versionRaw = parsed.version?.trim()
+  if (!versionRaw) return null
+  const version = stripVersionPrefix(versionRaw)
+  if (fileHint) {
+    const hinted = stripVersionPrefix(fileHint.replace(/\.md$/i, ''))
+    if (hinted && hinted !== version) return null
+  }
+  const body = (match[2] ?? '').trim()
+  const summary = parsed.summary?.trim() ?? ''
+  const bullets: string[] = []
+  for (const line of body.split('\n')) {
+    const bullet = line.match(/^\s*[-*+]\s+(.+)$/)
+    if (bullet) bullets.push(bullet[1]!.trim())
+  }
+  if (!summary && bullets.length === 0) return null
+  return {
+    version,
+    date: parsed.date?.trim() || null,
+    summary,
+    bullets,
+    screenshots: parsed.screenshots.filter((shot) => shot.src),
+  }
+}
 
 function resolveWhatsNewDir(): string | null {
   const candidates = [
@@ -19,6 +145,30 @@ function resolveWhatsNewDir(): string | null {
     if (existsSync(dir)) return dir
   }
   return null
+}
+
+function loadFriendlyNotesFromDir(dir: string): FriendlyNote[] {
+  const notes: FriendlyNote[] = []
+  for (const name of readdirSync(dir).sort().reverse()) {
+    if (!FILE_RE.test(name)) continue
+    const parsed = parseFriendlyNoteMarkdown(
+      readFileSync(join(dir, name), 'utf8'),
+      name
+    )
+    if (parsed) notes.push(parsed)
+  }
+  return notes
+}
+
+function indexFriendlyNotes(
+  notes: readonly FriendlyNote[]
+): Map<string, FriendlyNote> {
+  const map = new Map<string, FriendlyNote>()
+  for (const note of notes) {
+    map.set(note.version, note)
+    map.set(`v${note.version}`, note)
+  }
+  return map
 }
 
 let cached: Map<string, FriendlyNote> | null = null

--- a/apps/landing/src/lib/load-friendly-notes.ts
+++ b/apps/landing/src/lib/load-friendly-notes.ts
@@ -1,0 +1,50 @@
+import type { FriendlyNote } from '../../../dashboard/src/lib/whats-new/types'
+
+import { loadFriendlyNotesFromDir } from '../../../dashboard/src/lib/whats-new/load-friendly-notes'
+import { indexFriendlyNotes } from '../../../dashboard/src/lib/whats-new/parse-friendly-note'
+import {
+  formatInline,
+  type ReleaseNoteImage,
+} from './parse-github-release-notes'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function resolveWhatsNewDir(): string | null {
+  const candidates = [
+    join(process.cwd(), '../../docs/whats-new'),
+    fileURLToPath(new URL('../../../../docs/whats-new', import.meta.url)),
+  ]
+  for (const dir of candidates) {
+    if (existsSync(dir)) return dir
+  }
+  return null
+}
+
+let cached: Map<string, FriendlyNote> | null = null
+
+export function loadLandingFriendlyNotes(): Map<string, FriendlyNote> {
+  if (cached) return cached
+  const dir = resolveWhatsNewDir()
+  cached = dir ? indexFriendlyNotes(loadFriendlyNotesFromDir(dir)) : new Map()
+  return cached
+}
+
+export function friendlyNoteToHtml(note: FriendlyNote): string {
+  const parts: string[] = []
+  if (note.summary) parts.push(`<p>${formatInline(note.summary)}</p>`)
+  if (note.bullets.length > 0) {
+    const items = note.bullets
+      .map((bullet) => `<li>${formatInline(bullet)}</li>`)
+      .join('')
+    parts.push(`<ul>${items}</ul>`)
+  }
+  return parts.join('')
+}
+
+export function friendlyNoteImages(note: FriendlyNote): ReleaseNoteImage[] {
+  return note.screenshots.map((shot) => ({
+    src: shot.src,
+    alt: shot.alt || 'Release screenshot',
+  }))
+}

--- a/apps/landing/src/lib/parse-github-release-notes.test.ts
+++ b/apps/landing/src/lib/parse-github-release-notes.test.ts
@@ -106,4 +106,27 @@ describe('parseGithubReleaseNotes', () => {
     expect(parsed.html).toContain('second product bullet')
     expect(parsed.html).not.toContain('50 commits')
   })
+
+  test('drops 0.2.x recap blockquote, shoutout, and Docker', () => {
+    const body = `> In this exciting release of **chmonitor**, we’ve celebrated 3 agents over 13 days, resulting in a remarkable 63 commits and 62 pull requests. A special shoutout goes to @github-actions[bot].
+
+## ✨ Features
+- Introduce outage escalation and error spike alerts.
+
+## 📊 Release recap
+- 📦 **63 commits** across **62 pull requests**
+- 🏆 Shoutout to **@github-actions[bot]**
+
+## 🐳 Docker image
+
+\`\`\`bash
+docker pull ghcr.io/chmonitor/chmonitor:0.2.16
+\`\`\`
+`
+    const parsed = parseGithubReleaseNotes(body)
+    expect(parsed.html).toContain('outage escalation')
+    expect(parsed.html).not.toContain('63 commits')
+    expect(parsed.html).not.toContain('shoutout')
+    expect(parsed.html).not.toContain('docker pull')
+  })
 })

--- a/apps/landing/src/lib/parse-github-release-notes.ts
+++ b/apps/landing/src/lib/parse-github-release-notes.ts
@@ -1,5 +1,3 @@
-import { isRecapLikeText } from '../../../dashboard/src/lib/whats-new/parse-release-body'
-
 export const PRODUCT_RELEASE_TAG_RE = /^v\d+\.\d+\.\d+$/
 
 export const MAX_CHANGELOG_ITEMS = 8
@@ -35,6 +33,34 @@ export function classifyReleaseHeading(headingLine: string): SectionKind {
 
 export function isProductReleaseTag(tag: string): boolean {
   return PRODUCT_RELEASE_TAG_RE.test(tag.trim())
+}
+
+/**
+ * Recap / shoutout / Docker copy that older 0.2.x GitHub Release bodies put
+ * in a leading blockquote. Keep in sync with the dashboard parser
+ * (`apps/dashboard/src/lib/whats-new/parse-release-body.ts`).
+ */
+export function isRecapLikeText(text: string): boolean {
+  const value = text.toLowerCase()
+  if (!value.trim()) return false
+  if (/\bshoutout\b/.test(value)) return true
+  if (/\bdocker\s+pull\b/.test(value)) return true
+  if (
+    /\b\d[\d,]*\s+commits?\b/.test(value) &&
+    /\bpull requests?\b/.test(value)
+  ) {
+    return true
+  }
+  if (
+    /\b\d[\d,]*\s+commits?\b/.test(value) &&
+    /\b(agents?|daytime|night-?time|night owls?)\b/.test(value)
+  ) {
+    return true
+  }
+  if (/\b\d[\d,]*\s+commits?\b/.test(value) && /\bacross\b/.test(value)) {
+    return true
+  }
+  return false
 }
 
 export function formatInline(text: string): string {

--- a/apps/landing/src/lib/parse-github-release-notes.ts
+++ b/apps/landing/src/lib/parse-github-release-notes.ts
@@ -1,6 +1,8 @@
+import { isRecapLikeText } from '../../../dashboard/src/lib/whats-new/parse-release-body'
+
 export const PRODUCT_RELEASE_TAG_RE = /^v\d+\.\d+\.\d+$/
 
-export const MAX_CHANGELOG_ITEMS = 5
+export const MAX_CHANGELOG_ITEMS = 8
 export const MAX_CHANGELOG_IMAGES = 4
 
 export type ReleaseNoteImage = { src: string; alt: string }
@@ -35,7 +37,7 @@ export function isProductReleaseTag(tag: string): boolean {
   return PRODUCT_RELEASE_TAG_RE.test(tag.trim())
 }
 
-function formatInline(text: string): string {
+export function formatInline(text: string): string {
   return text
     .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
     .replace(/<img[^>]*>/gi, '')
@@ -73,14 +75,6 @@ function collectImages(md: string, maxImages: number): ReleaseNoteImage[] {
   return images
 }
 
-function isRecapLikeBullet(text: string): boolean {
-  return (
-    /\b\d+\s+commits?\b/i.test(text) ||
-    /\bshoutout\b/i.test(text) ||
-    /\bdocker\s+pull\b/i.test(text)
-  )
-}
-
 /**
  * Render Highlights + Features / Fixes / Perf from a GitHub Release body.
  * Skips recap stats, Docker, and the duplicated full-changelog dump so the
@@ -112,7 +106,9 @@ export function parseGithubReleaseNotes(
 
     const quote = line.match(/^>\s?(.*)$/)
     if (quote && (section === 'preface' || section === 'keep')) {
-      const text = formatInline(quote[1] ?? '')
+      const rawQuote = quote[1] ?? ''
+      if (section === 'preface' && isRecapLikeText(rawQuote)) continue
+      const text = formatInline(rawQuote)
       if (text) quotes.push(text)
       keptForImages.push(line)
       continue
@@ -121,7 +117,7 @@ export function parseGithubReleaseNotes(
     const bullet = line.match(/^[*-]\s+(.*)/)
     if (!bullet) continue
     const rawText = bullet[1] ?? ''
-    if (section === 'preface' && isRecapLikeBullet(rawText)) continue
+    if (section === 'preface' && isRecapLikeText(rawText)) continue
     const text = formatInline(rawText)
     if (!text) {
       keptForImages.push(line)

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -11,8 +11,8 @@ import {
   friendlyNoteImages,
   friendlyNoteToHtml,
   loadLandingFriendlyNotes,
+  stripVersionPrefix,
 } from '../lib/load-friendly-notes'
-import { normalizeVersion } from '../../../dashboard/src/lib/whats-new/version'
 
 interface Release {
   tag_name: string
@@ -46,7 +46,7 @@ const friendlyNotes = loadLandingFriendlyNotes()
 function notesForRelease(release: Release) {
   const friendly =
     friendlyNotes.get(release.tag_name) ??
-    friendlyNotes.get(normalizeVersion(release.tag_name))
+    friendlyNotes.get(stripVersionPrefix(release.tag_name))
   if (friendly) {
     return {
       html: friendlyNoteToHtml(friendly),

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -7,6 +7,12 @@ import {
   isProductReleaseTag,
   mdToHtml,
 } from '../lib/parse-github-release-notes'
+import {
+  friendlyNoteImages,
+  friendlyNoteToHtml,
+  loadLandingFriendlyNotes,
+} from '../lib/load-friendly-notes'
+import { normalizeVersion } from '../../../dashboard/src/lib/whats-new/version'
 
 interface Release {
   tag_name: string
@@ -33,6 +39,24 @@ try {
 
 function fmtDate(iso: string) {
   return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+const friendlyNotes = loadLandingFriendlyNotes()
+
+function notesForRelease(release: Release) {
+  const friendly =
+    friendlyNotes.get(release.tag_name) ??
+    friendlyNotes.get(normalizeVersion(release.tag_name))
+  if (friendly) {
+    return {
+      html: friendlyNoteToHtml(friendly),
+      images: friendlyNoteImages(friendly),
+    }
+  }
+  return {
+    html: release.body ? mdToHtml(release.body) : '',
+    images: extractImages(release.body),
+  }
 }
 
 const canonical = new URL(Astro.url.pathname, Astro.site).toString()
@@ -63,7 +87,9 @@ const breadcrumbJsonLd = {
 
         {releases.length > 0 ? (
           <div class="cl-list">
-            {releases.map((r) => (
+            {releases.map((r) => {
+              const notes = notesForRelease(r)
+              return (
               <div class="cl-entry" id={r.tag_name}>
                 <div class="cl-meta">
                   <a class="cl-tag" href={r.html_url} target="_blank" rel="noopener">{r.tag_name}</a>
@@ -71,12 +97,12 @@ const breadcrumbJsonLd = {
                 </div>
                 <div class="cl-body">
                   <h4>{r.name || r.tag_name}</h4>
-                  {r.body && (
-                    <div class="cl-notes" set:html={mdToHtml(r.body)} />
+                  {notes.html && (
+                    <div class="cl-notes" set:html={notes.html} />
                   )}
-                  {extractImages(r.body).length > 0 && (
+                  {notes.images.length > 0 && (
                     <div class="cl-shots">
-                      {extractImages(r.body).map((img) => (
+                      {notes.images.map((img) => (
                         <a href={img.src} target="_blank" rel="noopener" title={img.alt}>
                           <img src={img.src} alt={img.alt} loading="lazy" decoding="async" />
                         </a>
@@ -89,7 +115,8 @@ const breadcrumbJsonLd = {
                   </a>
                 </div>
               </div>
-            ))}
+              )
+            })}
           </div>
         ) : (
           <div style="margin-top:52px;text-align:center;padding:48px 24px;border:1px solid var(--border);border-radius:var(--radius)">

--- a/assets/README.md
+++ b/assets/README.md
@@ -5,6 +5,9 @@ Committed source of truth for images reused across the marketing/docs sites
 
 - `screenshots/` — product screenshots (dashboard captures, dialogs), both
   `-light`/`-dark` variants where available.
+- `whats-new/` — optional What's new dialog / `/changelog` screenshots.
+  Reference them as `/assets/whats-new/<file>` in `docs/whats-new/vX.Y.Z.md`.
+  Do not invent captures; omit the frontmatter key when none exist.
 - `videos/` — landing/blog launch films (mp4 + poster). Served at
   `/assets/videos/<file>` after sync.
 - `illustrations/` — bespoke brand illustrations (spot art, hero graphics) as

--- a/assets/whats-new/README.md
+++ b/assets/whats-new/README.md
@@ -1,0 +1,2 @@
+# Optional What's new screenshots. Served at /assets/whats-new/<file>
+# after scripts/sync-shared-assets.mjs. Reference from docs/whats-new/*.md.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -95,9 +95,9 @@ header and footer are `shrink-0`; only the notes list
 scrolls. Native overflow on that body — not `ScrollArea` + `flex-1` — so a
 tall list cannot paint under GitHub Releases / Changelog / Got it. Footer
 resets the primitive's `-mx-4 -mb-4` (`mx-0 mb-0`) because the dialog is
-`p-0`. Notes come from `GET /api/v1/releases` (server-side GitHub Releases; airgap
-fallback is a **build-time snapshot** of latest `v*` Features, not
-the full CHANGELOG.md). Settings icon is lucide `Settings` (`size-4`, `strokeWidth={1.5}`),
+`p-0`. Notes come from `GET /api/v1/releases` (server-side GitHub Releases with
+`docs/whats-new` friendly copy first). Airgap fallback is a **build-time
+snapshot** of latest `v*` notes, not the full CHANGELOG.md. Settings icon is lucide `Settings` (`size-4`, `strokeWidth={1.5}`),
 `aria-label="Open settings"`, `data-testid="nav-settings-button"`, tooltip
 "Settings". Hide when `canUseSettings` / `SETTINGS_FEATURE_PERMISSION` is off.
 Local settings do not need an account — the gear stays outside `SignInButton`

--- a/docs/knowledge/release-automation.md
+++ b/docs/knowledge/release-automation.md
@@ -58,16 +58,27 @@ version) → `## 🔁 Full changelog` (compare link `PREVIOUS_TAG...RELEASE_TAG`
 → build footer.
 Repo-specific prompts (`.github/release-notes-prompt.md`,
 `.github/release-notes-system-prompt.md`, `.github/release-migration-prompt.md`)
-are passed to the action via its `*-prompt-file` inputs. The dashboard What's
-new dialog (`GET /api/v1/releases`) displays the GitHub Release body after
-stripping recap/Docker/internal sections. When GitHub is unreachable, the
-Worker serves a **build-time airgap snapshot** of latest `vX.Y.Z` Features
-(Vite writes a gitignored generated file from CHANGELOG.md; a small committed
-fixture covers tests). Do not fetch `CHANGELOG.md` at runtime — the file is
-too large to ship to the client or pull on every fallback.
-`pnpm --filter dashboard whats-new:snapshot` regenerates the same file.
-The public landing page `/changelog` uses the skip-recap parser
-(`parse-github-release-notes.ts`) so recap stats do not replace Features.
+are passed to the action via its `*-prompt-file` inputs.
+
+The dashboard What's new dialog (`GET /api/v1/releases`) and landing
+`/changelog` prefer **friendly notes** in `docs/whats-new/vX.Y.Z.md` (summary +
+4–8 bullets + optional screenshots). GitHub Releases stay the detailed
+changelog (recap stats, Docker, full commit list) — do not rewrite those
+bodies. If a version has no friendly file, both UIs fall back to the
+strip-to-Features parser (`parse-release-body.ts` /
+`parse-github-release-notes.ts`), which also drops 0.2.x recap blockquotes.
+When GitHub is unreachable, the Worker serves a **build-time airgap snapshot**
+(friendly notes overlaid on latest CHANGELOG Features). Vite writes a
+gitignored generated file; a small committed fixture covers tests. Do not
+fetch `CHANGELOG.md` at runtime.
+`pnpm --filter dashboard whats-new:snapshot` regenerates the snapshot.
+After a dashboard release, `release.yml` job `whats-new` drafts
+`docs/whats-new/vX.Y.Z.md` from the detailed `release-notes.md` plus any
+`## [Unreleased] ### Highlights`, using the same Copilot → GitHub Models
+tiers. It never replaces the GitHub Release body.
+`bun scripts/write-whats-new.ts --tag vX.Y.Z --release-notes release-notes.md`
+does the same locally. Screenshot files live in `assets/whats-new/` (served
+as `/assets/whats-new/…` after `scripts/sync-shared-assets.mjs`).
 
 ## LLM summary tiers (best-effort, never blocks a release)
 
@@ -122,10 +133,11 @@ version block above it on release. Don't hand-edit released version blocks.
 Do not reintroduce changesets.
 
 `## [Unreleased]` **may** include a `### Highlights` subsection with short
-user-facing bullets and optional markdown screenshots (`![alt](url)`). Those
-highlights are the source for the GitHub Release opening summary and the
-in-dashboard What's new dialog. Keep Highlights product-facing — no refactor /
-CI / chore dumps.
+user-facing bullets and optional markdown screenshots (`![alt](/assets/whats-new/…)`).
+Those highlights seed the GitHub Release opening summary **and** the friendly
+`docs/whats-new/vX.Y.Z.md` file generated after the dashboard release. Keep
+Highlights product-facing — no refactor / CI / chore dumps. GitHub Release
+bodies stay detailed (recap, Docker, commits).
 
 ## Migration prompt (AI-assisted upgrades)
 

--- a/docs/whats-new/README.md
+++ b/docs/whats-new/README.md
@@ -1,0 +1,54 @@
+# What's new notes
+
+Short, human-readable notes for the in-dashboard **What's new** dialog and the
+landing `/changelog` page. GitHub Releases stay the detailed changelog (recap
+stats, Docker, full commit list). Do not rewrite GitHub Release bodies.
+
+## File per version
+
+`docs/whats-new/vX.Y.Z.md`:
+
+```md
+---
+version: 0.3.3
+date: 2026-08-16
+summary: Guest AI caps, simpler alerts, and pinned favorites you can drag.
+screenshots:
+  - /assets/whats-new/v0.3.3-nav.png
+  - src: /assets/screenshots/overview-dark-with-bg.jpeg
+    alt: Overview heatmap
+---
+
+- Cap and track guest AI usage on Cloud.
+- Alert settings use templates and presets.
+- Drag to reorder pinned favorites.
+```
+
+Rules: no commit SHAs, no PR-number walls, no recap stats, no agent shoutouts,
+no Docker pull blocks. 4–8 user-facing bullets. Screenshots are optional.
+
+## Screenshots
+
+Put image files in repo-root `assets/whats-new/` (same shared library as
+`assets/screenshots/`). `scripts/sync-shared-assets.mjs` copies them to
+`/assets/<category>/<file>` on landing, docs, and blog.
+
+Frontmatter paths should be site-root URLs (`/assets/whats-new/…` or
+`/assets/screenshots/…`). The dashboard rewrites those to
+`https://chmonitor.dev/assets/…` so the dialog can load them. Do not invent
+screenshot files — omit `screenshots` until a real capture exists.
+
+## Fallback
+
+If a version has no file, both UIs strip the GitHub Release body down to
+Features / Fixes / Perf (and drop recap / Docker / shoutouts).
+
+## After a dashboard release
+
+`release.yml` generates or updates `docs/whats-new/vX.Y.Z.md` from the detailed
+release notes plus any `## [Unreleased] ### Highlights` in `CHANGELOG.md`. It
+does not replace the GitHub Release body. You can also run:
+
+```bash
+bun scripts/write-whats-new.ts --tag v0.3.4
+```

--- a/docs/whats-new/v0.3.0.md
+++ b/docs/whats-new/v0.3.0.md
@@ -1,0 +1,16 @@
+---
+version: 0.3.0
+date: 2026-08-06
+summary: The TanStack Start release — Cloud, Postgres, alerting, and AI on a new runtime.
+screenshots:
+  - src: /assets/screenshots/overview-dark-with-bg.jpeg
+    alt: Overview with cluster status, storage, and query activity heatmap
+---
+
+- Dashboard runs on TanStack Start and Vite; Docker and Cloudflare Workers come from the same app.
+- Hosted Cloud at dash.chmonitor.dev with a public demo and per-user connections.
+- Monitor Postgres (beta) and PeerDB CDC next to your existing clusters.
+- Alerting engine with templates, channels, and health reports.
+- AI agent, Insights, advisors, and MCP at /api/mcp.
+- Pluggable auth: none, Clerk, proxy, or trusted.
+- Helm chart and one-click deploys; connection vars stay the same.

--- a/docs/whats-new/v0.3.1.md
+++ b/docs/whats-new/v0.3.1.md
@@ -1,0 +1,13 @@
+---
+version: 0.3.1
+date: 2026-08-11
+summary: Interactive cluster topology and smarter model picking for the agent.
+screenshots:
+  - src: /assets/screenshots/cluster-topology-dark.png
+    alt: Cluster topology
+---
+
+- Drag and inspect cluster topology with glass glyphs.
+- Auto-pick AnyRouter models by real usage, not a static list.
+- Surface why parts were postponed on 26.2+.
+- Keep the Cloudflare Worker under the free 3 MiB limit.

--- a/docs/whats-new/v0.3.2.md
+++ b/docs/whats-new/v0.3.2.md
@@ -1,0 +1,11 @@
+---
+version: 0.3.2
+date: 2026-08-12
+summary: A denser fleet view, a live MCP playground, and alert channels that start from what you already configured.
+---
+
+- Alert channels show as a configured-first card grid.
+- The query-activity heatmap picks a month window that fits the screen.
+- Table Overview in Explorer is denser and engine-aware, with SQL highlighting for DDL.
+- Fleet summary strip with richer host metrics and sparklines.
+- MCP Playground talks to a live client and covers the 2026-07-28 spec gaps.

--- a/docs/whats-new/v0.3.3.md
+++ b/docs/whats-new/v0.3.3.md
@@ -1,0 +1,12 @@
+---
+version: 0.3.3
+date: 2026-08-16
+summary: Guest AI caps, simpler alerts, and pinned favorites you can drag.
+---
+
+- Cap and track guest AI usage on Cloud.
+- Pick models dynamically, including AnyRouter presets and a custom model field.
+- Alert settings use templates and presets instead of a wall of forms.
+- See recently completed merges when none are running.
+- Drag to reorder pinned favorites in the sidebar.
+- Open Settings from the icon next to Sign in.

--- a/scripts/build-whats-new-prompt.ts
+++ b/scripts/build-whats-new-prompt.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+
+/**
+ * Fill `.github/whats-new-prompt.md` placeholders for the release.yml
+ * Copilot / GitHub Models step.
+ *
+ *   bun scripts/build-whats-new-prompt.ts \
+ *     --tag v0.3.4 --date 2026-08-19 \
+ *     --release-notes release-notes.md \
+ *     --out whats-new-prompt.txt
+ */
+
+import { extractUnreleasedHighlights } from '../apps/dashboard/src/lib/whats-new/draft-friendly-note'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function argValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag)
+  if (index < 0) return undefined
+  return process.argv[index + 1]
+}
+
+function readRequired(path: string): string {
+  const resolved = resolve(path)
+  if (!existsSync(resolved)) {
+    throw new Error(`missing file: ${resolved}`)
+  }
+  return readFileSync(resolved, 'utf8')
+}
+
+const tag = argValue('--tag') ?? process.env.RELEASE_TAG ?? ''
+const date = argValue('--date') ?? new Date().toISOString().slice(0, 10)
+const notesPath = argValue('--release-notes')
+const changelogPath = argValue('--changelog') ?? join(REPO_ROOT, 'CHANGELOG.md')
+const templatePath =
+  argValue('--template') ?? join(REPO_ROOT, '.github/whats-new-prompt.md')
+const outPath = argValue('--out') ?? 'whats-new-prompt.txt'
+
+if (!tag || !notesPath) {
+  console.error(
+    'usage: bun scripts/build-whats-new-prompt.ts --tag vX.Y.Z --release-notes <file>'
+  )
+  process.exit(1)
+}
+
+const highlights = existsSync(changelogPath)
+  ? extractUnreleasedHighlights(readFileSync(changelogPath, 'utf8'))
+  : {
+      bullets: [] as string[],
+      screenshots: [] as Array<{ src: string; alt: string }>,
+    }
+
+const highlightLines = [
+  ...highlights.bullets.map((bullet) => `- ${bullet}`),
+  ...highlights.screenshots.map(
+    (shot) => `- ![${shot.alt || 'screenshot'}](${shot.src})`
+  ),
+]
+const highlightsText = highlightLines.join('\n') || '(none)'
+
+let template = readRequired(templatePath)
+template = template.replaceAll('{{RELEASE_TAG}}', tag)
+template = template.replaceAll('{{DATE}}', date)
+template = template.replaceAll('{{HIGHLIGHTS}}', highlightsText)
+template = template.replaceAll('{{RELEASE_NOTES}}', readRequired(notesPath))
+writeFileSync(outPath, template)
+console.log(`Wrote ${outPath}`)

--- a/scripts/write-whats-new.ts
+++ b/scripts/write-whats-new.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+
+/**
+ * Write docs/whats-new/vX.Y.Z.md from a detailed GitHub Release body plus
+ * CHANGELOG Unreleased Highlights. Does not edit the GitHub Release.
+ *
+ *   bun scripts/write-whats-new.ts --tag v0.3.4
+ *   bun scripts/write-whats-new.ts --tag v0.3.4 --release-notes release-notes.md --ai-file ai-whats-new.md
+ */
+
+import {
+  draftFriendlyNoteMarkdown,
+  pickFriendlyNoteMarkdown,
+} from '../apps/dashboard/src/lib/whats-new/draft-friendly-note'
+import {
+  normalizeVersion,
+  toProductTag,
+} from '../apps/dashboard/src/lib/whats-new/version'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function argValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag)
+  if (index < 0) return undefined
+  return process.argv[index + 1]
+}
+
+function isoDate(value?: string): string {
+  if (value && /^\d{4}-\d{2}-\d{2}$/.test(value)) return value
+  return new Date().toISOString().slice(0, 10)
+}
+
+function readOptional(path: string | undefined): string {
+  if (!path) return ''
+  const resolved = resolve(path)
+  if (!existsSync(resolved)) return ''
+  return readFileSync(resolved, 'utf8')
+}
+
+const tagArg = argValue('--tag') ?? process.env.RELEASE_TAG
+if (!tagArg) {
+  console.error('usage: bun scripts/write-whats-new.ts --tag vX.Y.Z')
+  process.exit(1)
+}
+
+const tag = toProductTag(tagArg)
+const version = normalizeVersion(tag)
+const date = isoDate(argValue('--date') ?? process.env.RELEASE_DATE)
+const outDir = resolve(
+  argValue('--out-dir') ?? join(REPO_ROOT, 'docs/whats-new')
+)
+const outPath = join(outDir, `${tag}.md`)
+
+const releaseNotes =
+  readOptional(argValue('--release-notes')) ||
+  readOptional(join(process.cwd(), 'release-notes.md')) ||
+  readOptional(join(REPO_ROOT, 'release-notes.md'))
+
+if (!releaseNotes.trim()) {
+  console.error('No release-notes.md found. Pass --release-notes <file>.')
+  process.exit(1)
+}
+
+const changelog =
+  readOptional(argValue('--changelog')) ||
+  readOptional(join(REPO_ROOT, 'CHANGELOG.md'))
+
+const deterministic = draftFriendlyNoteMarkdown({
+  version,
+  date,
+  releaseBody: releaseNotes,
+  changelogMarkdown: changelog || undefined,
+})
+
+const aiFile = readOptional(argValue('--ai-file'))
+const markdown = pickFriendlyNoteMarkdown(deterministic, aiFile, version)
+
+mkdirSync(outDir, { recursive: true })
+writeFileSync(outPath, markdown)
+console.log(`Wrote ${outPath}`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

What's new (dashboard dialog) and landing `/changelog` now prefer short, human-readable per-version notes. GitHub Releases stay the detailed changelog (recap stats, Docker, full commit list) and are not rewritten.

Fixes #3132

Rebased onto `main` including #3136 (`cfea7fd`) and #3141 (`717c38f`). Spec-only Cypress fix: keep unavailable pages dimmed in the sidebar seed. `expandGroup` clicks once, waits up to 2s for `a[href*="…"]` on the **document**, then clicks again only if the href never appeared (a first click can close an already-open Queries group). Nested group links can render in a Popover portal outside `[data-sidebar="sidebar"]`. Do not sync `$body.find` immediately after click.

## Changes

- Add `docs/whats-new/vX.Y.Z.md` as the shared source (frontmatter: version, date, summary, optional screenshots; body: 4–8 user-facing bullets).
- Seed v0.3.0–v0.3.3 from existing Features, with optional screenshots wired to existing `assets/screenshots/` images (no invented screenshot files).
- Dashboard `GET /api/v1/releases` overlays friendly notes on GitHub / airgap snapshot; landing `/changelog` reads the same markdown files.
- Fallback still strips GitHub bodies to Features / Fixes / Perf, including older 0.2.x recap blockquotes, Docker blocks, and shoutouts.
- After a dashboard release, `release.yml` job `whats-new` drafts `docs/whats-new/vX.Y.Z.md` from the detailed release notes + Unreleased Highlights (Copilot → GitHub Models). It does not replace the GitHub Release body.
- `sidebar-navigation.cy.ts`: unscoped href lookup; re-open the group if the href is still missing after ~2s; keep `dimUnavailablePages: true` so a failed healthz probe does not hide Running Queries.

## Test plan

- [x] Targeted unit tests pass (`bun test src/lib/whats-new`, landing parser + friendly-note loaders, What's new dialog scroll tests from #3136)
- [x] Biome check on touched files
- [x] `bun scripts/write-whats-new.ts` smoke-writes a fake version from a recap-heavy Features body
- [x] `pnpm run depcruise` no longer reports landing → dashboard imports
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Product sidebar / menu / `tableCheck` / dim-unavailable behavior is unchanged. GitHub Release bodies are unchanged.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-417816d0-4900-401c-953d-f2480dbf49d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-417816d0-4900-401c-953d-f2480dbf49d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

