### PR TITLE
feat(cli): add chm upgrade alias and explicit update fallbacks

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -50,20 +50,24 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default \
 
 ## Update
 
-`chm` can update itself in place from GitHub Releases — no re-running the
-install script, no `sudo`:
+`chm update` and `chm upgrade` are the same command (`upgrade` is a first-class
+alias). Both print current -> target version and update in place from GitHub
+Releases — no re-running the install script, and they never invoke `sudo`:
 
 ```bash
-chm update            # download + verify + replace with the latest chm-v* release
-chm update --check     # only report whether a newer release exists (exit 1 if so)
-chm update --version chm-v0.2.0   # pin a specific release
+chm upgrade           # alias of update — download + verify + replace
+chm update            # same behaviour
+chm update --check    # only report whether a newer release exists (exit 1 if so)
+chm upgrade --version chm-v0.2.0   # pin a specific release
 ```
 
-`update` downloads the binary for your platform plus its `.sha256`, verifies the
-checksum (mandatory — it aborts on a mismatch or missing checksum), then
-atomically replaces the running executable. If the install directory is not
-writable it prints the manual command instead of asking for `sudo`. Installed
-via `cargo install`? Use `cargo install ch-monitor-cli` to upgrade instead.
+The command downloads the binary for your platform plus its `.sha256`, verifies
+the checksum (mandatory — it aborts on a mismatch or missing checksum), then
+atomically replaces the running executable. Checksum, permission, and
+unsupported-target failures print a copy-pasteable fallback
+(`scripts/install.sh` or `cargo install ch-monitor-cli --force`) instead of
+failing silently or asking for `sudo`. Installed via `cargo install`? Use
+`cargo install ch-monitor-cli --force` to upgrade instead.
 
 <Callout type="info" title="Update reminder">
 After a `chm diagnose` run, `chm` does a fast, best-effort check for a newer

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -3,7 +3,7 @@ id: standalone-cli
 title: Standalone CLI (Rust)
 type: reference
 status: active
-updated: 2026-07-17
+updated: 2026-08-19
 tags:
   - rust
   - cli
@@ -108,6 +108,20 @@ curl -X POST http://localhost:3000/api/v1/auth/api-key \
 | `comfy-table` | Table rendering |
 | `ratatui` + `crossterm` | TUI stack |
 
+## Self-update (`chm update` / `chm upgrade`)
+
+`chm upgrade` is a first-class alias of `chm update` (same `--check` /
+`--version` flags, same `cli_run`/`update` telemetry). Both print
+current -> target version, download the matching `chm-<target>` GitHub Release
+asset, require a matching `.sha256`, and atomically replace the running
+binary. They never invoke sudo. Checksum, permission, and unsupported-target
+failures print a copy-pasteable fallback (`scripts/install.sh` or
+`cargo install ch-monitor-cli --force`). Implementation: `src/update.rs`.
+
+```bash
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
+```
+
 ## CI & Release
 
 - **CI**: `cli-rust-ci.yml` — fmt, clippy, build, test
@@ -118,10 +132,6 @@ curl -X POST http://localhost:3000/api/v1/auth/api-key \
   `chm-<target>` / `chm-<target>.sha256`. Only runs the upload step on an
   actual tag push (`github.ref_type == 'tag'`); `workflow_dispatch` builds but
   doesn't publish.
-- **No `chm-v*` tag has been pushed yet** (as of 2026-07-17) — the workflow is
-  wired correctly but has never produced a real release. A maintainer needs to
-  push a `chm-v0.1.0` tag to cut the first one before `scripts/install.sh`
-  (below) has anything to download.
 
 ## One-line install (`scripts/install.sh`)
 
@@ -136,16 +146,14 @@ curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/ins
   repo's overall "latest" release — that's dashboard/Helm releases); pin a
   specific one with `CHM_VERSION=chm-vX.Y.Z`.
 - Downloads the binary + its `.sha256` asset and verifies the checksum before
-  installing; fails loud (`set -euo pipefail`) on any download/verify/write
-  failure rather than degrading silently.
+  installing; a missing or mismatched checksum is fatal (never installs an
+  unverified binary). Fails loud (`set -euo pipefail`) on any
+  download/verify/write failure rather than degrading silently.
 - Installs to `$HOME/.local/bin` by default (override with
   `CHM_INSTALL_DIR`); never invokes `sudo` — if the target dir isn't
