### PR TITLE
fix(dashboard): advisor pick-query dialog empty list and layout

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -11,7 +11,8 @@ description: >-
   Triggers: "new page", "add a chart", "build UI", "design", "component",
   "empty state", "loading", "consistent", "follow-up feature", "match the design",
   "what's new", "changelog", "dialog scroll", "settings gear",
-  "schema compare", "settings diff", "add host".
+  "schema compare", "settings diff", "add host", "pick a query",
+  "query picker", "select labels".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -85,9 +86,16 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   Header and footer are `shrink-0`. The body is `min-h-0 flex-1 overflow-y-auto`
   — that element is the scroll container. Do not use `ScrollArea` with `flex-1`
   for this: its viewport is `size-full` and does not constrain unless the root
-  has an explicit height, so notes paint under the footer. Reset
-  `DialogFooter`'s default `-mx-4 -mb-4` to `mx-0 mb-0` when the dialog is
-  `p-0`. See `components/whats-new/whats-new-dialog.tsx`.
+  has an explicit height, so notes paint under the footer and EmptyState can
+  vanish inside a blank scrollbar box. Reset `DialogFooter`'s default
+  `-mx-4 -mb-4` to `mx-0 mb-0` when the dialog is `p-0`. Same list-scroll
+  pattern without a footer: `components/agents/advisor-query-picker.tsx`.
+  See `components/whats-new/whats-new-dialog.tsx`.
+- **Base UI Select labels:** pass `items={{ value: 'Human label' }}` on
+  `Select` (the Root) so `SelectValue` shows the label, not the raw value.
+  `placeholder` only appears when nothing is selected — a selected `24` /
+  `__all__` otherwise renders as those strings. See
+  `components/agents/advisor-query-picker.tsx`.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).

