### PR TITLE
feat(advisor): copyable local vs ON CLUSTER DDL variants

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   "empty state", "loading", "consistent", "follow-up feature", "match the design",
   "what's new", "changelog", "dialog scroll", "settings gear",
   "schema compare", "settings diff", "add host", "pick a query",
-  "query picker", "select labels".
+  "query picker", "select labels", "ON CLUSTER", "advisor DDL".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -255,6 +255,12 @@ chart in `components/charts/` as the template — don't reinvent the wiring.
   `query_id` — use the same EmptyState with next steps, never `ErrorAlert`
   titled "Analysis failed". `ErrorAlert` is for host/schema/fetch failures.
   Picking a query from the picker auto-runs, same as `/explain`.
+- **Recommend-only DDL pairs:** when cluster topology is known (Distributed
+  engine or cluster metadata), Advisor findings and schema-diff plan items
+  show the local table name plus a copyable `ON CLUSTER` variant of the same
+  statement via `RecommendDdlBlocks` (`components/ddl/recommend-ddl-blocks.tsx`).
+  Single-node / no topology stays a single statement. Never a Run/apply
+  button — `lib/ddl/on-cluster.ts` is a pure transform.
 - **Error (graceful):** initial error (`error && !hasData`) → full `ChartError`
   with retry. Revalidation error (`staleError`) → KEEP showing data + subtle
   amber `ChartStaleIndicator` (hover-revealed), auto-clears on next success.

