### PR TITLE
feat(landing): hero latest-post pill and blog restyle

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -52,6 +52,7 @@ published (`draft: false`, merged to main)
 | 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-07-10) |
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
 | 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-07-10) |
+| 14 | product | A DBA, an SRE, and an engineer should not share a sidebar | customize clickhouse monitoring dashboard | `/reference/settings` | done (`customize-dashboard.md`, published 2026-08-20) |
 
 ## Published this cycle (homepage redesign + SEO expansion)
 

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -3,10 +3,11 @@
 The chmonitor blog — release notes and product updates — served at
 [blog.chmonitor.dev](https://blog.chmonitor.dev).
 
-A plain **Astro** static site (no React/SSR) that reuses the same black/white/
-orange design tokens as `apps/landing`, so the marketing site, blog and docs feel
-like one product. Posts are Markdown in `src/content/blog/` validated by the
-content-collection schema in `src/content.config.ts`.
+A plain **Astro** static site (no React/SSR) that uses the same Tailwind v4 +
+shadcn semantic tokens as `apps/landing` (`bg-card`, `text-muted-foreground`,
+`--brand-ink`), so the marketing site, blog and docs feel like one product.
+Posts are Markdown in `src/content/blog/` validated by the content-collection
+schema in `src/content.config.ts`.
 
 ## Develop
 

--- a/apps/blog/astro.config.mjs
+++ b/apps/blog/astro.config.mjs
@@ -1,7 +1,11 @@
-import { defineConfig } from 'astro/config'
 import sitemap from '@astrojs/sitemap'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'astro/config'
 
 export default defineConfig({
   site: 'https://blog.chmonitor.dev',
   integrations: [sitemap()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
 })

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -10,14 +10,17 @@
     "preview": "astro preview",
     "build:og": "bun run scripts/build-og.ts",
     "release-to-post": "bun run scripts/release-to-post.mjs",
-    "test": "bun test src/lib",
+    "test": "bun test src",
     "cf:deploy": "wrangler deploy"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.3.0",
+    "@tailwindcss/vite": "^4.3.2",
     "astro": "^7.0.0",
-    "posthog-js": "^1.396.5"
+    "posthog-js": "^1.396.5",
+    "tailwindcss": "^4.3.2",
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/apps/blog/pnpm-lock.yaml
+++ b/apps/blog/pnpm-lock.yaml
@@ -14,12 +14,21 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.3.0
         version: 3.7.3
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       astro:
         specifier: ^7.0.0
-        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.2)
+        version: 7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.2)(jiti@2.7.0)
       posthog-js:
         specifier: ^1.396.5
         version: 1.396.5
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.3
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
     devDependencies:
       '@resvg/resvg-js':
         specifier: ^2.6.2
@@ -50,28 +59,24 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-arm64-musl@0.3.0':
     resolution: {integrity: sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-linux-x64-gnu@0.3.0':
     resolution: {integrity: sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@astrojs/compiler-binding-linux-x64-musl@0.3.0':
     resolution: {integrity: sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@astrojs/compiler-binding-wasm32-wasi@0.3.0':
     resolution: {integrity: sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==}
@@ -149,25 +154,21 @@ packages:
     resolution: {integrity: sha512-gJxU9rGGoqIznSEgEzpjxkry24jeHuMpoo1tCIAhHYh7WaD3j5F8zt3jmHxEaN1Uwa+K5+wFgIR2uIGOnMzEmw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@bruits/satteri-linux-arm64-musl@0.9.4':
     resolution: {integrity: sha512-Wjzu9hmmAbfmDkBfPI1VdZygJtYz9uYZQnkEyrXi6S2JFi+2pXQ1A5irj38bqm0IZmWcTbk0cVG4NZnPdtVNJA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@bruits/satteri-linux-x64-gnu@0.9.4':
     resolution: {integrity: sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@bruits/satteri-linux-x64-musl@0.9.4':
     resolution: {integrity: sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@bruits/satteri-wasm32-wasi@0.9.4':
     resolution: {integrity: sha512-/CEG8LUlpaBEnhFnYVn0UnlHFLs51UhrkJBUPDUXLzkadzAcnR88iRA/nOl7Zwhjb4WhfBV4p3P5qeOJMtH0iA==}
@@ -441,105 +442,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -564,12 +549,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -639,28 +633,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -719,42 +709,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.4':
     resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
@@ -828,6 +812,96 @@ packages:
 
   '@speed-highlight/core@1.2.17':
     resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1014,6 +1088,10 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1089,6 +1167,9 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
@@ -1136,6 +1217,10 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
@@ -1182,28 +1267,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1452,6 +1533,13 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
@@ -1475,6 +1563,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -2076,9 +2167,24 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -2275,6 +2381,74 @@ snapshots:
 
   '@speed-highlight/core@1.2.17': {}
 
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -2330,7 +2504,7 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.2):
+  astro@7.0.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.13.2)(jiti@2.7.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
       '@astrojs/internal-helpers': 0.10.1
@@ -2380,8 +2554,8 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unstorage: 1.17.5
-      vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)
-      vitefu: 1.1.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1))
+      vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -2524,6 +2698,11 @@ snapshots:
 
   dset@3.1.4: {}
 
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   entities@4.5.0: {}
 
   error-stack-parser-es@1.0.5: {}
@@ -2614,6 +2793,8 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
+  graceful-fs@4.2.11: {}
+
   h3@1.15.11:
     dependencies:
       cookie-es: 1.2.3
@@ -2667,6 +2848,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  jiti@2.7.0: {}
 
   js-yaml@4.3.0:
     dependencies:
@@ -3018,6 +3201,10 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
   tiny-inflate@1.0.3: {}
 
   tinyclip@0.1.15: {}
@@ -3035,6 +3222,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tw-animate-css@1.4.0: {}
 
   ufo@1.6.4: {}
 
@@ -3110,7 +3299,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1):
+  vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -3121,10 +3310,11 @@ snapshots:
       '@types/node': 24.13.2
       esbuild: 0.28.1
       fsevents: 2.3.3
+      jiti: 2.7.0
 
-  vitefu@1.1.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)):
+  vitefu@1.1.3(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)):
     optionalDependencies:
-      vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)
+      vite: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)
 
   web-vitals@5.3.0: {}
 

--- a/apps/blog/src/chrome.test.ts
+++ b/apps/blog/src/chrome.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const blog = join(import.meta.dir, '..')
+const read = (rel: string) => readFileSync(join(blog, rel), 'utf8')
+
+describe('blog chrome matches landing shadcn tokens', () => {
+  test('Base imports the new globals.css', () => {
+    expect(existsSync(join(blog, 'src/styles/globals.css'))).toBe(true)
+    expect(read('src/layouts/Base.astro')).toContain(
+      "import '../styles/globals.css'"
+    )
+  })
+
+  test('globals.css keeps landing brand / hairline / shadcn tokens', () => {
+    const css = read('src/styles/globals.css')
+    expect(css).toContain('--brand')
+    expect(css).toContain('--brand-ink')
+    expect(css).toContain('--brand-soft')
+    expect(css).toContain('--surface-strong')
+    expect(css).toContain('--hairline-soft')
+    expect(css).toContain('--hairline-strong')
+    expect(css).toContain("@custom-variant dark (&:is([data-theme='dark'] *))")
+  })
+
+  test('Nav uses semantic token classes', () => {
+    const nav = read('src/components/Nav.astro')
+    expect(nav).toContain('text-muted-foreground')
+    expect(nav).toContain('border-border')
+  })
+
+  test('Footer uses semantic token classes', () => {
+    const footer = read('src/components/Footer.astro')
+    expect(footer).toContain('text-muted-foreground')
+    expect(footer).toContain('border-border')
+  })
+
+  test('featured card is not the old #fff8f1 hardcode', () => {
+    const home = read('src/pages/index.astro')
+    const base = read('src/layouts/Base.astro')
+    expect(home).not.toContain('#fff8f1')
+    expect(base).not.toContain('#fff8f1')
+    expect(home).toContain('bg-card')
+    expect(home).toContain('--brand-soft')
+  })
+})

--- a/apps/blog/src/components/Footer.astro
+++ b/apps/blog/src/components/Footer.astro
@@ -1,43 +1,57 @@
-<footer>
-  <div class="wrap">
-    <div class="foot">
-      <div class="foot-brand">
-        <a class="brand" href="https://chmonitor.dev">
+---
+import ThemeToggle from './ThemeToggle.astro'
+
+const footLink = 'text-sm text-muted-foreground transition-colors hover:text-foreground'
+---
+<footer class="border-t border-border">
+  <div class="mx-auto max-w-[1080px] px-6 py-12">
+    <div class="flex flex-col gap-10 lg:flex-row lg:justify-between">
+      <div class="max-w-xs">
+        <a class="flex items-center gap-2.5 text-[15px] font-semibold tracking-tight" href="https://chmonitor.dev">
           <span class="mark" aria-hidden="true">
             <img src="/brand/logo-chmonitor.svg" alt="chmonitor" />
           </span>
           chmonitor
         </a>
-        <p>chmonitor reads your cluster's system tables and turns them into views your whole team can act on, no more memorising table names or hand-writing diagnostic SQL.</p>
+        <p class="mt-4 text-pretty text-sm text-muted-foreground">chmonitor reads your cluster's system tables and turns them into views your whole team can act on, no more memorising table names or hand-writing diagnostic SQL.</p>
       </div>
-      <div class="foot-cols">
-        <div class="foot-col">
-          <h5>Product</h5>
-          <a href="https://chmonitor.dev/#features">Features</a>
-          <a href="https://chmonitor.dev/#pricing">Pricing</a>
-          <a href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
-          <a href="https://chmonitor.dev/changelog">Changelog</a>
-          <a href="/">Blog</a>
-          <a href="/rss.xml">RSS feed</a>
+      <div class="grid grid-cols-2 gap-x-8 gap-y-10 sm:flex sm:flex-wrap sm:gap-x-16">
+        <div class="min-w-0 sm:min-w-36">
+          <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Product</h5>
+          <div class="mt-3 flex flex-col gap-2.5">
+            <a class={footLink} href="https://chmonitor.dev/#features">Features</a>
+            <a class={footLink} href="https://chmonitor.dev/#pricing">Pricing</a>
+            <a class={footLink} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
+            <a class={footLink} href="https://chmonitor.dev/changelog">Changelog</a>
+            <a class={footLink} href="/">Blog</a>
+            <a class={footLink} href="/rss.xml">RSS feed</a>
+          </div>
         </div>
