### PR TITLE
fix(dashboard): cap refresh fan-out and remaining perf findings

### DIFF
--- a/apps/dashboard/src/components/cluster-topology/topo-canvas.tsx
+++ b/apps/dashboard/src/components/cluster-topology/topo-canvas.tsx
@@ -16,7 +16,7 @@ import {
   groupSafeDelta,
 } from './topo-canvas-geometry'
 import { ChGlyph, curvePath, HullLabel, KeeperGlyph } from './topo-glyphs'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 interface TopoCanvasProps {
   model: TopologyModel
@@ -28,7 +28,7 @@ interface TopoCanvasProps {
   onClearSelect: () => void
 }
 
-export function TopoCanvas({
+export const TopoCanvas = memo(function TopoCanvas({
   model,
   liveById,
   selected,
@@ -510,4 +510,4 @@ export function TopoCanvas({
       ))}
     </svg>
   )
-}
+})

--- a/apps/dashboard/src/components/cluster-topology/topology-select.test.ts
+++ b/apps/dashboard/src/components/cluster-topology/topology-select.test.ts
@@ -1,0 +1,49 @@
+/**
+ * WHY: a fresh `() => setSelected(null)` each TopologyView render would
+ * defeat React.memo on TopoCanvas. useOnClearSelect must keep identity
+ * while setSelected is stable.
+ */
+
+import { useOnClearSelect } from './topology-select'
+import { describe, expect, test } from 'bun:test'
+import { createElement, useState } from 'react'
+
+describe('useOnClearSelect', () => {
+  test('returns the same function across rerenders', async () => {
+    if (typeof document === 'undefined') {
+      const { GlobalRegistrator } = await import(
+        '@happy-dom/global-registrator'
+      )
+      GlobalRegistrator.register()
+    }
+
+    const { act } = await import('react')
+    const { createRoot } = await import('react-dom/client')
+
+    const seen: Array<() => void> = []
+    function Probe({ tick }: { tick: number }) {
+      const [, setSelected] = useState<string | null>(null)
+      const onClear = useOnClearSelect(setSelected)
+      seen.push(onClear)
+      return createElement('span', null, String(tick))
+    }
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    await act(async () => {
+      root.render(createElement(Probe, { tick: 0 }))
+    })
+    await act(async () => {
+      root.render(createElement(Probe, { tick: 1 }))
+    })
+
+    expect(seen.length).toBeGreaterThanOrEqual(2)
+    expect(seen[0]).toBe(seen[1])
+
+    await act(async () => {
+      root.unmount()
+    })
+    container.remove()
+  })
+})

--- a/apps/dashboard/src/components/cluster-topology/topology-select.ts
+++ b/apps/dashboard/src/components/cluster-topology/topology-select.ts
@@ -1,0 +1,14 @@
+import { type Dispatch, type SetStateAction, useCallback } from 'react'
+
+/**
+ * Stable clear-selection callback for TopoCanvas. setSelected from useState
+ * is identity-stable, so this hook's return value stays the same across
+ * TopologyView rerenders and does not defeat React.memo on the canvas.
+ */
+export function useOnClearSelect(
+  setSelected: Dispatch<SetStateAction<string | null>>
+): () => void {
+  return useCallback(() => {
+    setSelected(null)
+  }, [setSelected])
+}

--- a/apps/dashboard/src/components/cluster-topology/topology-updated-ago.tsx
+++ b/apps/dashboard/src/components/cluster-topology/topology-updated-ago.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Isolated "updated Ns ago" ticker. Lives in its own component so the 1s
+ * interval cannot re-render TopologyView / TopoCanvas.
+ */
+export function TopologyUpdatedAgo({
+  topology,
+  liveRow,
+}: {
+  topology: unknown
+  liveRow: unknown
+}) {
+  const [secsAgo, setSecsAgo] = useState(0)
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset the ticker when fresh topology/live data arrives
+  useEffect(() => {
+    setSecsAgo(0)
+  }, [topology, liveRow])
+
+  useEffect(() => {
+    const t = setInterval(() => setSecsAgo((s) => s + 1), 1000)
+    return () => clearInterval(t)
+  }, [])
+
+  return <span className="tabular-nums">{secsAgo}s</span>
+}

--- a/apps/dashboard/src/components/cluster-topology/topology-view.test.ts
+++ b/apps/dashboard/src/components/cluster-topology/topology-view.test.ts
@@ -1,0 +1,44 @@
+/**
+ * WHY: the 1s "updated Ns ago" tick used to live on TopologyView, so the
+ * 500-line TopoCanvas re-rendered every second. The tick belongs in
+ * TopologyUpdatedAgo; onClearSelect must be useCallback so memo works.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+
+function src(name: string): string {
+  return readFileSync(join(dir, name), 'utf8')
+}
+
+describe('topology tick isolation + stable clear-select', () => {
+  test('TopologyUpdatedAgo owns the 1s interval; TopologyView does not tick', () => {
+    const view = src('topology-view.tsx')
+    const ago = src('topology-updated-ago.tsx')
+
+    expect(ago).toContain('setInterval')
+    expect(ago).toContain('setSecsAgo')
+    expect(view).not.toContain('setInterval')
+    expect(view).not.toContain('setSecsAgo')
+    expect(view).toContain('TopologyUpdatedAgo')
+  })
+
+  test('onClearSelect is created with useOnClearSelect / useCallback', () => {
+    const view = src('topology-view.tsx')
+    const select = src('topology-select.ts')
+
+    expect(select).toContain('useCallback')
+    expect(view).toContain('useOnClearSelect')
+    expect(view).toContain('onClearSelect={onClearSelect}')
+    expect(view).not.toContain('onClearSelect={() => setSelected(null)}')
+  })
+
+  test('TopoCanvas is wrapped in React.memo', () => {
+    const canvas = src('topo-canvas.tsx')
+    expect(canvas).toMatch(/export const TopoCanvas = memo\(/)
+  })
+})

--- a/apps/dashboard/src/components/cluster-topology/topology-view.tsx
+++ b/apps/dashboard/src/components/cluster-topology/topology-view.tsx
@@ -22,6 +22,8 @@ import {
 } from './inspector'
 import { isKeeperNode, layoutTopology, STATUS_COLOR } from './model'
 import { TopoCanvas } from './topo-canvas'
+import { useOnClearSelect } from './topology-select'
+import { TopologyUpdatedAgo } from './topology-updated-ago'
 import { useTopology } from './use-topology'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { AppLink as Link } from '@/components/ui/app-link'
@@ -183,7 +185,7 @@ export function TopologyView({
   // ── selection + cluster filter ──
   const [selected, setSelected] = useState<string | null>(null)
   const [activeCluster, setActiveCluster] = useState<string | null>(null)
-  const [secsAgo, setSecsAgo] = useState(0)
+  const onClearSelect = useOnClearSelect(setSelected)
 
   // A hidden physical cluster must not act as the filter — its hull isn't drawn,
   // so it would fade every visible hull with no anchor. Derive the EFFECTIVE
@@ -194,15 +196,6 @@ export function TopologyView({
     (showPhysical || !model.clusterById[activeCluster]?.outline)
       ? activeCluster
       : null
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset the "updated Ns ago" counter whenever fresh data arrives, not on every render
-  useEffect(() => {
-    setSecsAgo(0)
-  }, [topology, liveRow])
-  useEffect(() => {
-    const t = setInterval(() => setSecsAgo((s) => s + 1), 1000)
-    return () => clearInterval(t)
-  }, [])
 
   // ── fast-tick live snapshot for the LOCAL node (overrides the 60s server one) ──
   const fastLocalLive: NodeLiveMetrics | null = useMemo(() => {
@@ -337,7 +330,7 @@ export function TopologyView({
           </span>
           <span className="text-[11.5px] text-muted-foreground">
             · cluster <span className="font-mono">{dfltCluster}</span> · updated{' '}
-            <span className="tabular-nums">{secsAgo}s</span> ago
+            <TopologyUpdatedAgo topology={topology} liveRow={liveRow} /> ago
           </span>
         </div>
         <div className="flex items-center gap-1.5">
@@ -533,7 +526,7 @@ export function TopologyView({
                 selected={selected}
                 activeCluster={effectiveActiveCluster}
                 onSelect={setSelected}
-                onClearSelect={() => setSelected(null)}
+                onClearSelect={onClearSelect}
               />
             </div>
           </div>

--- a/apps/dashboard/src/components/data-table/hooks/use-data-table-view.test.ts
+++ b/apps/dashboard/src/components/data-table/hooks/use-data-table-view.test.ts
@@ -1,0 +1,30 @@
+/**
+ * WHY: card view used to disable row virtualization, so a 1000-row cards
+ * table mounted every card. Virtualization is only incompatible with
+ * expandable rows — MobileTableCards already renders virtual items.
+ */
+
+import { isRowVirtualizationDisabled } from './use-data-table-view'
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+describe('isRowVirtualizationDisabled', () => {
+  test('only expandable rows disable virtualization', () => {
+    expect(isRowVirtualizationDisabled(undefined)).toBe(false)
+    expect(isRowVirtualizationDisabled(null)).toBe(false)
+    expect(isRowVirtualizationDisabled(false)).toBe(false)
+    expect(isRowVirtualizationDisabled(true)).toBe(true)
+    expect(isRowVirtualizationDisabled({ render: () => null })).toBe(true)
+  })
+
+  test('the hook no longer disables virtualization because view is cards', () => {
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'use-data-table-view.ts'),
+      'utf8'
+    )
+    expect(src).not.toContain("view === 'cards'")
+    expect(src).toContain('isRowVirtualizationDisabled(expandable)')
+  })
+})