--- a/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
+++ b/apps/dashboard/src/components/agents/advisor-recommendations-panel.tsx
@@ -21,10 +21,7 @@ import {
 import type { Recommendation } from '@/lib/ai/advisor/recommendation-engine'
 
 import { useEffect, useRef } from 'react'
-import {
-  CodeBlock,
-  CodeBlockCopyButton,
-} from '@/components/ai-elements/code-block'
+import { RecommendDdlBlocks } from '@/components/ddl/recommend-ddl-blocks'
 import { Badge } from '@/components/ui/badge'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { cn } from '@/lib/utils'
@@ -66,7 +63,11 @@ function RiskBadge({ risk }: { risk: Recommendation['risk'] }) {
 function RecommendationCard({
   recommendation,
 }: {
-  recommendation: Recommendation
+  recommendation: Recommendation & {
+    localTableName?: string | null
+    onClusterStatement?: string | null
+    localOnlyReason?: string | null
+  }
 }) {
   const Icon = KIND_ICON[recommendation.kind]
   const code = recommendation.ddl ?? recommendation.rewrittenSql ?? ''
@@ -102,9 +103,12 @@ function RecommendationCard({
       </div>
 
       {code ? (
-        <CodeBlock code={code} language="sql" className="max-h-56 text-xs">
-          <CodeBlockCopyButton />
-        </CodeBlock>
+        <RecommendDdlBlocks
+          statement={code}
+          onClusterStatement={recommendation.onClusterStatement}
+          localTableName={recommendation.localTableName}
+          localOnlyReason={recommendation.localOnlyReason}
+        />
       ) : null}
 
       <div className="text-xs text-muted-foreground">

--- a/apps/dashboard/src/components/agents/tuning-findings-panel.tsx
+++ b/apps/dashboard/src/components/agents/tuning-findings-panel.tsx
@@ -27,6 +27,7 @@ import {
   CodeBlock,
   CodeBlockCopyButton,
 } from '@/components/ai-elements/code-block'
+import { RecommendDdlBlocks } from '@/components/ddl/recommend-ddl-blocks'
 import { Badge } from '@/components/ui/badge'
 import { trackEvent } from '@/lib/analytics/analytics'
 import { cn } from '@/lib/utils'
@@ -108,9 +109,12 @@ function FindingCard({ finding }: { finding: TuningFinding }) {
         </div>
       </div>
 
-      <CodeBlock code={finding.ddl} language="sql" className="max-h-56 text-xs">
-        <CodeBlockCopyButton />
-      </CodeBlock>
+      <RecommendDdlBlocks
+        statement={finding.ddl}
+        onClusterStatement={finding.onClusterStatement}
+        localTableName={finding.localTableName}
+        localOnlyReason={finding.localOnlyReason}
+      />
 
       {finding.verifyQuery ? (
         <div className="space-y-1">

--- a/apps/dashboard/src/components/ddl/recommend-ddl-blocks.tsx
+++ b/apps/dashboard/src/components/ddl/recommend-ddl-blocks.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+/**
+ * Copyable recommend-only DDL: single-host statement plus, when topology is
+ * known, an ON CLUSTER variant. Never an apply/run control.
+ */
+
+import {
+  CodeBlock,
+  CodeBlockCopyButton,
+} from '@/components/ai-elements/code-block'
+
+export interface RecommendDdlBlocksProps {
+  statement: string
+  onClusterStatement?: string | null
+  localTableName?: string | null
+  localOnlyReason?: string | null
+}
+
+export function RecommendDdlBlocks({
+  statement,
+  onClusterStatement,
+  localTableName,
+  localOnlyReason,
+}: RecommendDdlBlocksProps) {
+  if (!statement) return null
+
+  return (
+    <div className="space-y-2">
+      {localTableName ? (
+        <p className="text-xs text-muted-foreground">
+          Local table{' '}
+          <span className="font-medium text-foreground">{localTableName}</span>
+        </p>
+      ) : null}
+      <CodeBlock code={statement} language="sql" className="max-h-56 text-xs">
+        <CodeBlockCopyButton />
+      </CodeBlock>
+      {onClusterStatement ? (
+        <div className="space-y-1">
+          <div className="text-[11px] font-medium text-muted-foreground">
+            ON CLUSTER
+          </div>
+          <CodeBlock
+            code={onClusterStatement}
+            language="sql"
+            className="max-h-56 text-xs"
+          >
+            <CodeBlockCopyButton />
+          </CodeBlock>
+        </div>
+      ) : localOnlyReason ? (
+        <p className="text-xs text-muted-foreground">{localOnlyReason}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
+++ b/apps/dashboard/src/components/explorer/explorer-tuning-section.tsx
@@ -19,6 +19,7 @@ import { TableSkeleton } from '@/components/skeletons'
 import { AppLink as Link } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
+import { annotateDdlForTopology } from '@/lib/ddl/on-cluster'
 import {
   type ClusterReplicaRow,
   formatDistributedTopologyNote,
@@ -114,7 +115,27 @@ export function ExplorerTuningSection({
     if (dist) {
       notes.unshift(formatDistributedTopologyNote(dist, topologyRows))
     }
-    return { ...data, notes }
+    const topology = dist
+      ? {
+          cluster: dist.cluster,
+          localDatabase: dist.database,
+          localTable: dist.table,
+        }
+      : null
+    const findings = topology
+      ? data.findings.map((finding) => {
+          if (finding.onClusterStatement) return finding
+          const variant = annotateDdlForTopology(finding.ddl, topology)
+          return {
+            ...finding,
+            ddl: variant.statement || finding.ddl,
+            localTableName: variant.localTableName,
+            onClusterStatement: variant.onClusterStatement,
+            localOnlyReason: variant.localOnlyReason,
+          }
+        })
+      : data.findings
+    return { ...data, notes, findings }
   }, [data, dist, topologyRows])
 
   const advisorHref = buildUrl('/advisor', { host: hostId })

--- a/apps/dashboard/src/components/schema-diff/plan-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/plan-list.tsx
@@ -1,11 +1,8 @@
-import { CopyIcon } from 'lucide-react'
-
 import type { PlanItem } from '@/lib/schema-diff'
 
-import { Button } from '@/components/ui/button'
+import { RecommendDdlBlocks } from '@/components/ddl/recommend-ddl-blocks'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
-import { copyToClipboard } from '@/lib/utils/clipboard'
 
 interface PlanListProps {
   items: PlanItem[]
@@ -35,30 +32,22 @@ export function PlanList({ items }: PlanListProps) {
           <ul className="flex flex-col gap-2">
             {items.map((item) => (
               <li key={item.id} className="rounded-md border border-border p-3">
-                <div className="flex items-start justify-between gap-2">
-                  <div>
-                    <p className="text-sm">{item.summary}</p>
-                    <p className="mt-0.5 text-xs text-muted-foreground">
-                      {riskLabel(item.risk)}
-                      {item.safe ? ' · safe to copy' : ''}
-                    </p>
-                  </div>
-                  {item.statement ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-8 shrink-0"
-                      onClick={() => copyToClipboard(item.statement)}
-                    >
-                      <CopyIcon className="size-3.5" strokeWidth={1.5} />
-                      Copy
-                    </Button>
-                  ) : null}
+                <div>
+                  <p className="text-sm">{item.summary}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {riskLabel(item.risk)}
+                    {item.safe ? ' · safe to copy' : ''}
+                  </p>
                 </div>
                 {item.statement ? (
-                  <pre className="mt-2 overflow-x-auto font-mono text-xs text-muted-foreground">
-                    {item.statement}
-                  </pre>
+                  <div className="mt-2">
+                    <RecommendDdlBlocks
+                      statement={item.statement}
+                      onClusterStatement={item.onClusterStatement}
+                      localTableName={item.localTableName}
+                      localOnlyReason={item.localOnlyReason}
+                    />
+                  </div>
                 ) : null}
               </li>
             ))}

--- a/apps/dashboard/src/lib/ai/advisor/__tests__/analyze-query.test.ts
+++ b/apps/dashboard/src/lib/ai/advisor/__tests__/analyze-query.test.ts
@@ -25,12 +25,21 @@ function respond(query: string): { data: unknown[]; error: null } {
     }
   }
   if (q.includes('system.tables')) {
+    if (q.includes('engine_full') || q.includes('engine,')) {
+      return {
+        data: [{ engine: 'MergeTree', engine_full: 'MergeTree' }],
+        error: null,
+      }
+    }
     return {
       data: [
         { partition_key: 'event_date', sorting_key: 'event_date, user_id' },
       ],
       error: null,
     }
+  }
+  if (q.includes('system.clusters')) {
+    return { data: [], error: null }
   }
   if (q.includes('system.columns')) {
     return {

--- a/apps/dashboard/src/lib/ai/advisor/query-context.ts
+++ b/apps/dashboard/src/lib/ai/advisor/query-context.ts
@@ -22,6 +22,10 @@ import type {
 
 import { parseExplainIndexes } from '@chm/query-advisor-core'
 import { readOnlyQuery } from '@/lib/ai/agent/tools/helpers'
+import {
+  type ClusterTopology,
+  topologyFromDistributedTable,
+} from '@/lib/ddl/on-cluster'
 
 /** Resolve the SQL to analyze: the caller's raw `sql`, or the query text behind a `query_id`. */
 export async function resolveSql(
@@ -127,6 +131,39 @@ export async function fetchTableSchema(
       expression: i.expression,
       granularity: Number(i.granularity),
     })),
+  }
+}
+
+/** Best-effort cluster topology for copyable ON CLUSTER variants. Never throws. */
+export async function fetchTableTopology(
+  hostId: number,
+  database: string,
+  table: string
+): Promise<ClusterTopology> {
+  try {
+    const tableRows = (await readOnlyQuery({
+      query:
+        'SELECT engine, engine_full FROM system.tables WHERE database = {database:String} AND name = {table:String} LIMIT 1',
+      query_params: { database, table },
+      hostId,
+    })) as Array<{ engine: string; engine_full: string }>
+    const row = tableRows[0]
+    const fromDist = topologyFromDistributedTable({
+      engine: row?.engine,
+      engineFull: row?.engine_full,
+    })
+    if (fromDist) return fromDist
+
+    const clusterRows = (await readOnlyQuery({
+      query:
+        'SELECT cluster FROM system.clusters WHERE is_local = 1 ORDER BY cluster LIMIT 1',
+      hostId,
+    })) as Array<{ cluster: string }>
+    const cluster = clusterRows[0]?.cluster?.trim()
+    if (!cluster) return null
+    return { cluster, localDatabase: database, localTable: table }
+  } catch {
+    return null
   }
 }
 

--- a/apps/dashboard/src/lib/ai/advisor/recommendation-engine.ts
+++ b/apps/dashboard/src/lib/ai/advisor/recommendation-engine.ts
@@ -51,6 +51,7 @@ import {
   fetchExplainIndexes,
   fetchPartsStats,
   fetchTableSchema,
+  fetchTableTopology,
   resolveSql,
 } from './query-context'
 import {
@@ -66,6 +67,7 @@ import {
   scoreSkipIndex,
 } from '@chm/query-advisor-core'
 import { validateSqlQuery } from '@chm/sql-builder'
+import { annotateDdlForTopology } from '@/lib/ddl/on-cluster'
 
 // Re-exported so existing `from './recommendation-engine'` imports (tests,
 // tool wiring) keep working unchanged — see `./types`, the app-local import
@@ -120,7 +122,13 @@ export interface AnalyzeQueryOk {
   sql: string
   database: string
   table: string
-  recommendations: Recommendation[]
+  recommendations: Array<
+    Recommendation & {
+      localTableName?: string | null
+      onClusterStatement?: string | null
+      localOnlyReason?: string | null
+    }
+  >
   notes: string[]
 }
 
@@ -246,13 +254,45 @@ export async function analyzeQuery(
     }
   }
 
+  const ranked = rankRecommendations(recommendations)
+  let topology = null
+  try {
+    topology = await fetchTableTopology(hostId, target.database, target.table)
+  } catch {
+    topology = null
+  }
+
+  const annotated = ranked.map((rec) => {
+    if (!rec.ddl) {
+      return {
+        ...rec,
+        localTableName:
+          topology?.localDatabase && topology.localTable
+            ? `${topology.localDatabase}.${topology.localTable}`
+            : null,
+        onClusterStatement: null,
+        localOnlyReason: topology?.cluster
+          ? 'This recommendation is a query rewrite, not table DDL — ON CLUSTER does not apply.'
+          : null,
+      }
+    }
+    const variant = annotateDdlForTopology(rec.ddl, topology)
+    return {
+      ...rec,
+      ddl: variant.statement,
+      localTableName: variant.localTableName,
+      onClusterStatement: variant.onClusterStatement,
+      localOnlyReason: variant.localOnlyReason,
+    }
+  })
+
   return {
     ok: true,
     type: 'query_advisor_recommendations',
     sql,
     database: target.database,
     table: target.table,
-    recommendations: rankRecommendations(recommendations),
+    recommendations: annotated,
     notes,
   }
 }

--- a/apps/dashboard/src/lib/ai/advisor/tuning/tuning-engine.ts
+++ b/apps/dashboard/src/lib/ai/advisor/tuning/tuning-engine.ts
@@ -22,9 +22,11 @@ import type {
   TuningReport,
 } from './types'
 
+import { fetchTableTopology } from '../query-context'
 import { runSchemaRules } from './schema-rules'
 import { runSettingsRules } from './settings-rules'
 import { readOnlyQuery } from '@/lib/ai/agent/tools/helpers'
+import { annotateDdlForTopology } from '@/lib/ddl/on-cluster'
 
 /** System databases never worth linting. */
 const SYSTEM_DATABASES = new Set([
@@ -242,12 +244,34 @@ export async function analyzeTuning(
     ...runSettingsRules(settings),
   ])
 
+  let topology = null
+  try {
+    topology = await fetchTableTopology(
+      hostId,
+      database,
+      table ?? columns[0]?.table ?? ''
+    )
+  } catch {
+    topology = null
+  }
+
+  const annotated = findings.map((finding) => {
+    const variant = annotateDdlForTopology(finding.ddl, topology)
+    return {
+      ...finding,
+      ddl: variant.statement || finding.ddl,
+      localTableName: variant.localTableName,
+      onClusterStatement: variant.onClusterStatement,
+      localOnlyReason: variant.localOnlyReason,
+    }
+  })
+
   return {
     ok: true,
     type: 'schema_tuning_findings',
     database,
     ...(table ? { table } : {}),
-    findings,
+    findings: annotated,
     notes,
   }
 }

--- a/apps/dashboard/src/lib/ai/advisor/tuning/types.ts
+++ b/apps/dashboard/src/lib/ai/advisor/tuning/types.ts
@@ -82,6 +82,12 @@ export interface TuningFinding {
   severity: TuningSeverity
   /** Ready-to-review statement. NEVER executed — the user runs it themselves. */
   ddl: string
+  /** Qualified local table when topology is known. */
+  localTableName?: string | null
+  /** Copyable ON CLUSTER variant of `ddl`. Recommend-only. */
+  onClusterStatement?: string | null
+  /** Why ON CLUSTER was not offered. */
+  localOnlyReason?: string | null
   /**
    * Optional read-only query to confirm the finding before applying its DDL
    * (e.g. count NULLs, observe an integer's real range, measure distinct

--- a/apps/dashboard/src/lib/ddl/on-cluster.test.ts
+++ b/apps/dashboard/src/lib/ddl/on-cluster.test.ts
@@ -6,7 +6,8 @@ import {
 } from './on-cluster'
 import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const ALTER = 'ALTER TABLE `app`.`events_dist` ADD COLUMN `note` String'
 
@@ -82,7 +83,10 @@ describe('annotateDdlForTopology', () => {
   })
 
   test('does not invoke any execute/apply helper', () => {
-    const src = readFileSync(join(import.meta.dir, 'on-cluster.ts'), 'utf8')
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'on-cluster.ts'),
+      'utf8'
+    )
     expect(src).not.toMatch(/\bfetchData\b/)
     expect(src).not.toMatch(/\bexecuteDdl\b/)
     expect(src).not.toMatch(/\bapplyDdl\b/)

--- a/apps/dashboard/src/lib/ddl/on-cluster.test.ts
+++ b/apps/dashboard/src/lib/ddl/on-cluster.test.ts
@@ -1,0 +1,140 @@
+import {
+  annotateDdlForTopology,
+  insertOnClusterClause,
+  rewriteDdlTableName,
+  topologyFromDistributedTable,
+} from './on-cluster'
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ALTER = 'ALTER TABLE `app`.`events_dist` ADD COLUMN `note` String'
+
+describe('annotateDdlForTopology', () => {
+  test('Distributed/cluster fixture exposes local table and copyable ON CLUSTER variant', () => {
+    const result = annotateDdlForTopology(ALTER, {
+      cluster: 'analytics',
+      localDatabase: 'default',
+      localTable: 'events_local',
+    })
+
+    expect(result.localTableName).toBe('default.events_local')
+    expect(result.statement).toBe(
+      'ALTER TABLE `default`.`events_local` ADD COLUMN `note` String'
+    )
+    expect(result.onClusterStatement).toBe(
+      "ALTER TABLE `default`.`events_local` ON CLUSTER 'analytics' ADD COLUMN `note` String"
+    )
+    expect(result.onClusterStatement).toContain('ADD COLUMN `note` String')
+    expect(result.onClusterStatement).not.toBe(result.statement)
+    expect(result.localOnlyReason).toBeNull()
+  })
+
+  test('single-node / empty topology leaves single-host SQL unchanged', () => {
+    const empty = annotateDdlForTopology(ALTER, null)
+    expect(empty.statement).toBe(ALTER)
+    expect(empty.onClusterStatement).toBeNull()
+    expect(empty.localTableName).toBeNull()
+    expect(empty.localOnlyReason).toBeNull()
+
+    const blank = annotateDdlForTopology(ALTER, { cluster: '' })
+    expect(blank.statement).toBe(ALTER)
+    expect(blank.onClusterStatement).toBeNull()
+  })
+
+  test('Replicated table with cluster metadata keeps the same table and adds ON CLUSTER', () => {
+    const stmt =
+      'ALTER TABLE `app`.`events` ADD INDEX `idx_note` note TYPE bloom_filter GRANULARITY 1'
+    const result = annotateDdlForTopology(stmt, {
+      cluster: 'prod',
+      localDatabase: 'app',
+      localTable: 'events',
+    })
+    expect(result.localTableName).toBe('app.events')
+    expect(result.statement).toContain('`app`.`events`')
+    expect(result.onClusterStatement).toContain("ON CLUSTER 'prod'")
+    expect(result.onClusterStatement).toContain('ADD INDEX `idx_note`')
+  })
+
+  test('CREATE TABLE gets ON CLUSTER after the table identifier', () => {
+    const create =
+      'CREATE TABLE app.new_tbl (`id` UInt64) ENGINE = MergeTree ORDER BY id'
+    const result = annotateDdlForTopology(create, {
+      cluster: 'analytics',
+      localDatabase: 'app',
+      localTable: 'new_tbl',
+    })
+    expect(result.onClusterStatement).toBe(
+      "CREATE TABLE `app`.`new_tbl` ON CLUSTER 'analytics' (`id` UInt64) ENGINE = MergeTree ORDER BY id"
+    )
+  })
+
+  test('non-DDL (PREWHERE / SET) stays local-only with an explicit reason', () => {
+    const rewrite = "SELECT * FROM events PREWHERE status = 'error'"
+    const result = annotateDdlForTopology(rewrite, {
+      cluster: 'analytics',
+      localDatabase: 'default',
+      localTable: 'events_local',
+    })
+    expect(result.statement).toBe(rewrite)
+    expect(result.onClusterStatement).toBeNull()
+    expect(result.localOnlyReason).toMatch(/not table DDL/i)
+  })
+
+  test('does not invoke any execute/apply helper', () => {
+    const src = readFileSync(join(import.meta.dir, 'on-cluster.ts'), 'utf8')
+    expect(src).not.toMatch(/\bfetchData\b/)
+    expect(src).not.toMatch(/\bexecuteDdl\b/)
+    expect(src).not.toMatch(/\bapplyDdl\b/)
+    expect(src).not.toMatch(/clickhouse-client/)
+    expect(src).not.toMatch(/readOnlyQuery/)
+
+    const result = annotateDdlForTopology(ALTER, {
+      cluster: 'analytics',
+      localDatabase: 'default',
+      localTable: 'events_local',
+    })
+    expect(typeof result.statement).toBe('string')
+    expect(typeof result.onClusterStatement).toBe('string')
+  })
+})
+
+describe('insertOnClusterClause / rewriteDdlTableName', () => {
+  test('is idempotent when ON CLUSTER is already present', () => {
+    const already =
+      "ALTER TABLE `app`.`t` ON CLUSTER 'analytics' ADD COLUMN x UInt8"
+    expect(insertOnClusterClause(already, 'analytics')).toBe(already)
+  })
+
+  test('rewrites only the table identifier', () => {
+    expect(rewriteDdlTableName(ALTER, 'default', 'events_local')).toBe(
+      'ALTER TABLE `default`.`events_local` ADD COLUMN `note` String'
+    )
+  })
+})
+
+describe('topologyFromDistributedTable', () => {
+  test('parses ENGINE = Distributed from CREATE TABLE', () => {
+    const topology = topologyFromDistributedTable({
+      engine: 'Distributed',
+      createTableQuery:
+        "CREATE TABLE app.events_dist (`id` UInt64) ENGINE = Distributed('analytics', 'default', 'events_local', rand())",
+    })
+    expect(topology).toEqual({
+      cluster: 'analytics',
+      localDatabase: 'default',
+      localTable: 'events_local',
+    })
+  })
+
+  test('returns null for MergeTree / missing engine', () => {
+    expect(
+      topologyFromDistributedTable({
+        engine: 'MergeTree',
+        createTableQuery:
+          'CREATE TABLE app.t (`id` UInt64) ENGINE = MergeTree ORDER BY id',
+      })
+    ).toBeNull()
+    expect(topologyFromDistributedTable({})).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/ddl/on-cluster.ts
+++ b/apps/dashboard/src/lib/ddl/on-cluster.ts
@@ -1,0 +1,194 @@
+/**
+ * Recommend-only local vs ON CLUSTER DDL variants.
+ *
+ * Pure string transform: never executes, applies, or mutates anything.
+ * Used by Query Advisor, schema-tuning findings, and schema-diff plan items
+ * when cluster topology is known (Distributed engine or cluster metadata).
+ */
+
+import { parseDistributedEngine } from '@/lib/explorer/engine-kind'
+
+/** Cluster context for copyable ON CLUSTER variants. `null` = single-host. */
+export type ClusterTopology = {
+  cluster: string
+  /** Local table when the analyzed object is a Distributed wrapper. */
+  localDatabase?: string
+  localTable?: string
+} | null
+
+export type ClusterDdlAnnotation = {
+  /** Qualified local table (`db.table`) when topology names one, else null. */
+  localTableName: string | null
+  /** Single-host statement (rewritten onto the local table when needed). */
+  statement: string
+  /** Copyable ON CLUSTER variant of the same statement, or null. */
+  onClusterStatement: string | null
+  /** Why ON CLUSTER was not offered (null when the variant exists). */
+  localOnlyReason: string | null
+}
+
+const TABLE_DDL_PREFIX =
+  /^((?:ALTER|CREATE(?:\s+TEMPORARY)?|ATTACH|DETACH|RENAME|TRUNCATE|OPTIMIZE)\s+(?:TABLE|MATERIALIZED\s+VIEW)(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+)((?:`[^`]+`|[A-Za-z_][\w$]*)(?:\.(?:`[^`]+`|[A-Za-z_][\w$]*))?)(\s+)([\s\S]+)$/i
+
+function quoteClusterName(cluster: string): string {
+  const trimmed = cluster.trim()
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    return `'${trimmed.replace(/'/g, "\\'")}'`
+  }
+  return `'${trimmed.replace(/'/g, "\\'")}'`
+}
+
+function quoteIdent(name: string): string {
+  return `\`${name.replace(/`/g, '``')}\``
+}
+
+function qualifiedLocal(database: string, table: string): string {
+  return `${quoteIdent(database)}.${quoteIdent(table)}`
+}
+
+function parseTableDdl(statement: string) {
+  return statement
+    .trim()
+    .replace(/;+\s*$/, '')
+    .match(TABLE_DDL_PREFIX)
+}
+
+/**
+ * Insert `ON CLUSTER 'name'` after the table identifier. Returns null when
+ * the statement is not table DDL (settings, PREWHERE rewrites, empty).
+ */
+export function insertOnClusterClause(
+  statement: string,
+  cluster: string
+): string | null {
+  const trimmed = statement.trim()
+  if (!trimmed || !cluster.trim()) return null
+  if (/\bON\s+CLUSTER\b/i.test(trimmed)) return trimmed
+  const match = parseTableDdl(trimmed)
+  if (!match) return null
+  const [, prefix, tableIdent, space, rest] = match
+  const trailingSemi = /;\s*$/.test(statement.trim()) ? ';' : ''
+  return `${prefix}${tableIdent}${space}ON CLUSTER ${quoteClusterName(cluster)} ${rest}${trailingSemi}`
+}
+
+/**
+ * Point table DDL at a local table (Distributed wrapper → inner table).
+ * Non-DDL statements are returned unchanged.
+ */
+export function rewriteDdlTableName(
+  statement: string,
+  database: string,
+  table: string
+): string {
+  const trimmed = statement.trim()
+  const match = parseTableDdl(trimmed)
+  if (!match) return trimmed
+  const [, prefix, , space, rest] = match
+  const trailingSemi = /;\s*$/.test(trimmed) ? ';' : ''
+  return `${prefix}${qualifiedLocal(database, table)}${space}${rest}${trailingSemi}`
+}
+
+export function topologyFromDistributedTable(opts: {
+  engine?: string | null
+  engineFull?: string | null
+  createTableQuery?: string | null
+}): ClusterTopology {
+  const fromFull = parseDistributedEngine(opts.engineFull)
+  if (fromFull) {
+    return {
+      cluster: fromFull.cluster,
+      localDatabase: fromFull.database,
+      localTable: fromFull.table,
+    }
+  }
+
+  const create = opts.createTableQuery?.trim() ?? ''
+  if (create) {
+    const engineMatch = create.match(
+      /ENGINE\s*=\s*(Distributed\s*\([\s\S]*\))/i
+    )
+    const fromCreate = parseDistributedEngine(engineMatch?.[1] ?? create)
+    if (fromCreate) {
+      return {
+        cluster: fromCreate.cluster,
+        localDatabase: fromCreate.database,
+        localTable: fromCreate.table,
+      }
+    }
+  }
+
+  if (opts.engine && /Distributed/i.test(opts.engine)) {
+    const fromEngine = parseDistributedEngine(opts.engine)
+    if (fromEngine) {
+      return {
+        cluster: fromEngine.cluster,
+        localDatabase: fromEngine.database,
+        localTable: fromEngine.table,
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Annotate a recommend-only statement with a local table name and a copyable
+ * ON CLUSTER variant when topology is known. Single-node / empty topology
+ * returns the original statement unchanged.
+ *
+ * This function does not execute SQL and must not grow I/O.
+ */
+export function annotateDdlForTopology(
+  statement: string,
+  topology: ClusterTopology
+): ClusterDdlAnnotation {
+  const original = statement.trim()
+  if (!original) {
+    return {
+      localTableName: null,
+      statement: original,
+      onClusterStatement: null,
+      localOnlyReason: null,
+    }
+  }
+
+  if (!topology?.cluster?.trim()) {
+    return {
+      localTableName: null,
+      statement: original,
+      onClusterStatement: null,
+      localOnlyReason: null,
+    }
+  }
+
+  const localDatabase = topology.localDatabase?.trim()
+  const localTable = topology.localTable?.trim()
+  const localTableName =
+    localDatabase && localTable ? `${localDatabase}.${localTable}` : null
+
+  let localStatement = original
+  if (localDatabase && localTable) {
+    localStatement = rewriteDdlTableName(original, localDatabase, localTable)
+  }
+
+  const onClusterStatement = insertOnClusterClause(
+    localStatement,
+    topology.cluster
+  )
+  if (!onClusterStatement) {
+    return {
+      localTableName,
+      statement: original,
+      onClusterStatement: null,
+      localOnlyReason:
+        'This statement is not table DDL, so ON CLUSTER does not apply — run it on a single node.',
+    }
+  }
+
+  return {
+    localTableName,
+    statement: localStatement,
+    onClusterStatement,
+    localOnlyReason: null,
+  }
+}

--- a/apps/dashboard/src/lib/schema-diff/plan.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/plan.test.ts
@@ -165,4 +165,91 @@ describe('buildChangePlan', () => {
     expect(plan.items[0].statement).toContain('MODIFY COLUMN')
     expect(plan.safeStatements).toEqual([])
   })
+
+  test('Distributed table plan items expose local table + ON CLUSTER variant', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'events_dist',
+          engine: 'Distributed',
+          createTableQuery:
+            "CREATE TABLE app.events_dist (`id` UInt64, `note` String) ENGINE = Distributed('analytics', 'default', 'events_local', rand())",
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'note', type: 'String', codec: '' },
+          ],
+        }),
+      ],
+    }
+    const target = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'events_dist',
+          engine: 'Distributed',
+          createTableQuery:
+            "CREATE TABLE app.events_dist (`id` UInt64) ENGINE = Distributed('analytics', 'default', 'events_local', rand())",
+        }),
+      ],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    const add = plan.items.find((i) => i.kind === 'add_column')
+    expect(add).toBeTruthy()
+    expect(add?.localTableName).toBe('default.events_local')
+    expect(add?.statement).toContain('`default`.`events_local`')
+    expect(add?.onClusterStatement).toContain("ON CLUSTER 'analytics'")
+    expect(add?.onClusterStatement).toContain('ADD COLUMN')
+    expect(add?.localOnlyReason).toBeNull()
+  })
+
+  test('cluster metadata without Distributed still adds ON CLUSTER to the same table', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'events',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'note', type: 'String', codec: '' },
+          ],
+        }),
+      ],
+    }
+    const target = {
+      tables: [table({ database: 'app', table: 'events' })],
+    }
+
+    const plan = buildChangePlan(compareCatalogs(source, target), {
+      cluster: 'prod',
+    })
+    const add = plan.items.find((i) => i.kind === 'add_column')
+    expect(add?.localTableName).toBe('app.events')
+    expect(add?.onClusterStatement).toContain("ON CLUSTER 'prod'")
+    expect(add?.statement).not.toMatch(/ON CLUSTER/i)
+  })
+
+  test('single-host plan without topology does not add ON CLUSTER', () => {
+    const source = {
+      tables: [
+        table({
+          database: 'app',
+          table: 'events',
+          columns: [
+            { name: 'id', type: 'UInt64', codec: '' },
+            { name: 'note', type: 'String', codec: '' },
+          ],
+        }),
+      ],
+    }
+    const target = {
+      tables: [table({ database: 'app', table: 'events' })],
+    }
+    const plan = buildChangePlan(compareCatalogs(source, target))
+    const add = plan.items.find((i) => i.kind === 'add_column')
+    expect(add?.onClusterStatement ?? null).toBeNull()
+    expect(add?.statement).toMatch(/^ALTER TABLE /)
+    expect(add?.statement).not.toMatch(/ON CLUSTER/i)
+  })
 })