-        <div class="foot-col">
-          <h5>Open source</h5>
-          <a href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">GitHub</a>
-          <a href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Documentation</a>
-          <a href="https://github.com/chmonitor/chmonitor/issues" target="_blank" rel="noopener">Issues</a>
-          <a href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener">Releases</a>
+        <div class="min-w-0 sm:min-w-36">
+          <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Open source</h5>
+          <div class="mt-3 flex flex-col gap-2.5">
+            <a class={footLink} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">GitHub</a>
+            <a class={footLink} href="https://docs.chmonitor.dev" target="_blank" rel="noopener">Documentation</a>
+            <a class={footLink} href="https://github.com/chmonitor/chmonitor/issues" target="_blank" rel="noopener">Issues</a>
+            <a class={footLink} href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener">Releases</a>
+          </div>
         </div>
-        <div class="foot-col">
-          <h5>Legal &amp; trust</h5>
-          <a href="https://github.com/chmonitor/chmonitor/blob/main/LICENSE" target="_blank" rel="noopener">License (GPL-3.0)</a>
-          <a href="https://github.com/chmonitor/chmonitor/security" target="_blank" rel="noopener">Security policy</a>
-          <a href="https://chmonitor.dev/brand">Brand</a>
+        <div class="min-w-0 sm:min-w-36">
+          <h5 class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Legal &amp; trust</h5>
+          <div class="mt-3 flex flex-col gap-2.5">
+            <a class={footLink} href="https://github.com/chmonitor/chmonitor/blob/main/LICENSE" target="_blank" rel="noopener">License (GPL-3.0)</a>
+            <a class={footLink} href="https://github.com/chmonitor/chmonitor/security" target="_blank" rel="noopener">Security policy</a>
+            <a class={footLink} href="https://chmonitor.dev/brand">Brand</a>
+          </div>
         </div>
       </div>
     </div>
-    <div class="foot-bottom">
+    <div class="mt-12 flex flex-col items-start justify-between gap-3 border-t border-border pt-6 text-sm text-muted-foreground sm:flex-row sm:items-center">
       <span>© 2026 chmonitor · Open source (GPL-3.0)</span>
-      <span class="mono" style="font-size:12px">Not affiliated with ClickHouse, Inc.</span>
+      <div class="flex items-center gap-3">
+        <span class="font-mono text-xs">Not affiliated with ClickHouse, Inc.</span>
+        <ThemeToggle />
+      </div>
     </div>
   </div>
 </footer>

--- a/apps/blog/src/components/Nav.astro
+++ b/apps/blog/src/components/Nav.astro
@@ -1,32 +1,39 @@
-<header class="nav">
-  <div class="wrap nav-row">
-    <a class="brand" href="https://chmonitor.dev">
+---
+import { btnOutline, btnPrimary } from '../lib/button-classes'
+import ThemeToggle from './ThemeToggle.astro'
+
+const navLink =
+  'inline-flex h-9 items-center rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+---
+<header class="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
+  <div class="mx-auto flex h-16 w-full max-w-[1080px] items-center justify-between gap-7 px-6">
+    <a class="flex shrink-0 items-center gap-2.5 text-[15px] font-semibold tracking-tight" href="https://chmonitor.dev">
       <span class="mark" aria-hidden="true">
         <img src="/brand/logo-chmonitor.svg" alt="chmonitor" />
       </span>
       chmonitor
-      <span class="tag">Blog</span>
+      <span class="ml-0.5 rounded-full border border-border px-2 py-px text-xs font-semibold text-muted-foreground">Blog</span>
     </a>
-    <nav class="nav-links">
-      <a href="https://chmonitor.dev/#features">Features</a>
-      <a href="https://chmonitor.dev/#open-source">Open source</a>
-      <a href="https://chmonitor.dev/#pricing">Pricing</a>
-      <a href="https://docs.chmonitor.dev">Docs</a>
-      <a href="https://chmonitor.dev/changelog">Changelog</a>
-      <a href="/">Blog</a>
+    <nav class="nav-links hidden items-center gap-1 lg:flex">
+      <a class={navLink} href="https://chmonitor.dev/#features">Features</a>
+      <a class={navLink} href="https://chmonitor.dev/#open-source">Open source</a>
+      <a class={navLink} href="https://chmonitor.dev/#pricing">Pricing</a>
+      <a class={navLink} href="https://docs.chmonitor.dev">Docs</a>
+      <a class={navLink} href="https://chmonitor.dev/changelog">Changelog</a>
+      <a class={navLink} href="/">Blog</a>
+      <a class={navLink} href="/rss.xml">RSS</a>
     </nav>
-    <div class="nav-cta">
-      <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
-        <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
-        <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
-      </button>
-      <a class="btn btn-ghost btn-sm" href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
-        <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
-        Star
-      </a>
-      <a class="btn btn-primary btn-sm" href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
+    <div class="flex shrink-0 items-center gap-2.5">
+      <ThemeToggle />
+      <span class="nav-cta-star">
+        <a class={btnOutline} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
+          <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
+          Star
+        </a>
+      </span>
+      <a class={btnPrimary} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">
         Dashboard
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+        <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
       </a>
     </div>
   </div>

--- a/apps/blog/src/components/ThemeToggle.astro
+++ b/apps/blog/src/components/ThemeToggle.astro
@@ -1,0 +1,10 @@
+---
+// Dark-mode toggle — markup only. The global `.theme-toggle` CSS, state and
+// click-delegation handler both live in Base.astro, so every instance works
+// regardless of where it's rendered (nav, footer).
+---
+<button type="button" class="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+  <svg class="i-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+  <svg class="i-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+  <svg class="i-system" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+</button>