--- a/apps/dashboard/src/components/data-table/hooks/use-data-table-view.ts
+++ b/apps/dashboard/src/components/data-table/hooks/use-data-table-view.ts
@@ -13,6 +13,11 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useCallback, useState } from 'react'
 import { computeTableBodyRenderKey } from '@/components/data-table/utils/body-render-key'
 
+/** Row virtualization is only incompatible with expandable rows. */
+export function isRowVirtualizationDisabled(expandable: unknown): boolean {
+  return Boolean(expandable)
+}
+
 interface UseDataTableViewParams<TData extends RowData> {
   table: Table<TData>
   defaultView: 'table' | 'cards' | 'auto' | undefined
@@ -50,11 +55,12 @@ export function useDataTableView<TData extends RowData>({
 
   // Virtual rows for datasets larger than the standard pagination range.
   // Disabled when row expansion is on because expanded rows add out-of-band
-  // height the fixed-size virtualizer can't account for.
+  // height the fixed-size virtualizer can't account for. Card view stays
+  // virtualized — MobileTableCards already renders virtual items.
   const rows: Row<TData>[] = table.getRowModel().rows
   const { virtualizer, tableContainerRef, isVirtualized } = useVirtualRows(
     rows.length,
-    { disabled: Boolean(expandable) || view === 'cards' }
+    { disabled: isRowVirtualizationDisabled(expandable) }
   )
 
   // Auto-fit columns functionality

--- a/apps/dashboard/src/lib/api/__tests__/chart-batch.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/chart-batch.test.ts
@@ -1,0 +1,107 @@
+/**
+ * WHY: stats-grid used to fire ~20 independent chart requests. The shipped
+ * grouping executor must return per-name keys for the frozen insights-stats
+ * list and reject unknown grouping ids — otherwise a free-form batch would
+ * fragment the cache key and skip rate-limit accounting.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockFetchJsonEachRow = mock(async (args: { query?: string }) => ({
+  data: null,
+  dataJson: JSON.stringify([{ query: args.query?.slice(0, 24) ?? '' }]),
+  metadata: { queryId: 'q', duration: 1, rows: 1, host: 'h' },
+  error: undefined,
+}))
+
+mock.module('@chm/clickhouse-client', () => ({
+  fetchData: async () => ({
+    data: [],
+    metadata: { queryId: 'q', duration: 0, rows: 0, host: 'h' },
+    error: undefined,
+  }),
+  fetchJsonEachRowAsNormalizedJson: mockFetchJsonEachRow,
+  getClient: async () => ({ query: async () => ({}) }),
+}))
+
+const realClickHouseVersion = await import(
+  '@chm/clickhouse-client/clickhouse-version'
+)
+mock.module('@chm/clickhouse-client/clickhouse-version', () => ({
+  ...realClickHouseVersion,
+  getClickHouseVersion: async () => ({
+    major: 24,
+    minor: 8,
+    patch: 0,
+    raw: '24.8.0',
+  }),
+  selectVersionedSql: (sql: unknown) =>
+    Array.isArray(sql) ? sql[sql.length - 1].sql : sql,
+}))
+
+const {
+  CHART_GROUPINGS,
+  chartGroupingIdForName,
+  executeChartGrouping,
+  groupingCacheControl,
+  INSIGHTS_STATS_GROUPING,
+  isChartGroupingId,
+  isKnownChartGrouping,
+  UnknownChartGroupingError,
+} = await import('@/lib/api/chart-batch')
+
+describe('executeChartGrouping', () => {
+  beforeEach(() => {
+    mockFetchJsonEachRow.mockClear()
+  })
+
+  test('runs the frozen insights-stats grouping and returns per-name keys', async () => {
+    const result = await executeChartGrouping('insights-stats', 0, {
+      lastHours: 24,
+      params: { percentile: '99' },
+    })
+
+    expect(Object.keys(result).sort()).toEqual(
+      [...INSIGHTS_STATS_GROUPING].slice().sort()
+    )
+    expect(INSIGHTS_STATS_GROUPING).toHaveLength(20)
+    expect(mockFetchJsonEachRow.mock.calls.length).toBe(
+      INSIGHTS_STATS_GROUPING.length
+    )
+
+    for (const name of INSIGHTS_STATS_GROUPING) {
+      expect(result[name]).toBeDefined()
+      expect(result[name]?.dataJson).toBeTruthy()
+      expect(result[name]?.error).toBeUndefined()
+    }
+    expect(CHART_GROUPINGS['insights-stats']).toBe(INSIGHTS_STATS_GROUPING)
+  })
+
+  test('rejects an unknown grouping id', async () => {
+    expect(isKnownChartGrouping('not-a-group')).toBe(false)
+    expect(isChartGroupingId('insights-stats')).toBe(true)
+    expect(isChartGroupingId('arbitrary-free-form')).toBe(false)
+    expect(chartGroupingIdForName('insight-active-queries')).toBe(
+      'insights-stats'
+    )
+    expect(chartGroupingIdForName('query-count')).toBeUndefined()
+
+    let thrown: unknown
+    try {
+      await executeChartGrouping('not-a-group', 0)
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(UnknownChartGroupingError)
+    expect(
+      (thrown as InstanceType<typeof UnknownChartGroupingError>).groupingId
+    ).toBe('not-a-group')
+  })
+
+  test('Cache-Control uses the minimum s-maxage of grouping members', () => {
+    // insights-stats mixes realtime (10s) and historical (120s) tiles.
+    expect(groupingCacheControl(INSIGHTS_STATS_GROUPING)).toBe(
+      'public, s-maxage=10, stale-while-revalidate=30'
+    )
+  })
+})

--- a/apps/dashboard/src/lib/api/chart-batch.ts
+++ b/apps/dashboard/src/lib/api/chart-batch.ts
@@ -1,0 +1,242 @@
+/**
+ * Fixed chart groupings for batch execution.
+ *
+ * Arbitrary name lists are rejected: a free-form batch would fragment the
+ * cache key and bypass per-chart rate-limit accounting. Callers pick a
+ * known grouping id; the server runs that frozen name list through the
+ * existing `executeChartQuery` / registry path.
+ */
+
+import type { FetchDataResult } from '@chm/clickhouse-client'
+import type { ExecuteOptions } from '@/lib/api/query-executor'
+
+import {
+  cachePolicyToQueryCacheTtlSeconds,
+  getChartQuery,
+} from '@/lib/api/chart-registry'
+import { executeChartQuery } from '@/lib/api/query-executor'
+import { chartCachePolicy } from '@/lib/swr/chart-freshness'
+
+/** Insight stats-grid tiles — one grouping, one request. */
+export const INSIGHTS_STATS_GROUPING = Object.freeze([
+  'insight-largest-scan',
+  'insight-fastest-scan',
+  'insight-longest-query',
+  'insight-total-storage',
+  'insight-total-queries',
+  'insight-total-scanned',
+  'insight-total-rows-read',
+  'insight-peak-memory',
+  'insight-active-queries',
+  'insight-current-memory',
+  'insight-http-connections',
+  'insight-active-merges',
+  'insight-active-parts',
+  'insight-detached-parts',
+  'insight-active-mutations',
+  'insight-busiest-day-queries',
+  'insight-busiest-day-bytes',
+  'insight-busiest-second',
+  'insight-avg-duration',
+  'insight-error-rate',
+] as const)
+
+export const CHART_GROUPINGS = Object.freeze({
+  'insights-stats': INSIGHTS_STATS_GROUPING,
+} as const)
+
+export type ChartGroupingId = keyof typeof CHART_GROUPINGS
+
+export class UnknownChartGroupingError extends Error {
+  readonly groupingId: string
+  constructor(groupingId: string) {
+    super(`Unknown chart grouping: ${groupingId}`)
+    this.name = 'UnknownChartGroupingError'
+    this.groupingId = groupingId
+  }
+}
+
+export function isKnownChartGrouping(id: string): id is ChartGroupingId {
+  return Object.hasOwn(CHART_GROUPINGS, id)
+}
+
+/** @deprecated alias — prefer isKnownChartGrouping */
+export const isChartGroupingId = isKnownChartGrouping
+
+const NAME_TO_GROUPING = new Map<string, ChartGroupingId>()
+for (const [id, names] of Object.entries(CHART_GROUPINGS)) {
+  for (const name of names) {
+    NAME_TO_GROUPING.set(name, id as ChartGroupingId)
+  }
+}
+
+export function chartGroupingIdForName(
+  chartName: string
+): ChartGroupingId | undefined {
+  return NAME_TO_GROUPING.get(chartName)
+}
+
+export function getChartGrouping(
+  groupingId: string
+): readonly string[] | undefined {
+  if (!isKnownChartGrouping(groupingId)) return undefined
+  return CHART_GROUPINGS[groupingId]
+}
+
+export interface ChartGroupingEntry {
+  dataJson: string | null
+  error?: FetchDataResult<never>['error']
+  metadata?: Record<string, string | number>
+  executedSql?: string
+}
+
+export interface ExecuteChartGroupingOptions extends ExecuteOptions {
+  lastHours?: number
+  params?: Record<string, unknown>
+}
+
+/**
+ * Run every chart in a known grouping via `executeChartQuery`. Per-name
+ * errors are isolated so one missing table does not fail the rest.
+ */
+export async function executeChartGrouping(
+  groupingId: string,
+  hostId: number,
+  opts: ExecuteChartGroupingOptions = {}
+): Promise<Record<string, ChartGroupingEntry>> {
+  const names = getChartGrouping(groupingId)
+  if (!names) throw new UnknownChartGroupingError(groupingId)
+
+  const { lastHours, params, timezone, bindings } = opts
+  const entries = await Promise.all(
+    names.map(async (name): Promise<[string, ChartGroupingEntry]> => {
+      try {
+        const queryDef = getChartQuery(name, { lastHours, params, timezone })
+        if (!queryDef) {
+          return [
+            name,
+            {
+              dataJson: null,
+              error: {
+                type: 'query_error',
+                message: `Failed to build query for chart: ${name}`,
+              },
+            },
+          ]
+        }
+        if ('queries' in queryDef) {
+          return [
+            name,
+            {
+              dataJson: null,
+              error: {
+                type: 'query_error',
+                message: `Multi-query chart not supported in grouping: ${name}`,
+              },
+            },
+          ]
+        }
+
+        const result = await executeChartQuery(
+          name,
+          queryDef.sql ?? queryDef.query,
+          hostId,
+          queryDef.queryParams,
+          {
+            bindings,
+            timezone,
+            optional: queryDef.optional,
+            tableCheck: queryDef.tableCheck,
+            columnCheck: queryDef.columnCheck,
+            ttlSeconds: cachePolicyToQueryCacheTtlSeconds(queryDef.cachePolicy),
+            disableQueryCache: queryDef.disableQueryCache,
+          }
+        )
+
+        if (
+          result.error &&
+          queryDef.optional &&
+          (result.error.type === 'table_not_found' ||
+            result.error.type === 'column_not_found')
+        ) {
+          return [
+            name,
+            {
+              dataJson: '[]',
+              metadata: result.metadata,
+              executedSql: result.executedSql,
+            },
+          ]
+        }
+
+        return [
+          name,
+          {
+            dataJson: result.dataJson,
+            error: result.error,
+            metadata: result.metadata,
+            executedSql: result.executedSql,
+          },
+        ]
+      } catch (err) {
+        return [
+          name,
+          {
+            dataJson: null,
+            error: {
+              type: 'query_error',
+              message: err instanceof Error ? err.message : 'Unknown error',
+            },
+          },
+        ]
+      }
+    })
+  )
+
+  return Object.fromEntries(entries)
+}
+
+/** s-maxage for a cache policy — mirrors GET /api/v1/charts/$name. */
+function sMaxAgeForPolicy(policy: string | undefined): number {
+  if (policy === 'realtime') return 10
+  if (policy === 'historical') return 120
+  return 30
+}
+
+function policyForName(name: string): string | undefined {
+  const def = getChartQuery(name)
+  if (def && 'cachePolicy' in def && def.cachePolicy) return def.cachePolicy
+  return chartCachePolicy(name)
+}
+
+/** Tightest cache policy among grouping members (realtime < standard < historical). */
+export function groupingCachePolicy(
+  groupingId: ChartGroupingId,
+  _params?: unknown
+): 'realtime' | 'standard' | 'historical' {
+  const names = CHART_GROUPINGS[groupingId]
+  let min = Number.POSITIVE_INFINITY
+  let policy: 'realtime' | 'standard' | 'historical' = 'standard'
+  for (const name of names) {
+    const member = policyForName(name)
+    const sMax = sMaxAgeForPolicy(member)
+    if (sMax < min) {
+      min = sMax
+      policy =
+        sMax === 10 ? 'realtime' : sMax === 120 ? 'historical' : 'standard'
+    }
+  }
+  return policy
+}
+
+/** Cache-Control using the minimum s-maxage of grouping members. */
+export function groupingCacheControl(names: readonly string[]): string {
+  let min = Number.POSITIVE_INFINITY
+  for (const name of names) {
+    const sMax = sMaxAgeForPolicy(policyForName(name))
+    if (sMax < min) min = sMax
+  }
+  const sMaxAge = Number.isFinite(min) ? min : 30
+  const swr = sMaxAge === 10 ? 30 : sMaxAge === 120 ? 300 : 60
+  return `public, s-maxage=${sMaxAge}, stale-while-revalidate=${swr}`
+}

--- a/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
+++ b/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck — bun:test fixture; PersistedClient's dehydrated query state is wider than this stub
 /**
  * WHY: once localStorage is over quota the persister would drop the entire
  * write for that tick (and every later tick) unless retry evicts something.

--- a/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
+++ b/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
@@ -35,7 +35,7 @@ function persisted(
         },
       })),
     },
-  }
+  } as PersistedClient
 }
 
 function quotaError(message = 'QuotaExceededError'): Error {

--- a/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
+++ b/apps/dashboard/src/lib/query/__tests__/persist-retry.test.ts
@@ -1,0 +1,126 @@
+/**
+ * WHY: once localStorage is over quota the persister would drop the entire
+ * write for that tick (and every later tick) unless retry evicts something.
+ * These tests drive the shipped PersistRetryer with a real PersistedClient
+ * shape so a "drop the largest query" regression fails here.
+ */
+
+import type { PersistedClient } from '@tanstack/react-query-persist-client'
+
+import {
+  PERSIST_RETRY_MAX_ERROR_COUNT,
+  retryPersistOnQuotaOverflow,
+} from '../persist-retry'
+import { describe, expect, test } from 'bun:test'
+
+function persisted(
+  queries: Array<{
+    key: string
+    data: unknown
+    dataUpdatedAt?: number
+  }>
+): PersistedClient {
+  return {
+    timestamp: 1,
+    buster: 'test',
+    clientState: {
+      mutations: [],
+      queries: queries.map((q) => ({
+        queryHash: JSON.stringify([q.key]),
+        queryKey: [q.key],
+        state: {
+          data: q.data,
+          dataUpdatedAt: q.dataUpdatedAt ?? 1,
+          status: 'success' as const,
+        },
+      })),
+    },
+  }
+}
+
+function quotaError(message = 'QuotaExceededError'): Error {
+  const err = new Error(message)
+  err.name = 'QuotaExceededError'
+  return err
+}
+
+function queryKeys(client: PersistedClient | undefined): string[] {
+  return (client?.clientState.queries ?? []).map((q) => String(q.queryKey[0]))
+}
+
+describe('retryPersistOnQuotaOverflow', () => {
+  test('evicts the largest query by JSON size of state.data and retries', () => {
+    const client = persisted([
+      { key: 'small', data: { n: 1 } },
+      { key: 'medium', data: { n: 'x'.repeat(80) } },
+      { key: 'large', data: { n: 'y'.repeat(8_000) } },
+    ])
+
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: client,
+      error: quotaError(),
+      errorCount: 1,
+    })
+
+    expect(next).toBeDefined()
+    expect(next).not.toBe(client)
+    expect(queryKeys(next)).toEqual(['small', 'medium'])
+    expect(queryKeys(next)).not.toContain('large')
+  })
+
+  test('treats a QuotaExceededError message (any name) as quota overflow', () => {
+    const err = new Error(
+      "Failed to execute 'setItem' on 'Storage': Setting the value exceeded the quota."
+    )
+    err.name = 'Error'
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: persisted([
+        { key: 'keep', data: 1 },
+        { key: 'drop', data: { blob: 'z'.repeat(4_000) } },
+      ]),
+      error: err,
+      errorCount: 1,
+    })
+    expect(queryKeys(next)).toEqual(['keep'])
+  })
+
+  test('returns undefined for a non-quota error so persist aborts', () => {
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: persisted([{ key: 'a', data: { n: 1 } }]),
+      error: new Error('disk is read-only'),
+      errorCount: 1,
+    })
+    expect(next).toBeUndefined()
+  })
+
+  test('returns undefined when no queries are left to evict', () => {
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: persisted([]),
+      error: quotaError(),
+      errorCount: 1,
+    })
+    expect(next).toBeUndefined()
+  })
+
+  test('returns undefined after the max retry count so persist aborts', () => {
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: persisted([{ key: 'a', data: { n: 1 } }]),
+      error: quotaError(),
+      errorCount: PERSIST_RETRY_MAX_ERROR_COUNT + 1,
+    })
+    expect(next).toBeUndefined()
+  })
+
+  test('when sizes tie, evicts the oldest query', () => {
+    const payload = { n: 'same-size' }
+    const next = retryPersistOnQuotaOverflow({
+      persistedClient: persisted([
+        { key: 'newer', data: payload, dataUpdatedAt: 200 },
+        { key: 'older', data: payload, dataUpdatedAt: 50 },
+      ]),
+      error: quotaError(),
+      errorCount: 1,
+    })
+    expect(queryKeys(next)).toEqual(['newer'])
+  })
+})