--- a/apps/dashboard/src/lib/schema-diff/plan.ts
+++ b/apps/dashboard/src/lib/schema-diff/plan.ts
@@ -10,6 +10,11 @@ import type {
 
 import { tableKey } from './catalog'
 import { namedDelta } from './named-delta'
+import {
+  annotateDdlForTopology,
+  type ClusterTopology,
+  topologyFromDistributedTable,
+} from '@/lib/ddl/on-cluster'
 
 function quoteIdent(name: string): string {
   return `\`${name.replace(/`/g, '``')}\``
@@ -215,7 +220,55 @@ function planForChangedTable(
   return items
 }
 
-export function buildChangePlan(diff: SchemaDiffResult): SchemaChangePlan {
+function tableByKey(
+  diff: SchemaDiffResult,
+  key: string
+): TableSchema | undefined {
+  for (const row of [...diff.onlySource, ...diff.changed, ...diff.identical]) {
+    if (row.key === key) return row.source ?? row.target
+  }
+  return undefined
+}
+
+function topologyForItem(
+  item: PlanItem,
+  diff: SchemaDiffResult,
+  fallback: ClusterTopology
+): ClusterTopology {
+  const table = tableByKey(diff, item.tableKey)
+  const fromDist = table
+    ? topologyFromDistributedTable({
+        engine: table.engine,
+        createTableQuery: table.createTableQuery,
+      })
+    : null
+  if (fromDist) return fromDist
+  if (fallback?.cluster && table) {
+    return {
+      cluster: fallback.cluster,
+      localDatabase: table.database,
+      localTable: table.table,
+    }
+  }
+  return fallback
+}
+
+function annotatePlanItem(item: PlanItem, topology: ClusterTopology): PlanItem {
+  if (!item.statement) return item
+  const annotated = annotateDdlForTopology(item.statement, topology)
+  return {
+    ...item,
+    statement: annotated.statement,
+    localTableName: annotated.localTableName,
+    onClusterStatement: annotated.onClusterStatement,
+    localOnlyReason: annotated.localOnlyReason,
+  }
+}
+
+export function buildChangePlan(
+  diff: SchemaDiffResult,
+  topology: ClusterTopology = null
+): SchemaChangePlan {
   const items: PlanItem[] = []
 
   for (const row of diff.onlySource) {
@@ -228,9 +281,13 @@ export function buildChangePlan(diff: SchemaDiffResult): SchemaChangePlan {
     }
   }
 
-  const safeStatements = items
+  const annotated = items.map((item) =>
+    annotatePlanItem(item, topologyForItem(item, diff, topology))
+  )
+
+  const safeStatements = annotated
     .filter((item) => item.safe && item.statement)
     .map((item) => item.statement)
 
-  return { items, safeStatements }
+  return { items: annotated, safeStatements }
 }

--- a/apps/dashboard/src/lib/schema-diff/types.ts
+++ b/apps/dashboard/src/lib/schema-diff/types.ts
@@ -115,6 +115,12 @@ export type PlanItem = {
   statement: string
   summary: string
   safe: boolean
+  /** Qualified local table when topology is known. */
+  localTableName?: string | null
+  /** Copyable ON CLUSTER variant of `statement`. Recommend-only. */
+  onClusterStatement?: string | null
+  /** Why ON CLUSTER was not offered. */
+  localOnlyReason?: string | null
 }
 
 export type SchemaChangePlan = {

--- a/apps/dashboard/src/routes/api/v1/schema-diff.ts
+++ b/apps/dashboard/src/routes/api/v1/schema-diff.ts
@@ -271,7 +271,7 @@ async function handleSchemaDiff(request: Request): Promise<Response> {
         targetNode
       )
       const diff = compareCatalogs(sourceCatalog, targetCatalog)
-      const plan = buildChangePlan(diff)
+      const plan = buildChangePlan(diff, { cluster })
       return Response.json({
         success: true,
         hosts,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -300,6 +300,11 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   chart failure automatically gets the matching illustration. Table query
   failures (`TableClient`) use the full EmptyState, not `compact`, so timeout
   and missing-column copy stays visible.
+- **Recommend-only DDL pairs** (Advisor / schema-diff): when topology is
+  known, show the local table name and a copyable `ON CLUSTER` variant of
+  the same statement (`components/ddl/recommend-ddl-blocks.tsx`, transform
+  in `lib/ddl/on-cluster.ts`). Single-node stays one statement. Never
+  execute or add a Run button.
 - **Interactive tool pages** (Explain, Advisor): before the first run, a
   dashed-border `EmptyState variant="no-data"` ("Nothing to analyze/explain
   yet"). User-input issues — table-less SQL like `SELECT 1`, a missing


### PR DESCRIPTION
## Summary

When cluster topology is known (Distributed engine or cluster metadata), Advisor findings and schema-diff plan items now expose the local table name plus a copyable `ON CLUSTER` variant of the same recommend-only statement.

- Pure transform in `lib/ddl/on-cluster.ts` — no execute/apply path
- Schema-diff `buildChangePlan` annotates items (Distributed inner table, or cluster name from node-vs-node compare)
- Query Advisor + schema tuning attach the same fields; Explorer fills them from `engine_full` when the API has no topology
- `RecommendDdlBlocks` renders local SQL + ON CLUSTER copy controls
- Single-node / empty topology keeps the current single-host statement

Closes #3120

## Test plan

- [x] `bun test src/lib/ddl/on-cluster.test.ts src/lib/schema-diff/plan.test.ts --isolate` (twice)
- [x] Distributed fixture: local table name + ON CLUSTER variant of the same ADD COLUMN
- [x] Empty topology: statement unchanged, no ON CLUSTER
- [x] Transform source has no fetchData / executeDdl / applyDdl
- [ ] `pnpm run lint` / required CI `unit-tests` + `dashboard`

Co-Authored-By: duyetbot <bot@duyet.net>