### PR TITLE
fix(advisor): treat table-less SQL as a guided empty state

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -249,6 +249,12 @@ chart in `components/charts/` as the template — don't reinvent the wiring.
   `action`/`onRefresh`. Table query failures use the full (non-compact)
   EmptyState so timeout / missing-column copy is visible — never hourglass +
   Retry with no description.
+- **Interactive tool pages** (Explain, Advisor): before the first run, a
+  dashed-border `EmptyState variant="no-data"` ("Nothing to analyze/explain
+  yet"). User-input issues — table-less SQL like `SELECT 1`, missing
+  `query_id` — use the same EmptyState with next steps, never `ErrorAlert`
+  titled "Analysis failed". `ErrorAlert` is for host/schema/fetch failures.
+  Picking a query from the picker auto-runs, same as `/explain`.
 - **Error (graceful):** initial error (`error && !hasData`) → full `ChartError`
   with retry. Revalidation error (`staleError`) → KEEP showing data + subtle
   amber `ChartStaleIndicator` (hover-revealed), auto-clears on next success.

--- a/apps/dashboard/src/components/agents/advisor-query-picker.tsx
+++ b/apps/dashboard/src/components/agents/advisor-query-picker.tsx
@@ -313,8 +313,8 @@ export function AdvisorQueryPicker({
         <DialogHeader className="shrink-0 border-b border-border px-4 py-3">
           <DialogTitle>Pick a query to analyze</DialogTitle>
           <DialogDescription>
-            Start from a quick example or browse your query history. Selecting a
-            query loads it into the advisor input.
+            Start from a quick example or browse query history. Selecting a
+            query loads it and runs analysis.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
+++ b/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
@@ -15,7 +15,7 @@ import {
   DatabaseZapIcon,
   FilterIcon,
   LayersIcon,
-  WandSparklesIcon,
+  ScanSearchIcon,
 } from 'lucide-react'
 
 import type { Recommendation } from '@/lib/ai/advisor/recommendation-engine'
@@ -42,7 +42,7 @@ const KIND_ICON: Record<Recommendation['kind'], typeof FilterIcon> = {
   skip_index: FilterIcon,
   projection: LayersIcon,
   partition_key: DatabaseZapIcon,
-  prewhere: WandSparklesIcon,
+  prewhere: ScanSearchIcon,
 }
 
 const KIND_LABEL: Record<Recommendation['kind'], string> = {
@@ -140,12 +140,11 @@ export function AdvisorRecommendationsPanel({
   }, [output.recommendations.length])
 
   return (
-    <div className="rounded-md border border-border/60 bg-muted/20">
-      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
+    <div className="rounded-xl border bg-card shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
         <div className="flex min-w-0 items-center gap-2">
-          <WandSparklesIcon className="size-4 text-primary" />
-          <span className="truncate text-sm font-semibold">
-            Optimization advisor: {output.database}.{output.table}
+          <span className="truncate text-sm font-medium">
+            {output.database}.{output.table}
           </span>
         </div>
         <Badge variant="outline" className="text-[10px]">

--- a/apps/dashboard/src/components/agents/advisor-tuning-tab.tsx
+++ b/apps/dashboard/src/components/agents/advisor-tuning-tab.tsx
@@ -84,13 +84,10 @@ export function AdvisorTuningTab() {
       <Card>
         <CardContent className="space-y-4 pt-6">
           <p className="text-sm text-muted-foreground">
-            Scan a database for ranked schema lint findings (needless Nullable,
-            oversized integers, compression-codec opportunities, LowCardinality
-            candidates) and settings that differ from defaults in risky ways.
-            Every suggestion is copyable text to review and run yourself —
-            nothing here is ever applied automatically. Findings that depend on
-            data (null counts, integer ranges, distinct ratios) include a
-            verification query to confirm first.
+            Scan a database for schema lint (needless Nullable, oversized
+            integers, compression, LowCardinality) and settings that differ from
+            defaults in risky ways. Recommend-only — copy and run the
+            suggestions yourself.
           </p>
 
           <div className="grid gap-3 sm:grid-cols-2">
@@ -140,6 +137,16 @@ export function AdvisorTuningTab() {
           title="Scan failed"
           message={error instanceof Error ? error.message : String(error)}
         />
+      ) : null}
+
+      {!committed && !isLoading && !error ? (
+        <div className="rounded-xl border border-dashed bg-card/40 px-6 py-10">
+          <EmptyState
+            variant="no-data"
+            title="Nothing scanned yet"
+            description="Enter a database (and optionally a table), then press Scan."
+          />
+        </div>
       ) : null}
 
       {!isLoading && !error && data ? (

--- a/apps/dashboard/src/lib/ai/advisor/__tests__/analyze-query.test.ts
+++ b/apps/dashboard/src/lib/ai/advisor/__tests__/analyze-query.test.ts
@@ -219,7 +219,21 @@ describe('analyzeQuery — orchestration', () => {
   test('returns a clear error when neither sql nor queryId is given', async () => {
     const result = await analyzeQuery({ hostId: 0 })
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.error).toContain('sql')
+    if (!result.ok) {
+      expect(result.code).toBe('missing_input')
+      expect(result.error).toContain('sql')
+    }
+  })
+
+  test('SELECT 1 is a no_target_table error and does not look up schema', async () => {
+    calls.length = 0
+    const result = await analyzeQuery({ hostId: 0, sql: 'select 1' })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('no_target_table')
+      expect(result.error).toContain('FROM')
+    }
+    expect(calls).toHaveLength(0)
   })
 
   test('degrades gracefully (still ok) when EXPLAIN fails, with a note explaining reduced precision', async () => {

--- a/apps/dashboard/src/lib/ai/advisor/__tests__/empty-copy.test.ts
+++ b/apps/dashboard/src/lib/ai/advisor/__tests__/empty-copy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test'
+import { advisorUserInputCopy } from '@/lib/ai/advisor/empty-copy'
+
+describe('advisorUserInputCopy', () => {
+  test('no_target_table is a next-step empty, not a parser dump', () => {
+    const copy = advisorUserInputCopy(
+      'no_target_table',
+      'Could not identify a target table in the query (no FROM/JOIN found).'
+    )
+    expect(copy.title).toBe('Needs a table to analyze')
+    expect(copy.description).toContain('FROM')
+    expect(copy.description).not.toContain('no FROM/JOIN found')
+  })
+
+  test('query_not_found keeps the server message', () => {
+    const copy = advisorUserInputCopy('query_not_found', 'No finished query')
+    expect(copy.title).toBe('Query not found')
+    expect(copy.description).toBe('No finished query')
+  })
+})

--- a/apps/dashboard/src/lib/ai/advisor/empty-copy.ts
+++ b/apps/dashboard/src/lib/ai/advisor/empty-copy.ts
@@ -1,0 +1,45 @@
+import type { AdvisorErrorCode } from '@chm/query-advisor-core'
+
+import {
+  ADVISOR_NO_TARGET_TABLE_MESSAGE,
+  isAdvisorUserInputError,
+} from '@chm/query-advisor-core'
+
+export interface AdvisorEmptyCopy {
+  title: string
+  description: string
+}
+
+export function advisorUserInputCopy(
+  code: Exclude<AdvisorErrorCode, 'schema_unavailable'>,
+  message: string
+): AdvisorEmptyCopy {
+  switch (code) {
+    case 'no_target_table':
+      return {
+        title: 'Needs a table to analyze',
+        description: ADVISOR_NO_TARGET_TABLE_MESSAGE,
+      }
+    case 'invalid_sql':
+      return {
+        title: 'Query cannot be analyzed',
+        description: message,
+      }
+    case 'query_not_found':
+      return {
+        title: 'Query not found',
+        description: message,
+      }
+    case 'missing_input':
+      return {
+        title: 'Nothing to analyze',
+        description: message,
+      }
+    default: {
+      const _exhaustive: never = code
+      return _exhaustive
+    }
+  }
+}
+
+export { isAdvisorUserInputError }

--- a/apps/dashboard/src/lib/ai/advisor/recommendation-engine.ts
+++ b/apps/dashboard/src/lib/ai/advisor/recommendation-engine.ts
@@ -54,8 +54,11 @@ import {
   resolveSql,
 } from './query-context'
 import {
+  type AdvisorErrorCode,
   buildPrewhereRecommendation,
   buildQueryContext,
+  extractReferencedTables,
+  findAdvisorTargetTable,
   proposePrewhereRewrite,
   rankRecommendations,
   scorePartitionKey,
@@ -63,7 +66,6 @@ import {
   scoreSkipIndex,
 } from '@chm/query-advisor-core'
 import { validateSqlQuery } from '@chm/sql-builder'
-import { extractReferencedTables } from '@/lib/ai/agent/tools/sql-analysis'
 
 // Re-exported so existing `from './recommendation-engine'` imports (tests,
 // tool wiring) keep working unchanged — see `./types`, the app-local import
@@ -125,6 +127,7 @@ export interface AnalyzeQueryOk {
 export interface AnalyzeQueryError {
   ok: false
   error: string
+  code?: AdvisorErrorCode
 }
 
 export type AnalyzeQueryResult = AnalyzeQueryOk | AnalyzeQueryError
@@ -149,6 +152,7 @@ export async function analyzeQuery(
   } catch (err) {
     return {
       ok: false,
+      code: 'query_not_found',
       error: `Could not resolve query_id: ${err instanceof Error ? err.message : String(err)}`,
     }
   }
@@ -156,8 +160,9 @@ export async function analyzeQuery(
   if (!sql) {
     return {
       ok: false,
+      code: input.queryId ? 'query_not_found' : 'missing_input',
       error: input.queryId
-        ? `No finished query found in system.query_log for query_id "${input.queryId}".`
+        ? `No finished query found in system.query_log for query_id "${input.queryId}". Paste the SQL, or pick a query from history.`
         : 'Provide either `sql` or `queryId`.',
     }
   }
@@ -167,19 +172,15 @@ export async function analyzeQuery(
   } catch (err) {
     return {
       ok: false,
+      code: 'invalid_sql',
       error: `Query failed validation: ${err instanceof Error ? err.message : String(err)}`,
     }
   }
 
+  const targetResult = findAdvisorTargetTable(sql, database)
+  if (!targetResult.ok) return targetResult
+  const target = targetResult.table
   const referencedTables = extractReferencedTables(sql, database)
-  const target = referencedTables[0]
-  if (!target) {
-    return {
-      ok: false,
-      error:
-        'Could not identify a target table in the query (no FROM/JOIN found).',
-    }
-  }
   if (referencedTables.length > 1) {
     notes.push(
       `Query references ${referencedTables.length} tables; only \`${target.qualifiedName}\` (the first) was analyzed.`
@@ -196,6 +197,7 @@ export async function analyzeQuery(
   } catch (err) {
     return {
       ok: false,
+      code: 'schema_unavailable',
       error: `Could not read schema/parts for ${target.qualifiedName}: ${err instanceof Error ? err.message : String(err)}`,
     }
   }

--- a/apps/dashboard/src/routes/(dashboard)/advisor.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/advisor.tsx
@@ -1,4 +1,3 @@
-import { WandSparklesIcon } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import {
   createFileRoute,
@@ -8,6 +7,10 @@ import {
 
 import type { AdvisorRecommendationsOutput } from '@/components/agents/advisor-recommendations-panel'
 
+import {
+  type AdvisorErrorCode,
+  findAdvisorTargetTable,
+} from '@chm/query-advisor-core'
 import { lazy, Suspense, useState } from 'react'
 import { AdvisorQueryPicker } from '@/components/agents/advisor-query-picker'
 import { AdvisorRecommendationsPanel } from '@/components/agents/advisor-recommendations-panel'
@@ -15,13 +18,16 @@ import { AdvisorTuningTab } from '@/components/agents/advisor-tuning-tab'
 import { ErrorAlert } from '@/components/feedback'
 import { TableSkeleton } from '@/components/skeletons'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useUrlSearchParams } from '@/hooks/use-url-search-params'
+import {
+  advisorUserInputCopy,
+  isAdvisorUserInputError,
+} from '@/lib/ai/advisor/empty-copy'
 import { useHostId } from '@/lib/swr'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useFeatureTracking } from '@/lib/telemetry'
@@ -40,14 +46,26 @@ interface AdvisorApiResponse extends AdvisorRecommendationsOutput {
 interface AdvisorApiError {
   success: false
   error: string
+  code?: AdvisorErrorCode
+}
+
+class AdvisorClientError extends Error {
+  code?: AdvisorErrorCode
+  constructor(message: string, code?: AdvisorErrorCode) {
+    super(message)
+    this.name = 'AdvisorClientError'
+    this.code = code
+  }
 }
 
 const fetcher = async (url: string): Promise<AdvisorApiResponse> => {
   const res = await apiFetch(url)
   const body = (await res.json()) as AdvisorApiResponse | AdvisorApiError
   if (!res.ok || !body.success) {
-    throw new Error(
-      (body as AdvisorApiError).error || `Analysis failed (HTTP ${res.status})`
+    const err = body as AdvisorApiError
+    throw new AdvisorClientError(
+      err.error || `Analysis failed (HTTP ${res.status})`,
+      err.code
     )
   }
   return body
@@ -57,9 +75,80 @@ function EditorFallback() {
   return <Skeleton className="h-[120px] w-full rounded-md" />
 }
 
+function advisorErrorCode(error: unknown): AdvisorErrorCode | undefined {
+  return error instanceof AdvisorClientError ? error.code : undefined
+}
+
+function AdvisorResult({
+  committed,
+  data,
+  error,
+  isLoading,
+}: {
+  committed: { mode: 'sql'; sql: string } | { mode: 'queryId'; queryId: string }
+  data: AdvisorApiResponse | undefined
+  error: unknown
+  isLoading: boolean
+}) {
+  const localTableCheck =
+    committed.mode === 'sql' ? findAdvisorTargetTable(committed.sql) : null
+  const localCode =
+    localTableCheck && !localTableCheck.ok ? localTableCheck.code : undefined
+  const remoteCode = advisorErrorCode(error)
+  const code = localCode ?? remoteCode
+  const message =
+    localTableCheck && !localTableCheck.ok
+      ? localTableCheck.error
+      : error instanceof Error
+        ? error.message
+        : String(error ?? '')
+
+  if (isLoading) return <TableSkeleton rows={4} />
+
+  if (isAdvisorUserInputError(code)) {
+    const copy = advisorUserInputCopy(code, message)
+    return (
+      <div
+        className="rounded-xl border border-dashed bg-card/40 px-6 py-10"
+        data-testid="advisor-user-input-empty"
+      >
+        <EmptyState
+          variant="no-results"
+          title={copy.title}
+          description={copy.description}
+        />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <ErrorAlert
+        title="Analysis failed"
+        message={error instanceof Error ? error.message : String(error)}
+      />
+    )
+  }
+
+  if (!data) return null
+
+  if (data.recommendations.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed bg-card/40 px-6 py-10">
+        <EmptyState
+          variant="no-data"
+          title="No recommendations"
+          description="This query looks well-tuned for the table's current schema — no skip-index, projection, partition-key, or PREWHERE opportunities were found."
+        />
+      </div>
+    )
+  }
+
+  return <AdvisorRecommendationsPanel output={data} />
+}
+
 function AdvisorContent() {
   const hostId = useHostId()
-  // Fire-and-forget product telemetry — no-op unless enabled.
   useFeatureTracking('advisor')
   const navigate = useNavigate()
   const pathname = useLocation({ select: (l) => l.pathname })
@@ -82,6 +171,9 @@ function AdvisorContent() {
     return null
   })
 
+  const skipFetch =
+    committed?.mode === 'sql' && !findAdvisorTargetTable(committed.sql).ok
+
   const apiUrl = committed
     ? (() => {
         const params = new URLSearchParams()
@@ -95,137 +187,117 @@ function AdvisorContent() {
   const { data, error, isLoading, isFetching } = useQuery<AdvisorApiResponse>({
     queryKey: [apiUrl],
     queryFn: () => fetcher(apiUrl as string),
-    enabled: Boolean(apiUrl),
+    enabled: Boolean(apiUrl) && !skipFetch,
   })
+
+  const commitSql = (sql: string) => {
+    setCommitted({ mode: 'sql', sql })
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('query', sql)
+    params.delete('queryId')
+    navigate({
+      ...splitHref(`${pathname}?${params.toString()}`),
+      replace: true,
+    })
+  }
 
   const handleAnalyze = () => {
     if (mode === 'sql') {
       if (!sqlInput.trim()) return
-      setCommitted({ mode: 'sql', sql: sqlInput })
-      const params = new URLSearchParams(searchParams.toString())
-      params.set('query', sqlInput)
-      params.delete('queryId')
-      navigate({
-        ...splitHref(`${pathname}?${params.toString()}`),
-        replace: true,
-      })
-    } else {
-      if (!queryIdInput.trim()) return
-      setCommitted({ mode: 'queryId', queryId: queryIdInput })
-      const params = new URLSearchParams(searchParams.toString())
-      params.set('queryId', queryIdInput)
-      params.delete('query')
-      navigate({
-        ...splitHref(`${pathname}?${params.toString()}`),
-        replace: true,
-      })
+      commitSql(sqlInput)
+      return
     }
+    if (!queryIdInput.trim()) return
+    setCommitted({ mode: 'queryId', queryId: queryIdInput })
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('queryId', queryIdInput)
+    params.delete('query')
+    navigate({
+      ...splitHref(`${pathname}?${params.toString()}`),
+      replace: true,
+    })
   }
 
   const handlePickQuery = (sql: string) => {
     setMode('sql')
     setSqlInput(sql)
+    commitSql(sql)
   }
 
   const canAnalyze =
     mode === 'sql' ? Boolean(sqlInput.trim()) : Boolean(queryIdInput.trim())
+  const analyzing = Boolean(apiUrl) && !skipFetch && (isLoading || isFetching)
 
   return (
     <div className="flex flex-col gap-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-lg">
-            <WandSparklesIcon className="size-5" />
-            Query Advisor
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">
-            Analyze a slow query and get ranked, recommend-only optimization
-            suggestions — skip indexes, projections, partition keys, and
-            PREWHERE rewrites. Every DDL/rewrite is text to review and run
-            yourself; nothing here is ever applied automatically. Pick a query
-            from{' '}
-            <a href="/slow-queries" className="underline underline-offset-2">
-              Slow Queries
-            </a>{' '}
-            and copy its query ID, or paste SQL directly.
-          </p>
+      <p className="text-sm text-muted-foreground">
+        Ranked skip-index, projection, partition-key, and PREWHERE suggestions
+        for a slow query. Recommend-only — nothing is applied for you.
+      </p>
 
-          <Tabs
-            value={mode}
-            onValueChange={(v) => setMode(v as 'sql' | 'queryId')}
-          >
-            <div className="flex items-center justify-between gap-2">
-              <TabsList>
-                <TabsTrigger value="sql">SQL</TabsTrigger>
-                <TabsTrigger value="queryId">Query ID</TabsTrigger>
-              </TabsList>
-              <AdvisorQueryPicker onPick={handlePickQuery} />
-            </div>
+      <Tabs value={mode} onValueChange={(v) => setMode(v as 'sql' | 'queryId')}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <TabsList>
+            <TabsTrigger value="sql">SQL</TabsTrigger>
+            <TabsTrigger value="queryId">Query ID</TabsTrigger>
+          </TabsList>
+          <AdvisorQueryPicker onPick={handlePickQuery} />
+        </div>
 
-            <TabsContent value="sql" className="space-y-2 pt-2">
-              <Suspense fallback={<EditorFallback />}>
-                <SqlEditor
-                  value={sqlInput}
-                  onChange={setSqlInput}
-                  onRun={handleAnalyze}
-                  placeholder="Enter the slow SELECT query to analyze..."
-                />
-              </Suspense>
-              <p className="text-xs text-muted-foreground">
-                Press Cmd/Ctrl + Enter to analyze.
-              </p>
-            </TabsContent>
+        <TabsContent value="sql" className="space-y-2 pt-2">
+          <Suspense fallback={<EditorFallback />}>
+            <SqlEditor
+              value={sqlInput}
+              onChange={setSqlInput}
+              onRun={handleAnalyze}
+              placeholder="SELECT … FROM events WHERE …"
+            />
+          </Suspense>
+        </TabsContent>
 
-            <TabsContent value="queryId" className="space-y-2 pt-2">
-              <Label htmlFor="advisor-query-id" className="text-xs">
-                query_id from system.query_log
-              </Label>
-              <Input
-                id="advisor-query-id"
-                value={queryIdInput}
-                onChange={(e) => setQueryIdInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleAnalyze()
-                }}
-                placeholder="e.g. 5f2b1e3a-..."
-              />
-            </TabsContent>
-          </Tabs>
+        <TabsContent value="queryId" className="space-y-2 pt-2">
+          <Label htmlFor="advisor-query-id" className="text-xs">
+            query_id from system.query_log
+          </Label>
+          <Input
+            id="advisor-query-id"
+            value={queryIdInput}
+            onChange={(e) => setQueryIdInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAnalyze()
+            }}
+            placeholder="e.g. 5f2b1e3a-…"
+          />
+        </TabsContent>
+      </Tabs>
 
-          <div className="flex justify-end">
-            <Button onClick={handleAnalyze} disabled={!canAnalyze}>
-              Analyze
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          {mode === 'sql'
+            ? 'Press Cmd/Ctrl + Enter to analyze.'
+            : 'Press Enter to analyze.'}
+        </p>
+        <Button onClick={handleAnalyze} disabled={!canAnalyze || analyzing}>
+          {analyzing ? 'Analyzing…' : 'Analyze'}
+        </Button>
+      </div>
 
-      {isLoading || (isFetching && !data) ? <TableSkeleton rows={4} /> : null}
-
-      {error ? (
-        <ErrorAlert
-          title="Analysis failed"
-          message={error instanceof Error ? error.message : String(error)}
+      {committed ? (
+        <AdvisorResult
+          committed={committed}
+          data={data}
+          error={skipFetch ? undefined : error}
+          isLoading={analyzing && !data}
         />
-      ) : null}
-
-      {!isLoading && !error && data ? (
-        data.recommendations.length === 0 ? (
-          <Card>
-            <CardContent className="py-8">
-              <EmptyState
-                variant="no-data"
-                title="No recommendations"
-                description="This query looks well-tuned for the table's current schema — no skip-index, projection, partition-key, or PREWHERE opportunities were found."
-              />
-            </CardContent>
-          </Card>
-        ) : (
-          <AdvisorRecommendationsPanel output={data} />
-        )
-      ) : null}
+      ) : (
+        <div className="rounded-xl border border-dashed bg-card/40 px-6 py-10">
+          <EmptyState
+            variant="no-data"
+            title="Nothing to analyze yet"
+            description="Paste a SELECT that reads a table, pick a slow query, or look up a query_id — then press Analyze."
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/routes/api/v1/advisor.test.ts
+++ b/apps/dashboard/src/routes/api/v1/advisor.test.ts
@@ -80,12 +80,14 @@ beforeEach(() => {
 })
 
 describe('advisor route — AI-usage metering gate', () => {
+  const ANALYZABLE_SQL = "SELECT * FROM events WHERE status = 'error'"
+
   test('over the daily allowance: 402, releases the reservation, never runs the engine', async () => {
     // free plan: aiRequestsPerDay = 5, hard cap (aiOverage: null). A
     // post-increment count of 6 means this would be the 6th request today.
     reserveAiUsage = mock(async () => 6)
 
-    const res = await runAdvisor(0, 'SELECT 1', null, null)
+    const res = await runAdvisor(0, ANALYZABLE_SQL, null, null)
 
     expect(res.status).toBe(402)
     const body = (await res.json()) as { success: boolean; error: string }
@@ -100,7 +102,7 @@ describe('advisor route — AI-usage metering gate', () => {
   test('within the allowance: runs the engine, does not release the reservation', async () => {
     reserveAiUsage = mock(async () => 3)
 
-    const res = await runAdvisor(0, 'SELECT 1', null, null)
+    const res = await runAdvisor(0, ANALYZABLE_SQL, null, null)
 
     expect(res.status).toBe(200)
     const body = (await res.json()) as { success: boolean }
@@ -115,7 +117,7 @@ describe('advisor route — AI-usage metering gate', () => {
       throw new Error('ClickHouse unreachable')
     })
 
-    const res = await runAdvisor(0, 'SELECT 1', null, null)
+    const res = await runAdvisor(0, ANALYZABLE_SQL, null, null)
 
     expect(res.status).toBe(500)
     const body = (await res.json()) as { success: boolean; error: string }
@@ -129,7 +131,7 @@ describe('advisor route — AI-usage metering gate', () => {
       throw new Error('Authentication is required for billing.')
     })
 
-    const res = await runAdvisor(0, 'SELECT 1', null, null)
+    const res = await runAdvisor(0, ANALYZABLE_SQL, null, null)
 
     expect(res.status).toBe(200)
     expect(reserveAiUsage).not.toHaveBeenCalled()
@@ -140,10 +142,27 @@ describe('advisor route — AI-usage metering gate', () => {
   test('enterprise-style unlimited plan (aiRequestsPerDay: null): never reserves, never blocks', async () => {
     getPlanForOwner = mock(async () => getPlan('enterprise'))
 
-    const res = await runAdvisor(0, 'SELECT 1', null, null)
+    const res = await runAdvisor(0, ANALYZABLE_SQL, null, null)
 
     expect(res.status).toBe(200)
     expect(reserveAiUsage).not.toHaveBeenCalled()
     expect(analyzeQuery).toHaveBeenCalledTimes(1)
+  })
+
+  test('table-less SQL is 400 and never meters or runs the engine', async () => {
+    const res = await runAdvisor(0, 'select 1', null, null)
+
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as {
+      success: boolean
+      code?: string
+      error: string
+    }
+    expect(body.success).toBe(false)
+    expect(body.code).toBe('no_target_table')
+    expect(body.error).toContain('FROM')
+    expect(reserveAiUsage).not.toHaveBeenCalled()
+    expect(analyzeQuery).not.toHaveBeenCalled()
+    expect(releaseAiUsage).not.toHaveBeenCalled()
   })
 })

--- a/apps/dashboard/src/routes/api/v1/advisor.ts
+++ b/apps/dashboard/src/routes/api/v1/advisor.ts
@@ -20,6 +20,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 
 import { env } from 'cloudflare:workers'
+import { findAdvisorTargetTable } from '@chm/query-advisor-core'
+import { validateSqlQuery } from '@chm/sql-builder'
 import { bridgeClickHouseEnv } from '@/lib/api/server-env'
 import {
   demoHiddenUnavailable,
@@ -116,6 +118,7 @@ async function runAdvisor(
     return Response.json(
       {
         success: false,
+        code: 'missing_input',
         error: 'Provide either `sql` or `queryId`.',
         ...ROUTE_CONTEXT,
       },
@@ -155,6 +158,36 @@ async function runAdvisor(
     )
   }
 
+  // Cheap local checks before burning an AI-request unit: `SELECT 1` and
+  // other table-less queries are user-input issues, not analysis.
+  if (sql && sql.trim() !== '') {
+    try {
+      validateSqlQuery(sql)
+    } catch (err) {
+      return Response.json(
+        {
+          success: false,
+          code: 'invalid_sql',
+          error: `Query failed validation: ${err instanceof Error ? err.message : String(err)}`,
+          ...ROUTE_CONTEXT,
+        },
+        { status: 400 }
+      )
+    }
+    const target = findAdvisorTargetTable(sql, database ?? 'default')
+    if (!target.ok) {
+      return Response.json(
+        {
+          success: false,
+          code: target.code,
+          error: target.error,
+          ...ROUTE_CONTEXT,
+        },
+        { status: 400 }
+      )
+    }
+  }
+
   const { ownerId, reserved, blocked } = await reserveAdvisorUsage()
   if (blocked) {
     return Response.json(
@@ -186,7 +219,12 @@ async function runAdvisor(
     if (!result.ok) {
       if (reserved) await releaseAdvisorUsage(ownerId)
       return Response.json(
-        { success: false, error: result.error, ...ROUTE_CONTEXT },
+        {
+          success: false,
+          error: result.error,
+          code: result.code,
+          ...ROUTE_CONTEXT,
+        },
         { status: 400 }
       )
     }

--- a/docs/content/guide/guides/dba-workflows.mdx
+++ b/docs/content/guide/guides/dba-workflows.mdx
@@ -33,9 +33,12 @@ Open **Tools → Schema Compare**. Pick a source and target host (or two nodes o
 
 ### Advisor (`/advisor`)
 
-Open **Queries → Advisor**. Two tabs:
+Open **Tools → Advisor**. Two tabs:
 
-- **Query Advisor** — paste SQL or look up a `query_id` from `system.query_log`.
+- **Query Advisor** — paste a `SELECT` that reads a table, pick a slow query
+  (loads it and runs analysis), or look up a `query_id` from `system.query_log`.
+  Table-less SQL such as `SELECT 1` is explained as "needs a table", not treated
+  as a failed analysis.
 - **Schema & Settings** — scan a database or table for lint findings.
 
 The same recommend-only engine is available from the [AI agent](/guide/ai-agent) and the MCP server. There is no Apply button.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -300,6 +300,12 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   chart failure automatically gets the matching illustration. Table query
   failures (`TableClient`) use the full EmptyState, not `compact`, so timeout
   and missing-column copy stays visible.
+- **Interactive tool pages** (Explain, Advisor): before the first run, a
+  dashed-border `EmptyState variant="no-data"` ("Nothing to analyze/explain
+  yet"). User-input issues — table-less SQL like `SELECT 1`, a missing
+  `query_id` — use the same EmptyState with next steps, never `ErrorAlert`
+  titled "Analysis failed". `ErrorAlert` is for host/schema/fetch failures.
+  Picking a query from the picker auto-runs, same as `/explain`.
 - **Illustrations:** bespoke, theme-aware, token-driven, motion-safe inline SVGs
   in `components/illustrations/` — prefer over a lone lucide glyph for
   high-impact moments. `WelcomeIllustration` (first-run hero),

--- a/packages/mcp-server/src/tools/advisor/index.ts
+++ b/packages/mcp-server/src/tools/advisor/index.ts
@@ -24,6 +24,7 @@
 import { z } from 'zod'
 
 import type {
+  AdvisorErrorCode,
   PartsStats,
   Recommendation,
   TableSchema,
@@ -47,6 +48,7 @@ import {
   buildPrewhereRecommendation,
   buildQueryContext,
   extractReferencedTables,
+  findAdvisorTargetTable,
   proposePrewhereRewrite,
   rankRecommendations,
   scorePartitionKey,
@@ -63,6 +65,7 @@ interface AnalyzeQueryResult {
   recommendations?: Recommendation[]
   notes?: string[]
   error?: string
+  code?: AdvisorErrorCode
 }
 
 async function analyzeQuery(params: {
@@ -86,8 +89,9 @@ async function analyzeQuery(params: {
   if (!sql) {
     return {
       ok: false,
+      code: params.queryId ? 'query_not_found' : 'missing_input',
       error: params.queryId
-        ? `No finished query found in system.query_log for query_id "${params.queryId}".`
+        ? `No finished query found in system.query_log for query_id "${params.queryId}". Paste the SQL, or pick a query from history.`
         : 'Provide either `sql` or `queryId`.',
     }
   }
@@ -97,19 +101,15 @@ async function analyzeQuery(params: {
   } catch (err) {
     return {
       ok: false,
+      code: 'invalid_sql',
       error: `Query failed validation: ${err instanceof Error ? err.message : String(err)}`,
     }
   }
 
+  const targetResult = findAdvisorTargetTable(sql, database)
+  if (!targetResult.ok) return targetResult
+  const target = targetResult.table
   const referencedTables = extractReferencedTables(sql, database)
-  const target = referencedTables[0]
-  if (!target) {
-    return {
-      ok: false,
-      error:
-        'Could not identify a target table in the query (no FROM/JOIN found).',
-    }
-  }
   if (referencedTables.length > 1) {
     notes.push(
       `Query references ${referencedTables.length} tables; only \`${target.qualifiedName}\` (the first) was analyzed.`

--- a/packages/query-advisor-core/src/advisor-errors.test.ts
+++ b/packages/query-advisor-core/src/advisor-errors.test.ts
@@ -1,0 +1,45 @@
+import {
+  ADVISOR_NO_TARGET_TABLE_MESSAGE,
+  findAdvisorTargetTable,
+  isAdvisorUserInputError,
+} from './advisor-errors'
+import { describe, expect, test } from 'bun:test'
+
+describe('findAdvisorTargetTable', () => {
+  test('SELECT 1 has no target table', () => {
+    const result = findAdvisorTargetTable('select 1')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.code).toBe('no_target_table')
+      expect(result.error).toBe(ADVISOR_NO_TARGET_TABLE_MESSAGE)
+    }
+  })
+
+  test('SELECT now() has no target table', () => {
+    const result = findAdvisorTargetTable('SELECT now()')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.code).toBe('no_target_table')
+  })
+
+  test('SELECT with FROM returns the table', () => {
+    const result = findAdvisorTargetTable(
+      "SELECT * FROM events WHERE status = 'error'",
+      'default'
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.table.qualifiedName).toBe('default.events')
+    }
+  })
+})
+
+describe('isAdvisorUserInputError', () => {
+  test('classifies input issues vs schema failures', () => {
+    expect(isAdvisorUserInputError('no_target_table')).toBe(true)
+    expect(isAdvisorUserInputError('query_not_found')).toBe(true)
+    expect(isAdvisorUserInputError('invalid_sql')).toBe(true)
+    expect(isAdvisorUserInputError('missing_input')).toBe(true)
+    expect(isAdvisorUserInputError('schema_unavailable')).toBe(false)
+    expect(isAdvisorUserInputError(undefined)).toBe(false)
+  })
+})

--- a/packages/query-advisor-core/src/advisor-errors.ts
+++ b/packages/query-advisor-core/src/advisor-errors.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared advisor input errors — used by the dashboard engine, `/api/v1/advisor`,
+ * and the MCP tool so all three surfaces classify the same "cannot analyze"
+ * cases the same way (no FROM/JOIN, missing input, unresolved query_id).
+ *
+ * Pure: no I/O. Callers still run `validateSqlQuery` themselves (that lives
+ * in `@chm/sql-builder`).
+ */
+
+import type { ReferencedTable } from './types'
+
+import { extractReferencedTables } from './sql-parsing'
+
+export const ADVISOR_ERROR_CODES = [
+  'missing_input',
+  'invalid_sql',
+  'no_target_table',
+  'query_not_found',
+  'schema_unavailable',
+] as const
+
+export type AdvisorErrorCode = (typeof ADVISOR_ERROR_CODES)[number]
+
+export const ADVISOR_NO_TARGET_TABLE_MESSAGE =
+  'This query does not read a table. Paste a SELECT with FROM, or pick a slow query, so the advisor can suggest skip indexes, projections, and PREWHERE.'
+
+export interface AdvisorInputError {
+  ok: false
+  code: AdvisorErrorCode
+  error: string
+}
+
+export interface AdvisorTargetTableOk {
+  ok: true
+  table: ReferencedTable
+}
+
+export type AdvisorTargetTableResult = AdvisorTargetTableOk | AdvisorInputError
+
+/**
+ * User-input issues the UI should explain with EmptyState + next steps.
+ * Schema/host failures stay on ErrorAlert.
+ */
+export function isAdvisorUserInputError(
+  code: string | undefined
+): code is Exclude<AdvisorErrorCode, 'schema_unavailable'> {
+  return (
+    code === 'missing_input' ||
+    code === 'invalid_sql' ||
+    code === 'no_target_table' ||
+    code === 'query_not_found'
+  )
+}
+
+export function advisorNoTargetTableError(): AdvisorInputError {
+  return {
+    ok: false,
+    code: 'no_target_table',
+    error: ADVISOR_NO_TARGET_TABLE_MESSAGE,
+  }
+}
+
+/**
+ * Find the first real FROM/JOIN table. Queries like `SELECT 1` fail closed
+ * with `no_target_table` instead of proceeding to schema lookup.
+ */
+export function findAdvisorTargetTable(
+  sql: string,
+  defaultDatabase = 'default'
+): AdvisorTargetTableResult {
+  const table = extractReferencedTables(sql, defaultDatabase)[0]
+  if (!table) return advisorNoTargetTableError()
+  return { ok: true, table }
+}

--- a/packages/query-advisor-core/src/index.ts
+++ b/packages/query-advisor-core/src/index.ts
@@ -20,10 +20,22 @@
  * Layers:
  *  - `types.ts` — the shared vocabulary (`QueryContext`, `Recommendation`, …).
  *  - `sql-parsing.ts` — hand-rolled, best-effort SQL/EXPLAIN parsing.
+ *  - `advisor-errors.ts` — shared no-table / missing-input classification.
  *  - `scorers.ts` — the pure scoring rules + ranking.
  *  - `impact.ts` — estimate math and the honest estimate summaries.
  */
 
+export {
+  ADVISOR_ERROR_CODES,
+  ADVISOR_NO_TARGET_TABLE_MESSAGE,
+  type AdvisorErrorCode,
+  type AdvisorInputError,
+  type AdvisorTargetTableOk,
+  type AdvisorTargetTableResult,
+  advisorNoTargetTableError,
+  findAdvisorTargetTable,
+  isAdvisorUserInputError,
+} from './advisor-errors'
 export {
   estimateBytesSaved,
   formatBytes,

--- a/packages/query-advisor-core/src/recommend-only.test.ts
+++ b/packages/query-advisor-core/src/recommend-only.test.ts
@@ -17,6 +17,7 @@ const SOURCE_FILES = [
   'index.ts',
   'types.ts',
   'sql-parsing.ts',
+  'advisor-errors.ts',
   'scorers.ts',
   'impact.ts',
 ]

--- a/packages/query-advisor-core/src/sql-parsing.test.ts
+++ b/packages/query-advisor-core/src/sql-parsing.test.ts
@@ -153,6 +153,11 @@ describe('parseExplainIndexes', () => {
 })
 
 describe('extractReferencedTables', () => {
+  test('SELECT 1 reports no tables', () => {
+    expect(extractReferencedTables('select 1')).toEqual([])
+    expect(extractReferencedTables('SELECT now()')).toEqual([])
+  })
+
   test('JOIN across two databases returns both qualified tables', () => {
     const sql =
       'SELECT * FROM db1.events e JOIN db2.users u ON e.user_id = u.id'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`SELECT 1` (and any query with no `FROM`/`JOIN`) was shown as **Analysis failed** with a parser-style message. The advisor needs a table to score skip indexes, projections, and PREWHERE — that is a guided empty state, not a crash.

## Changes

- Classify table-less SQL as `no_target_table` in `@chm/query-advisor-core` (shared by the dashboard engine, `/api/v1/advisor`, and MCP)
- Preflight that check **before** AI-usage metering so `SELECT 1` does not consume a daily AI request
- Match `/explain` UX: shorter copy, no nested title card, idle “Nothing to analyze yet”, user-input EmptyState instead of ErrorAlert
- Pick-a-query now loads SQL **and** runs analysis
- Quieter recommendations header; Schema & Settings idle empty

## Test plan

- [x] Unit tests: `SELECT 1` is `no_target_table`, no schema lookup, no metering
- [x] Advisor metering tests use a real `FROM` query; new table-less case
- [x] Biome check on changed files
- [ ] CI `unit-tests` + `dashboard`

## Notes for reviewer

Recommend-only is unchanged — still no Apply. Host/schema failures still use ErrorAlert.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-948c54f4-1264-4dc9-9a8d-1f2fff7035ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-948c54f4-1264-4dc9-9a8d-1f2fff7035ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

