### PR TITLE
fix(advisor): history picker ILLEGAL_AGGREGATION on event_time

### DIFF
--- a/apps/dashboard/src/lib/ai/advisor/__tests__/history-picker.test.ts
+++ b/apps/dashboard/src/lib/ai/advisor/__tests__/history-picker.test.ts
@@ -106,6 +106,34 @@ describe('buildHistoryPickerQuery', () => {
       'query_duration_ms >='
     )
   })
+
+  test('filters in a CTE so aggregate aliases cannot leak into WHERE', () => {
+    const { sql } = buildHistoryPickerQuery({
+      user: 'duyet',
+      minDurationMs: 1000,
+    })
+    expect(sql).toMatch(/WITH\s+filtered\s+AS\s*\(/i)
+    expect(sql).toMatch(/FROM\s+filtered/i)
+
+    const cteOpen = sql.search(/WITH\s+filtered\s+AS\s*\(/i)
+    const cteSelect = sql.indexOf('SELECT', cteOpen)
+    const outerSelect = sql.indexOf('SELECT', cteSelect + 1)
+    expect(cteOpen).toBeGreaterThanOrEqual(0)
+    expect(cteSelect).toBeGreaterThan(cteOpen)
+    expect(outerSelect).toBeGreaterThan(cteSelect)
+
+    const cteBody = sql.slice(cteSelect, outerSelect)
+    expect(cteBody).toContain('event_time >= now()')
+    expect(cteBody).toContain('user = {user:String}')
+    expect(cteBody).toContain('query_duration_ms >= 1000')
+    expect(cteBody).not.toContain('max(event_time)')
+    expect(cteBody).not.toContain('any(user)')
+    expect(cteBody).not.toContain('max(query_duration_ms)')
+
+    const outer = sql.slice(outerSelect)
+    expect(outer).toContain('max(event_time) AS event_time')
+    expect(outer).not.toContain('WHERE')
+  })
 })
 
 describe('buildHistoryUsersQuery', () => {

--- a/apps/dashboard/src/lib/ai/advisor/history-picker.ts
+++ b/apps/dashboard/src/lib/ai/advisor/history-picker.ts
@@ -178,7 +178,23 @@ export function buildHistoryPickerQuery(
     where.push(`query_duration_ms >= ${minDurationMs}`)
   }
 
+  // Filter in a CTE, then aggregate. The analyzer substitutes SELECT
+  // aliases into WHERE when they share a column name — so
+  // `max(event_time) AS event_time` + `WHERE event_time >= …` (and the
+  // same for `user` / `query_duration_ms`) raises ILLEGAL_AGGREGATION
+  // (code 184). Keeping WHERE on the un-aggregated scan avoids that.
   const sql = `
+    WITH filtered AS (
+      SELECT
+        query_id,
+        query,
+        user,
+        query_duration_ms,
+        event_time,
+        read_rows
+      FROM system.query_log
+      WHERE ${where.join('\n        AND ')}
+    )
     SELECT
       query_id,
       any(query) AS query,
@@ -186,8 +202,7 @@ export function buildHistoryPickerQuery(
       max(query_duration_ms) AS query_duration_ms,
       max(event_time) AS event_time,
       max(read_rows) AS read_rows
-    FROM system.query_log
-    WHERE ${where.join('\n      AND ')}
+    FROM filtered
     GROUP BY query_id
     ORDER BY query_duration_ms DESC
     LIMIT ${limit}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`GET /api/v1/advisor/history` was failing on production (`ILLEGAL_AGGREGATION`, code 184) because the picker query aliased `max(event_time) AS event_time` in the same SELECT that filtered `WHERE event_time >= …`. The analyzer substitutes that alias into WHERE, which is illegal.

## Changes

- Filter `system.query_log` in a CTE first, then aggregate in the outer query so WHERE never sees `max(event_time) AS event_time` (same for `user` and `query_duration_ms`)
- Add a unit test that the time/user/duration predicates live in the CTE, not next to the aggregates

## Test plan

- [x] Unit tests for `history-picker` SQL builder (`32 pass` including the new CTE regression and the history route tests)
- [x] Biome check on the changed files
- [ ] `pnpm run lint` / `pnpm run build` in CI
- [ ] Docs updated in `docs/content/` if behaviour or config changed (N/A)

## Notes for reviewer

Reproduced against `https://dash.chmonitor.dev/api/v1/advisor/history?hostId=0&hours=24&limit=50&user=duyet`. Row shape is unchanged (`event_time` still comes back from the outer SELECT).

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-948c54f4-1264-4dc9-9a8d-1f2fff7035ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-948c54f4-1264-4dc9-9a8d-1f2fff7035ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