-  writable it errors with the manual `sudo cp` command instead of escalating
-  itself.
-- `rust/ch-monitor-cli/Cargo.toml` now carries `authors`/`repository`/
-  `readme`/`keywords`/`categories` (matching the sibling `ch-json`/`ch-pivot`
-  crates) so it's ready for a future `cargo publish` — **not yet published**;
-  `cargo-publish.yml`'s path filter still only watches `ch-json`/`ch-pivot`.
-  Publishing `ch-monitor-cli` to crates.io and/or a Homebrew tap needs a
-  maintainer with crates.io/Homebrew-org credentials (tracked as a follow-up
-  on issue #2699, not done here).
+  writable it errors with `CHM_INSTALL_DIR` / `cargo install` fallback
+  instead of escalating itself.
+- `rust/ch-monitor-cli/Cargo.toml` carries `authors`/`repository`/`readme`/
+  `keywords`/`categories`. `cargo-publish.yml` publishes the crate so
+  `cargo install ch-monitor-cli` works as a self-update fallback. Homebrew
+  is still out of scope.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -191,7 +191,7 @@ version = "0.1.0"
 
 [[package]]
 name = "ch-monitor-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -32,19 +32,24 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
 
 ## Update
 
-`chm` self-updates from GitHub Releases (downloads the matching binary, verifies
-its sha256, and atomically replaces itself — no sudo):
+`chm update` and `chm upgrade` are the same command (`upgrade` is a first-class
+alias). Both print current -> target version, download the matching GitHub
+Release binary, verify sha256, and atomically replace the running executable.
+They never invoke sudo: checksum, permission, and unsupported-target failures
+print a copy-pasteable fallback (`scripts/install.sh` or
+`cargo install ch-monitor-cli --force`).
 
 ```bash
-chm update                       # install the latest chm-v* release
+chm upgrade                      # alias of update — install the latest chm-v* release
+chm update                       # same behaviour
 chm update --check               # only report if a newer release exists (exit 1 if so)
-chm update --version chm-v0.2.0  # pin a specific release
+chm upgrade --version chm-v0.2.0 # pin a specific release
 ```
 
 After a `chm diagnose` run, a one-line "update available" hint is printed to
 stderr when a newer release exists (best-effort, sub-second timeout). Silence it
 with `CHM_NO_UPDATE_CHECK=1`. Installed via `cargo install`? Upgrade with
-`cargo install ch-monitor-cli` instead.
+`cargo install ch-monitor-cli --force` instead.
 
 See [docs.chmonitor.dev/guide/guides/diagnostics-cli](https://docs.chmonitor.dev/guide/guides/diagnostics-cli)
 for the full CLI reference.

--- a/rust/ch-monitor-cli/build.rs
+++ b/rust/ch-monitor-cli/build.rs
@@ -1,6 +1,6 @@
 // Expose the compile-time target triple (e.g. `x86_64-unknown-linux-gnu`) to the
 // crate as `env!("CHM_TARGET")`. Cargo sets `TARGET` for build scripts; we re-emit
-// it as a rustc-env so `chm update` can pick the matching release asset.
+// it as a rustc-env so `chm update` / `chm upgrade` can pick the matching release asset.
 fn main() {
     let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
     println!("cargo:rustc-env=CHM_TARGET={target}");

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use comfy_table::{presets::UTF8_FULL, Table};
 use crossterm::{
     event, execute,
@@ -80,15 +80,26 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Update chm to the latest release from GitHub (self-update).
-    Update {
-        /// Only check whether an update is available; exit 1 if one exists.
-        #[arg(long)]
-        check: bool,
-        /// Install a specific release tag, e.g. chm-v0.2.0.
-        #[arg(long)]
-        version: Option<String>,
-    },
+    /// Update chm to the latest GitHub release (self-update).
+    ///
+    /// Prints current -> target version, verifies sha256, and atomically
+    /// replaces this binary. Never invokes sudo: checksum, permission, and
+    /// unsupported-target failures print a copy-pasteable fallback
+    /// (`scripts/install.sh` or `cargo install ch-monitor-cli`).
+    Update(UpdateArgs),
+    /// Alias of `update`. Same flags (`--check`, `--version`), same behaviour.
+    Upgrade(UpdateArgs),
+}
+
+/// Shared flags for `chm update` and `chm upgrade`.
+#[derive(Args, Debug)]
+struct UpdateArgs {
+    /// Only check whether an update is available; exit 1 if one exists.
+    #[arg(long)]
+    check: bool,
+    /// Install a specific release tag, e.g. chm-v0.2.0.
+    #[arg(long)]
+    version: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -211,6 +222,7 @@ fn row_metric(row: &Value) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
     use serde_json::json;
 
     #[test]
@@ -233,6 +245,72 @@ mod tests {
     fn row_metric_ignores_negative_or_invalid_values() {
         assert_eq!(row_metric(&json!({ "value": -1 })), 0);
         assert_eq!(row_metric(&json!({ "value": "not-a-number" })), 0);
+    }
+
+    fn update_args(cli: Cli) -> UpdateArgs {
+        match cli.command {
+            Commands::Update(args) | Commands::Upgrade(args) => args,
+            other => panic!("expected update/upgrade, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn upgrade_is_first_class_alias_of_update() {
+        for argv in [["chm", "update"], ["chm", "upgrade"]] {
+            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
+            assert!(!args.check);
+            assert!(args.version.is_none());
+        }
+    }
+
+    #[test]
+    fn upgrade_and_update_share_check_flag() {
+        for argv in [["chm", "update", "--check"], ["chm", "upgrade", "--check"]] {
+            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
+            assert!(args.check);
+            assert!(args.version.is_none());
+        }
+    }
+
+    #[test]
+    fn upgrade_and_update_share_version_flag() {
+        for argv in [
+            ["chm", "update", "--version", "chm-v0.2.0"],
+            ["chm", "upgrade", "--version", "chm-v0.2.0"],
+        ] {
+            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
+            assert!(!args.check);
+            assert_eq!(args.version.as_deref(), Some("chm-v0.2.0"));
+        }
+    }
+
+    #[test]
+    fn help_lists_update_and_upgrade() {
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(help.contains("update"), "{help}");
+        assert!(help.contains("upgrade"), "{help}");
+    }
+
+    #[test]
+    fn update_and_upgrade_help_share_flags() {
+        // clap 4's render_long_help takes &mut self.
+        let mut cmd = Cli::command();
+        let update_help = cmd
+            .find_subcommand_mut("update")
+            .expect("update subcommand")
+            .render_long_help()
+            .to_string();
+        let mut cmd = Cli::command();
+        let upgrade_help = cmd
+            .find_subcommand_mut("upgrade")
+            .expect("upgrade subcommand")
+            .render_long_help()
+            .to_string();
+        for help in [&update_help, &upgrade_help] {
+            assert!(help.contains("--check"), "{help}");
+            assert!(help.contains("--version"), "{help}");
+        }
     }
 }
 
@@ -365,7 +443,7 @@ async fn main() -> Result<()> {
         Commands::Chart { .. } => ("cli_run", "chart"),
         Commands::Table { .. } => ("cli_run", "table"),
         Commands::Tui { .. } => ("cli_run", "tui"),
-        Commands::Update { .. } => ("cli_run", "update"),
+        Commands::Update(_) | Commands::Upgrade(_) => ("cli_run", "update"),
     };
     let tel_handle = telemetry::spawn(tel_event, tel_command);
 
@@ -458,14 +536,14 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
         }
-        Commands::Update { check, version } => {
-            if check {
+        Commands::Update(args) | Commands::Upgrade(args) => {
+            if args.check {
                 let available = update::check(&client).await?;
                 if available {
                     std::process::exit(1);
                 }
             } else {
-                update::run(&client, version).await?;
+                update::run(&client, args.version).await?;
             }
         }
     }

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -1,19 +1,23 @@
-//! Self-update: `chm update`.
+//! Self-update: `chm update` / `chm upgrade`.
 //!
 //! Downloads the newest (or a pinned) `chm-v*` release from GitHub, verifies its
-//! sha256 checksum, and atomically replaces the running executable. No sudo — if
-//! the install directory is not writable we print the manual command instead.
+//! sha256 checksum, and atomically replaces the running executable. Never
+//! invokes sudo — checksum, permission, and unsupported-target failures print a
+//! copy-pasteable fallback (`scripts/install.sh` or `cargo install`).
 
 use std::{env, fs, path::Path, time::Duration};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases";
+const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases?per_page=100";
 const RELEASE_DOWNLOAD: &str = "https://github.com/chmonitor/chmonitor/releases/download";
 const USER_AGENT: &str = concat!("chm-cli/", env!("CARGO_PKG_VERSION"));
+const INSTALL_SH: &str =
+    "curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash";
+const CARGO_INSTALL: &str = "cargo install ch-monitor-cli --force";
 
 /// Compile-time target triple, injected by `build.rs`.
 const TARGET: &str = env!("CHM_TARGET");
@@ -66,6 +70,26 @@ fn newest_chm_tag(releases: &[Release]) -> Option<String> {
         .map(|(_, tag)| tag)
 }
 
+/// Copy-pasteable recovery when self-update cannot finish. Never includes a
+/// `sudo ` command — this path does not escalate privileges.
+fn fallback_block() -> String {
+    format!(
+        "This command never invokes sudo. Copy-paste a fallback:\n  {INSTALL_SH}\n\nor:\n  {CARGO_INSTALL}"
+    )
+}
+
+fn unsupported_target_error(target: &str) -> anyhow::Error {
+    anyhow!(
+        "unsupported platform for self-update ('{target}'). \
+         Prebuilt binaries ship for Linux and macOS (x86_64, aarch64) only.\n\
+         Build from source instead:\n  {CARGO_INSTALL}"
+    )
+}
+
+fn checksum_failure(detail: &str) -> anyhow::Error {
+    anyhow!("{detail}\n{}", fallback_block())
+}
+
 /// Fetch the newest published `chm-v*` release tag.
 async fn latest_tag(client: &Client) -> Result<String> {
     let releases: Vec<Release> = client
@@ -90,29 +114,24 @@ fn current_version() -> Version {
 
 fn ensure_supported_target() -> Result<()> {
     if !SUPPORTED_TARGETS.contains(&TARGET) {
-        bail!(
-            "unsupported platform for self-update ('{TARGET}'). \
-             Install from source instead: cargo install ch-monitor-cli"
-        );
+        return Err(unsupported_target_error(TARGET));
     }
     Ok(())
 }
 
-/// `chm update --check`: report whether a newer release exists.
+/// `chm update --check` / `chm upgrade --check`: report whether a newer release exists.
 /// Returns `true` when an update is available.
 pub async fn check(client: &Client) -> Result<bool> {
     let current = current_version();
     let latest_tag = latest_tag(client).await?;
     let latest = parse_version(&latest_tag)
         .ok_or_else(|| anyhow!("could not parse latest release tag '{latest_tag}'"))?;
+    println!("chm v{} -> {latest_tag}", env!("CARGO_PKG_VERSION"));
     if latest > current {
-        println!(
-            "update available: {} -> {latest_tag} (run `chm update`)",
-            env!("CARGO_PKG_VERSION")
-        );
+        println!("update available (run `chm update` or `chm upgrade`)");
         Ok(true)
     } else {
-        println!("chm is up to date (v{})", env!("CARGO_PKG_VERSION"));
+        println!("chm is up to date");
         Ok(false)
     }
 }
@@ -145,13 +164,13 @@ pub async fn hint(client: &Client) {
     };
     if let Ok(Some(tag)) = tokio::time::timeout(Duration::from_millis(900), fut).await {
         eprintln!(
-            "note: a newer chm is available ({} -> {tag}). Run `chm update`. (set CHM_NO_UPDATE_CHECK=1 to silence)",
+            "note: a newer chm is available (v{} -> {tag}). Run `chm update` or `chm upgrade`. (set CHM_NO_UPDATE_CHECK=1 to silence)",
             env!("CARGO_PKG_VERSION")
         );
     }
 }
 
-/// `chm update` (and `chm update --version <tag>`): download, verify, replace.
+/// `chm update` / `chm upgrade` (and `--version <tag>`): download, verify, replace.
 pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
     ensure_supported_target()?;
     let current = current_version();
@@ -169,8 +188,10 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
     let target_version = parse_version(&target_tag)
         .ok_or_else(|| anyhow!("could not parse target tag '{target_tag}'"))?;
 
-    if pinned_is_none_and_current(&target_version, &current) {
-        println!("chm is already up to date (v{})", env!("CARGO_PKG_VERSION"));
+    println!("chm v{} -> {target_tag}", env!("CARGO_PKG_VERSION"));
+
+    if target_version == current {
+        println!("chm is already up to date");
         return Ok(());
     }
 
@@ -178,7 +199,7 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
     let bin_url = format!("{RELEASE_DOWNLOAD}/{target_tag}/{asset}");
     let sha_url = format!("{bin_url}.sha256");
 
-    println!("Downloading {asset} ({target_tag})...");
+    println!("Downloading {asset}...");
     let bin_bytes = client
         .get(&bin_url)
         .header("User-Agent", USER_AGENT)
@@ -194,29 +215,36 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
         .context("failed to read downloaded binary")?;
 
     // Checksum verification is mandatory: abort on a missing or mismatched sum.
-    let sha_text = client
+    let sha_text = match client
         .get(&sha_url)
         .header("User-Agent", USER_AGENT)
         .send()
         .await
         .and_then(|r| r.error_for_status())
-        .with_context(|| {
-            format!("no checksum asset at {sha_url} — refusing to install unverified binary")
-        })?
-        .text()
-        .await
-        .context("failed to read checksum file")?;
+    {
+        Ok(resp) => resp.text().await.context("failed to read checksum file")?,
+        Err(_) => {
+            return Err(checksum_failure(&format!(
+                "no checksum asset at {sha_url} — refusing to install unverified binary"
+            )));
+        }
+    };
     let expected = sha_text
         .split_whitespace()
         .next()
         .unwrap_or("")
         .to_lowercase();
     if expected.is_empty() {
-        bail!("checksum file was empty — refusing to install unverified binary");
+        return Err(checksum_failure(
+            "checksum file was empty — refusing to install unverified binary",
+        ));
     }
     let actual = hex_sha256(&bin_bytes);
     if actual != expected {
-        bail!("checksum mismatch for {asset}: expected {expected}, got {actual}. Download may be corrupt or tampered with — aborting.");
+        return Err(checksum_failure(&format!(
+            "checksum mismatch for {asset}: expected {expected}, got {actual}. \
+             Download may be corrupt or tampered with — aborting."
+        )));
     }
 
     let exe = env::current_exe().context("could not locate the running executable")?;
@@ -224,18 +252,14 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
         .parent()
         .ok_or_else(|| anyhow!("executable has no parent directory"))?;
 
-    install_binary(dir, &exe, &bin_bytes).map_err(|e| manual_hint(&exe, &e))?;
+    install_binary(dir, &exe, &bin_bytes).map_err(|e| permission_hint(&exe, &e))?;
 
     println!(
-        "Updated chm {} -> {target_tag} ({})",
+        "Updated chm v{} -> {target_tag} ({})",
         env!("CARGO_PKG_VERSION"),
         exe.display()
     );
     Ok(())
-}
-
-fn pinned_is_none_and_current(target: &Version, current: &Version) -> bool {
-    target == current
 }
 
 fn hex_sha256(bytes: &[u8]) -> String {
@@ -292,15 +316,15 @@ fn set_executable(_path: &Path) -> Result<()> {
 }
 
 /// Turn an install failure into a clear, sudo-free manual instruction.
-fn manual_hint(exe: &Path, err: &anyhow::Error) -> anyhow::Error {
+fn permission_hint(exe: &Path, err: &anyhow::Error) -> anyhow::Error {
     anyhow!(
         "could not install the update automatically ({err}).\n\
          The install directory may not be writable ({}).\n\
-         Re-run the installer manually (no sudo needed if you own the dir):\n\
-             curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash\n\
-         or move a downloaded `chm-{TARGET}` binary over {} yourself.",
-        exe.parent().map(|p| p.display().to_string()).unwrap_or_default(),
-        exe.display(),
+         {}",
+        exe.parent()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default(),
+        fallback_block(),
     )
 }
 
@@ -315,6 +339,14 @@ mod tests {
         assert_eq!(parse_version("v2.0.0"), Some(Version(2, 0, 0)));
         assert_eq!(parse_version("0.3"), Some(Version(0, 3, 0)));
         assert_eq!(parse_version("chm-v1.2.3-rc1"), Some(Version(1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_version_rejects_junk() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("chm-v"), None);
+        assert_eq!(parse_version("not-a-version"), None);
+        assert_eq!(parse_version("chm-vlater"), None);
     }
 
     #[test]
@@ -341,6 +373,14 @@ mod tests {
     }
 
     #[test]
+    fn newest_tag_empty_or_unrelated_is_none() {
+        assert_eq!(newest_chm_tag(&[]), None);
+        let json = r#"[{"tag_name":"v9.9.9","prerelease":false,"draft":false}]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(newest_chm_tag(&releases), None);
+    }
+
+    #[test]
     fn checksum_matches_known_vector() {
         // sha256("abc")
         assert_eq!(
@@ -353,5 +393,50 @@ mod tests {
     fn supported_targets_cover_shipped_platforms() {
         assert!(SUPPORTED_TARGETS.contains(&"x86_64-unknown-linux-gnu"));
         assert!(SUPPORTED_TARGETS.contains(&"aarch64-apple-darwin"));
+    }
+
+    fn assert_copy_pasteable_fallback(msg: &str) {
+        assert!(msg.contains("scripts/install.sh"), "{msg}");
+        assert!(msg.contains("cargo install ch-monitor-cli"), "{msg}");
+        // Match `sudo ` as a command. The phrase "never invokes sudo" must not trip this.
+        assert!(
+            !msg.contains("sudo "),
+            "fallback must not suggest a sudo command: {msg}"
+        );
+    }
+
+    #[test]
+    fn fallback_is_copy_pasteable_and_sudo_free() {
+        assert_copy_pasteable_fallback(&fallback_block());
+    }
+
+    #[test]
+    fn checksum_failure_includes_fallback() {
+        let msg =
+            checksum_failure("checksum mismatch for chm-x: expected aaa, got bbb").to_string();
+        assert!(msg.contains("checksum mismatch"), "{msg}");
+        assert_copy_pasteable_fallback(&msg);
+    }
+
+    #[test]
+    fn permission_hint_includes_fallback() {
+        let err = permission_hint(
+            Path::new("/usr/local/bin/chm"),
+            &anyhow!("permission denied"),
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("/usr/local/bin"), "{msg}");
+        assert_copy_pasteable_fallback(&msg);
+    }
+
+    #[test]
+    fn unsupported_target_points_at_cargo() {
+        let msg = unsupported_target_error("wasm32-unknown-unknown").to_string();
+        assert!(msg.contains("wasm32-unknown-unknown"), "{msg}");
+        assert!(msg.contains("cargo install ch-monitor-cli"), "{msg}");
+        assert!(
+            !msg.contains("sudo "),
+            "unsupported-target fallback must not suggest a sudo command: {msg}"
+        );
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -72,7 +72,7 @@ resolve_version() {
 
   log "Looking up latest chm-v* release..."
   releases_json="$(curl -fsSL -H "User-Agent: chmonitor-installer" \
-    "https://api.github.com/repos/${REPO}/releases" 2>/dev/null)" \
+    "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null)" \
     || die "failed to query GitHub releases API for ${REPO}"
 
   # The API returns compact single-line JSON, so extract just the matching
@@ -111,30 +111,34 @@ if [ ! -s "$BIN_PATH" ]; then
   die "downloaded file is empty: ${BIN_URL}"
 fi
 
-# --- verify checksum (best-effort but fatal if the asset exists and mismatches) ---
-if curl -fsSL -o "$SHA_PATH" "$SHA_URL" 2>/dev/null; then
-  expected="$(awk '{print $1}' "$SHA_PATH")"
-  if command -v sha256sum >/dev/null 2>&1; then
-    actual="$(sha256sum "$BIN_PATH" | awk '{print $1}')"
-  elif command -v shasum >/dev/null 2>&1; then
-    actual="$(shasum -a 256 "$BIN_PATH" | awk '{print $1}')"
-  else
-    die "neither sha256sum nor shasum found — cannot verify checksum, refusing to install unverified binary"
-  fi
-
-  if [ "$expected" != "$actual" ]; then
-    die "checksum mismatch for ${ASSET_NAME}: expected ${expected}, got ${actual}. Download may be corrupt or tampered with — aborting."
-  fi
-  log "Checksum verified."
-else
-  log "warning: no .sha256 checksum asset found for ${VERSION}/${ASSET_NAME} — installing without verification."
+# --- verify checksum (mandatory; never install an unverified binary) ---
+if ! curl -fsSL -o "$SHA_PATH" "$SHA_URL"; then
+  die "no checksum asset at ${SHA_URL} — refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
 fi
+
+expected="$(awk '{print $1}' "$SHA_PATH")"
+if [ -z "$expected" ]; then
+  die "checksum file was empty — refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$BIN_PATH" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$BIN_PATH" | awk '{print $1}')"
+else
+  die "neither sha256sum nor shasum found — cannot verify checksum, refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
+fi
+
+if [ "$expected" != "$actual" ]; then
+  die "checksum mismatch for ${ASSET_NAME}: expected ${expected}, got ${actual}. Download may be corrupt or tampered with — aborting. Fallback: cargo install ch-monitor-cli --force"
+fi
+log "Checksum verified."
 
 chmod +x "$BIN_PATH"
 
 mkdir -p "$INSTALL_DIR" 2>/dev/null || die "could not create install directory '$INSTALL_DIR'"
 if [ ! -w "$INSTALL_DIR" ]; then
-  die "install directory '$INSTALL_DIR' is not writable. Re-run with CHM_INSTALL_DIR pointing at a writable directory, or move the binary yourself (sudo may be required): sudo cp '$BIN_PATH' '$INSTALL_DIR/$BIN_NAME'"
+  die "install directory '$INSTALL_DIR' is not writable. This script never invokes sudo. Re-run with CHM_INSTALL_DIR pointing at a writable directory, or: cargo install ch-monitor-cli --force"
 fi
 
 mv "$BIN_PATH" "${INSTALL_DIR}/${BIN_NAME}"
@@ -154,6 +158,9 @@ esac
 log ""
 log "Run a zero-signup health check against a ClickHouse host:"
 log "  CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default ${INSTALL_DIR}/${BIN_NAME} diagnose"
+log ""
+log "Update later with:"
+log "  ${BIN_NAME} upgrade"
 
 # --- anonymous, opt-out install ping (best-effort, backgrounded) -----------
 # Records a single anonymous cli_install event (os/arch + version) to the same


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3145.

`chm upgrade` is a first-class alias of `chm update` (same `--check` / `--version` flags, same `cli_run`/`update` telemetry). Self-update now prints current -> target version, and checksum / permission / unsupported-target failures are explicit with a copy-pasteable fallback (`scripts/install.sh` or `cargo install ch-monitor-cli --force`). The command never invokes sudo.

## Summary

Users say `upgrade` as often as `update`. The CLI, installer, and docs now treat them as one product without breaking `chm update`.

## Changes

- `chm upgrade` and `chm update` share `UpdateArgs` (`--check`, `--version`) in `rust/ch-monitor-cli/src/main.rs`
- Self-update UX in `src/update.rs`: print `chm vX -> tag` before work; checksum / permission / unsupported-target errors include install.sh or cargo fallback; never a `sudo ` command
- `scripts/install.sh`: missing/empty checksum is fatal (no silent unverified install); unwritable dir suggests `CHM_INSTALL_DIR` / cargo instead of a doomed temp-path `sudo cp`; mentions `chm upgrade`
- Docs kept in sync: `rust/ch-monitor-cli/README.md`, `docs/content/guide/guides/diagnostics-cli.mdx`, `docs/knowledge/standalone-cli.md`
- `rust/Cargo.lock` package version aligned to crate `0.1.1` (no version bump)

## Left alone

- `chm update` kept as-is for existing scripts
- Telemetry stays `("cli_run", "update")` for both commands; `CHM_LICENSE_KEY` honor-system ping unchanged
- No Homebrew / crates.io / DRM / new product features
- release-please configs and `chm-v*` release PRs not touched

## Test plan

- [x] `cargo test --locked` in `rust/ch-monitor-cli` — 39 passed (version parse, newest-tag pick, alias wiring, fallback copy-paste)
- [x] `cargo clippy --locked -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `chm --help` lists both `update` and `upgrade`; `chm upgrade --help` exposes `--check` and `--version`
- [x] `bash -n scripts/install.sh`
- [ ] `pnpm run lint` — not applicable (Rust CLI / docs / install script only)
- [ ] `pnpm run build` — not applicable
- [ ] `pnpm run type-check:test` — not applicable
- [ ] `pnpm run test:unit` — not applicable
- [x] Docs updated in `docs/content/`
- [ ] `docs/content/ai-agent.mdx` — not applicable (no agent tools/skills/env vars)

## Notes for reviewer

Unsupported-target errors point at `cargo install` (source build) rather than `install.sh`, which would also refuse that platform.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6629d1d0-cc04-4a15-9987-e650aa19c2f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6629d1d0-cc04-4a15-9987-e650aa19c2f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

