### PR TITLE
fix(cli): rank chm-v* tags by semver and polish upgrade UX

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -58,7 +58,7 @@ Releases — no re-running the install script, and they never invoke `sudo`:
 chm upgrade           # alias of update — download + verify + replace
 chm update            # same behaviour
 chm update --check    # only report whether a newer release exists (exit 1 if so)
-chm upgrade --version chm-v0.2.0   # pin a specific release
+chm upgrade --version chm-v0.2.0   # pin a specific release (`0.2.0` / `v0.2.0` also work)
 ```
 
 The command downloads the binary for your platform plus its `.sha256`, verifies

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -114,9 +114,12 @@ curl -X POST http://localhost:3000/api/v1/auth/api-key \
 `--version` flags, same `cli_run`/`update` telemetry). Both print
 current -> target version, download the matching `chm-<target>` GitHub Release
 asset, require a matching `.sha256`, and atomically replace the running
-binary. They never invoke sudo. Checksum, permission, and unsupported-target
-failures print a copy-pasteable fallback (`scripts/install.sh` or
-`cargo install ch-monitor-cli --force`). Implementation: `src/update.rs`.
+binary. They never invoke sudo. Checksum, permission, download, and
+unsupported-target failures print a copy-pasteable fallback (`scripts/install.sh`
+or `cargo install ch-monitor-cli --force`; unsupported targets point at cargo
+only). `--version` accepts `chm-v0.2.0`, `v0.2.0`, `0.2.0`, or `chm-0.2.0`.
+Implementation: `src/update.rs`. Latest-tag lookup pages past dashboard/Helm
+releases and ranks published `chm-v*` tags by semver.
 
 ```bash
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
@@ -142,9 +145,10 @@ curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/ins
 - Detects OS (`Linux`/`Darwin`) + arch (`x86_64`/`aarch64`), maps to the
   release workflow's target triples, and refuses to run on anything else
   (no silent wrong-arch installs).