--- a/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
+++ b/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
@@ -1,68 +1,76 @@
 import { keepPreviousData, QueryClient } from '@tanstack/react-query'
 
-import { shouldDehydrateQuery } from '../provider'
+import {
+  invalidateActiveQueriesInBatches,
+  REFRESH_BATCH_SIZE,
+  shouldDehydrateQuery,
+} from '../provider'
 import { createQueryClient } from '../query-client'
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { USER_CONNECTIONS_QUERY_PREFIX } from '@/lib/hooks/use-user-connections'
 import { USER_SETTINGS_QUERY_KEY } from '@/lib/hooks/use-user-settings'
 
-describe('QueryProvider swr:revalidate integration', () => {
+describe('invalidateActiveQueriesInBatches', () => {
   let queryClient: QueryClient
   let invalidateSpy: ReturnType<typeof spyOn>
+  const unsubs: Array<() => void> = []
 
   beforeEach(() => {
-    queryClient = new QueryClient()
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
     invalidateSpy = spyOn(queryClient, 'invalidateQueries')
   })
 
   afterEach(() => {
+    for (const unsub of unsubs) unsub()
+    unsubs.length = 0
     invalidateSpy.mockRestore()
+    queryClient.clear()
   })
 
-  it('calls invalidateQueries({ type: "active" }) when swr:revalidate fires', () => {
-    // Simulate the effect body from QueryProvider directly.
-    // The effect registers a window listener; we replicate that wiring here
-    // so the test stays decoupled from React rendering internals.
-    const listeners: Record<string, EventListenerOrEventListenerObject[]> = {}
-    const mockWindow = {
-      addEventListener: (
-        event: string,
-        cb: EventListenerOrEventListenerObject
-      ) => {
-        listeners[event] = listeners[event] || []
-        listeners[event].push(cb)
-      },
-      removeEventListener: (
-        event: string,
-        cb: EventListenerOrEventListenerObject
-      ) => {
-        if (listeners[event]) {
-          listeners[event] = listeners[event].filter((x) => x !== cb)
-        }
-      },
+  async function seedActiveQueries(count: number) {
+    const { QueryObserver } = await import('@tanstack/react-query')
+    for (let i = 0; i < count; i++) {
+      const key = ['refresh-test', i] as const
+      queryClient.setQueryData(key, i)
+      const observer = new QueryObserver(queryClient, {
+        queryKey: key,
+        queryFn: async () => i,
+        staleTime: Number.POSITIVE_INFINITY,
+      })
+      unsubs.push(observer.subscribe(() => {}))
+    }
+  }
+
+  it('invalidates each active query by exact key, never type:"active"', async () => {
+    await seedActiveQueries(20)
+
+    await invalidateActiveQueriesInBatches(queryClient, {
+      batchSize: REFRESH_BATCH_SIZE,
+      delayMs: 0,
+    })
+
+    const calls = invalidateSpy.mock.calls.map((c) => c[0])
+    expect(calls.some((arg) => arg && arg.type === 'active')).toBe(false)
+    expect(invalidateSpy).toHaveBeenCalledTimes(20)
+
+    for (let i = 0; i < 20; i++) {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['refresh-test', i],
+        exact: true,
+      })
     }
 
-    // Wire up the same handler logic as in provider.tsx's useEffect
-    const handleRevalidate = () => {
-      queryClient.invalidateQueries({ type: 'active' })
-    }
-    mockWindow.addEventListener('swr:revalidate', handleRevalidate)
-
-    // Trigger the event
-    listeners['swr:revalidate'].forEach((cb) =>
-      typeof cb === 'function'
-        ? (cb as any)()
-        : cb.handleEvent(new Event('swr:revalidate'))
-    )
-
-    expect(invalidateSpy).toHaveBeenCalledWith({ type: 'active' })
-
-    // Cleanup unregisters the listener
-    mockWindow.removeEventListener('swr:revalidate', handleRevalidate)
-    expect(listeners['swr:revalidate'].length).toBe(0)
+    const firstBatchKeys = calls.slice(0, REFRESH_BATCH_SIZE).map((arg) => {
+      const key = arg?.queryKey as readonly unknown[]
+      return key[1]
+    })
+    expect(firstBatchKeys).toEqual([0, 1, 2, 3, 4, 5])
+    expect(calls.length).toBe(20)
   })
 
-  it('does not call invalidateQueries before the event fires', () => {
+  it('does not call invalidateQueries before the batch helper runs', () => {
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
+++ b/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
@@ -1,3 +1,4 @@
+// @ts-nocheck — bun:test spies; type-check:test has no bun mock typings
 import { keepPreviousData, QueryClient } from '@tanstack/react-query'
 
 import {

--- a/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
+++ b/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
@@ -51,7 +51,10 @@ describe('invalidateActiveQueriesInBatches', () => {
       delayMs: 0,
     })
 
-    const calls = invalidateSpy.mock.calls.map((c) => c[0])
+    type InvalidateArg = { type?: string; queryKey?: readonly unknown[] }
+    const calls = invalidateSpy.mock.calls.map(
+      (c) => (c as [InvalidateArg])[0]
+    )
     expect(calls.some((arg) => arg && arg.type === 'active')).toBe(false)
     expect(invalidateSpy).toHaveBeenCalledTimes(20)
 
@@ -63,7 +66,7 @@ describe('invalidateActiveQueriesInBatches', () => {
     }
 
     const firstBatchKeys = calls.slice(0, REFRESH_BATCH_SIZE).map((arg) => {
-      const key = arg?.queryKey as readonly unknown[]
+      const key = arg?.queryKey ?? []
       return key[1]
     })
     expect(firstBatchKeys).toEqual([0, 1, 2, 3, 4, 5])

--- a/apps/dashboard/src/lib/query/persist-retry.ts
+++ b/apps/dashboard/src/lib/query/persist-retry.ts
@@ -1,0 +1,77 @@
+import type {
+  PersistedClient,
+  PersistRetryer,
+} from '@tanstack/react-query-persist-client'
+
+/** Abort persist retries after this many quota evictions. */
+export const PERSIST_RETRY_MAX_ERROR_COUNT = 5
+
+/**
+ * True when `setItem` failed because localStorage is over quota.
+ * Matches the DOM `QuotaExceededError` name, the Firefox
+ * `NS_ERROR_DOM_QUOTA_REACHED` name, and a message that names either.
+ */
+export function isQuotaExceededError(error: Error): boolean {
+  if (error.name === 'QuotaExceededError') return true
+  if (error.name === 'NS_ERROR_DOM_QUOTA_REACHED') return true
+  return (
+    /quotaexceedederror/i.test(error.message) ||
+    /quota exceeded/i.test(error.message) ||
+    /exceeded the quota/i.test(error.message)
+  )
+}
+
+function queryDataJsonSize(data: unknown): number {
+  try {
+    return JSON.stringify(data ?? null).length
+  } catch {
+    return 0
+  }
+}
+
+/** Largest `state.data` (JSON size); oldest `dataUpdatedAt` wins a tie. */
+function evictIndex(
+  queries: PersistedClient['clientState']['queries']
+): number {
+  let best = 0
+  let bestSize = -1
+  let bestUpdatedAt = Number.POSITIVE_INFINITY
+  for (let i = 0; i < queries.length; i++) {
+    const query = queries[i]
+    const size = queryDataJsonSize(query?.state.data)
+    const updatedAt = query?.state.dataUpdatedAt ?? 0
+    if (size > bestSize || (size === bestSize && updatedAt < bestUpdatedAt)) {
+      best = i
+      bestSize = size
+      bestUpdatedAt = updatedAt
+    }
+  }
+  return best
+}
+
+/**
+ * PersistRetryer: on QuotaExceededError, drop the largest (or oldest) query
+ * and return the trimmed client so `createSyncStoragePersister` retries
+ * `setItem`. Abort when the error is not quota, nothing is left to evict, or
+ * we have already retried {@link PERSIST_RETRY_MAX_ERROR_COUNT} times.
+ */
+export const retryPersistOnQuotaOverflow: PersistRetryer = ({
+  persistedClient,
+  error,
+  errorCount,
+}) => {
+  if (errorCount > PERSIST_RETRY_MAX_ERROR_COUNT) return undefined
+  if (!isQuotaExceededError(error)) return undefined
+
+  const queries = persistedClient.clientState.queries
+  if (queries.length === 0) return undefined
+
+  const index = evictIndex(queries)
+  return {
+    ...persistedClient,
+    clientState: {
+      ...persistedClient.clientState,
+      queries: queries.filter((_, i) => i !== index),
+    },
+  }
+}

--- a/apps/dashboard/src/lib/query/provider.tsx
+++ b/apps/dashboard/src/lib/query/provider.tsx
@@ -1,11 +1,47 @@
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
+import type { QueryClient } from '@tanstack/react-query'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 
+import { retryPersistOnQuotaOverflow } from './persist-retry'
 import { createQueryClient } from './query-client'
 import { useEffect, useState } from 'react'
 import { USER_CONNECTIONS_QUERY_PREFIX } from '@/lib/hooks/use-user-connections'
 import { USER_SETTINGS_QUERY_KEY } from '@/lib/hooks/use-user-settings'
+
+/** Max concurrent invalidations per refresh tick. */
+export const REFRESH_BATCH_SIZE = 6
+
+/** Pause between refresh batches so the Worker/ClickHouse burst stays bounded. */
+export const REFRESH_BATCH_DELAY_MS = 50
+
+/**
+ * Invalidate currently-active queries in chunks instead of one
+ * `invalidateQueries({ type: 'active' })` fan-out.
+ */
+export async function invalidateActiveQueriesInBatches(
+  queryClient: QueryClient,
+  options?: { batchSize?: number; delayMs?: number }
+): Promise<void> {
+  const batchSize = options?.batchSize ?? REFRESH_BATCH_SIZE
+  const delayMs = options?.delayMs ?? REFRESH_BATCH_DELAY_MS
+  const active = queryClient.getQueryCache().findAll({ type: 'active' })
+
+  for (let i = 0; i < active.length; i += batchSize) {
+    const batch = active.slice(i, i + batchSize)
+    await Promise.all(
+      batch.map((query) =>
+        queryClient.invalidateQueries({
+          queryKey: query.queryKey,
+          exact: true,
+        })
+      )
+    )
+    if (i + batchSize < active.length && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+}
 
 interface QueryProviderProps {
   children: React.ReactNode
@@ -82,6 +118,7 @@ export function QueryProvider({ children }: QueryProviderProps) {
           storage: window.localStorage,
           key: PERSIST_KEY,
           throttleTime: PERSIST_THROTTLE_MS,
+          retry: retryPersistOnQuotaOverflow,
         })
       )
     } catch {
@@ -95,7 +132,9 @@ export function QueryProvider({ children }: QueryProviderProps) {
     if (typeof window === 'undefined') return
 
     const handleRevalidate = () => {
-      queryClient.invalidateQueries({ type: 'active' })
+      void invalidateActiveQueriesInBatches(queryClient).catch((err) => {
+        console.error('[QueryProvider] batched refresh invalidate failed', err)
+      })
     }
 
     window.addEventListener('swr:revalidate', handleRevalidate)

--- a/apps/dashboard/src/lib/query/query-keys.ts
+++ b/apps/dashboard/src/lib/query/query-keys.ts
@@ -55,6 +55,32 @@ export function chartQueryKey({
   ] as const
 }
 
+export function chartGroupingQueryKey({
+  groupingId,
+  hostId,
+  lastHours,
+  paramsKey,
+  timezone,
+  connectionKey,
+}: {
+  groupingId: string
+  hostId?: number | string
+  lastHours?: number
+  paramsKey: string
+  timezone?: string
+  connectionKey: string | undefined
+}) {
+  return [
+    '/api/v1/charts/batch',
+    groupingId,
+    hostId,
+    lastHours,
+    paramsKey,
+    timezone,
+    connectionKey,
+  ] as const
+}
+
 /**
  * Canonical serialization of table `searchParams` for the cache key. Callers
  * (`useTableData`, `prefetch`) serialize ONCE via this helper and pass the

--- a/apps/dashboard/src/lib/query/use-chart-grouping.tsx
+++ b/apps/dashboard/src/lib/query/use-chart-grouping.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+import type { ChartGroupingId } from '@/lib/api/chart-batch'
+import type { ChartMetadata, UseChartResult } from '@/lib/query/use-chart-data'
+
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import { getChartGrouping } from '@/lib/api/chart-batch'
+import {
+  fetchChartForHost,
+  isCustomHost,
+} from '@/lib/host-fetch/resolve-host-fetch'
+import { hostConnectionKey } from '@/lib/query/host-query-key'
+import {
+  chartGroupingQueryKey,
+  serializeChartParams,
+} from '@/lib/query/query-keys'
+import { apiFetch } from '@/lib/swr/api-fetch'
+import { chartRefreshInterval } from '@/lib/swr/chart-freshness'
+import { REFRESH_INTERVAL } from '@/lib/swr/config'
+import { throwIfNotOk } from '@/lib/swr/fetch-error'
+import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
+
+export interface GroupedChartTile {
+  data: unknown[]
+  metadata?: ChartMetadata
+  error?: { type?: string; message: string }
+}
+
+interface ChartGroupingContextValue {
+  charts: Record<string, GroupedChartTile>
+  isLoading: boolean
+  isValidating: boolean
+  mutate: () => Promise<undefined>
+}
+
+const ChartGroupingContext = createContext<ChartGroupingContextValue | null>(
+  null
+)
+
+interface ChartGroupingProviderProps {
+  groupingId: ChartGroupingId
+  hostId: number
+  lastHours?: number
+  params?: Record<string, unknown>
+  timezone?: string
+  children: ReactNode
+}
+
+interface BatchResponse {
+  success: boolean
+  data: Record<string, GroupedChartTile>
+}
+
+export function ChartGroupingProvider({
+  groupingId,
+  hostId,
+  lastHours,
+  params,
+  timezone,
+  children,
+}: ChartGroupingProviderProps) {
+  const { hosts, getConnectionByHostId } = useMergedHosts()
+  const names = getChartGrouping(groupingId) ?? []
+  const paramsKey = serializeChartParams(params)
+  const browserConnection = hostId < 0 ? getConnectionByHostId(hostId) : null
+  const connectionKey = hostConnectionKey(hostId, browserConnection)
+
+  const refreshInterval = names.reduce((min, name) => {
+    const next = chartRefreshInterval(name) ?? REFRESH_INTERVAL.DEFAULT_60S
+    return Math.min(min, next)
+  }, REFRESH_INTERVAL.DEFAULT_60S)
+
+  const { data, error, isPending, isFetching, refetch } = useQuery<
+    Record<string, GroupedChartTile>,
+    Error
+  >({
+    queryKey: chartGroupingQueryKey({
+      groupingId,
+      hostId,
+      lastHours,
+      paramsKey,
+      timezone,
+      connectionKey,
+    }),
+    queryFn: async () => {
+      if (isCustomHost(hostId)) {
+        const entries = await Promise.all(
+          names.map(async (name) => {
+            const result = await fetchChartForHost<unknown[]>({
+              chartName: name,
+              hostId,
+              hosts,
+              browserConnection,
+              lastHours,
+              params,
+              timezone,
+            })
+            return [
+              name,
+              {
+                data: Array.isArray(result.data)
+                  ? result.data
+                  : result.data
+                    ? [result.data]
+                    : [],
+                metadata: result.metadata as ChartMetadata | undefined,
+              } satisfies GroupedChartTile,
+            ] as const
+          })
+        )
+        return Object.fromEntries(entries)
+      }
+
+      const response = await apiFetch('/api/v1/charts/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          groupingId,
+          hostId,
+          lastHours,
+          params,
+          timezone,
+        }),
+      })
+      await throwIfNotOk(response, 'Failed to fetch chart grouping')
+      const json = (await response.json()) as BatchResponse
+      return json.data ?? {}
+    },
+    staleTime: Math.max(refreshInterval * 0.9, 5_000),
+    refetchInterval: () =>
+      typeof document !== 'undefined' && document.hidden
+        ? false
+        : refreshInterval,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    placeholderData: (prev) => prev,
+  })
+
+  const value = useMemo<ChartGroupingContextValue>(() => {
+    const charts: Record<string, GroupedChartTile> = { ...(data ?? {}) }
+    if (error) {
+      for (const name of names) {
+        const existing = charts[name]
+        if (!existing) {
+          charts[name] = { data: [], error: { message: error.message } }
+        } else if (!existing.error) {
+          charts[name] = {
+            ...existing,
+            error: { message: error.message },
+          }
+        }
+      }
+    }
+    return {
+      charts,
+      isLoading: isPending && isFetching,
+      isValidating: isFetching,
+      mutate: () => refetch().then(() => undefined),
+    }
+  }, [data, error, isPending, isFetching, refetch, names])
+
+  return (
+    <ChartGroupingContext.Provider value={value}>
+      {children}
+    </ChartGroupingContext.Provider>
+  )
+}
+
+export function useGroupedChartData<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>({ chartName }: { chartName: string }): UseChartResult<T> {
+  const ctx = useContext(ChartGroupingContext)
+  if (!ctx) {
+    throw new Error(
+      'useGroupedChartData must be used within ChartGroupingProvider'
+    )
+  }
+
+  const entry = ctx.charts[chartName]
+  const dataArray = (entry?.data ?? []) as T[]
+  const groupedError = entry?.error
+    ? Object.assign(new Error(entry.error.message), {
+        type: entry.error.type,
+      })
+    : undefined
+
+  return {
+    data: dataArray,
+    metadata: entry?.metadata,
+    sql: entry?.metadata?.sql,
+    error: groupedError,
+    isLoading: ctx.isLoading,
+    isValidating: ctx.isValidating,
+    mutate: ctx.mutate,
+    hasData: dataArray.length > 0,
+    staleError: undefined,
+    chartName,
+  }
+}

--- a/apps/dashboard/src/lib/query/use-chart-grouping.tsx
+++ b/apps/dashboard/src/lib/query/use-chart-grouping.tsx
@@ -67,7 +67,7 @@ export function ChartGroupingProvider({
   const browserConnection = hostId < 0 ? getConnectionByHostId(hostId) : null
   const connectionKey = hostConnectionKey(hostId, browserConnection)
 
-  const refreshInterval = names.reduce((min, name) => {
+  const refreshInterval = names.reduce<number>((min, name) => {
     const next = chartRefreshInterval(name) ?? REFRESH_INTERVAL.DEFAULT_60S
     return Math.min(min, next)
   }, REFRESH_INTERVAL.DEFAULT_60S)
@@ -129,10 +129,13 @@ export function ChartGroupingProvider({
       return json.data ?? {}
     },
     staleTime: Math.max(refreshInterval * 0.9, 5_000),
-    refetchInterval: () =>
-      typeof document !== 'undefined' && document.hidden
-        ? false
-        : refreshInterval,
+    refetchInterval:
+      refreshInterval > 0
+        ? () =>
+            typeof document !== 'undefined' && document.hidden
+              ? false
+              : refreshInterval
+        : false,
     refetchOnMount: true,
     refetchOnReconnect: true,
     placeholderData: (prev) => prev,

--- a/apps/dashboard/src/routes/(dashboard)/-insights/activity-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/activity-stats.tsx
@@ -9,12 +9,11 @@ import {
 } from 'lucide-react'
 
 import { StatCard, statEmpty, statLoading } from './stat-card'
-import { useChartData } from '@/lib/query/use-chart-data'
+import { useGroupedChartData } from '@/lib/query/use-chart-grouping'
 
-export function ActiveQueriesStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function ActiveQueriesStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-active-queries',
-    hostId,
   })
   if (isLoading) return statLoading('Active Queries')
   if (error || !data?.length)
@@ -33,10 +32,9 @@ export function ActiveQueriesStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function CurrentMemoryStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function CurrentMemoryStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-current-memory',
-    hostId,
   })
   if (isLoading) return statLoading('Current Memory')
   if (error || !data?.length)
@@ -55,10 +53,9 @@ export function CurrentMemoryStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function HttpConnectionsStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function HttpConnectionsStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-http-connections',
-    hostId,
   })
   if (isLoading) return statLoading('HTTP Connections')
   if (error || !data?.length)
@@ -77,10 +74,9 @@ export function HttpConnectionsStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function ActiveMergesStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function ActiveMergesStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-active-merges',
-    hostId,
   })
   if (isLoading) return statLoading('Active Merges')
   if (error || !data?.length)
@@ -99,10 +95,9 @@ export function ActiveMergesStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function ActivePartsStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function ActivePartsStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-active-parts',
-    hostId,
   })
   if (isLoading) return statLoading('Active Parts')
   if (error || !data?.length)
@@ -125,10 +120,9 @@ export function ActivePartsStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function DetachedPartsStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function DetachedPartsStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-detached-parts',
-    hostId,
   })
   if (isLoading) return statLoading('Detached Parts')
   if (error || !data?.length)
@@ -147,10 +141,9 @@ export function DetachedPartsStat({ hostId }: { readonly hostId: number }) {
   )
 }
 
-export function ActiveMutationsStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function ActiveMutationsStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-active-mutations',
-    hostId,
   })
   if (isLoading) return statLoading('Active Mutations')
   if (error || !data?.length)

--- a/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/query-stats.tsx
@@ -6,24 +6,15 @@ import {
 } from 'lucide-react'
 
 import { StatCard, statEmpty, statLoading } from './stat-card'
-import { useChartData } from '@/lib/query/use-chart-data'
-
-interface RangeStatProps {
-  readonly hostId: number
-  readonly lastHours?: number
-  readonly percentile: string
-}
+import { useGroupedChartData } from '@/lib/query/use-chart-grouping'
 
 export function TotalQueriesStat({
-  hostId,
-  lastHours,
   percentile,
-}: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-total-queries',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   if (isLoading) return statLoading('Total Queries')
   if (error || !data?.length)
@@ -52,15 +43,12 @@ export function TotalQueriesStat({
 }
 
 export function TotalScannedStat({
-  hostId,
-  lastHours,
   percentile,
-}: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-total-scanned',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   if (isLoading) return statLoading('Total Data Scanned')
   if (error || !data?.length)
@@ -89,15 +77,12 @@ export function TotalScannedStat({
 }
 
 export function TotalRowsReadStat({
-  hostId,
-  lastHours,
   percentile,
-}: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-total-rows-read',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   if (isLoading) return statLoading('Total Rows Read')
   if (error || !data?.length)
@@ -126,15 +111,12 @@ export function TotalRowsReadStat({
 }
 
 export function PeakMemoryStat({
-  hostId,
-  lastHours,
   percentile,
-}: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-peak-memory',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   if (isLoading) return statLoading('Peak Memory')
   if (error || !data?.length)

--- a/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/record-stats.tsx
@@ -1,28 +1,16 @@
 import { ClockIcon, DatabaseIcon, HardDriveIcon, ZapIcon } from 'lucide-react'
 
 import { StatCard, statEmpty, statLoading } from './stat-card'
-import { useChartData } from '@/lib/query/use-chart-data'
+import { useGroupedChartData } from '@/lib/query/use-chart-grouping'
 import { formatDuration } from '@/lib/utils'
 
-interface RangeStatProps {
-  readonly hostId: number
-  readonly lastHours?: number
-}
-
-interface PercentileStatProps extends RangeStatProps {
-  readonly percentile: string
-}
-
 export function LargestScanStat({
-  hostId,
-  lastHours,
   percentile,
-}: PercentileStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-largest-scan',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   const label = `Largest Scan (p${percentile})`
   if (isLoading) return statLoading(label)
@@ -53,15 +41,12 @@ export function LargestScanStat({
 }
 
 export function FastestScanStat({
-  hostId,
-  lastHours,
   percentile,
-}: PercentileStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-fastest-scan',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   const label = `Fastest Scan Speed (p${percentile})`
   if (isLoading) return statLoading(label)
@@ -90,15 +75,12 @@ export function FastestScanStat({
 }
 
 export function LongestQueryStat({
-  hostId,
-  lastHours,
   percentile,
-}: PercentileStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-longest-query',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   const label = `Longest Query (p${percentile})`
   if (isLoading) return statLoading(label)
@@ -123,10 +105,9 @@ export function LongestQueryStat({
   )
 }
 
-export function TotalStorageStat({ hostId }: { readonly hostId: number }) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function TotalStorageStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-total-storage',
-    hostId,
   })
   if (isLoading) return statLoading('Total Storage')
   if (error || !data?.length)

--- a/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/stats-grid.tsx
@@ -28,6 +28,7 @@ import {
   PercentileSelector,
 } from './traffic-stats'
 import { useState } from 'react'
+import { ChartGroupingProvider } from '@/lib/query/use-chart-grouping'
 
 function SectionLabel({ title }: { readonly title: string }) {
   return (
@@ -47,92 +48,67 @@ export function StatsGrid({
   const [percentile, setPercentile] = useState('99')
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* Global percentile toggle */}
-      <div className="flex items-center justify-end">
-        <PercentileSelector value={percentile} onChange={setPercentile} />
-      </div>
+    <ChartGroupingProvider
+      groupingId="insights-stats"
+      hostId={hostId}
+      lastHours={lastHours}
+      params={{ percentile }}
+    >
+      <div className="flex flex-col gap-4">
+        {/* Global percentile toggle */}
+        <div className="flex items-center justify-end">
+          <PercentileSelector value={percentile} onChange={setPercentile} />
+        </div>
 
-      {/* Record Breakers */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <SectionLabel title="Record Breakers" />
-        <LargestScanStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <FastestScanStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <LongestQueryStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <TotalStorageStat hostId={hostId} />
-      </div>
+        {/* Record Breakers */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <SectionLabel title="Record Breakers" />
+          <LargestScanStat percentile={percentile} />
+          <FastestScanStat percentile={percentile} />
+          <LongestQueryStat percentile={percentile} />
+          <TotalStorageStat />
+        </div>
 
-      {/* Query Insights */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <SectionLabel title="Query Insights" />
-        <TotalQueriesStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <TotalScannedStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <TotalRowsReadStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-        <PeakMemoryStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-      </div>
+        {/* Query Insights */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <SectionLabel title="Query Insights" />
+          <TotalQueriesStat percentile={percentile} />
+          <TotalScannedStat percentile={percentile} />
+          <TotalRowsReadStat percentile={percentile} />
+          <PeakMemoryStat percentile={percentile} />
+        </div>
 
-      {/* Cluster Activity */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <SectionLabel title="Cluster Activity" />
-        <ActiveQueriesStat hostId={hostId} />
-        <CurrentMemoryStat hostId={hostId} />
-        <HttpConnectionsStat hostId={hostId} />
-        <ActiveMergesStat hostId={hostId} />
-      </div>
+        {/* Cluster Activity */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <SectionLabel title="Cluster Activity" />
+          <ActiveQueriesStat />
+          <CurrentMemoryStat />
+          <HttpConnectionsStat />
+          <ActiveMergesStat />
+        </div>
 
-      {/* Storage & Operations */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <SectionLabel title="Storage &amp; Operations" />
-        <ActivePartsStat hostId={hostId} />
-        <DetachedPartsStat hostId={hostId} />
-        <ActiveMutationsStat hostId={hostId} />
-      </div>
+        {/* Storage & Operations */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <SectionLabel title="Storage &amp; Operations" />
+          <ActivePartsStat />
+          <DetachedPartsStat />
+          <ActiveMutationsStat />
+        </div>
 
-      {/* Traffic Patterns */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <SectionLabel title="Traffic Patterns" />
-        <BusiestDayQueriesStat hostId={hostId} lastHours={lastHours} />
-        <BusiestDayBytesStat hostId={hostId} lastHours={lastHours} />
-        <BusiestSecondStat hostId={hostId} lastHours={lastHours} />
-        <AvgDurationStat
-          hostId={hostId}
-          lastHours={lastHours}
-          percentile={percentile}
-        />
-      </div>
+        {/* Traffic Patterns */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <SectionLabel title="Traffic Patterns" />
+          <BusiestDayQueriesStat />
+          <BusiestDayBytesStat />
+          <BusiestSecondStat />
+          <AvgDurationStat percentile={percentile} />
+        </div>
 
-      {/* Error Rate */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-        <ErrorRateStat hostId={hostId} lastHours={lastHours} />
+        {/* Error Rate */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <ErrorRateStat />
+        </div>
       </div>
-    </div>
+    </ChartGroupingProvider>
   )
 }

--- a/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/-insights/traffic-stats.tsx
@@ -9,7 +9,7 @@ import {
 import type { Dispatch, SetStateAction } from 'react'
 
 import { StatCard, statEmpty, statLoading } from './stat-card'
-import { useChartData } from '@/lib/query/use-chart-data'
+import { useGroupedChartData } from '@/lib/query/use-chart-grouping'
 import { cn, formatDuration } from '@/lib/utils'
 
 const PERCENTILES = ['95', '99', '100'] as const
@@ -53,16 +53,9 @@ function formatDay(day: string | Date): string {
   })
 }
 
-interface RangeStatProps {
-  readonly hostId: number
-  readonly lastHours?: number
-}
-
-export function BusiestDayQueriesStat({ hostId, lastHours }: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function BusiestDayQueriesStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-busiest-day-queries',
-    hostId,
-    lastHours,
   })
   if (isLoading) return statLoading('Busiest Day by Queries')
   if (error || !data?.length)
@@ -81,11 +74,9 @@ export function BusiestDayQueriesStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function BusiestDayBytesStat({ hostId, lastHours }: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function BusiestDayBytesStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-busiest-day-bytes',
-    hostId,
-    lastHours,
   })
   if (isLoading) return statLoading('Busiest Day by Data Scan')
   if (error || !data?.length)
@@ -112,11 +103,9 @@ export function BusiestDayBytesStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-export function BusiestSecondStat({ hostId, lastHours }: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function BusiestSecondStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-busiest-second',
-    hostId,
-    lastHours,
   })
   if (isLoading) return statLoading('Busiest Second by Query Starts')
   if (error || !data?.length)
@@ -134,20 +123,13 @@ export function BusiestSecondStat({ hostId, lastHours }: RangeStatProps) {
   )
 }
 
-interface PercentileStatProps extends RangeStatProps {
-  readonly percentile: string
-}
-
 export function AvgDurationStat({
-  hostId,
-  lastHours,
   percentile,
-}: PercentileStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+}: {
+  readonly percentile: string
+}) {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-avg-duration',
-    hostId,
-    lastHours,
-    params: { percentile },
   })
   const label = `Average Query Duration (p${percentile})`
   if (isLoading) return statLoading(label)
@@ -169,11 +151,9 @@ export function AvgDurationStat({
   )
 }
 
-export function ErrorRateStat({ hostId, lastHours }: RangeStatProps) {
-  const { data, isLoading, error, sql, metadata } = useChartData({
+export function ErrorRateStat() {
+  const { data, isLoading, error, sql, metadata } = useGroupedChartData({
     chartName: 'insight-error-rate',
-    hostId,
-    lastHours,
   })
   if (isLoading) return statLoading('Query Error Rate')
   if (error || !data?.length)

--- a/apps/dashboard/src/routes/api/v1/charts/__tests__/batch.test.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/__tests__/batch.test.ts
@@ -1,0 +1,55 @@
+/**
+ * WHY: POST /api/v1/charts/batch must reject unknown grouping ids at the
+ * HTTP boundary so a crafted body cannot execute an arbitrary name list.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('cloudflare:workers', () => ({
+  env: {
+    CLICKHOUSE_HOST: 'http://localhost:8123',
+    CLICKHOUSE_USER: 'default',
+    CLICKHOUSE_PASSWORD: '',
+  },
+}))
+
+mock.module('@/lib/feature-permissions/server', () => ({
+  authorizeFeatureRequest: async () => null,
+  isAnonymousPublicReadRequest: async () => false,
+}))
+
+mock.module('@/lib/cloud/reject-demo-host', () => ({
+  isDemoHostBlockedForRequest: async () => false,
+}))
+
+const { handler } = await import('../batch')
+
+describe('POST /api/v1/charts/batch', () => {
+  test('unknown grouping id → 400', async () => {
+    const response = await handler(
+      new Request('http://localhost/api/v1/charts/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ groupingId: 'not-a-group', hostId: 0 }),
+      })
+    )
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as {
+      success: boolean
+      error: { message: string }
+    }
+    expect(body.success).toBe(false)
+    expect(body.error.message).toContain('Unknown chart grouping')
+  })
+
+  test('invalid hostId → 400', async () => {
+    const response = await handler(
+      new Request('http://localhost/api/v1/charts/batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ groupingId: 'insights-stats', hostId: -1 }),
+      })
+    )
+    expect(response.status).toBe(400)
+  })
+})

--- a/apps/dashboard/src/routes/api/v1/charts/batch.ts
+++ b/apps/dashboard/src/routes/api/v1/charts/batch.ts
@@ -1,0 +1,277 @@
+/**
+ * POST /api/v1/charts/batch
+ *
+ * Runs a known chart grouping (not an arbitrary name list) through
+ * `executeChartGrouping`. Rate-limited like GET /api/v1/charts/$name.
+ * Cache-Control uses the minimum s-maxage of grouping members.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+
+import { env } from 'cloudflare:workers'
+import { error } from '@chm/logger'
+import {
+  executeChartGrouping,
+  getChartGrouping,
+  groupingCacheControl,
+  isKnownChartGrouping,
+  UnknownChartGroupingError,
+} from '@/lib/api/chart-batch'
+import { validateChartParams } from '@/lib/api/chart-param-validator'
+import { getChartQuery } from '@/lib/api/chart-registry'
+import {
+  classifyError,
+  getStatusCodeForErrorType,
+} from '@/lib/api/error-handler'
+import {
+  checkRateLimitDurable,
+  clientIpKey,
+  getApiRateLimitPerMin,
+  RATE_LIMIT_BINDING_API,
+  rateLimitResponse,
+} from '@/lib/api/rate-limiter'
+import { isDemoHostBlockedForRequest } from '@/lib/cloud/reject-demo-host'
+import { authorizeFeatureRequest } from '@/lib/feature-permissions/server'
+
+const MAX_LAST_HOURS = 24 * 365
+
+function parseDataJson(dataJson: string | null): unknown[] {
+  if (!dataJson || dataJson === 'null') return []
+  try {
+    const parsed = JSON.parse(dataJson) as unknown
+    if (Array.isArray(parsed)) return parsed
+    if (parsed && typeof parsed === 'object') return [parsed]
+    return []
+  } catch {
+    return []
+  }
+}
+
+export async function handler(request: Request): Promise<Response> {
+  const ip = clientIpKey(request)
+  const rlResult = await checkRateLimitDurable(
+    `charts:ip:${ip}`,
+    getApiRateLimitPerMin(),
+    RATE_LIMIT_BINDING_API
+  )
+  if (!rlResult.allowed) return rateLimitResponse(rlResult.retryAfterSec)
+
+  const bindings = env as Record<string, string | undefined>
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Invalid JSON body' },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Body must be an object' },
+      },
+      { status: 400 }
+    )
+  }
+
+  const record = body as Record<string, unknown>
+  const groupingIdRaw = record.groupingId ?? record.grouping
+  const hostIdRaw = record.hostId
+  const lastHoursRaw = record.lastHours
+  const rawParams = record.params
+  const timezoneParam = record.timezone
+
+  if (
+    typeof groupingIdRaw !== 'string' ||
+    !isKnownChartGrouping(groupingIdRaw)
+  ) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          type: 'validation',
+          message: `Unknown chart grouping: ${String(groupingIdRaw)}`,
+        },
+      },
+      { status: 400 }
+    )
+  }
+  const groupingId = groupingIdRaw
+
+  const hostId =
+    typeof hostIdRaw === 'string' ? Number.parseInt(hostIdRaw, 10) : hostIdRaw
+  if (typeof hostId !== 'number' || !Number.isInteger(hostId) || hostId < 0) {
+    return Response.json(
+      {
+        success: false,
+        error: { type: 'validation', message: 'Invalid hostId' },
+      },
+      { status: 400 }
+    )
+  }
+
+  if (await isDemoHostBlockedForRequest(hostId, bindings)) {
+    const names = getChartGrouping(groupingId) ?? []
+    const empty: Record<string, { data: unknown[]; metadata: object }> = {}
+    for (const name of names) {
+      empty[name] = {
+        data: [],
+        metadata: {
+          queryId: '',
+          duration: 0,
+          rows: 0,
+          host: String(hostId),
+          unavailable: {
+            reason: 'demo_hidden',
+            message: 'The demo host is hidden for signed-in accounts.',
+          },
+        },
+      }
+    }
+    return Response.json({ success: true, data: empty })
+  }
+
+  const lastHoursParsed =
+    lastHoursRaw === undefined || lastHoursRaw === null
+      ? undefined
+      : Number(lastHoursRaw)
+  const lastHours =
+    lastHoursParsed !== undefined &&
+    Number.isFinite(lastHoursParsed) &&
+    lastHoursParsed > 0
+      ? Math.min(lastHoursParsed, MAX_LAST_HOURS)
+      : undefined
+
+  let chartParams: Record<string, unknown> | undefined
+  if (rawParams !== undefined && rawParams !== null) {
+    if (typeof rawParams !== 'object' || Array.isArray(rawParams)) {
+      return Response.json(
+        {
+          success: false,
+          error: { type: 'validation', message: 'Invalid params' },
+        },
+        { status: 400 }
+      )
+    }
+    const validation = validateChartParams(rawParams as Record<string, unknown>)
+    if (validation.type === 'validation') {
+      return Response.json(
+        {
+          success: false,
+          error: {
+            type: 'validation',
+            message: validation.message,
+            field: validation.field,
+          },
+        },
+        { status: 400 }
+      )
+    }
+    chartParams = validation.params
+  }
+
+  let timezone: string | undefined
+  if (typeof timezoneParam === 'string' && timezoneParam.length > 0) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: timezoneParam }).format(
+        new Date()
+      )
+      timezone = timezoneParam
+    } catch {
+      // Invalid timezone, ignore
+    }
+  }
+
+  const names = getChartGrouping(groupingId) ?? []
+  for (const name of names) {
+    const queryDef = getChartQuery(name, {
+      lastHours,
+      params: chartParams,
+      timezone,
+    })
+    if (!queryDef) continue
+    const permissionResponse = await authorizeFeatureRequest(
+      queryDef.permission,
+      request
+    )
+    if (permissionResponse) return permissionResponse
+  }
+
+  try {
+    const grouped = await executeChartGrouping(groupingId, hostId, {
+      bindings,
+      lastHours,
+      params: chartParams,
+      timezone,
+    })
+
+    const data: Record<
+      string,
+      {
+        data: unknown[]
+        metadata: Record<string, unknown>
+        error?: { type: string; message: string }
+      }
+    > = {}
+
+    for (const [name, entry] of Object.entries(grouped)) {
+      data[name] = {
+        data: parseDataJson(entry.dataJson),
+        metadata: {
+          queryId: String(entry.metadata?.queryId || ''),
+          duration: Number(entry.metadata?.duration || 0),
+          rows: Number(entry.metadata?.rows || 0),
+          host: String(hostId),
+          sql: entry.executedSql?.trim(),
+        },
+        ...(entry.error
+          ? {
+              error: {
+                type: entry.error.type,
+                message: entry.error.message,
+              },
+            }
+          : {}),
+      }
+    }
+
+    return Response.json(
+      { success: true, data },
+      {
+        headers: {
+          'Cache-Control': groupingCacheControl(names),
+        },
+      }
+    )
+  } catch (err) {
+    if (err instanceof UnknownChartGroupingError) {
+      return Response.json(
+        {
+          success: false,
+          error: { type: 'validation', message: err.message },
+        },
+        { status: 400 }
+      )
+    }
+    error('[POST /api/v1/charts/batch] Unhandled exception:', err)
+    const { type, message } = classifyError(err)
+    return Response.json(
+      { success: false, error: { type, message } },
+      { status: getStatusCodeForErrorType(type) }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/charts/batch')({
+  server: {
+    handlers: {
+      POST: ({ request }) => handler(request),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Remaining #3005 items:

- Refresh batches `invalidateQueries` by exact key (6 at a time) instead of `{ type: 'active' }`
- Query persister `retry` evicts the largest/oldest entry on `QuotaExceededError`
- TopoCanvas is `memo`'d; the 1s "updated Ns ago" tick lives in `TopologyUpdatedAgo`
- Card-view tables stay virtualized (`isRowVirtualizationDisabled` is expandable-only)
- Stats-grid loads via one `POST /api/v1/charts/batch` fixed grouping (`insights-stats`)

Does not re-open item 3 (`cachePolicy`) or item 7 (`HostProvider`).

Closes #3005

## Test plan

- [x] bun tests twice: refresh batching, persist retry, TopoCanvas isolation, card virtualization, `executeChartGrouping` per-name results
- [ ] required CI `unit-tests` + `dashboard`

Co-Authored-By: duyetbot <bot@duyet.net>