--- a/apps/dashboard/src/components/agents/advisor-query-picker.test.tsx
+++ b/apps/dashboard/src/components/agents/advisor-query-picker.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * Advisor "Pick a query" dialog: empty / error / demo_hidden / list,
+ * human Select labels, and include-self control. happy-dom + react-dom/client.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type { ReactElement } from 'react'
+import type { HistoryQueryRow } from '@/lib/ai/advisor/history-picker'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+mock.module('@/lib/swr', () => ({
+  useHostId: () => 0,
+}))
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+const SAMPLE_ROW: HistoryQueryRow = {
+  query_id: 'abc-123',
+  query: 'SELECT count() FROM events WHERE ts > now() - INTERVAL 1 HOUR',
+  user: 'default',
+  query_duration_ms: 1840,
+  event_time: '2026-08-19 12:00:00',
+  read_rows: 42000,
+}
+
+type HistoryPayload = {
+  success: boolean
+  data?: HistoryQueryRow[] | string[]
+  error?: { message?: string }
+  metadata?: { unavailable?: { reason: string; message: string } }
+}
+
+let historyPayload: HistoryPayload = { success: true, data: [] }
+let historyStatus = 200
+let fetchMock: ReturnType<typeof mock>
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  historyPayload = { success: true, data: [] }
+  historyStatus = 200
+  fetchMock = mock(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('facet=users')) {
+      return jsonResponse({ success: true, data: ['default', 'readonly'] })
+    }
+    return jsonResponse(historyPayload, historyStatus)
+  })
+  globalThis.fetch = fetchMock as typeof fetch
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+async function openPicker() {
+  const { act } = await import('react')
+  const onPick = mock((sql: string) => sql)
+  const { AdvisorQueryPicker } = await import('./advisor-query-picker')
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const { cleanup } = await renderInto(
+    <QueryClientProvider client={queryClient}>
+      <AdvisorQueryPicker onPick={onPick} />
+    </QueryClientProvider>
+  )
+
+  const trigger = document.querySelector(
+    '[data-testid="advisor-query-picker-trigger"]'
+  ) as HTMLButtonElement | null
+  expect(trigger).not.toBeNull()
+
+  await act(async () => {
+    trigger?.click()
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+
+  return { onPick, cleanup }
+}
+
+async function openHistoryTab() {
+  const { act } = await import('react')
+  const tab = document.querySelector(
+    '[data-testid="advisor-query-picker-tab-history"]'
+  ) as HTMLElement | null
+  expect(tab).not.toBeNull()
+  await act(async () => {
+    tab?.click()
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+describe('AdvisorQueryPicker', () => {
+  test('empty history shows EmptyState copy, never a blank box', async () => {
+    historyPayload = { success: true, data: [] }
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const list = document.querySelector(
+        '[data-testid="advisor-query-picker-history-list"]'
+      )
+      expect(list).not.toBeNull()
+      expect(list?.textContent).toContain('No queries found')
+      expect(list?.textContent).toContain('Include dashboard queries')
+      expect(list?.querySelector('[data-slot="scroll-area"]')).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('error shows EmptyState with the server message', async () => {
+    historyPayload = {
+      success: false,
+      error: { message: 'query_log is disabled' },
+    }
+    historyStatus = 503
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const list = document.querySelector(
+        '[data-testid="advisor-query-picker-history-list"]'
+      )
+      expect(list?.textContent).toContain("Couldn't load queries")
+      expect(list?.textContent).toContain('query_log is disabled')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('demo_hidden is surfaced instead of a blank list', async () => {
+    historyPayload = {
+      success: true,
+      data: [],
+      metadata: {
+        unavailable: {
+          reason: 'demo_hidden',
+          message: 'The demo host is hidden for signed-in accounts.',
+        },
+      },
+    }
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const list = document.querySelector(
+        '[data-testid="advisor-query-picker-history-list"]'
+      )
+      expect(list?.textContent).toContain('Demo host is hidden')
+      expect(list?.textContent).toContain(
+        'The demo host is hidden for signed-in accounts.'
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('a non-empty list renders rows and onPick fills the advisor input', async () => {
+    historyPayload = { success: true, data: [SAMPLE_ROW] }
+    const { onPick, cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const row = document.querySelector(
+        '[data-testid="advisor-query-row"]'
+      ) as HTMLButtonElement | null
+      expect(row).not.toBeNull()
+      expect(row?.textContent).toContain('SELECT count() FROM events')
+
+      const { act } = await import('react')
+      await act(async () => {
+        row?.click()
+      })
+      expect(onPick).toHaveBeenCalledTimes(1)
+      expect(onPick.mock.calls[0]?.[0]).toBe(SAMPLE_ROW.query)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('Time / User / Kind show human labels, not raw values', async () => {
+    historyPayload = { success: true, data: [] }
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const hours = document.querySelector(
+        '[data-testid="advisor-query-picker-hours"]'
+      )
+      const user = document.querySelector(
+        '[data-testid="advisor-query-picker-user"]'
+      )
+      const kind = document.querySelector(
+        '[data-testid="advisor-query-picker-kind"]'
+      )
+      expect(hours?.textContent).toContain('Last 24 hours')
+      expect(user?.textContent).toContain('All users')
+      expect(user?.textContent).not.toContain('__all__')
+      expect(kind?.textContent).toContain('All kinds')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('include-self is off by default and history requests omit includeSelf', async () => {
+    historyPayload = { success: true, data: [] }
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const toggle = document.querySelector(
+        '[data-testid="advisor-query-picker-include-self"]'
+      )
+      expect(toggle).not.toBeNull()
+      expect(toggle?.getAttribute('data-checked')).not.toBe('')
+      expect(toggle?.getAttribute('aria-checked')).not.toBe('true')
+
+      const browseUrls = fetchMock.mock.calls
+        .map((c) => String(c[0]))
+        .filter(
+          (url) =>
+            url.includes('/api/v1/advisor/history') && url.includes('limit=50')
+        )
+      expect(browseUrls.length).toBeGreaterThan(0)
+      expect(browseUrls.every((url) => !url.includes('includeSelf'))).toBe(true)
+      expect(browseUrls.every((url) => !url.includes('kind='))).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('turning on include-self refetches with includeSelf=1', async () => {
+    historyPayload = { success: true, data: [] }
+    const { cleanup } = await openPicker()
+    try {
+      await openHistoryTab()
+      const toggle = document.querySelector(
+        '[data-testid="advisor-query-picker-include-self"]'
+      ) as HTMLElement | null
+      expect(toggle).not.toBeNull()
+
+      const { act } = await import('react')
+      await act(async () => {
+        toggle?.click()
+      })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      const withSelf = fetchMock.mock.calls
+        .map((c) => String(c[0]))
+        .filter((url) => url.includes('includeSelf=1'))
+      expect(withSelf.length).toBeGreaterThan(0)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('dialog chrome stays put; the list is the scroll container', async () => {
+    historyPayload = { success: true, data: [SAMPLE_ROW] }
+    const { cleanup } = await openPicker()
+    try {
+      const dialog = document.querySelector(
+        '[data-testid="advisor-query-picker-dialog"]'
+      )
+      const header = dialog?.querySelector('[data-slot="dialog-header"]')
+      const list = document.querySelector(
+        '[data-testid="advisor-query-picker-list"]'
+      )
+      expect(dialog?.className).toContain('flex-col')
+      expect(dialog?.className).toContain('overflow-hidden')
+      expect(dialog?.className).toContain('sm:max-w-2xl')
+      expect(header?.className).toContain('shrink-0')
+      expect(list?.className).toContain('min-h-0')
+      expect(list?.className).toContain('overflow-y-auto')
+      expect(list?.querySelector('[data-slot="scroll-area"]')).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/agents/advisor-query-picker.tsx
+++ b/apps/dashboard/src/components/agents/advisor-query-picker.tsx
@@ -7,7 +7,7 @@
  *    min-duration / time-window filters (all parameterized server-side).
  *
  * Picking a row calls `onPick(sql)` and closes the dialog. Additive only — the
- * advisor's paste/query-id flow is untouched.
+ * advisor's paste/query-id flow is untouched. Recommend-only: never runs DDL.
  */
 
 import { ClockIcon, DatabaseIcon, ListPlusIcon, SearchIcon } from 'lucide-react'
@@ -27,7 +27,6 @@ import {
 import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   Select,
   SelectContent,
@@ -36,9 +35,11 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
-  HISTORY_PICKER_KINDS,
+  HISTORY_PICKER_KIND_ALL,
+  HISTORY_PICKER_KIND_OPTIONS,
   HISTORY_PICKER_MAX_LIMIT,
   type HistoryQueryRow,
   truncateQueryText,
@@ -48,14 +49,25 @@ import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { formatCount, formatDuration } from '@/lib/utils'
 
+interface UnavailableMeta {
+  reason: string
+  message: string
+}
+
 interface HistoryApiResponse {
   success: boolean
   data?: HistoryQueryRow[]
   error?: { message?: string }
+  metadata?: { unavailable?: UnavailableMeta }
 }
 interface UsersApiResponse {
   success: boolean
   data?: string[]
+}
+
+interface HistoryFetchResult {
+  rows: HistoryQueryRow[]
+  unavailable?: UnavailableMeta
 }
 
 const HOUR_OPTIONS = [
@@ -64,11 +76,19 @@ const HOUR_OPTIONS = [
   { label: 'Last 24 hours', value: '24' },
   { label: 'Last 7 days', value: '168' },
   { label: 'Last 30 days', value: '720' },
-]
+] as const
+
+const HOUR_ITEMS: Record<string, string> = Object.fromEntries(
+  HOUR_OPTIONS.map((o) => [o.value, o.label])
+)
+
+const KIND_ITEMS: Record<string, string> = Object.fromEntries(
+  HISTORY_PICKER_KIND_OPTIONS.map((o) => [o.value, o.label])
+)
 
 const ALL_USERS = '__all__'
 
-async function fetchHistory(url: string): Promise<HistoryQueryRow[]> {
+async function fetchHistory(url: string): Promise<HistoryFetchResult> {
   const res = await apiFetch(url)
   const body = (await res.json()) as HistoryApiResponse
   if (!res.ok || !body.success) {
@@ -76,7 +96,10 @@ async function fetchHistory(url: string): Promise<HistoryQueryRow[]> {
       body.error?.message || `Request failed (HTTP ${res.status})`
     )
   }
-  return body.data ?? []
+  return {
+    rows: body.data ?? [],
+    unavailable: body.metadata?.unavailable,
+  }
 }
 
 function QueryRowButton({
@@ -89,6 +112,7 @@ function QueryRowButton({
   return (
     <button
       type="button"
+      data-testid="advisor-query-row"
       onClick={() => onPick(row.query)}
       className="w-full rounded-md border border-border/60 bg-card p-3 text-left transition-colors hover:border-border hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
@@ -117,18 +141,22 @@ function ResultsList({
   isLoading,
   error,
   rows,
+  unavailable,
   onPick,
   emptyVariant,
+  includeSelf,
 }: {
   isLoading: boolean
   error: unknown
   rows: HistoryQueryRow[]
+  unavailable?: UnavailableMeta
   onPick: (sql: string) => void
   emptyVariant: 'no-data' | 'filtered-empty'
+  includeSelf: boolean
 }) {
   if (isLoading) {
     return (
-      <div className="space-y-2">
+      <div className="space-y-2" data-testid="advisor-query-picker-loading">
         {['s0', 's1', 's2', 's3', 's4'].map((k) => (
           <Skeleton key={k} className="h-16 w-full rounded-md" />
         ))}
@@ -144,15 +172,30 @@ function ResultsList({
       />
     )
   }
+  if (unavailable?.reason === 'demo_hidden') {
+    return (
+      <EmptyState
+        variant="no-data"
+        title="Demo host is hidden"
+        description={
+          unavailable.message ||
+          'The demo host is hidden for signed-in accounts. Connect your own host to browse query history.'
+        }
+      />
+    )
+  }
   if (rows.length === 0) {
+    const includeHint = includeSelf
+      ? ''
+      : ' Turn on “Include dashboard queries” if you want those rows too.'
     return (
       <EmptyState
         variant={emptyVariant}
         title="No queries found"
         description={
           emptyVariant === 'filtered-empty'
-            ? 'No queries match these filters. Try widening the time window or clearing the keyword.'
-            : 'No recent SELECT queries were found in system.query_log for this host.'
+            ? `No queries match these filters. Try All kinds, a wider time window, or clearing the keyword.${includeHint}`
+            : `No recent queries were found in system.query_log for this host.${includeHint}`
         }
       />
     )
@@ -174,12 +217,12 @@ export function AdvisorQueryPicker({
   const hostId = useHostId()
   const [open, setOpen] = useState(false)
 
-  // History filters
   const [keyword, setKeyword] = useState('')
   const [user, setUser] = useState<string>(ALL_USERS)
-  const [kind, setKind] = useState<string>('Select')
+  const [kind, setKind] = useState<string>(HISTORY_PICKER_KIND_ALL)
   const [minDurationSec, setMinDurationSec] = useState('')
   const [hours, setHours] = useState('24')
+  const [includeSelf, setIncludeSelf] = useState(false)
 
   const debouncedKeyword = useDebounce(keyword, DEBOUNCE_DELAY.SLOW)
 
@@ -188,32 +231,33 @@ export function AdvisorQueryPicker({
     setOpen(false)
   }
 
-  // Quick tab: slowest recent SELECTs.
-  const quickUrl = `/api/v1/advisor/history?hostId=${hostId}&hours=24&limit=6`
-  const quick = useQuery<HistoryQueryRow[]>({
-    queryKey: ['advisor-quick', hostId],
+  const includeSelfParam = includeSelf ? '&includeSelf=1' : ''
+
+  const quickUrl = `/api/v1/advisor/history?hostId=${hostId}&hours=24&limit=6&kind=Select${includeSelfParam}`
+  const quick = useQuery<HistoryFetchResult>({
+    queryKey: ['advisor-quick', hostId, includeSelf],
     queryFn: () => fetchHistory(quickUrl),
     enabled: open,
   })
 
-  // History tab: filtered browse.
   const historyUrl = useMemo(() => {
     const params = new URLSearchParams({
       hostId: String(hostId),
       hours,
-      kind,
       limit: String(HISTORY_PICKER_MAX_LIMIT),
     })
+    if (kind && kind !== HISTORY_PICKER_KIND_ALL) params.set('kind', kind)
     if (debouncedKeyword.trim()) params.set('keyword', debouncedKeyword.trim())
     if (user !== ALL_USERS) params.set('user', user)
+    if (includeSelf) params.set('includeSelf', '1')
     const sec = Number(minDurationSec)
     if (Number.isFinite(sec) && sec > 0) {
       params.set('minDurationMs', String(Math.floor(sec * 1000)))
     }
     return `/api/v1/advisor/history?${params.toString()}`
-  }, [hostId, hours, kind, debouncedKeyword, user, minDurationSec])
+  }, [hostId, hours, kind, debouncedKeyword, user, minDurationSec, includeSelf])
 
-  const history = useQuery<HistoryQueryRow[]>({
+  const history = useQuery<HistoryFetchResult>({
     queryKey: ['advisor-history', historyUrl],
     queryFn: () => fetchHistory(historyUrl),
     enabled: open,
@@ -231,19 +275,42 @@ export function AdvisorQueryPicker({
     enabled: open,
   })
 
+  const userItems = useMemo(() => {
+    const items: Record<string, string> = { [ALL_USERS]: 'All users' }
+    for (const u of users.data ?? []) {
+      items[u] = u
+    }
+    return items
+  }, [users.data])
+
   const hasHistoryFilters =
     debouncedKeyword.trim() !== '' ||
     user !== ALL_USERS ||
+    kind !== HISTORY_PICKER_KIND_ALL ||
     Number(minDurationSec) > 0
+
+  const historyRows = history.data?.rows ?? []
+  const quickRows = quick.data?.rows ?? []
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button variant="outline" size="sm" />}>
+      <DialogTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="advisor-query-picker-trigger"
+          />
+        }
+      >
         <ListPlusIcon className="size-4" />
         Pick a query
       </DialogTrigger>
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
+      <DialogContent
+        className="flex h-[min(36rem,85vh)] max-w-2xl flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-2xl"
+        data-testid="advisor-query-picker-dialog"
+      >
+        <DialogHeader className="shrink-0 border-b border-border px-4 py-3">
           <DialogTitle>Pick a query to analyze</DialogTitle>
           <DialogDescription>
             Start from a quick example or browse your query history. Selecting a
@@ -251,30 +318,49 @@ export function AdvisorQueryPicker({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="quick">
-          <TabsList>
+        <Tabs
+          defaultValue="quick"
+          className="flex min-h-0 flex-1 flex-col gap-0 px-4 pb-4"
+        >
+          <TabsList className="mt-3 shrink-0">
             <TabsTrigger value="quick">Quick queries</TabsTrigger>
-            <TabsTrigger value="history">From history</TabsTrigger>
+            <TabsTrigger
+              value="history"
+              data-testid="advisor-query-picker-tab-history"
+            >
+              From history
+            </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="quick" className="pt-3">
-            <p className="mb-3 text-xs text-muted-foreground">
+          <TabsContent
+            value="quick"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3"
+          >
+            <p className="mb-3 shrink-0 text-xs text-muted-foreground">
               The slowest SELECT queries on this host in the last 24 hours — the
               best candidates for optimization.
             </p>
-            <ScrollArea className="h-[420px] pr-3">
+            <div
+              className="min-h-0 flex-1 overflow-y-auto"
+              data-testid="advisor-query-picker-list"
+            >
               <ResultsList
                 isLoading={quick.isLoading}
                 error={quick.error}
-                rows={quick.data ?? []}
+                rows={quickRows}
+                unavailable={quick.data?.unavailable}
                 onPick={handlePick}
                 emptyVariant="no-data"
+                includeSelf={includeSelf}
               />
-            </ScrollArea>
+            </div>
           </TabsContent>
 
-          <TabsContent value="history" className="pt-3">
-            <div className="space-y-3">
+          <TabsContent
+            value="history"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden pt-3"
+          >
+            <div className="shrink-0 space-y-3">
               <div className="relative">
                 <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
@@ -285,14 +371,20 @@ export function AdvisorQueryPicker({
                 />
               </div>
 
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
                   <Label className="text-xs">Time</Label>
                   <Select
                     value={hours}
-                    onValueChange={(v) => setHours(v ?? '24')}
+                    items={HOUR_ITEMS}
+                    onValueChange={(v) => {
+                      if (v != null) setHours(v)
+                    }}
                   >
-                    <SelectTrigger className="h-8">
+                    <SelectTrigger
+                      className="h-8 w-full"
+                      data-testid="advisor-query-picker-hours"
+                    >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -309,10 +401,16 @@ export function AdvisorQueryPicker({
                   <Label className="text-xs">User</Label>
                   <Select
                     value={user}
-                    onValueChange={(v) => setUser(v ?? ALL_USERS)}
+                    items={userItems}
+                    onValueChange={(v) => {
+                      if (v != null) setUser(v)
+                    }}
                   >
-                    <SelectTrigger className="h-8">
-                      <SelectValue placeholder="All users" />
+                    <SelectTrigger
+                      className="h-8 w-full"
+                      data-testid="advisor-query-picker-user"
+                    >
+                      <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value={ALL_USERS}>All users</SelectItem>
@@ -329,15 +427,21 @@ export function AdvisorQueryPicker({
                   <Label className="text-xs">Kind</Label>
                   <Select
                     value={kind}
-                    onValueChange={(v) => setKind(v ?? 'Select')}
+                    items={KIND_ITEMS}
+                    onValueChange={(v) => {
+                      if (v != null) setKind(v)
+                    }}
                   >
-                    <SelectTrigger className="h-8">
+                    <SelectTrigger
+                      className="h-8 w-full"
+                      data-testid="advisor-query-picker-kind"
+                    >
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {HISTORY_PICKER_KINDS.map((k) => (
-                        <SelectItem key={k} value={k}>
-                          {k}
+                      {HISTORY_PICKER_KIND_OPTIONS.map((k) => (
+                        <SelectItem key={k.value} value={k.value}>
+                          {k.label}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -357,29 +461,42 @@ export function AdvisorQueryPicker({
                 </div>
               </div>
 
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <Switch
+                  checked={includeSelf}
+                  onCheckedChange={(checked) => setIncludeSelf(checked)}
+                  aria-label="Include dashboard queries"
+                  data-testid="advisor-query-picker-include-self"
+                />
+                <span>Include dashboard queries</span>
+              </label>
+
               <div className="flex items-center justify-between">
                 <p className="text-xs text-muted-foreground">
                   Showing up to {HISTORY_PICKER_MAX_LIMIT} slowest matches.
                 </p>
-                {history.data && history.data.length > 0 ? (
+                {historyRows.length > 0 ? (
                   <Badge variant="secondary" className="text-xs">
-                    {history.data.length} result
-                    {history.data.length === 1 ? '' : 's'}
+                    {historyRows.length} result
+                    {historyRows.length === 1 ? '' : 's'}
                   </Badge>
                 ) : null}
               </div>
+            </div>
 
-              <ScrollArea className="h-[300px] pr-3">
-                <ResultsList
-                  isLoading={history.isLoading}
-                  error={history.error}
-                  rows={history.data ?? []}
-                  onPick={handlePick}
-                  emptyVariant={
-                    hasHistoryFilters ? 'filtered-empty' : 'no-data'
-                  }
-                />
-              </ScrollArea>
+            <div
+              className="mt-3 min-h-0 flex-1 overflow-y-auto"
+              data-testid="advisor-query-picker-history-list"
+            >
+              <ResultsList
+                isLoading={history.isLoading}
+                error={history.error}
+                rows={historyRows}
+                unavailable={history.data?.unavailable}
+                onPick={handlePick}
+                emptyVariant={hasHistoryFilters ? 'filtered-empty' : 'no-data'}
+                includeSelf={includeSelf}
+              />
             </div>
           </TabsContent>
         </Tabs>

--- a/apps/dashboard/src/lib/ai/advisor/__tests__/history-picker.test.ts
+++ b/apps/dashboard/src/lib/ai/advisor/__tests__/history-picker.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the advisor query-history picker's pure SQL/param builders and
  * text helpers (`lib/ai/advisor/history-picker.ts`). No I/O — these guard the
- * injection-safe parameterization and the numeric clamping.
+ * injection-safe parameterization, kind=all, and the default self-query exclude.
  */
 
 import { describe, expect, test } from 'bun:test'
@@ -9,19 +9,63 @@ import {
   buildHistoryPickerQuery,
   buildHistoryUsersQuery,
   HISTORY_PICKER_DEFAULT_HOURS,
+  HISTORY_PICKER_KIND_ALL,
   HISTORY_PICKER_MAX_LIMIT,
   truncateQueryText,
 } from '@/lib/ai/advisor/history-picker'
 
 describe('buildHistoryPickerQuery', () => {
-  test('defaults to finished Select queries within the default window', () => {
+  test('defaults to finished queries of any kind within the default window', () => {
     const { sql, params } = buildHistoryPickerQuery()
     expect(sql).toContain("type = 'QueryFinish'")
     expect(sql).toContain(`INTERVAL ${HISTORY_PICKER_DEFAULT_HOURS} HOUR`)
-    expect(sql).toContain('query_kind = {kind:String}')
-    expect(params.kind).toBe('Select')
+    expect(sql).not.toContain('query_kind = {kind:String}')
+    expect(params.kind).toBeUndefined()
     expect(sql).toContain('ORDER BY query_duration_ms DESC')
     expect(sql).toContain(`LIMIT ${HISTORY_PICKER_MAX_LIMIT}`)
+  })
+
+  test('All kinds omits the query_kind predicate', () => {
+    const { sql, params } = buildHistoryPickerQuery({
+      kind: HISTORY_PICKER_KIND_ALL,
+    })
+    expect(sql).not.toContain('query_kind')
+    expect(params.kind).toBeUndefined()
+  })
+
+  test('unset kind does not fall back to Select', () => {
+    const { sql, params } = buildHistoryPickerQuery({})
+    expect(sql).not.toContain('query_kind = {kind:String}')
+    expect(params.kind).toBeUndefined()
+  })
+
+  test('honors a valid non-Select kind', () => {
+    const { sql, params } = buildHistoryPickerQuery({ kind: 'Insert' })
+    expect(params.kind).toBe('Insert')
+    expect(sql).toContain('query_kind = {kind:String}')
+  })
+
+  test('ignores an unknown kind instead of forcing Select', () => {
+    const { sql, params } = buildHistoryPickerQuery({
+      // @ts-expect-error deliberately invalid kind
+      kind: 'Nonsense',
+    })
+    expect(params.kind).toBeUndefined()
+    expect(sql).not.toContain('query_kind')
+  })
+
+  test('default excludes dashboard queries via the query-comment fingerprint', () => {
+    const { sql, params } = buildHistoryPickerQuery()
+    expect(params.selfFingerprint).toBeDefined()
+    expect(params.selfFingerprint?.length).toBeGreaterThan(0)
+    expect(sql).toContain('position(query, {selfFingerprint:String}) = 0')
+    expect(sql).not.toContain(params.selfFingerprint as string)
+  })
+
+  test('excludeSelf:false (include-self) omits the dashboard fingerprint', () => {
+    const { sql, params } = buildHistoryPickerQuery({ excludeSelf: false })
+    expect(params.selfFingerprint).toBeUndefined()
+    expect(sql).not.toContain('selfFingerprint')
   })
 
   test('binds keyword as a parameter (never interpolated)', () => {
@@ -31,7 +75,6 @@ describe('buildHistoryPickerQuery', () => {
     expect(sql).toContain(
       'positionCaseInsensitiveUTF8(query, {keyword:String}) > 0'
     )
-    // The raw value must not leak into the SQL text.
     expect(sql).not.toContain('DROP TABLE')
   })
 
@@ -62,19 +105,6 @@ describe('buildHistoryPickerQuery', () => {
     expect(buildHistoryPickerQuery({ minDurationMs: 0 }).sql).not.toContain(
       'query_duration_ms >='
     )
-  })
-
-  test('falls back to Select for an unknown kind', () => {
-    const { params } = buildHistoryPickerQuery({
-      // @ts-expect-error deliberately invalid kind
-      kind: 'Nonsense',
-    })
-    expect(params.kind).toBe('Select')
-  })
-
-  test('honors a valid non-Select kind', () => {
-    const { params } = buildHistoryPickerQuery({ kind: 'Insert' })
-    expect(params.kind).toBe('Insert')
   })
 })
 

--- a/apps/dashboard/src/lib/ai/advisor/history-picker.ts
+++ b/apps/dashboard/src/lib/ai/advisor/history-picker.ts
@@ -13,6 +13,8 @@
  * `routes/api/v1/advisor/history.ts` runs the built query with `fetchData`.
  */
 
+import { QUERY_COMMENT } from '@chm/clickhouse-client/constants' // pragma: allowlist secret
+
 /** A ClickHouse query-kind the picker can filter on (subset of query_kind). */
 export const HISTORY_PICKER_KINDS = [
   'Select',
@@ -24,19 +26,54 @@ export const HISTORY_PICKER_KINDS = [
 ] as const
 export type HistoryPickerKind = (typeof HISTORY_PICKER_KINDS)[number]
 
+/** Omit the `query_kind` predicate — every kind in the window. */
+export const HISTORY_PICKER_KIND_ALL = 'all' as const
+export type HistoryPickerKindFilter =
+  | HistoryPickerKind
+  | typeof HISTORY_PICKER_KIND_ALL
+
+export const HISTORY_PICKER_KIND_OPTIONS: ReadonlyArray<{
+  value: HistoryPickerKindFilter
+  label: string
+}> = [
+  { value: HISTORY_PICKER_KIND_ALL, label: 'All kinds' },
+  { value: 'Select', label: 'Select' },
+  { value: 'Insert', label: 'Insert' },
+  { value: 'Create', label: 'Create' },
+  { value: 'Alter', label: 'Alter' },
+  { value: 'Drop', label: 'Drop' },
+  { value: 'System', label: 'System' },
+]
+
+/**
+ * Distinctive prefix `fetchData` prepends to every dashboard query. Running
+ * query counts already drop rows whose query text contains this comment.
+ * Trim the trailing newline so the match is independent of how query_log
+ * stores whitespace after the block comment.
+ */
+export const DASHBOARD_QUERY_FINGERPRINT = QUERY_COMMENT.trim() // pragma: allowlist secret
+
 export interface HistoryPickerFilters {
   /** Free-text, case-insensitive substring match on the query body. */
   keyword?: string
   /** Exact `user` match. */
   user?: string
-  /** Restrict to a single `query_kind`. Defaults to `Select` (advisor target). */
-  kind?: HistoryPickerKind
+  /**
+   * Restrict to a single `query_kind`. Unset / `'all'` means no kind
+   * predicate — do not default to Select.
+   */
+  kind?: HistoryPickerKindFilter
   /** Minimum `query_duration_ms`. */
   minDurationMs?: number
   /** Look-back window in hours (event_time). */
   hours?: number
   /** Max rows returned (hard-capped). */
   limit?: number
+  /**
+   * When true (the default), drop queries that carry the dashboard
+   * `QUERY_COMMENT` fingerprint. Pass `false` to include them.
+   */
+  excludeSelf?: boolean
 }
 
 /** One row surfaced to the picker UI. */
@@ -72,6 +109,10 @@ function clampInt(
 export interface BuiltHistoryQuery {
   sql: string
   params: Record<string, string>
+}
+
+function isHistoryPickerKind(value: string): value is HistoryPickerKind {
+  return (HISTORY_PICKER_KINDS as readonly string[]).includes(value)
 }
 
 /**
@@ -121,14 +162,17 @@ export function buildHistoryPickerQuery(
     where.push('user = {user:String}')
   }
 
-  // Default to Select (the advisor only analyzes read queries) unless the
-  // caller explicitly widens the kind.
-  const kind: HistoryPickerKind =
-    filters.kind && HISTORY_PICKER_KINDS.includes(filters.kind)
-      ? filters.kind
-      : 'Select'
-  params.kind = kind
-  where.push('query_kind = {kind:String}')
+  const kind = filters.kind
+  if (kind && kind !== HISTORY_PICKER_KIND_ALL && isHistoryPickerKind(kind)) {
+    params.kind = kind
+    where.push('query_kind = {kind:String}')
+  }
+
+  const excludeSelf = filters.excludeSelf !== false
+  if (excludeSelf && DASHBOARD_QUERY_FINGERPRINT !== '') {
+    params.selfFingerprint = DASHBOARD_QUERY_FINGERPRINT // pragma: allowlist secret
+    where.push('position(query, {selfFingerprint:String}) = 0')
+  }
 
   if (minDurationMs > 0) {
     where.push(`query_duration_ms >= ${minDurationMs}`)

--- a/apps/dashboard/src/routes/api/v1/advisor/__tests__/history.cloud-demo-host-guard.test.ts
+++ b/apps/dashboard/src/routes/api/v1/advisor/__tests__/history.cloud-demo-host-guard.test.ts
@@ -1,0 +1,206 @@
+/**
+ * #2172 + #3139 — GET /api/v1/advisor/history
+ *
+ * Guest/OSS hostId=0 must reach the env/demo host. Signed-in cloud + hostId=0 returns
+ * demo_hidden with data:[]. Kind defaults to all (no query_kind). Dashboard
+ * queries are excluded unless includeSelf=1.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+let cloudMode = false
+let signedIn = false
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123', // pragma: allowlist secret
+    CLICKHOUSE_USER: 'default', // pragma: allowlist secret
+    CLICKHOUSE_PASSWORD: '', // pragma: allowlist secret
+    get CHM_CLOUD_MODE() {
+      return cloudMode ? 'true' : 'false'
+    },
+  },
+}))
+
+mock.module('@/lib/api/server-env', () => ({
+  bridgeClickHouseEnv: mock(() => undefined), // pragma: allowlist secret
+}))
+
+import * as realProvider from '@/lib/auth/provider'
+
+mock.module('@/lib/auth/provider', () => ({
+  ...realProvider,
+  isClerkAuthProvider: () => true,
+}))
+
+mock.module('@clerk/tanstack-react-start/server', () => ({
+  auth: async () => (signedIn ? { userId: 'user_123' } : { userId: null }),
+}))
+
+mock.module('@chm/logger', () => ({
+  error: mock(() => undefined),
+  log: mock(() => undefined),
+  isDebugEnabled: mock(() => false),
+}))
+
+type FetchArg = {
+  query: string
+  query_params: Record<string, string>
+}
+
+const mockFetchData = mock(async (_args?: unknown) => ({
+  data: [
+    {
+      query_id: 'q1',
+      query: 'SELECT 1',
+      user: 'default',
+      query_duration_ms: 12,
+      event_time: '2026-08-19 00:00:00',
+      read_rows: 1,
+    },
+  ] as unknown,
+  metadata: { queryId: '' } as Record<string, unknown>,
+  error: null as { type?: string; message?: string } | null,
+}))
+
+function lastFetchArg(): FetchArg {
+  const calls = mockFetchData.mock.calls as unknown as Array<[FetchArg]>
+  const arg = calls[0]?.[0]
+  if (!arg) throw new Error('fetchData was not called')
+  return arg
+}
+
+mock.module('@chm/clickhouse-client', () => ({ // pragma: allowlist secret
+  // pragma: allowlist secret
+  fetchData: mockFetchData,
+}))
+
+type GetHandler = (ctx: { request: Request }) => Promise<Response>
+
+function getGetHandler(route: { options: { server?: unknown } }): GetHandler {
+  const handlers = (route.options.server as { handlers?: { GET?: GetHandler } })
+    ?.handlers
+  const fn = handlers?.GET
+  if (!fn) throw new Error('Route has no GET handler')
+  return fn
+}
+
+const { Route } = await import('../history')
+const handler = getGetHandler(Route)
+
+function get(search: string): Promise<Response> {
+  return handler({
+    request: new Request(`http://x/api/v1/advisor/history?${search}`),
+  })
+}
+
+describe('GET /api/v1/advisor/history — cloud demo-host guard (#2172)', () => {
+  beforeEach(() => {
+    cloudMode = false
+    signedIn = false
+    mockFetchData.mockClear()
+  })
+
+  test('OSS: authenticated caller + hostId=0 is unaffected (reaches fetchData)', async () => {
+    cloudMode = false
+    signedIn = true
+    const res = await get('hostId=0')
+    expect(res.status).toBe(200)
+    expect(mockFetchData).toHaveBeenCalled()
+  })
+
+  test('anonymous cloud: hostId=0 is unaffected (reaches fetchData)', async () => {
+    cloudMode = true
+    signedIn = false
+    const res = await get('hostId=0')
+    expect(res.status).toBe(200)
+    expect(mockFetchData).toHaveBeenCalled()
+    const body = (await res.json()) as { success: boolean; data: unknown[] }
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(1)
+  })
+
+  test('authenticated cloud + hostId=0: rejected with demo_hidden empty payload', async () => {
+    cloudMode = true
+    signedIn = true
+    const res = await get('hostId=0')
+    expect(res.status).toBe(200)
+    expect(mockFetchData).not.toHaveBeenCalled()
+    const body = (await res.json()) as {
+      success: boolean
+      data: unknown[]
+      metadata: { unavailable: { reason: string; message: string } }
+    }
+    expect(body.success).toBe(true)
+    expect(body.data).toEqual([])
+    expect(body.metadata.unavailable.reason).toBe('demo_hidden')
+    expect(body.metadata.unavailable.message.length).toBeGreaterThan(0)
+  })
+})
+
+describe('GET /api/v1/advisor/history — picker filters (#3139)', () => {
+  beforeEach(() => {
+    cloudMode = false
+    signedIn = false
+    mockFetchData.mockClear()
+  })
+
+  test('omits query_kind when kind is absent (All)', async () => {
+    await get('hostId=0&hours=24')
+    expect(mockFetchData).toHaveBeenCalled()
+    const arg = lastFetchArg()
+    expect(arg.query).not.toContain('query_kind')
+    expect(arg.query_params.kind).toBeUndefined()
+  })
+
+  test('kind=all omits query_kind', async () => {
+    await get('hostId=0&kind=all')
+    const arg = lastFetchArg()
+    expect(arg.query).not.toContain('query_kind')
+    expect(arg.query_params.kind).toBeUndefined()
+  })
+
+  test('kind=Select binds query_kind', async () => {
+    await get('hostId=0&kind=Select')
+    const arg = lastFetchArg()
+    expect(arg.query).toContain('query_kind = {kind:String}')
+    expect(arg.query_params.kind).toBe('Select')
+  })
+
+  test('unknown kind is a 400', async () => {
+    const res = await get('hostId=0&kind=Nonsense')
+    expect(res.status).toBe(400)
+    expect(mockFetchData).not.toHaveBeenCalled()
+  })
+
+  test('default excludes dashboard queries', async () => {
+    await get('hostId=0')
+    const arg = lastFetchArg()
+    expect(arg.query_params.selfFingerprint).toBeDefined()
+    expect(arg.query_params.selfFingerprint.length).toBeGreaterThan(0)
+    expect(arg.query).toContain('position(query, {selfFingerprint:String}) = 0')
+  })
+
+  test('includeSelf=1 skips the dashboard fingerprint', async () => {
+    await get('hostId=0&includeSelf=1')
+    const arg = lastFetchArg()
+    expect(arg.query_params.selfFingerprint).toBeUndefined()
+    expect(arg.query).not.toContain('selfFingerprint')
+  })
+
+  test('query errors become 503 with a message the UI can show', async () => {
+    mockFetchData.mockImplementationOnce(async () => ({
+      data: null,
+      metadata: {},
+      error: { type: 'query_error', message: 'query_log is empty' },
+    }))
+    const res = await get('hostId=0')
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as {
+      success: boolean
+      error: { message: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe('query_log is empty')
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/advisor/history.ts
+++ b/apps/dashboard/src/routes/api/v1/advisor/history.ts
@@ -1,6 +1,6 @@
 /**
  * Query-history picker endpoint for the Query Advisor page.
- * GET /api/v1/advisor/history?hostId=0&keyword=...&user=...&kind=Select&minDurationMs=1000&hours=24&limit=50
+ * GET /api/v1/advisor/history?hostId=0&keyword=...&user=...&kind=all&minDurationMs=1000&hours=24&limit=50
  * GET /api/v1/advisor/history?hostId=0&facet=users
  *
  * Read-only browse of `system.query_log` so the advisor input can be populated
@@ -8,6 +8,10 @@
  * `{param:Type}` parameters via {@link buildHistoryPickerQuery} — never
  * interpolated into SQL. Runs in `readonly` mode. `facet=users` returns the
  * DISTINCT-user list used to populate the user filter.
+ *
+ * Anonymous cloud + OSS callers may use hostId=0 (the env/demo host). Signed-in
+ * cloud callers get a structured `demo_hidden` empty payload for non-negative
+ * ids — the client must surface that, not render a blank list.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
@@ -18,14 +22,19 @@ import { error } from '@chm/logger'
 import {
   buildHistoryPickerQuery,
   buildHistoryUsersQuery,
+  HISTORY_PICKER_KIND_ALL,
   HISTORY_PICKER_KINDS,
   type HistoryPickerFilters,
   type HistoryPickerKind,
+  type HistoryPickerKindFilter,
   type HistoryQueryRow,
 } from '@/lib/ai/advisor/history-picker'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import { ApiErrorType } from '@/lib/api/types'
-import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
+import {
+  demoHiddenUnavailable,
+  isDemoHostBlockedForRequest,
+} from '@/lib/cloud/reject-demo-host'
 
 const ROUTE_CONTEXT = { route: '/api/v1/advisor/history' }
 
@@ -57,11 +66,21 @@ function parseIntParam(raw: string | null): number | undefined {
   return Number.isFinite(n) ? n : undefined
 }
 
-function parseKind(raw: string | null): HistoryPickerKind | undefined {
-  if (!raw) return undefined
+function parseKind(
+  raw: string | null
+): HistoryPickerKindFilter | { message: string } {
+  if (!raw || raw === HISTORY_PICKER_KIND_ALL || raw === '__all__') {
+    return HISTORY_PICKER_KIND_ALL
+  }
   return HISTORY_PICKER_KINDS.includes(raw as HistoryPickerKind)
     ? (raw as HistoryPickerKind)
-    : undefined
+    : { message: `Invalid kind: ${raw}` }
+}
+
+function parseIncludeSelf(raw: string | null): boolean {
+  if (raw === null || raw.trim() === '') return false
+  const v = raw.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes'
 }
 
 function demoHiddenResponse(): Response {
@@ -69,10 +88,7 @@ function demoHiddenResponse(): Response {
     success: true,
     data: [],
     metadata: {
-      unavailable: {
-        reason: 'demo_hidden',
-        message: 'The demo host is hidden for signed-in accounts.',
-      },
+      unavailable: demoHiddenUnavailable(),
     },
   })
 }
@@ -101,6 +117,10 @@ export const Route = createFileRoute('/api/v1/advisor/history')({
         }
 
         const facet = searchParams.get('facet')
+        const kindResult = parseKind(searchParams.get('kind'))
+        if (typeof kindResult === 'object') {
+          return validationError(kindResult.message)
+        }
 
         const { sql, params } =
           facet === 'users'
@@ -108,10 +128,11 @@ export const Route = createFileRoute('/api/v1/advisor/history')({
             : buildHistoryPickerQuery({
                 keyword: searchParams.get('keyword') ?? undefined,
                 user: searchParams.get('user') ?? undefined,
-                kind: parseKind(searchParams.get('kind')),
+                kind: kindResult,
                 minDurationMs: parseIntParam(searchParams.get('minDurationMs')),
                 hours: parseIntParam(searchParams.get('hours')),
                 limit: parseIntParam(searchParams.get('limit')),
+                excludeSelf: !parseIncludeSelf(searchParams.get('includeSelf')),
               } satisfies HistoryPickerFilters)
 
         try {

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -215,6 +215,11 @@ caused a class of silent runtime breakage in #2361/#2363/#2364:
   `--accordion-panel-height`, collapsible `--collapsible-panel-height`. A stale
   `--radix-*` reference silently drops the animation/layout it drove.
 - **`asChild` → `render`.** Base UI uses a `render` prop, not `asChild`.
+- **`Select.Value` shows the raw value** unless you pass `items` (a
+  `{ value: label }` record or `{ value, label }[]`) on `Select.Root`, or
+  a render-function child. `placeholder` is empty-only — selected `24` /
+  `__all__` otherwise paint those strings in the trigger. Incident: the
+  Advisor pick-query dialog (#3139).
 - Ground-truth attribute/var names live in
   `node_modules/@base-ui/react/**/*DataAttributes.js` / `*CssVars.js`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3139.

The live Pick a query dialog on `/advisor?host=0` showed a caption plus a blank scrollbar, raw Select values (`24`, `__all__`, `Select`), and four filters cramped on one row.

## Audit (data path)

Traced `GET /api/v1/advisor/history` → `buildHistoryPickerQuery` → the picker UI.

- **Guest `hostId=0` is allowed.** OSS and anonymous cloud still reach `fetchData`. Signed-in cloud + `hostId=0` returns `{ success: true, data: [], metadata.unavailable.reason: 'demo_hidden' }` — the UI treated that as a successful empty list.
- **`kind=Select` was not emptying results by accident.** It is a valid `query_kind`. The builder also *forced* Select when kind was unset, so Quick (which omitted `kind`) still filtered to Select.
- **`QueryFinish` + 24h window is unchanged.** Errors already returned 503 with a message; the UI dropped them inside `ScrollArea`.
- **Blank box was layout, not a hung fetch.** Base UI `ScrollArea` + fixed height swallowed `EmptyState` (same class as #3133 / #3136). `DialogContent`'s `sm:max-w-sm` also beat `max-w-2xl`, which cramped the four filters.

Self-query fingerprint used here is the existing `QUERY_COMMENT` prefix `fetchData` prepends (same one running-query counts exclude with `query NOT LIKE`). `http_user_agent` / `client_name` are not dashboard-specific in this repo.

## Changes

- History default **Kind = All** (omit `query_kind`). Select / Insert / Create / Alter / Drop / System remain options. Quick tab still asks for Select (slowest read queries).
- Default **exclude dashboard queries** via parameterized `position(query, {selfFingerprint:String}) = 0`. **Include dashboard queries** switch opts back in (`includeSelf=1`).
- Surface empty / error / `demo_hidden` with a real `EmptyState`. Header stays; the list is `min-h-0 flex-1 overflow-y-auto` (no `ScrollArea`).
- Pass Base UI Select `items` so Time / User / Kind show labels. Filters wrap `1` → `2` columns.
- `onPick(sql)` still closes the dialog and fills the advisor input. Advisor stays recommend-only.

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run type-check:test` passes
- [x] Focused bun tests: empty, error, demo_hidden, non-empty + onPick, All kinds omits `query_kind`, default excludes dashboard queries, include-self toggle
- [ ] `pnpm run lint` in CI
- [ ] `pnpm run build` in CI
- [ ] `pnpm run test:unit` in CI
- [ ] Guest `/advisor?host=0`: history lists rows or a real empty/error state; Time / User / Kind show labels; picking a row fills the input

## Notes for reviewer

Out of scope: no host added (#3105 stays), no release-please, no #3132/#3134/#3135/#3137.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd89f3f3-77e5-42b6-842d-853dbc036cdd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd89f3f3-77e5-42b6-842d-853dbc036cdd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