-- Resolves the latest `chm-v*` release via the GitHub releases API (not the
-  repo's overall "latest" release — that's dashboard/Helm releases); pin a
-  specific one with `CHM_VERSION=chm-vX.Y.Z`.
+- Resolves the latest **published** `chm-v*` release via the GitHub releases
+  API, ranking by semver (not first-match / created_at) and skipping
+  drafts/prereleases. Dashboard/Helm tags share this API. Pin a specific
+  release with `CHM_VERSION=chm-vX.Y.Z` (`vX.Y.Z` / `X.Y.Z` also work).
 - Downloads the binary + its `.sha256` asset and verifies the checksum before
   installing; a missing or mismatched checksum is fatal (never installs an
   unverified binary). Fails loud (`set -euo pipefail`) on any

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -43,7 +43,7 @@ print a copy-pasteable fallback (`scripts/install.sh` or
 chm upgrade                      # alias of update — install the latest chm-v* release
 chm update                       # same behaviour
 chm update --check               # only report if a newer release exists (exit 1 if so)
-chm upgrade --version chm-v0.2.0 # pin a specific release
+chm upgrade --version chm-v0.2.0 # pin a specific release (`0.2.0` / `v0.2.0` also work)
 ```
 
 After a `chm diagnose` run, a one-line "update available" hint is printed to

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -34,15 +34,23 @@ struct FileConfig {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "chm", version, about = "chmonitor CLI")]
+#[command(
+    name = "chm",
+    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
+    about = "chmonitor CLI — dashboard API, TUI, and zero-signup diagnostics"
+)]
 struct Cli {
-    #[arg(long, env = "CHM_CONFIG")]
+    /// Path to config.toml (default ~/.config/chm/config.toml)
+    #[arg(long, env = "CHM_CONFIG", global = true)]
     config: Option<PathBuf>,
-    #[arg(long, env = "CHM_BASE_URL")]
+    /// Dashboard base URL (default http://localhost:3000)
+    #[arg(long, env = "CHM_BASE_URL", global = true)]
     base_url: Option<String>,
-    #[arg(long, env = "CHM_HOST_ID")]
+    /// Dashboard host id (default 0)
+    #[arg(long, env = "CHM_HOST_ID", global = true)]
     host_id: Option<u32>,
-    #[arg(long, env = "CHM_API_KEY")]
+    /// Dashboard API key (sent as x-api-key)
+    #[arg(long, env = "CHM_API_KEY", global = true)]
     api_key: Option<String>,
     #[command(subcommand)]
     command: Commands,
@@ -50,18 +58,27 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// List hosts from a running chmonitor dashboard
     Hosts,
+    /// Fetch a named chart from the dashboard API
     Chart {
+        /// Chart name, e.g. query-count
         name: String,
+        /// Max rows to print
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
+    /// Fetch a named table from the dashboard API
     Table {
+        /// Table name, e.g. running-queries
         name: String,
+        /// Max rows to print
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
+    /// Live terminal UI for a dashboard chart
     Tui {
+        /// Chart name (default: config `default_chart`, else query-count)
         chart: Option<String>,
     },
     /// Zero-signup local diagnostics: connect directly to a ClickHouse host
@@ -149,13 +166,55 @@ fn resolve_config(cli: &Cli) -> Result<AppConfig> {
     })
 }
 
+fn api_error_hint(status: u16) -> &'static str {
+    match status {
+        401 | 403 => " Check --api-key / CHM_API_KEY.",
+        404 => " Check the chart/table name and --host-id.",
+        _ => "",
+    }
+}
+
+fn truncate_body(s: &str, max_chars: usize) -> Option<String> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut iter = s.chars();
+    let head: String = iter.by_ref().take(max_chars).collect();
+    if iter.next().is_some() {
+        Some(format!("{head}…"))
+    } else {
+        Some(head)
+    }
+}
+
 async fn fetch(client: &Client, url: String, api_key: Option<&str>) -> Result<Value> {
-    let mut req = client.get(url);
+    let mut req = client.get(&url);
     if let Some(k) = api_key {
         req = req.header("x-api-key", k);
     }
-    let resp = req.send().await?.error_for_status()?;
-    let parsed: ApiResponse = resp.json().await?;
+    let resp = match req.send().await {
+        Ok(resp) => resp,
+        Err(err) => {
+            bail!(
+                "failed to reach chmonitor API at {url}: {err}\n\
+                 Is the dashboard running? Set --base-url / CHM_BASE_URL \
+                 (default http://localhost:3000)."
+            );
+        }
+    };
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        let hint = api_error_hint(status.as_u16());
+        let extra = match truncate_body(text.trim(), 200) {
+            None => String::new(),
+            Some(body) => format!(" {body}"),
+        };
+        bail!("chmonitor API returned HTTP {status} for {url}.{hint}{extra}");
+    }
+    let parsed: ApiResponse = serde_json::from_str(&text).with_context(|| {
+        format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})")
+    })?;
     Ok(parsed.data)
 }
 
@@ -282,6 +341,13 @@ mod tests {
             assert!(!args.check);
             assert_eq!(args.version.as_deref(), Some("chm-v0.2.0"));
         }
+        for argv in [
+            ["chm", "update", "--version", "0.2.0"],
+            ["chm", "upgrade", "--version", "0.2.0"],
+        ] {
+            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
+            assert_eq!(args.version.as_deref(), Some("0.2.0"));
+        }
     }
 
     #[test]
@@ -290,6 +356,59 @@ mod tests {
         let help = cmd.render_long_help().to_string();
         assert!(help.contains("update"), "{help}");
         assert!(help.contains("upgrade"), "{help}");
+    }
+
+    #[test]
+    fn dashboard_flags_are_accepted_after_subcommand() {
+        let cli = Cli::try_parse_from([
+            "chm",
+            "hosts",
+            "--base-url",
+            "http://127.0.0.1:3000",
+            "--host-id",
+            "2",
+        ])
+        .expect("global flags after subcommand");
+        assert_eq!(cli.base_url.as_deref(), Some("http://127.0.0.1:3000"));
+        assert_eq!(cli.host_id, Some(2));
+        assert!(matches!(cli.command, Commands::Hosts));
+    }
+
+    #[test]
+    fn version_output_includes_pkg_version_and_target() {
+        let cmd = Cli::command();
+        let version = cmd.get_version().expect("version");
+        assert!(version.contains(env!("CARGO_PKG_VERSION")), "{version}");
+        assert!(
+            version.contains(env!("CHM_TARGET")),
+            "expected compile-time target in version, got {version}"
+        );
+    }
+
+    #[test]
+    fn help_describes_core_commands() {
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(help.contains("List hosts"), "{help}");
+        assert!(help.contains("named chart"), "{help}");
+        assert!(help.contains("named table"), "{help}");
+        assert!(help.contains("zero-signup"), "{help}");
+        assert!(help.contains("--base-url"), "{help}");
+    }
+
+    #[test]
+    fn api_error_hint_covers_auth_and_missing() {
+        assert!(api_error_hint(401).contains("CHM_API_KEY"));
+        assert!(api_error_hint(403).contains("CHM_API_KEY"));
+        assert!(api_error_hint(404).contains("host-id"));
+        assert_eq!(api_error_hint(500), "");
+    }
+
+    #[test]
+    fn truncate_body_is_char_safe() {
+        assert_eq!(truncate_body("", 8), None);
+        assert_eq!(truncate_body("hello", 8).as_deref(), Some("hello"));
+        assert_eq!(truncate_body("éééé", 2).as_deref(), Some("éé…"));
     }
 
     #[test]
@@ -315,6 +434,9 @@ mod tests {
 }
 
 fn print_records(data: &[HashMap<String, Value>], limit: usize) {
+    if data.is_empty() {
+        return;
+    }
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
     if let Some(first) = data.first() {
@@ -450,31 +572,43 @@ async fn main() -> Result<()> {
     match cli.command {
         Commands::Hosts => {
             let url = format!("{}/api/v1/hosts", cfg.base_url);
-            let data = fetch(&client, url, cfg.api_key.as_deref()).await?;
+            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
             let hosts: Vec<HashMap<String, Value>> =
                 serde_json::from_value(data).context("hosts payload parse failed")?;
-            print_records(&hosts, 100);
+            if hosts.is_empty() {
+                eprintln!("no hosts returned from {url}");
+            } else {
+                print_records(&hosts, 100);
+            }
         }
         Commands::Chart { name, limit } => {
             let url = format!(
                 "{}/api/v1/charts/{}?hostId={}",
                 cfg.base_url, name, cfg.host_id
             );
-            let data = fetch(&client, url, cfg.api_key.as_deref()).await?;
+            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
             let data = Value::Array(rows_from_chart_data(data)?);
             let rows: Vec<HashMap<String, Value>> =
                 serde_json::from_value(data).context("chart payload parse failed")?;
-            print_records(&rows, limit);
+            if rows.is_empty() {
+                eprintln!("no rows returned from {url}");
+            } else {
+                print_records(&rows, limit);
+            }
         }
         Commands::Table { name, limit } => {
             let url = format!(
                 "{}/api/v1/tables/{}?hostId={}&pageSize={}",
                 cfg.base_url, name, cfg.host_id, limit
             );
-            let data = fetch(&client, url, cfg.api_key.as_deref()).await?;
+            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
             let rows: Vec<HashMap<String, Value>> =
                 serde_json::from_value(data).context("table payload parse failed")?;
-            print_records(&rows, limit);
+            if rows.is_empty() {
+                eprintln!("no rows returned from {url}");
+            } else {
+                print_records(&rows, limit);
+            }
         }
         Commands::Tui { chart } => {
             let c = chart.unwrap_or(cfg.default_chart.clone());
@@ -540,6 +674,7 @@ async fn main() -> Result<()> {
             if args.check {
                 let available = update::check(&client).await?;
                 if available {
+                    telemetry::finish(tel_handle).await;
                     std::process::exit(1);
                 }
             } else {

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -12,12 +12,16 @@ use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases?per_page=100";
+const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases";
 const RELEASE_DOWNLOAD: &str = "https://github.com/chmonitor/chmonitor/releases/download";
 const USER_AGENT: &str = concat!("chm-cli/", env!("CARGO_PKG_VERSION"));
 const INSTALL_SH: &str =
     "curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash";
 const CARGO_INSTALL: &str = "cargo install ch-monitor-cli --force";
+/// GitHub's default page size is 30; this repo also ships dashboard/Helm releases.
+const RELEASES_PER_PAGE: u32 = 100;
+/// Safety cap so a huge releases list cannot loop forever.
+const RELEASES_MAX_PAGES: u32 = 5;
 
 /// Compile-time target triple, injected by `build.rs`.
 const TARGET: &str = env!("CHM_TARGET");
@@ -70,12 +74,29 @@ fn newest_chm_tag(releases: &[Release]) -> Option<String> {
         .map(|(_, tag)| tag)
 }
 
+/// Normalize a user-supplied pin (`chm-v0.2.0`, `v0.2.0`, `0.2.0`, `chm-0.2.0`)
+/// into the GitHub release tag `chm-vX.Y.Z`.
+fn normalize_release_tag(tag: &str) -> String {
+    let t = tag.trim();
+    let rest = t
+        .strip_prefix("chm-v")
+        .or_else(|| t.strip_prefix("chm-"))
+        .or_else(|| t.strip_prefix('v'))
+        .unwrap_or(t)
+        .trim_start_matches('v');
+    format!("chm-v{rest}")
+}
+
 /// Copy-pasteable recovery when self-update cannot finish. Never includes a
 /// `sudo ` command — this path does not escalate privileges.
 fn fallback_block() -> String {
     format!(
         "This command never invokes sudo. Copy-paste a fallback:\n  {INSTALL_SH}\n\nor:\n  {CARGO_INSTALL}"
     )
+}
+
+fn with_fallback(detail: impl std::fmt::Display) -> anyhow::Error {
+    anyhow!("{detail}\n{}", fallback_block())
 }
 
 fn unsupported_target_error(target: &str) -> anyhow::Error {
@@ -87,25 +108,46 @@ fn unsupported_target_error(target: &str) -> anyhow::Error {
 }
 
 fn checksum_failure(detail: &str) -> anyhow::Error {
-    anyhow!("{detail}\n{}", fallback_block())
+    with_fallback(detail)
+}
+
+/// Fetch published GitHub releases, paging past dashboard/Helm tags.
+async fn fetch_releases(client: &Client, max_pages: u32) -> Result<Vec<Release>> {
+    let mut all = Vec::new();
+    for page in 1..=max_pages.max(1) {
+        let url = format!("{RELEASES_API}?per_page={RELEASES_PER_PAGE}&page={page}");
+        let batch: Vec<Release> = client
+            .get(&url)
+            .header("User-Agent", USER_AGENT)
+            .header("Accept", "application/vnd.github+json")
+            .send()
+            .await
+            .map_err(|e| with_fallback(format!("failed to reach GitHub releases API: {e}")))?
+            .error_for_status()
+            .map_err(|e| {
+                with_fallback(format!("GitHub releases API returned an error status: {e}"))
+            })?
+            .json()
+            .await
+            .map_err(|e| with_fallback(format!("failed to parse GitHub releases JSON: {e}")))?;
+        let n = batch.len();
+        all.extend(batch);
+        if n < RELEASES_PER_PAGE as usize {
+            break;
+        }
+    }
+    Ok(all)
 }
 
 /// Fetch the newest published `chm-v*` release tag.
 async fn latest_tag(client: &Client) -> Result<String> {
-    let releases: Vec<Release> = client
-        .get(RELEASES_API)
-        .header("User-Agent", USER_AGENT)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-        .context("failed to reach GitHub releases API")?
-        .error_for_status()
-        .context("GitHub releases API returned an error status")?
-        .json()
-        .await
-        .context("failed to parse GitHub releases JSON")?;
-    newest_chm_tag(&releases)
-        .ok_or_else(|| anyhow!("no chm-v* release found — has the CLI been released yet?"))
+    let releases = fetch_releases(client, RELEASES_MAX_PAGES).await?;
+    newest_chm_tag(&releases).ok_or_else(|| {
+        with_fallback(
+            "no published chm-v* release found — pin one with --version chm-vX.Y.Z, \
+             or has the CLI been released yet?",
+        )
+    })
 }
 
 fn current_version() -> Version {
@@ -144,16 +186,8 @@ pub async fn hint(client: &Client) {
         return;
     }
     let fut = async {
-        let releases: Vec<Release> = client
-            .get(RELEASES_API)
-            .header("User-Agent", USER_AGENT)
-            .header("Accept", "application/vnd.github+json")
-            .send()
-            .await
-            .ok()?
-            .json()
-            .await
-            .ok()?;
+        // One page is enough for a best-effort hint (sub-second timeout).
+        let releases = fetch_releases(client, 1).await.ok()?;
         let tag = newest_chm_tag(&releases)?;
         let latest = parse_version(&tag)?;
         if latest > current_version() {
@@ -176,13 +210,7 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
     let current = current_version();
 
     let target_tag = match pinned {
-        Some(tag) => {
-            if tag.starts_with("chm-v") {
-                tag
-            } else {
-                format!("chm-v{}", tag.trim_start_matches('v'))
-            }
-        }
+        Some(tag) => normalize_release_tag(&tag),
         None => latest_tag(client).await?,
     };
     let target_version = parse_version(&target_tag)
@@ -205,14 +233,16 @@ pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
         .header("User-Agent", USER_AGENT)
         .send()
         .await
-        .with_context(|| format!("failed to download {bin_url}"))?
+        .map_err(|e| with_fallback(format!("failed to download {bin_url}: {e}")))?
         .error_for_status()
-        .with_context(|| {
-            format!("no release asset at {bin_url} — is {TARGET} published for {target_tag}?")
+        .map_err(|_| {
+            with_fallback(format!(
+                "no release asset at {bin_url} — is {TARGET} published for {target_tag}?"
+            ))
         })?
         .bytes()
         .await
-        .context("failed to read downloaded binary")?;
+        .map_err(|e| with_fallback(format!("failed to read downloaded binary: {e}")))?;
 
     // Checksum verification is mandatory: abort on a missing or mismatched sum.
     let sha_text = match client
@@ -350,6 +380,24 @@ mod tests {
     }
 
     #[test]
+    fn normalize_release_tag_accepts_common_pins() {
+        assert_eq!(normalize_release_tag("chm-v0.2.0"), "chm-v0.2.0");
+        assert_eq!(normalize_release_tag("v0.2.0"), "chm-v0.2.0");
+        assert_eq!(normalize_release_tag("0.2.0"), "chm-v0.2.0");
+        assert_eq!(normalize_release_tag("chm-0.2.0"), "chm-v0.2.0");
+        assert_eq!(normalize_release_tag("  chm-v0.1.1  "), "chm-v0.1.1");
+    }
+
+    #[test]
+    fn newest_tag_picks_semver_not_list_order() {
+        // install.sh used to take the first chm-v* grep match (GitHub created_at
+        // order, including drafts). Self-update must rank published tags by semver.
+        let json = r#"[{"tag_name":"chm-v0.1.0","prerelease":false,"draft":true},{"tag_name":"v0.3.3","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false}]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(newest_chm_tag(&releases).as_deref(), Some("chm-v0.1.1"));
+    }
+
+    #[test]
     fn semver_ordering() {
         assert!(parse_version("chm-v0.2.0") > parse_version("chm-v0.1.9"));
         assert!(parse_version("chm-v1.0.0") > parse_version("chm-v0.99.99"));
@@ -430,10 +478,21 @@ mod tests {
     }
 
     #[test]
+    fn download_failure_includes_fallback() {
+        let msg = with_fallback("no release asset at https://example/chm-x").to_string();
+        assert!(msg.contains("no release asset"), "{msg}");
+        assert_copy_pasteable_fallback(&msg);
+    }
+
+    #[test]
     fn unsupported_target_points_at_cargo() {
         let msg = unsupported_target_error("wasm32-unknown-unknown").to_string();
         assert!(msg.contains("wasm32-unknown-unknown"), "{msg}");
         assert!(msg.contains("cargo install ch-monitor-cli"), "{msg}");
+        assert!(
+            !msg.contains("install.sh"),
+            "unsupported-target fallback must not point at install.sh: {msg}"
+        );
         assert!(
             !msg.contains("sudo "),
             "unsupported-target fallback must not suggest a sudo command: {msg}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,6 +40,95 @@ need_cmd curl
 need_cmd uname
 need_cmd mktemp
 
+# Normalize a pin (chm-v0.2.0 / v0.2.0 / 0.2.0 / chm-0.2.0) to chm-vX.Y.Z.
+normalize_chm_tag() {
+  rest="$1"
+  rest="${rest#chm-v}"
+  rest="${rest#chm-}"
+  rest="${rest#v}"
+  printf 'chm-v%s\n' "$rest"
+}
+
+# True when $1 (x.y.z) is strictly greater than $2.
+semver_gt() {
+  IFS=. read -r a1 a2 a3 _ <<EOF
+${1}
+EOF
+  IFS=. read -r b1 b2 b3 _ <<EOF
+${2}
+EOF
+  a1="${a1:-0}"; a2="${a2:-0}"; a3="${a3:-0}"
+  b1="${b1:-0}"; b2="${b2:-0}"; b3="${b3:-0}"
+  case "$a1$a2$a3$b1$b2$b3" in
+    *[!0-9]*) return 1 ;;
+  esac
+  if [ "$a1" -gt "$b1" ]; then return 0; fi
+  if [ "$a1" -lt "$b1" ]; then return 1; fi
+  if [ "$a2" -gt "$b2" ]; then return 0; fi
+  if [ "$a2" -lt "$b2" ]; then return 1; fi
+  [ "$a3" -gt "$b3" ]
+}
+
+# Newest published chm-v* tag from GitHub releases JSON (skip drafts/prereleases).
+# Ranks by semver, not list order — dashboard/Helm releases share this API.
+pick_newest_chm_tag() {
+  json="$1"
+  best_tag=""
+  best_ver="0.0.0"
+  cur_tag=""
+  cur_draft=""
+  cur_pre=""
+
+  consider_tag() {
+    tag="$1"
+    draft="$2"
+    pre="$3"
+    case "$tag" in
+      chm-v*) ;;
+      *) return 0 ;;
+    esac
+    if [ "$draft" = "true" ] || [ "$pre" = "true" ]; then
+      return 0
+    fi
+    ver="${tag#chm-v}"
+    case "$ver" in
+      *-*) return 0 ;;
+    esac
+    if [ -z "$best_tag" ] || semver_gt "$ver" "$best_ver"; then
+      best_tag="$tag"
+      best_ver="$ver"
+    fi
+    return 0
+  }
+
+  # Stream tag_name / draft / prerelease in document order (compact JSON, no jq).
+  # `|| true`: grep exits 1 on no match, and pipefail would abort the installer.
+  fields="$(printf '%s' "$json" | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)' | sed -E 's/"tag_name": *"([^"]*)"/tag_name \1/; s/"draft": *(true|false)/draft \1/; s/"prerelease": *(true|false)/prerelease \1/' || true)"
+  while read -r key val; do
+    [ -n "$key" ] || continue
+    case "$key" in
+      tag_name)
+        if [ -n "$cur_tag" ]; then
+          consider_tag "$cur_tag" "$cur_draft" "$cur_pre"
+        fi
+        cur_tag="$val"
+        cur_draft=""
+        cur_pre=""
+        ;;
+      draft) cur_draft="$val" ;;
+      prerelease) cur_pre="$val" ;;
+    esac
+  done <<EOF
+${fields}
+EOF
+  if [ -n "$cur_tag" ]; then
+    consider_tag "$cur_tag" "$cur_draft" "$cur_pre"
+  fi
+  if [ -n "$best_tag" ]; then
+    printf '%s\n' "$best_tag"
+  fi
+}
+
 # --- detect OS/arch, map to the release workflow's target triples ---------
 detect_target() {
   os="$(uname -s)"
@@ -60,31 +149,41 @@ detect_target() {
   printf '%s-%s\n' "$arch_part" "$os_part"
 }
 
+if [ "${CHM_INSTALL_SELF_TEST:-}" = "1" ]; then
+  [ "$(normalize_chm_tag '0.2.0')" = "chm-v0.2.0" ]
+  [ "$(normalize_chm_tag 'chm-0.2.0')" = "chm-v0.2.0" ]
+  [ "$(normalize_chm_tag 'v0.2.0')" = "chm-v0.2.0" ]
+  [ "$(normalize_chm_tag 'chm-v0.2.0')" = "chm-v0.2.0" ]
+  json='[{"tag_name":"chm-v0.1.0","prerelease":false,"draft":true},{"tag_name":"v0.3.3","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false},{"tag_name":"chm-v0.2.0","prerelease":true,"draft":false}]'
+  got="$(pick_newest_chm_tag "$json")"
+  if [ "$got" != "chm-v0.1.1" ]; then
+    die "pick_newest_chm_tag: expected chm-v0.1.1, got '$got'"
+  fi
+  empty="$(pick_newest_chm_tag '[]')"
+  [ -z "$empty" ]
+  log "install.sh self-test ok"
+  exit 0
+fi
+
 TARGET="$(detect_target)"
 ASSET_NAME="${BIN_NAME}-${TARGET}"
 
 # --- resolve the release tag ----------------------------------------------
 resolve_version() {
   if [ -n "${CHM_VERSION:-}" ]; then
-    printf '%s\n' "$CHM_VERSION"
+    normalize_chm_tag "$CHM_VERSION"
     return
   fi
 
-  log "Looking up latest chm-v* release..."
+  log "Looking up latest published chm-v* release..."
   releases_json="$(curl -fsSL -H "User-Agent: chmonitor-installer" \
     "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null)" \
-    || die "failed to query GitHub releases API for ${REPO}"
+    || die "failed to query GitHub releases API for ${REPO}. Fallback: cargo install ch-monitor-cli --force"
 
-  # The API returns compact single-line JSON, so extract just the matching
-  # fragment with `grep -o` — a line-based sed would greedily capture the LAST
-  # tag_name on the line instead of the first chm-v* one.
-  tag="$(printf '%s' "$releases_json" \
-    | grep -o '"tag_name": *"chm-v[^"]*"' \
-    | head -n 1 \
-    | sed -E 's/.*"(chm-v[^"]*)".*/\1/')"
+  tag="$(pick_newest_chm_tag "$releases_json")"
 
   if [ -z "$tag" ]; then
-    die "no chm-v* release found for ${REPO} yet. The CLI has not been cut a release yet — ask the maintainer to push a 'chm-v*' tag, or build from source: cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml. You can also pin an explicit tag with CHM_VERSION=chm-vX.Y.Z."
+    die "no published chm-v* release found for ${REPO} yet. Pin one with CHM_VERSION=chm-vX.Y.Z, or: cargo install ch-monitor-cli --force"
   fi
 
   printf '%s\n' "$tag"
@@ -104,7 +203,7 @@ BIN_PATH="${TMP_DIR}/${ASSET_NAME}"
 SHA_PATH="${TMP_DIR}/${ASSET_NAME}.sha256"
 
 if ! curl -fsSL -o "$BIN_PATH" "$BIN_URL"; then
-  die "failed to download ${BIN_URL} — the release may not include a binary for ${TARGET}, or the tag doesn't exist. Set CHM_VERSION to try a different release, or build from source."
+  die "failed to download ${BIN_URL} — the release may not include a binary for ${TARGET}, or the tag doesn't exist. Set CHM_VERSION=chm-vX.Y.Z to pin a different release, or: cargo install ch-monitor-cli --force"
 fi
 
 if [ ! -s "$BIN_PATH" ]; then
@@ -161,6 +260,7 @@ log "  CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default ${INSTALL_D
 log ""
 log "Update later with:"
 log "  ${BIN_NAME} upgrade"
+log "  ${BIN_NAME} update     # same command"
 
 # --- anonymous, opt-out install ping (best-effort, backgrounded) -----------
 # Records a single anonymous cli_install event (os/arch + version) to the same


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #3147 for #3145. The alias itself already shipped; this pass fixes remaining upgrade-path bugs and CLI polish found while verifying that work.

## Summary

`chm upgrade` / `chm update` and `scripts/install.sh` now pick the newest **published** `chm-v*` tag by semver (not the first GitHub API match), normalize pin tags like `0.2.0` / `chm-0.2.0`, and print a copy-pasteable fallback on download failures. Dashboard flags work after the subcommand (`chm hosts --base-url …`).

## Changes

- `rust/ch-monitor-cli/src/update.rs`: paginate GitHub releases; `normalize_release_tag`; download/API errors include install.sh / cargo fallback
- `scripts/install.sh`: same newest-published-tag pick (skip drafts/prereleases); `CHM_VERSION` normalization; `CHM_INSTALL_SELF_TEST=1`
- `rust/ch-monitor-cli/src/main.rs`: `--version` includes target triple; help text for every command; `global = true` on `--base-url` / `--host-id` / `--api-key` / `--config`; explicit hosts/chart/table HTTP errors; empty-result messages
- Docs kept in sync: crate README, `docs/content/guide/guides/diagnostics-cli.mdx`, `docs/knowledge/standalone-cli.md`

## Left alone

- `chm update` still works; telemetry stays `("cli_run", "update")` for both commands
- `CHM_LICENSE_KEY` honor-system ping unchanged
- No Homebrew / crates.io / DRM / dashboard UI / release-please

## Test plan

- [x] `CHM_INSTALL_SELF_TEST=1 bash scripts/install.sh`
- [ ] `cargo test --locked` in `rust/ch-monitor-cli` (running)
- [ ] `cargo clippy --locked -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] `chm --help` / `chm hosts --base-url http://127.0.0.1:9` error copy
- [ ] `pnpm run lint` — not applicable (Rust CLI / docs / install script)
- [ ] `pnpm run build` — not applicable
- [x] Docs updated in `docs/content/`
- [ ] `docs/content/ai-agent.mdx` — not applicable

## Notes for reviewer

Guess, then verified: install.sh `head -n 1` on `chm-v*` grep matches GitHub created_at order (and can include drafts/prereleases). Live API currently returns a draft `chm-v0.1.0` before published `chm-v0.1.1`. Rust already ranked by semver; the installer did not.

Pin `chm-0.2.0` previously became `chm-vchm-0.2.0`. Unsupported-target errors still point at `cargo install` only (install.sh would refuse that platform too).

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba398c99-872c-4d8c-9740-87d18a6adcb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba398c99-872c-4d8c-9740-87d18a6adcb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