--- a/apps/blog/src/content/blog/customize-dashboard.md
+++ b/apps/blog/src/content/blog/customize-dashboard.md
@@ -1,0 +1,69 @@
+---
+title: "A DBA, an SRE, and an engineer should not share a sidebar"
+description: "Pick a workspace role, hide pages you never open, pin the ones you do — the sidebar follows this browser, not the whole team."
+date: 2026-08-20
+tag: Product
+---
+
+chmonitor has more pages than any one person opens. A DBA lives in tables, merges, and keeper. An engineer lives in queries and the SQL console. An SRE lives in health, metrics, and logs. Same product. Different noise.
+
+**Settings → Workspace → Navigation** is the switch. The header says it: local to this browser. It slims the sidebar and the command palette for you. It does not change the server, and it does not change anyone else.
+
+## Pick a role
+
+Five presets. Named roles keep a stable set of top-level groups. **Full** is the only one that auto-expands: new pages stay visible.
+
+| Role | Groups you keep |
+|---|---|
+| **Full** | Every page the host and deployment already allow |
+| **DBA** | Overview, Tools, Queries, Tables, Merges, Metrics, Keeper, Security, Logs, Cluster, System |
+| **Engineer** | Overview, Tools, Queries, Tables, Insights, AI Agent |
+| **SRE** | Overview, Tools, Health, Insights, Queries, Tables, System, Operations, Metrics, Logs |
+| **Custom** | Start from a role, then hide extra pages |
+
+Pick a role and the Settings tree remounts **collapsed**, so you can scan groups instead of a wall of checkboxes. Expand only what you care about. Search filters the tree.
+
+The pill flips to **Custom** only when Hide/Show on a leaf diverges from that role's hide list. Collapsing a parent does not count.
+
+## Hide a page in Settings
+
+Leaves have **Hide** / **Show**. Hidden rows stay in the tree, dimmed. Parent rows are chevron-only — not hideable.
+
+Footer **About** is not in this list. It sits next to the Settings gear and the host switcher, and those three are never filtered.
+
+Hidden is not unauthorized. Routes stay reachable by URL. Restore always lives here: Settings → Workspace → Navigation.
+
+A separate toggle on the same tab covers pages whose system table is missing on this host (dim them, or drop them from the menu). That is not your hide list.
+
+## Hide from the sidebar
+
+Hover a leaf. **Hide** sits next to **Pin**. A toast says the page is hidden, with **Undo** and **Open Navigation**. The first one stays up longer so you see the restore path.
+
+## Pin and reorder
+
+Pin a page and it lands in **Favorites** at the top of the sidebar. Drag the grip to reorder. Pins are local to this browser too. Unpin from the same hover control.
+
+## Chrome vs the menu
+
+Theme, units, and layout stay on the Appearance / Units / Layout tabs — local chrome. The role plus hide list is the information architecture: which groups exist, which leaves you see.
+
+Workspace visibility is applied last. Permission, cloud, and engine gates still win. Switch to a Postgres host and the Navigation tree matches that sidebar.
+
+## The Tools menu
+
+Interactive work — run SQL, explore schema, explain a query, compare hosts — now lives in **Tools**, the last group in Main.
+
+- **SQL Console** — read-only SQL with history, EXPLAIN, query log, and scan analysis
+- **Data Explorer** — schema browser
+- **Explain** — execution plan
+- **Advisor** — ranked skip-index, projection, partition-key, and PREWHERE recommendations. Recommend only. It never applies DDL.
+- **Chart Builder** — custom charts
+- **Schema Compare** — table schemas across hosts or cluster nodes; copy a recommend-only change plan
+- **Settings Diff** — `system.settings` and `merge_tree_settings` across saved hosts or nodes
+
+**AI Agent** stays its own top-level group. Postgres hosts do not see Tools at all (ClickHouse-family only). DBA, Engineer, and SRE all keep Tools.
+
+## Related
+
+- Docs: [Settings](https://docs.chmonitor.dev/reference/settings) — Workspace / Navigation reference.
+- [The query advisor](https://blog.chmonitor.dev/clickhouse-query-optimization-advisor) — recommend-only, same rule as the Advisor page.

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -1,4 +1,7 @@
 ---
+// Global Tailwind v4 + shadcn tokens (preflight omitted — see globals.css).
+import '../styles/globals.css'
+
 const {
   title = 'chmonitor blog',
   description = 'Release notes, product updates and engineering notes from the team building chmonitor — the open-source ClickHouse monitoring dashboard.',
@@ -11,7 +14,7 @@ const ogImage = new URL(image, Astro.site).toString()
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="canonical" href={canonical} />
@@ -34,7 +37,8 @@ const ogImage = new URL(image, Astro.site).toString()
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/site.webmanifest" />
-  <meta name="theme-color" content="#f97316" />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
   <!-- Self-hosted variable fonts (latin subset, ~60KB total). No render-blocking
        Google Fonts request and no cross-origin connection — same-origin preload
        paints text fast with swap fallback. -->
@@ -45,12 +49,20 @@ const ogImage = new URL(image, Astro.site).toString()
     @font-face{font-family:'JetBrains Mono';font-style:normal;font-weight:400 600;font-display:swap;src:url('/fonts/jetbrains-mono-latin.woff2') format('woff2')}
   </style>
   <script is:inline>
-    // Resolve theme before paint (no flash): saved choice wins, else OS pref.
+    // Resolve theme before paint (no flash): blog defaults to auto, which
+    // follows the OS color scheme. An explicit choice still wins so the toggle
+    // keeps working. Mirrors apps/landing/src/layouts/Base.astro.
     (function () {
       try {
-        var saved = localStorage.getItem('chm-theme')
-        var theme = saved || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-        document.documentElement.setAttribute('data-theme', theme)
+        var legacy = localStorage.getItem('chm-theme')
+        var saved = localStorage.getItem('chm-theme-state') || (legacy === 'dark' || legacy === 'light' ? legacy : null) || 'auto'
+        document.documentElement.setAttribute('data-theme-state', saved)
+        if (saved === 'auto') {
+          var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+          document.documentElement.setAttribute('data-theme', systemDark ? 'dark' : 'light')
+        } else {
+          document.documentElement.setAttribute('data-theme', saved)
+        }
       } catch (e) {
         document.documentElement.setAttribute('data-theme', 'light')
       }
@@ -58,7 +70,6 @@ const ogImage = new URL(image, Astro.site).toString()
     // Theme-aware post screenshots: a single <img data-src-light data-src-dark>
     // per slot picks the right variant for the current theme, so only ONE
     // image ever downloads (no display:none sibling to fetch on scroll).
-    // Mirrors apps/landing/src/layouts/Base.astro.
     window.chmSyncThemedImages = function (root) {
       var theme = document.documentElement.getAttribute('data-theme')
       var imgs = (root || document).querySelectorAll('img[data-src-light]')
@@ -69,55 +80,56 @@ const ogImage = new URL(image, Astro.site).toString()
         if (wanted && img.getAttribute('src') !== wanted) img.setAttribute('src', wanted)
       }
     }
+    function chmApplyTheme(state) {
+      var html = document.documentElement
+      if (state === 'auto') {
+        var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        html.setAttribute('data-theme', isDark ? 'dark' : 'light')
+      } else {
+        html.setAttribute('data-theme', state)
+      }
+    }
+    // Theme toggle: event delegation on document so EVERY .theme-toggle works
+    // regardless of where it's rendered (nav, footer).
+    document.addEventListener('click', function (e) {
+      var toggle = e.target.closest('.theme-toggle')
+      if (!toggle) return
+      var html = document.documentElement
+      var state = html.getAttribute('data-theme-state') || 'auto'
+      var next
+      if (state === 'auto') next = 'dark'
+      else if (state === 'dark') next = 'light'
+      else next = 'auto'
+      html.setAttribute('data-theme-state', next)
+      try { localStorage.setItem('chm-theme-state', next) } catch (err) {}
+      chmApplyTheme(next)
+      toggle.setAttribute('aria-label', 'Theme: ' + next)
+      if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
+    })
+    try {
+      var chmThemeHtml = document.documentElement
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
+        if ((chmThemeHtml.getAttribute('data-theme-state') || 'auto') === 'auto') {
+          chmThemeHtml.setAttribute('data-theme', e.matches ? 'dark' : 'light')
+          if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
+        }
+      })
+    } catch (e) {}
   </script>
   <style is:global>
+    /* Hand-authored blog CSS lives in @layer base so Tailwind utilities win.
+       Unlayered `*{margin:0}` would beat every Tailwind margin/padding utility. */
+    @layer base {
     :root{
-      --bg:#ffffff;
-      --bg-soft:#fafafa;
-      --fg:#09090b;
-      --fg-soft:#3f3f46;
-      --muted-fg:#71717a;
-      --border:#e7e7ea;
-      --border-soft:#f1f1f3;
-      --border-hover:#dcdce0;
-      --muted:#f4f4f5;
-      --card:#ffffff;
-      --nav-bg:rgba(255,255,255,.78);
-      --btn-primary-bg:#09090b;
-      --btn-primary-bg-hover:#26262b;
-      --btn-primary-fg:#ffffff;
-      --amber:#f59e0b;
-      --orange:#f97316;
-      --emerald:#10b981;
-      --radius:14px;
-      --maxw:1140px;
+      --maxw:1080px;
       --maxw-prose:720px;
-      --shadow-card:0 1px 2px rgba(9,9,11,.04), 0 1px 0 rgba(9,9,11,.02);
-      --shadow-float:0 24px 60px -28px rgba(9,9,11,.30), 0 8px 24px -16px rgba(9,9,11,.18);
-    }
-    :root[data-theme="dark"]{
-      --bg:#0b0b0e;
-      --bg-soft:#101014;
-      --fg:#f4f4f5;
-      --fg-soft:#c4c4cb;
-      --muted-fg:#8a8a93;
-      --border:#26262c;
-      --border-soft:#1c1c21;
-      --border-hover:#34343c;
-      --muted:#1a1a1f;
-      --card:#141418;
-      --nav-bg:rgba(11,11,14,.72);
-      --btn-primary-bg:#fafafa;
-      --btn-primary-bg-hover:#e4e4e7;
-      --btn-primary-fg:#09090b;
-      --shadow-card:0 1px 2px rgba(0,0,0,.4), 0 1px 0 rgba(0,0,0,.3);
-      --shadow-float:0 24px 60px -28px rgba(0,0,0,.7), 0 8px 24px -16px rgba(0,0,0,.5);
     }
     *{margin:0;padding:0;box-sizing:border-box}
+    button{border:0 solid transparent}
     html{scroll-behavior:smooth}
     body{
-      background:var(--bg);
-      color:var(--fg);
+      background:var(--background);
+      color:var(--foreground);
       font-family:'Geist',ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
       -webkit-font-smoothing:antialiased;
       text-rendering:optimizeLegibility;
@@ -129,126 +141,56 @@ const ogImage = new URL(image, Astro.site).toString()
     a{color:inherit;text-decoration:none}
     .mono{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace}
     .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;width:100%}
-    .eyebrow{font-size:12px;font-weight:600;letter-spacing:.10em;text-transform:uppercase;color:var(--muted-fg)}
     main{flex:1 0 auto}
-
-    /* ── buttons ── */
-    .btn{display:inline-flex;align-items:center;gap:8px;height:42px;padding:0 18px;border-radius:10px;
-      font-size:14.5px;font-weight:600;white-space:nowrap;transition:.16s ease;border:1px solid transparent;cursor:pointer}
-    .btn svg{width:16px;height:16px}
-    .btn-primary{background:var(--btn-primary-bg);color:var(--btn-primary-fg)}
-    .btn-primary:hover{background:var(--btn-primary-bg-hover);transform:translateY(-1px)}
-    .btn-ghost{background:var(--card);color:var(--fg);border-color:var(--border)}
-    .btn-ghost:hover{background:var(--muted);border-color:var(--border-hover)}
-    .btn-sm{height:36px;padding:0 14px;font-size:13.5px;border-radius:9px}
 
     /* ── logo mark ── */
     .mark{width:30px;height:30px;display:flex;align-items:center;justify-content:center;flex:0 0 auto}
     .mark img{width:100%;height:100%;object-fit:contain;display:block}
 
-    /* ── nav ── */
-    header.nav{position:sticky;top:0;z-index:50;background:var(--nav-bg);
-      backdrop-filter:saturate(160%) blur(12px);border-bottom:1px solid var(--border-soft)}
-    .nav-row{display:flex;align-items:center;justify-content:space-between;gap:28px;height:64px}
-    .brand{display:flex;align-items:center;gap:10px;flex:0 0 auto;font-weight:600;font-size:16px;letter-spacing:-.01em}
-    .brand .tag{font-size:12.5px;font-weight:600;color:var(--muted-fg);border:1px solid var(--border);
-      border-radius:999px;padding:1px 9px;margin-left:2px}
-    .nav-links{display:flex;align-items:center;gap:22px}
-    .nav-links a{font-size:14px;color:var(--muted-fg);font-weight:500;white-space:nowrap;transition:color .15s}
-    .nav-links a:hover{color:var(--fg)}
-    .nav-cta{display:flex;align-items:center;gap:10px;flex:0 0 auto}
-
-    /* ── theme toggle ── */
-    .theme-toggle{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;
-      border-radius:9px;border:1px solid var(--border);background:var(--card);color:var(--fg-soft);
+    /* ── theme toggle (matches landing: 40px box, 8px radius, hairline) ── */
+    .theme-toggle{display:inline-flex;align-items:center;justify-content:center;width:40px;height:40px;
+      border-radius:var(--radius);border:1px solid var(--border);background:var(--card);color:var(--muted-foreground);
       cursor:pointer;transition:.16s ease;flex:0 0 auto;padding:0}
-    .theme-toggle:hover{color:var(--fg);border-color:var(--border-hover);background:var(--muted)}
+    .theme-toggle:hover{color:var(--foreground);border-color:var(--hairline-strong);background:var(--muted)}
     .theme-toggle svg{width:16px;height:16px}
     .theme-toggle .i-sun{display:none}
+    .theme-toggle .i-system{display:none}
     :root[data-theme="dark"] .theme-toggle .i-sun{display:block}
     :root[data-theme="dark"] .theme-toggle .i-moon{display:none}
+    :root[data-theme-state="auto"] .theme-toggle .i-system{display:block}
+    :root[data-theme-state="auto"] .theme-toggle .i-moon,
+    :root[data-theme-state="auto"] .theme-toggle .i-sun{display:none}
 
-    /* ── theme-aware post screenshots ──
-       A single <img data-src-light data-src-dark> per slot; `window.chmSyncThemedImages`
-       (defined in the head script) picks the right `src` for the current theme,
-       so only ONE variant ever downloads. */
-
-    /* ── blog header ── */
-    .blog-hero{padding:64px 0 36px;position:relative;overflow:hidden}
-    .blog-hero::before{content:"";position:absolute;inset:0;z-index:-1;
-      background:radial-gradient(ellipse 70% 50% at 50% -30%, rgba(249,115,22,.10), transparent 65%)}
-    .blog-hero h1{font-size:clamp(30px,4vw,42px);line-height:1.08;letter-spacing:-.03em;font-weight:700;margin-top:14px}
-    .blog-hero p{margin-top:14px;font-size:17px;color:var(--muted-fg);max-width:60ch;text-wrap:pretty}
-    .sec-eyebrow{display:flex;align-items:center;gap:9px}
-    .sec-eyebrow::before{content:"";width:18px;height:1.5px;background:var(--amber);border-radius:2px}
-
-    /* ── category grid (homepage) ── */
-    .cat-grid{padding:8px 0 80px;display:grid;grid-template-columns:repeat(2,1fr);gap:20px;align-items:stretch}
-    .cat-card{border:1px solid var(--border);border-radius:var(--radius);background:var(--card);
-      padding:24px 26px;transition:.22s cubic-bezier(0.16, 1, 0.3, 1);display:flex;flex-direction:column;height:100%}
-    .cat-card:hover{border-color:var(--border-hover);box-shadow:var(--shadow-card)}
-    .cat-card.is-featured{grid-column:1 / -1;background:linear-gradient(180deg,#fff8f1 0%,var(--card) 60%);
-      border-color:rgba(249,115,22,.35)}
-    :root[data-theme="dark"] .cat-card.is-featured{background:linear-gradient(180deg,#1d160f 0%,var(--card) 60%);
-      border-color:rgba(249,115,22,.30)}
-    .cat-head{display:flex;align-items:center;gap:10px}
-    .cat-head h2{font-size:17px;font-weight:700;letter-spacing:-.01em}
-    .cat-count{font-size:12px;font-weight:600;color:var(--muted-fg);background:var(--muted);
-      border-radius:999px;padding:1px 9px;font-family:'JetBrains Mono',monospace}
-    .cat-tagline{margin-top:8px;font-size:13.5px;color:var(--muted-fg);line-height:1.5;text-wrap:pretty}
-    .cat-list{margin-top:16px;list-style:none;display:flex;flex-direction:column;gap:2px;
-      border-top:1px solid var(--border-soft);padding-top:6px;flex:1 1 auto}
-    .cat-more{margin-top:14px;display:inline-flex;align-items:center;gap:6px;
-      font-size:13.5px;font-weight:600;color:var(--orange);transition:gap .15s}
-    .cat-more:hover{gap:9px}
-    .cat-more svg{width:14px;height:14px}
-    .cat-page-list{margin-top:24px;border-top:none;padding-top:0}
-    .cat-page-list .cat-item{padding:16px 0}
-    .cat-page-list .cat-title{font-size:17px;font-weight:600}
-    .cat-item{display:flex;flex-direction:column;gap:2px;padding:11px 0;border-bottom:1px solid var(--border-soft)}
-    .cat-item:last-child{border-bottom:none}
-    .cat-link{display:flex;align-items:baseline;justify-content:space-between;gap:14px;
-      text-decoration:none;transition:color .15s}
-    .cat-title{font-size:15px;font-weight:550;letter-spacing:-.01em;color:var(--fg)}
-    .cat-link:hover .cat-title{color:var(--orange)}
-    .cat-date{font-size:12.5px;color:var(--muted-fg);white-space:nowrap;flex:0 0 auto;
-      font-family:'JetBrains Mono',monospace}
-    .cat-desc{font-size:14px;color:var(--muted-fg);line-height:1.55;margin-top:4px;text-wrap:pretty;max-width:72ch}
-    @media (max-width:720px){.cat-grid{grid-template-columns:1fr}}
-
-    /* ── article ── */
+    /* ── article measure ── */
     .article-wrap{max-width:var(--maxw-prose);margin:0 auto;padding:0 24px;width:100%}
-    .article-head{padding:56px 0 32px;text-align:left}
-    .back-link{display:inline-flex;align-items:center;gap:7px;font-size:13.5px;font-weight:500;color:var(--muted-fg);transition:color .15s}
-    .back-link:hover{color:var(--fg)}
-    .back-link svg{width:15px;height:15px}
-    .article-head h1{font-size:clamp(30px,4.4vw,46px);line-height:1.06;letter-spacing:-.03em;font-weight:700;margin-top:22px;text-wrap:balance}
-    .article-head .lede{margin-top:18px;font-size:19px;color:var(--muted-fg);line-height:1.55;text-wrap:pretty}
-    .article-byline{margin-top:22px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:13.5px;color:var(--muted-fg)}
-    .article-byline .post-tag{height:24px}
+
+    /* ── post tag ── */
+    .post-tag{display:inline-flex;align-items:center;height:24px;padding:0 10px;border-radius:999px;
+      background:var(--muted);font-size:12px;font-weight:600;font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+      color:var(--muted-foreground)}
 
     /* ── prose ── */
     .prose{max-width:var(--maxw-prose);margin:0 auto;padding:8px 24px 96px;width:100%;
-      font-size:16.5px;line-height:1.75;color:var(--fg-soft)}
+      font-size:16.5px;line-height:1.75;color:var(--muted-foreground)}
     .prose > * + *{margin-top:20px}
-    .prose h2{font-size:26px;font-weight:700;letter-spacing:-.02em;color:var(--fg);margin-top:52px;line-height:1.2;
+    .prose h2{font-size:26px;font-weight:600;letter-spacing:-.02em;color:var(--foreground);margin-top:52px;line-height:1.2;
       padding-top:12px}
-    .prose h3{font-size:19.5px;font-weight:650;letter-spacing:-.01em;color:var(--fg);margin-top:36px;line-height:1.25}
+    .prose h3{font-size:19.5px;font-weight:600;letter-spacing:-.01em;color:var(--foreground);margin-top:36px;line-height:1.25}
     .prose h2 + p,.prose h3 + p{margin-top:12px}
     .prose p{text-wrap:pretty}
-    .prose strong{color:var(--fg);font-weight:650}
-    .prose a{color:var(--orange);text-decoration:underline;text-underline-offset:3px;text-decoration-thickness:1px}
+    .prose strong{color:var(--foreground);font-weight:600}
+    .prose a{color:var(--brand-ink);text-decoration:underline;text-underline-offset:3px;text-decoration-thickness:1px}
     .prose ul,.prose ol{padding-left:24px;display:flex;flex-direction:column;gap:10px}
     .prose li{padding-left:4px}
-    .prose li::marker{color:var(--muted-fg)}
-    .prose code{font-family:'JetBrains Mono',monospace;font-size:13.5px;background:var(--muted);
-      padding:2px 6px;border-radius:5px;color:var(--fg);white-space:nowrap}
-    .prose pre{background:#0c0c0f;border:1px solid var(--border);border-radius:var(--radius);
-      padding:18px 20px;overflow-x:auto;box-shadow:var(--shadow-card)}
-    .prose pre code{background:none;padding:0;color:#e4e4e7;font-size:13px;white-space:pre;line-height:1.7}
-    .prose blockquote{border-left:3px solid var(--amber);padding:6px 0 6px 20px;color:var(--muted-fg);
+    .prose li::marker{color:var(--muted-foreground)}
+    .prose code{font-family:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13.5px;background:var(--muted);
+      padding:2px 6px;border-radius:5px;color:var(--foreground);white-space:nowrap}
+    .prose pre{background:var(--surface-strong);border:1px solid var(--border);border-radius:calc(var(--radius) + 4px);
+      padding:18px 20px;overflow-x:auto}
+    .prose pre code{background:none;padding:0;color:var(--foreground);font-size:13px;white-space:pre;line-height:1.7}
+    .prose blockquote{border-left:3px solid var(--border);padding:6px 0 6px 20px;color:var(--muted-foreground);
       font-style:normal}
-    .prose hr{border:none;border-top:1px solid var(--border-soft);margin:44px 0}
+    .prose hr{border:none;border-top:1px solid var(--border);margin:44px 0}
     /* Screenshots break out past the 720px text measure (up to the site width),
        centred on the prose column. `height:auto` is load-bearing: posts ship
        intrinsic width/height attributes, so without it the attribute height is
@@ -257,68 +199,36 @@ const ogImage = new URL(image, Astro.site).toString()
     .prose img{display:block;width:auto;height:auto;
       max-width:min(var(--maxw), calc(100vw - 48px));
       margin:32px 0;margin-left:50%;transform:translateX(-50%);
-      border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow-card)}
+      border:1px solid var(--border);border-radius:calc(var(--radius) + 4px)}
     .prose table{width:100%;border-collapse:collapse;font-size:14.5px;display:block;overflow-x:auto}
-    .prose th{text-align:left;font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--muted-fg);
-      font-weight:600;padding:10px 14px;background:var(--bg-soft);border-bottom:1px solid var(--border)}
-    .prose td{padding:11px 14px;border-top:1px solid var(--border-soft);vertical-align:top;color:var(--fg-soft)}
-    .prose td:first-child{color:var(--fg);font-weight:500}
+    .prose th{text-align:left;font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--muted-foreground);
+      font-weight:600;padding:10px 14px;background:var(--canvas-soft);border-bottom:1px solid var(--border)}
+    .prose td{padding:11px 14px;border-top:1px solid var(--border);vertical-align:top;color:var(--muted-foreground)}
+    .prose td:first-child{color:var(--foreground);font-weight:500}
 
     /* ── video (the launch film) ── */
-    figure.video{margin:32px 0;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;
-      background:#0c0c0f;box-shadow:var(--shadow-float)}
-    figure.video video{display:block;width:100%;height:auto;background:#0c0c0f}
-    figure.video figcaption{font-size:13px;color:var(--muted-fg);padding:12px 16px;border-top:1px solid var(--border-soft);
+    figure.video{margin:32px 0;border:1px solid var(--border);border-radius:calc(var(--radius) + 4px);overflow:hidden;
+      background:var(--card)}
+    figure.video video{display:block;width:100%;height:auto;background:var(--card)}
+    figure.video figcaption{font-size:13px;color:var(--muted-foreground);padding:12px 16px;border-top:1px solid var(--border);
       background:var(--card);text-wrap:pretty}
 
     /* ── highlight grid (release highlights) ── */
     .hl-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px;margin:28px 0}
-    .hl{padding:20px;border:none;border-radius:var(--radius);background:#faf7f2;transition:.22s cubic-bezier(0.16, 1, 0.3, 1)}
-    :root[data-theme="dark"] .hl{background:#171613}
-    .hl:hover{background:#f5efe6;box-shadow:var(--shadow-card);transform:translateY(-2px)}
-    :root[data-theme="dark"] .hl:hover{background:#1f1e1a}
-    .hl b{font-size:15.5px;font-weight:650;letter-spacing:-.01em;color:var(--fg);display:block}
-    .hl span{font-size:13.5px;color:var(--muted-fg);margin-top:6px;display:block;line-height:1.55}
+    .hl{padding:20px;border:1px solid var(--border);border-radius:calc(var(--radius) + 4px);background:var(--card);
+      transition:border-color .18s ease}
+    .hl:hover{border-color:var(--hairline-strong)}
+    .hl b{font-size:15.5px;font-weight:600;letter-spacing:-.01em;color:var(--foreground);display:block}
+    .hl span{font-size:13.5px;color:var(--muted-foreground);margin-top:6px;display:block;line-height:1.55}
     @media (max-width:600px){.hl-grid{grid-template-columns:1fr}}
-
-
-    /* ── footer ── */
-    footer{border-top:1px solid var(--border-soft);padding:48px 0 40px;flex-shrink:0}
-    .foot{display:flex;align-items:flex-start;justify-content:space-between;gap:40px;flex-wrap:wrap}
-    .foot-brand{max-width:280px}
-    .foot-brand p{font-size:13.5px;color:var(--muted-fg);margin-top:14px;text-wrap:pretty}
-    .foot-cols{display:flex;gap:64px;flex-wrap:wrap}
-    .foot-col h5{font-size:12px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg);margin-bottom:14px}
-    .foot-col a{display:block;font-size:14px;color:var(--fg-soft);margin-bottom:10px;transition:color .15s}
-    .foot-col a:hover{color:var(--fg)}
-    .foot-bottom{margin-top:44px;padding-top:24px;border-top:1px solid var(--border-soft);
-      display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;font-size:13px;color:var(--muted-fg)}
-
-    @media (max-width:1024px){.nav-links{display:none}}
-    @media (max-width:560px){.nav-cta .btn-ghost{display:none}}
+    }
+    /* Unlayered so it beats the Star CTA's Tailwind `inline-flex`. */
+    @media (max-width:560px){.nav-cta-star{display:none}}
   </style>
 </head>
 <body>
   <slot />
   <script is:inline>
-    // Theme toggle: flip data-theme, persist the choice.
-    var toggle = document.querySelector('.theme-toggle')
-    if (toggle) {
-      toggle.addEventListener('click', function () {
-        var next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
-        document.documentElement.setAttribute('data-theme', next)
-        try { localStorage.setItem('chm-theme', next) } catch (e) {}
-        if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
-      })
-    }
-    try {
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function (e) {
-        if (!localStorage.getItem('chm-theme')) {
-          document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light')
-          if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
-        }
-      })
-    } catch (e) {}
     if (typeof window.chmSyncThemedImages === 'function') window.chmSyncThemedImages()
   </script>
   <script>

--- a/apps/blog/src/lib/button-classes.ts
+++ b/apps/blog/src/lib/button-classes.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared blog button classes — copied from apps/landing/src/lib/button-classes.ts.
+ * shadcn/ui geometry: rounded-md, compact heights, subtle shadow-xs.
+ * Color stays monochrome — the primary CTA is a solid ink/white button.
+ */
+
+const base =
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors active:scale-[.98] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--brand)]/40 disabled:pointer-events-none disabled:opacity-50'
+
+/** Compact size — the one size used across CTAs. */
+const size = `${base} h-10 px-4`
+
+/**
+ * The one primary CTA — shadcn "default" variant. Solid white on black in
+ * dark, solid ink on white in light (`--primary` / `--primary-foreground`).
+ */
+export const btnPrimary = `${size} bg-primary text-primary-foreground shadow-xs hover:bg-primary/90`
+
+/** shadcn "outline" variant. */
+export const btnOutline = `${size} border border-[var(--hairline-strong)] bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground`

--- a/apps/blog/src/pages/[...slug].astro
+++ b/apps/blog/src/pages/[...slug].astro
@@ -68,14 +68,14 @@ const breadcrumbJsonLd = {
   <Nav />
   <main>
     <div class="article-wrap">
-      <header class="article-head">
-        <a class="back-link" href="/">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+      <header class="pb-8 pt-14">
+        <a class="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground" href="/">
+          <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
           All posts
         </a>
-        <h1>{post.data.title}</h1>
-        <p class="lede">{post.data.description}</p>
-        <div class="article-byline">
+        <h1 class="mt-5 text-balance font-normal text-[clamp(1.5rem,4.4vw,2.75rem)] leading-[1.06] tracking-tight text-foreground">{post.data.title}</h1>
+        <p class="lede mt-4 text-pretty text-lg leading-relaxed text-muted-foreground">{post.data.description}</p>
+        <div class="mt-5 flex flex-wrap items-center gap-2.5 text-sm text-muted-foreground">
           <span class="post-tag">{post.data.version ?? post.data.tag}</span>
           <span>{fmtDate(post.data.date)}</span>
         </div>

--- a/apps/blog/src/pages/category/[tag].astro
+++ b/apps/blog/src/pages/category/[tag].astro
@@ -35,27 +35,27 @@ function fmtDate(d: Date) {
 >
   <Nav />
   <main>
-    <section class="blog-hero">
+    <section class="relative overflow-hidden pb-9 pt-16">
       <div class="wrap">
-        <span class="eyebrow sec-eyebrow">Blog</span>
-        <h1>{resolved}</h1>
-        <p>{items.length} {items.length === 1 ? 'post' : 'posts'} in this category.</p>
+        <span class="font-mono text-[11.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground">Blog</span>
+        <h1 class="mt-3.5 text-balance font-normal text-[clamp(1.5rem,4vw,2.625rem)] leading-[1.08] tracking-tight text-foreground">{resolved}</h1>
+        <p class="mt-3.5 text-pretty text-[17px] text-muted-foreground">{items.length} {items.length === 1 ? 'post' : 'posts'} in this category.</p>
       </div>
     </section>
-    <section class="wrap">
-      <ul class="cat-list cat-page-list">
+    <section class="wrap pb-20">
+      <ul class="list-none">
         {items.map((post) => (
-          <li class="cat-item">
-            <a class="cat-link" href={`/${postSlug(post)}/`}>
-              <span class="cat-title">{post.data.title}</span>
-              <span class="cat-date">{fmtDate(post.data.date)}</span>
+          <li class="border-b border-border py-4 last:border-b-0">
+            <a class="flex items-baseline justify-between gap-3.5" href={`/${postSlug(post)}/`}>
+              <span class="text-[17px] font-semibold tracking-tight text-foreground transition-colors hover:text-[var(--brand-ink)]">{post.data.title}</span>
+              <span class="shrink-0 font-mono text-[12.5px] text-muted-foreground">{fmtDate(post.data.date)}</span>
             </a>
-            {post.data.description && <p class="cat-desc">{post.data.description}</p>}
+            {post.data.description && <p class="mt-1 max-w-[72ch] text-pretty text-sm leading-relaxed text-muted-foreground">{post.data.description}</p>}
           </li>
         ))}
       </ul>
-      <a class="cat-more" href="/">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
+      <a class="mt-6 inline-flex items-center gap-1.5 text-[13.5px] font-semibold text-[var(--brand-ink)]" href="/">
+        <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 19-7-7 7-7"/><path d="M19 12H5"/></svg>
         All posts
       </a>
     </section>

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -63,42 +63,49 @@ const groups = allTags
 <Base title="chmonitor blog — release notes, guides & ClickHouse diagnostics" image="/og/blog/index.png">
   <Nav />
   <main>
-    <section class="blog-hero">
+    <section class="relative overflow-hidden pb-9 pt-16">
+      <div
+        class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(ellipse_70%_50%_at_50%_-30%,var(--brand-soft),transparent_65%)]"
+        aria-hidden="true"
+      ></div>
       <div class="wrap">
-        <span class="eyebrow sec-eyebrow">Blog</span>
-        <h1>What's new in chmonitor</h1>
-        <p>Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.</p>
+        <span class="font-mono text-[11.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground">Blog</span>
+        <h1 class="mt-3.5 text-balance font-normal text-[clamp(1.5rem,4vw,2.625rem)] leading-[1.08] tracking-tight text-foreground">What's new in chmonitor</h1>
+        <p class="mt-3.5 max-w-[60ch] text-pretty text-[17px] text-muted-foreground">Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.</p>
       </div>
     </section>
     <section class="wrap">
-      <div class="cat-grid">
+      <div class="grid grid-cols-1 gap-5 pb-20 pt-2 md:grid-cols-2">
         {groups.map((group) => (
-          <section class={`cat-card${group.featured ? ' is-featured' : ''}`}>
-            <header class="cat-head">
-              <h2>{group.tag}</h2>
-              <span class="cat-count">{group.items.length}</span>
+          <section class:list={[
+            'flex h-full flex-col rounded-xl border border-border p-6',
+            group.featured ? 'col-span-full bg-[var(--brand-soft)]' : 'bg-card',
+          ]}>
+            <header class="flex items-center gap-2.5">
+              <h2 class="text-[17px] font-semibold tracking-tight text-foreground">{group.tag}</h2>
+              <span class="rounded-full bg-muted px-2 py-px font-mono text-xs font-semibold text-muted-foreground">{group.items.length}</span>
             </header>
-            <p class="cat-tagline">{group.tagline}</p>
-            <ul class="cat-list">
+            <p class="mt-2 text-pretty text-[13.5px] leading-relaxed text-muted-foreground">{group.tagline}</p>
+            <ul class="mt-4 flex flex-1 list-none flex-col gap-0.5 border-t border-border pt-1.5">
               {group.visible.map((post) => (
-                <li class="cat-item">
-                  <a class="cat-link" href={`/${postSlug(post)}/`}>
-                    <span class="cat-title">{post.data.title}</span>
-                    {!group.featured && <span class="cat-date">{fmtDate(post.data.date)}</span>}
+                <li class="border-b border-border py-2.5 last:border-b-0">
+                  <a class="flex items-baseline justify-between gap-3.5" href={`/${postSlug(post)}/`}>
+                    <span class="text-[15px] font-medium tracking-tight text-foreground transition-colors hover:text-[var(--brand-ink)]">{post.data.title}</span>
+                    {!group.featured && <span class="shrink-0 font-mono text-[12.5px] text-muted-foreground">{fmtDate(post.data.date)}</span>}
                   </a>
                   {group.featured && (
-                    <span class="cat-date">{fmtDate(post.data.date)}</span>
+                    <span class="font-mono text-[12.5px] text-muted-foreground">{fmtDate(post.data.date)}</span>
                   )}
                   {group.featured && post.data.description && (
-                    <p class="cat-desc">{post.data.description}</p>
+                    <p class="mt-1 max-w-[72ch] text-pretty text-sm leading-relaxed text-muted-foreground">{post.data.description}</p>
                   )}
                 </li>
               ))}
             </ul>
             {group.items.length > group.visible.length && (
-              <a class="cat-more" href={`/category/${group.slug}/`}>
+              <a class="mt-3.5 inline-flex items-center gap-1.5 text-[13.5px] font-semibold text-[var(--brand-ink)]" href={`/category/${group.slug}/`}>
                 View all {group.items.length} posts
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
               </a>
             )}
           </section>

--- a/apps/blog/src/styles/globals.css
+++ b/apps/blog/src/styles/globals.css
@@ -1,0 +1,134 @@
+/* Tailwind v4 + shadcn tokens, copied from apps/landing/src/styles/globals.css.
+   IMPORTANT: preflight is intentionally OMITTED. The blog keeps a small
+   hand-authored reset and prose layer in Base.astro; importing Tailwind's
+   preflight globally would restyle every markdown class. So we pull in just
+   the theme (tokens) + utilities layers. */
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
+@import 'tw-animate-css';
+
+/* The blog flips theme via <html data-theme="dark">, not the `.dark` class,
+   so the shadcn `dark:` variant must key off that attribute. */
+@custom-variant dark (&:is([data-theme='dark'] *));
+
+/* shadcn tokens. Light: white floor, warm near-black ink. Dark: warm near-black
+   floor (never pure #000). Depth is carried by hairlines, not shadows.
+
+   Orange is split by ROLE, not by shade preference — a single hex cannot clear
+   WCAG AA in all three uses:
+     --brand        vivid accent. 3.52:1 on white → large text (≥24px), fills,
+                    focus rings, and non-text marks ONLY. Never small text.
+     --brand-strong filled-CTA background. White label clears AA at 4.71:1.
+     --brand-ink    orange as small TEXT on canvas/card (eyebrows, inline links).
+                    Goes darker in light (5.87:1), lighter in dark (6.16:1). */
+:root {
+  /* 8px CTA / form radius; --radius-xl lifts cards to 12px. */
+  --radius: 0.5rem;
+  --background: #ffffff;
+  --foreground: #26251e;
+  --card: #ffffff;
+  --card-foreground: #26251e;
+  --popover: #ffffff;
+  --popover-foreground: #26251e;
+  --primary: #26251e;
+  --primary-foreground: #ffffff;
+  --secondary: #fafafa;
+  --secondary-foreground: #26251e;
+  --muted: #f1f0ed;
+  --muted-foreground: #5a5852;
+  --accent: #f1f0ed;
+  --accent-foreground: #26251e;
+  --destructive: #cf2d56;
+  --border: #e7e6e2;
+  --input: #cfcdc4;
+  --ring: #f54e00;
+  /* Canvas + hairline scale. Bands use --canvas-soft to separate from the white
+     page floor, since cards are white and carry only a hairline. */
+  --canvas-soft: #fafafa;
+  --surface-strong: #eceae5;
+  --hairline-soft: #f1f0ed;
+  --hairline-strong: #cfcdc4;
+  --muted-soft: #a09c92;
+  /* Brand voltage — used scarcely. */
+  --brand: #f54e00;
+  --brand-strong: #d04200;
+  --brand-ink: #b03800;
+  --on-brand: #ffffff;
+  --brand-soft: rgba(245, 78, 0, 0.09);
+  /* Semantic — confirmation only, never a second brand action color. */
+  --semantic-success: #1f8a65;
+  /* One soft-blue accent link ("See what's new →"). */
+  --accent-link: #2f6feb;
+}
+
+/* Dark = the showcase theme. Near-black neutral canvas (#0A0A0A floor),
+   pure-white ink, and depth carried by ultra-subtle white hairlines
+   (6–14% opacity) — no heavy shadows. */
+[data-theme='dark'] {
+  --background: #0a0a0a;
+  --foreground: #ffffff;
+  --card: #141414;
+  --card-foreground: #f4f4f5;
+  --popover: #141414;
+  --popover-foreground: #f4f4f5;
+  --primary: #ffffff;
+  --primary-foreground: #0a0a0a;
+  --secondary: #1a1a1a;
+  --secondary-foreground: #f4f4f5;
+  --muted: #1a1a1a;
+  --muted-foreground: #9ca3af;
+  --accent: #1f1f1f;
+  --accent-foreground: #ffffff;
+  --destructive: #ff6b8b;
+  --border: rgba(255, 255, 255, 0.08);
+  --input: rgba(255, 255, 255, 0.14);
+  --ring: #f97316;
+  --canvas-soft: #0d0d0d;
+  --surface-strong: #1c1c1c;
+  --hairline-soft: rgba(255, 255, 255, 0.06);
+  --hairline-strong: rgba(255, 255, 255, 0.16);
+  --muted-soft: #6f6f6f;
+  --brand: #f97316;
+  --brand-strong: #f97316;
+  --brand-ink: #fb923c;
+  --on-brand: #0a0a0a;
+  --brand-soft: rgba(249, 115, 22, 0.10);
+  --semantic-success: #35b184;
+  /* One soft-blue accent link ("See what's new →"). */
+  --accent-link: #7aa2f7;
+}
+
+img {
+  border-radius: var(--radius);
+}
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --font-sans:
+    'Geist', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto,
+    sans-serif;
+  /* Blog ships JetBrains Mono (landing ships Geist Mono). Same role. */
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -2,6 +2,7 @@
  * Post-build structural assertions for the redesigned homepage.
  * Run: cd apps/landing && pnpm run build && bun scripts/verify-landing-structure.ts
  */
+import { getLatestBlogPost } from '../src/lib/latest-blog-post'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -18,7 +19,7 @@ const required = [
   // Headline may include a <br> between "dashboard" and "for" — match pieces.
   'The ops dashboard',
   'for ClickHouse',
-  'data-hero-oss',
+  'data-hero-latest-post',
 ] as const
 
 const forbidden = [
@@ -53,20 +54,32 @@ for (const marker of required) {
   }
 }
 
-const ossIdx = html.indexOf('data-hero-oss')
-const ossEnd = ossIdx === -1 ? -1 : html.indexOf('</a>', ossIdx)
-const ossChunk =
-  ossIdx === -1 || ossEnd === -1 ? '' : html.slice(ossIdx, ossEnd)
-if (!ossChunk.includes('self-host free')) {
-  console.error('MISSING self-host free claim in [data-hero-oss]')
+const latestIdx = html.indexOf('data-hero-latest-post')
+const latestStart = latestIdx === -1 ? -1 : html.lastIndexOf('<a', latestIdx)
+const latestEnd = latestIdx === -1 ? -1 : html.indexOf('</a>', latestIdx)
+const latestChunk =
+  latestStart === -1 || latestEnd === -1
+    ? ''
+    : html.slice(latestStart, latestEnd)
+const latestPost = getLatestBlogPost()
+if (!latestChunk.includes('blog.chmonitor.dev')) {
+  console.error('MISSING blog.chmonitor.dev href in [data-hero-latest-post]')
   failed = true
-} else if (/\btruncate\b/.test(ossChunk)) {
+} else if (latestPost && !latestChunk.includes(latestPost.href)) {
   console.error(
-    'FORBIDDEN truncate on hero OSS pill (clips SELF-HOST FREE at 320px)'
+    `MISSING latest post href in [data-hero-latest-post]: ${latestPost.href}`
   )
   failed = true
+} else if (latestPost && !latestChunk.includes(latestPost.title)) {
+  console.error(
+    `MISSING latest post title in [data-hero-latest-post]: ${latestPost.title}`
+  )
+  failed = true
+} else if (/\btruncate\b/.test(latestChunk)) {
+  console.error('FORBIDDEN truncate on hero latest-post pill')
+  failed = true
 } else {
-  console.log('OK: hero OSS pill keeps the full self-host claim (no truncate)')
+  console.log('OK: hero pill links to the latest blog post (no truncate)')
 }
 
 for (const text of forbidden) {

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import { ALERT_CHANNELS_SHORT } from '../data/alert-channels'
+import { getLatestBlogPost } from '../lib/latest-blog-post'
 
 const HERO_VIDEO = '/assets/videos/chmonitor-v0.3.mp4'
 const HERO_POSTER = '/assets/videos/chmonitor-v0.3-poster.jpg'
@@ -15,8 +16,10 @@ const HERO_FEATURES = [
   'AI advisor for schema and tuning — MCP-ready, read-only default',
 ] as const
 
+const latestPost = getLatestBlogPost()
+
 const checkSvg = `<svg class="mt-0.5 size-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
-const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>`
+const sparkSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v3"/><path d="M12 18v3"/><path d="M3 12h3"/><path d="M18 12h3"/><path d="m5.6 5.6 2.1 2.1"/><path d="m16.3 16.3 2.1 2.1"/><path d="m16.3 7.7 2.1-2.1"/><path d="m5.6 18.4 2.1-2.1"/></svg>`
 ---
 
 <section class="relative isolate overflow-hidden -mt-16 pt-16 pb-14 sm:pb-16 md:pb-[56px]" data-hero>
@@ -72,22 +75,28 @@ const githubSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="currentColor"
 
   <div class="relative mx-auto max-w-[1080px] px-4 sm:px-6 pt-12 sm:pt-16 lg:pt-20">
     <div class="mx-auto max-w-3xl text-center">
-      <a
-        href="https://github.com/chmonitor/chmonitor"
-        target="_blank"
-        rel="noopener"
-        class="inline-flex max-w-full"
-        data-hero-oss
-      >
-        {/* Wrap below ~360px so 320px shows the full self-host claim. 375+
-            stays one line. Type stays at 12px — no smaller squeeze. */}
-        <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-semibold uppercase tracking-[0.06em] sm:tracking-[0.08em] leading-snug transition-colors hover:bg-[var(--hairline-strong)] max-[359px]:py-1.5">
-          <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={githubSvg} />
-          <span class="min-w-0 text-center min-[360px]:whitespace-nowrap">
-            Open source · GPL-3.0 ·<br class="min-[360px]:hidden" /> self-host free
-          </span>
-        </span>
-      </a>
+      {
+        latestPost && (
+          <a
+            href={latestPost.href}
+            target="_blank"
+            rel="noopener"
+            class="inline-flex max-w-full"
+            data-hero-latest-post
+          >
+            {/* Compact announcement pill. Type stays at 12px; title may wrap
+                on narrow screens. Do not truncate. */}
+            <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-semibold leading-snug transition-colors hover:bg-[var(--hairline-strong)] max-[359px]:py-1.5">
+              <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={sparkSvg} />
+              <span class="min-w-0 text-center">
+                <span class="uppercase tracking-[0.06em] sm:tracking-[0.08em]">New</span>
+                {' · '}
+                {latestPost.title}
+              </span>
+            </span>
+          </a>
+        )
+      }
 
       {/* Display stays at weight 400 with negative tracking — the editorial
           voice depends on it. Do not bold. */}

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -1,3 +1,4 @@
+import { getLatestBlogPost } from './lib/latest-blog-post'
 import { describe, expect, test } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -8,6 +9,7 @@ const read = (rel: string) => readFileSync(join(landing, rel), 'utf8')
 const home = read('src/pages/index.astro')
 const nav = read('src/components/Nav.astro')
 const footer = read('src/components/Footer.astro')
+const hero = read('src/components/Hero.astro')
 
 describe('homepage hides Pricing and the Always shipping band', () => {
   test('does not import or render Pricing or ChangelogBand', () => {
@@ -40,5 +42,28 @@ describe('header nav does not advertise Pricing', () => {
 
   test('footer still links to /pricing', () => {
     expect(footer).toContain('href="/pricing"')
+  })
+})
+
+describe('hero pill links to the latest published blog post', () => {
+  const latest = getLatestBlogPost()
+
+  test('helper resolves a published post on blog.chmonitor.dev', () => {
+    expect(latest).not.toBeNull()
+    expect(latest!.href).toContain('blog.chmonitor.dev')
+    expect(latest!.href).toBe(
+      `https://blog.chmonitor.dev/${latest!.slug}/`
+    )
+    expect(latest!.title.length).toBeGreaterThan(0)
+  })
+
+  test('hero source renders that post via the helper (not a hardcoded slug)', () => {
+    expect(hero).toContain("from '../lib/latest-blog-post'")
+    expect(hero).toContain('getLatestBlogPost')
+    expect(hero).toContain('data-hero-latest-post')
+    expect(hero).toContain('href={latestPost.href}')
+    expect(hero).toContain('{latestPost.title}')
+    expect(hero).not.toContain('data-hero-oss')
+    expect(hero).not.toContain('https://github.com/chmonitor/chmonitor')
   })
 })

--- a/apps/landing/src/layouts/mobile-landing.test.ts
+++ b/apps/landing/src/layouts/mobile-landing.test.ts
@@ -94,19 +94,21 @@ describe('mobile nav: open menu shows X + dim, tap targets ≥44px', () => {
   })
 })
 
-describe('hero OSS pill: 320px shows the full self-host claim', () => {
-  test('does not truncate; wraps below 360px; 375+ stays one line', () => {
-    const oss = hero.split('data-hero-oss')[1] ?? ''
-    const pill = oss.slice(0, oss.indexOf('</a>'))
-    expect(pill).toContain('self-host free')
+describe('hero latest-post pill: compact, wrap-friendly, 12px type', () => {
+  test('does not truncate; title may wrap on narrow screens', () => {
+    const idx = hero.indexOf('data-hero-latest-post')
+    expect(idx).toBeGreaterThan(-1)
+    const start = hero.lastIndexOf('<a', idx)
+    const pill = hero.slice(start, hero.indexOf('</a>', idx))
+    expect(pill).toContain('{latestPost.title}')
+    expect(pill).toContain('{latestPost.href}')
     expect(pill).not.toMatch(/class="[^"]*\btruncate\b/)
-    expect(pill).toContain('min-[360px]:whitespace-nowrap')
-    expect(pill).toContain('<br class="min-[360px]:hidden"')
+    expect(pill).not.toMatch(/whitespace-nowrap/)
   })
 
   test('type is at least 12px (text-xs), not a squeeze below that', () => {
-    const oss = hero.split('data-hero-oss')[1] ?? ''
-    const pill = oss.slice(0, oss.indexOf('</a>'))
+    const latest = hero.split('data-hero-latest-post')[1] ?? ''
+    const pill = latest.slice(0, latest.indexOf('</a>'))
     expect(pill).toContain('text-xs')
     expect(pill).not.toMatch(/text-\[(?:9|10|11)px\]/)
   })

--- a/apps/landing/src/lib/latest-blog-post.test.ts
+++ b/apps/landing/src/lib/latest-blog-post.test.ts
@@ -1,0 +1,136 @@
+import { BLOG_ORIGIN, getLatestBlogPost } from './latest-blog-post'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let dir: string
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true })
+})
+
+function tmpDir(): string {
+  dir = mkdtempSync(join(tmpdir(), 'chm-latest-blog-'))
+  return dir
+}
+
+function writePost(name: string, frontmatter: string): void {
+  writeFileSync(join(dir, name), `---\n${frontmatter}\n---\nbody\n`)
+}
+
+describe('getLatestBlogPost', () => {
+  test('returns a real published post from the blog content dir', () => {
+    const latest = getLatestBlogPost()
+    expect(latest).not.toBeNull()
+    expect(latest!.title.length).toBeGreaterThan(0)
+    expect(latest!.description.length).toBeGreaterThan(0)
+    expect(latest!.href.startsWith(`${BLOG_ORIGIN}/`)).toBe(true)
+    expect(latest!.href.endsWith('/')).toBe(true)
+    expect(latest!.slug.length).toBeGreaterThan(0)
+    expect(latest!.date.valueOf()).toBeLessThanOrEqual(Date.now())
+  })
+
+  test('sorts by date and picks the newest published post', () => {
+    tmpDir()
+    writePost(
+      'old.md',
+      'title: "Old post"\ndescription: "d"\ndate: 2026-01-01'
+    )
+    writePost(
+      'mid.md',
+      'title: "Mid post"\ndescription: "d"\ndate: 2026-06-01'
+    )
+    writePost(
+      'new.md',
+      'title: "Newest post"\ndescription: "fresh"\ndate: 2026-08-01'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date('2026-08-20T12:00:00Z'),
+    })
+    expect(latest?.title).toBe('Newest post')
+    expect(latest?.slug).toBe('new')
+    expect(latest?.href).toBe(`${BLOG_ORIGIN}/new/`)
+    expect(latest?.description).toBe('fresh')
+  })
+
+  test('excludes drafts even when they are the newest', () => {
+    tmpDir()
+    writePost(
+      'live.md',
+      'title: "Live"\ndescription: "d"\ndate: 2026-08-01'
+    )
+    writePost(
+      'draft.md',
+      'title: "Draft"\ndescription: "d"\ndate: 2026-08-19\ndraft: true'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date('2026-08-20T12:00:00Z'),
+    })
+    expect(latest?.title).toBe('Live')
+    expect(latest?.slug).toBe('live')
+  })
+
+  test('treats a YYYY-MM-DD date as that local calendar day', () => {
+    tmpDir()
+    writePost(
+      'today.md',
+      'title: "Today"\ndescription: "d"\ndate: 2026-08-20'
+    )
+    writePost(
+      'yesterday.md',
+      'title: "Yesterday"\ndescription: "d"\ndate: 2026-08-19'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date(2026, 7, 20, 0, 20),
+    })
+    expect(latest?.title).toBe('Today')
+    expect(latest?.slug).toBe('today')
+  })
+
+  test('excludes future-dated posts (#2697)', () => {
+    tmpDir()
+    writePost(
+      'live.md',
+      'title: "Live"\ndescription: "d"\ndate: 2026-08-01'
+    )
+    writePost(
+      'scheduled.md',
+      'title: "Scheduled"\ndescription: "d"\ndate: 2026-12-01'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date('2026-08-20T12:00:00Z'),
+    })
+    expect(latest?.title).toBe('Live')
+    expect(latest?.slug).toBe('live')
+  })
+
+  test('uses version as the public slug when set', () => {
+    tmpDir()
+    writePost(
+      'chmonitor-v0-3.md',
+      'title: "chmonitor v0.3"\ndescription: "rebuild"\ndate: 2026-06-29\nversion: v0.3'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date('2026-08-20T12:00:00Z'),
+    })
+    expect(latest?.slug).toBe('v0.3')
+    expect(latest?.href).toBe(`${BLOG_ORIGIN}/v0.3/`)
+  })
+
+  test('returns null when the directory has no published posts', () => {
+    tmpDir()
+    writePost(
+      'soon.md',
+      'title: "Soon"\ndescription: "d"\ndate: 2099-01-01'
+    )
+    expect(
+      getLatestBlogPost({ dir, now: new Date('2026-08-20T12:00:00Z') })
+    ).toBeNull()
+  })
+})

--- a/apps/landing/src/lib/latest-blog-post.ts
+++ b/apps/landing/src/lib/latest-blog-post.ts
@@ -1,0 +1,129 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Public origin for blog posts linked from the landing page. */
+export const BLOG_ORIGIN = 'https://blog.chmonitor.dev'
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/
+
+export type LatestBlogPost = {
+  title: string
+  description: string
+  date: Date
+  slug: string
+  href: string
+}
+
+export type LatestBlogPostOptions = {
+  /** Override the blog content directory (tests). */
+  dir?: string
+  /** Override "now" so draft/future filtering is deterministic (tests). */
+  now?: Date
+}
+
+/**
+ * Newest published post in `apps/blog/src/content/blog/*.md`.
+ *
+ * Published = not `draft` and `date <= now`, matching the blog app's
+ * `isPublished` / `postSlug` (version frontmatter wins over filename id).
+ * Parses YAML frontmatter locally — do not import `astro:content` from blog.
+ */
+export function getLatestBlogPost(
+  options: LatestBlogPostOptions = {}
+): LatestBlogPost | null {
+  const dir = options.dir ?? resolveBlogContentDir()
+  if (!dir) return null
+  const now = options.now?.valueOf() ?? Date.now()
+
+  let latest: LatestBlogPost | null = null
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith('.md')) continue
+    const parsed = parseBlogPostFile(join(dir, name), name)
+    if (!parsed) continue
+    if (!isPublished(parsed, now)) continue
+    if (!latest || parsed.date.valueOf() > latest.date.valueOf()) {
+      latest = {
+        title: parsed.title,
+        description: parsed.description,
+        date: parsed.date,
+        slug: parsed.slug,
+        href: parsed.href,
+      }
+    }
+  }
+  return latest
+}
+
+export function resolveBlogContentDir(): string | null {
+  const candidates = [
+    fileURLToPath(new URL('../../../blog/src/content/blog', import.meta.url)),
+    join(process.cwd(), '../blog/src/content/blog'),
+  ]
+  for (const dir of candidates) {
+    if (existsSync(dir)) return dir
+  }
+  return null
+}
+
+function isPublished(
+  post: Pick<LatestBlogPost, 'date'> & { draft: boolean },
+  now: number
+): boolean {
+  return !post.draft && post.date.valueOf() <= now
+}
+
+function parseBlogPostFile(
+  path: string,
+  filename: string
+): (LatestBlogPost & { draft: boolean }) | null {
+  const raw = readFileSync(path, 'utf8')
+  const match = raw.match(FRONTMATTER_RE)
+  if (!match) return null
+
+  const fields = parseFrontmatter(match[1] ?? '')
+  const title = fields.title
+  const description = fields.description ?? ''
+  const date = parseDate(fields.date)
+  if (!title || !date) return null
+
+  const id = filename.replace(/\.md$/i, '')
+  const slug = fields.version || id
+  return {
+    title,
+    description,
+    date,
+    slug,
+    href: `${BLOG_ORIGIN}/${slug}/`,
+    draft: fields.draft === 'true',
+  }
+}
+
+function parseFrontmatter(block: string): Record<string, string> {
+  const fields: Record<string, string> = {}
+  for (const rawLine of block.split('\n')) {
+    const line = rawLine.replace(/\r$/, '')
+    const keyed = line.match(/^([A-Za-z][\w-]*)\s*:\s*(.*)$/)
+    if (!keyed) continue
+    fields[keyed[1]!] = unquote(keyed[2] ?? '')
+  }
+  return fields
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim()
+  const match = trimmed.match(/^["'](.*)["']$/)
+  return (match ? match[1] : trimmed).trim()
+}
+
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null
+  // Date-only YAML (`2026-08-20`) is that local calendar day, not UTC midnight.
+  const day = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (day) {
+    const date = new Date(Number(day[1]), Number(day[2]) - 1, Number(day[3]))
+    return Number.isNaN(date.valueOf()) ? null : date
+  }
+  const date = new Date(value)
+  return Number.isNaN(date.valueOf()) ? null : date
+}

--- a/docs/content/reference/settings.mdx
+++ b/docs/content/reference/settings.mdx
@@ -1,5 +1,5 @@
 ---
-description: Configure alert thresholds, browser connections, AI agent options, and UI theme from the in-app Settings page, or via server-side environment variables.
+description: Configure alert thresholds, browser connections, AI agent options, UI theme, and workspace navigation from the in-app Settings dialog, or via server-side environment variables.
 icon: Cog
 ---
 
@@ -9,7 +9,9 @@ The in-app Settings page (feature id: `settings`, route `/settings`) lets
 operators configure alert thresholds, manage browser connections, tune agent
 session options, and change the UI theme — without redeploying.
 
-To reach it, open the dashboard and click **Settings** in the navigation.
+To reach it, open the dashboard and click the **Settings** gear (or ⌘,).
+Workspace / Navigation lives in that dialog, not on the `/settings`
+`system.settings` table page.
 
 ## What you can configure in-app
 
@@ -19,9 +21,59 @@ To reach it, open the dashboard and click **Settings** in the navigation.
 | Browser connections | Add/remove personal ClickHouse connections stored in the browser |
 | Agent session | Model picker, token/cost display, conversation store selection |
 | Theme | Light / dark / system |
+| Workspace / Navigation | Role preset, hide/show pages, pin favorites; local to this browser |
 
 Settings changes made in-app are stored per browser session or in the configured
 conversation store. They do not affect server-side environment variables.
+
+## Workspace / Navigation
+
+Open **Settings → Workspace → Navigation**. The dialog header says **Local to
+this browser** — the role and hide list live in this browser, not on the
+server, and they do not change anyone else's sidebar.
+
+Narrative walkthrough: [A DBA, an SRE, and an engineer should not share a
+sidebar](https://blog.chmonitor.dev/customize-dashboard/).
+
+### Roles
+
+| Preset | Groups kept |
+|---|---|
+| **Full** | Every page the host and deployment already allow. New pages stay visible. |
+| **DBA** | Overview, Tools, Queries, Tables, Merges, Metrics, Keeper, Security, Logs, Cluster, System |
+| **Engineer** | Overview, Tools, Queries, Tables, Insights, AI Agent |
+| **SRE** | Overview, Tools, Health, Insights, Queries, Tables, System, Operations, Metrics, Logs |
+| **Custom** | Start from a role, then hide extra leaves |
+
+Picking a role remounts the Settings tree collapsed. Expand only what you care
+about; search filters the tree. The pill flips to **Custom** only when Hide/Show
+on a leaf diverges from that role's hide list. Collapsing a parent does not
+count.
+
+Footer **About** is not hideable. The Settings gear and host switcher are never
+filtered. Hidden pages stay reachable by URL; the sidebar and command palette
+drop them.
+
+### Hide, pin, restore
+
+- In Settings, leaves have **Hide** / **Show**. Hidden rows stay in the tree,
+  dimmed.
+- In the sidebar, hover a leaf: **Hide** sits next to **Pin**. A toast offers
+  **Undo** and **Open Navigation**.
+- Restore always lives at Settings → Workspace → Navigation.
+- Pin adds the page to **Favorites** at the top of the sidebar; drag to reorder.
+  Pins are local to this browser too.
+
+Theme, units, and layout stay on the other Settings tabs (local chrome). The
+role plus hide list is the menu IA. Workspace visibility is applied last —
+permission, cloud, and engine gates still win.
+
+### Tools
+
+**Tools** is the last Main group: SQL Console, Data Explorer, Explain, Advisor
+(recommend-only; never applies DDL), Chart Builder, Schema Compare, Settings
+Diff. **AI Agent** stays its own top-level group. Postgres hosts do not see
+Tools (ClickHouse-family only). DBA, Engineer, and SRE presets all keep Tools.
 
 ## Conversation history (agent settings sidebar)
 
@@ -163,4 +215,5 @@ these client-side variables.
 <Card title="Authentication" href="/operate/authentication" description="Setting up Clerk, Cloudflare Access, or proxy auth." />
 <Card title="AI agent" href="/guide/ai-agent" description="Agent configuration and conversation store options." />
 <Card title="Install & configure" href="/operate/deploy" description="Platform-specific deployment with all env vars." />
+<Card title="A DBA, an SRE, and an engineer should not share a sidebar" href="https://blog.chmonitor.dev/customize-dashboard/" description="Workspace roles, hide/pin, and the Tools menu — local to this browser." />
 </Cards>


### PR DESCRIPTION
## Summary

Landing hero pill now links to the latest published blog post. The blog chrome uses the same Tailwind v4 / shadcn tokens as the landing page. New Product post covers workspace roles, hide/pin, and the Tools menu.

## Changes

- Hero announcement pill (`New · {title}`) resolves the newest published post at build time from `apps/blog/src/content/blog/*.md` (no hardcoded slug)
- Blog layout/nav/footer/cards/prose restyled to landing semantic tokens (`bg-card`, `text-muted-foreground`, `--brand-ink`)
- New post: [A DBA, an SRE, and an engineer should not share a sidebar](https://blog.chmonitor.dev/customize-dashboard/)
- Settings docs: Workspace / Navigation subsection + reverse blog link

## Test plan

- [x] `bun test` landing helper + homepage + mobile landing tests
- [x] `bun test` blog chrome + published helpers
- [x] Blog `pnpm run build` (51 pages) during restyle
- [ ] Confirm hero pill on chmonitor.dev after deploy points at `/customize-dashboard/`
- [ ] Confirm blog.chmonitor.dev homepage/article look like landing in light and dark