### PR TITLE
fix(landing): restyle hero latest-post pill as title plus arrow

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -75,11 +75,11 @@ if (!latestChunk.includes('blog.chmonitor.dev')) {
     `MISSING latest post title in [data-hero-latest-post]: ${latestPost.title}`
   )
   failed = true
-} else if (/\btruncate\b/.test(latestChunk)) {
-  console.error('FORBIDDEN truncate on hero latest-post pill')
+} else if (!/\btruncate\b/.test(latestChunk)) {
+  console.error('MISSING truncate on hero latest-post pill (mobile overflow)')
   failed = true
 } else {
-  console.log('OK: hero pill links to the latest blog post (no truncate)')
+  console.log('OK: hero pill links to the latest blog post (truncates)')
 }
 
 for (const text of forbidden) {

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -19,7 +19,7 @@ const HERO_FEATURES = [
 const latestPost = getLatestBlogPost()
 
 const checkSvg = `<svg class="mt-0.5 size-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 12 5 5L20 7"/></svg>`
-const sparkSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v3"/><path d="M12 18v3"/><path d="M3 12h3"/><path d="M18 12h3"/><path d="m5.6 5.6 2.1 2.1"/><path d="m16.3 16.3 2.1 2.1"/><path d="m16.3 7.7 2.1-2.1"/><path d="m5.6 18.4 2.1-2.1"/></svg>`
+const arrowSvg = `<svg class="size-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`
 ---
 
 <section class="relative isolate overflow-hidden -mt-16 pt-16 pb-14 sm:pb-16 md:pb-[56px]" data-hero>
@@ -81,18 +81,15 @@ const sparkSvg = `<svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="
             href={latestPost.href}
             target="_blank"
             rel="noopener"
-            class="inline-flex max-w-full"
+            title={latestPost.title}
+            class="inline-flex min-w-0 max-w-full"
             data-hero-latest-post
           >
-            {/* Compact announcement pill. Type stays at 12px; title may wrap
-                on narrow screens. Do not truncate. */}
-            <span class="inline-flex max-w-full items-center gap-2 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-semibold leading-snug transition-colors hover:bg-[var(--hairline-strong)] max-[359px]:py-1.5">
-              <span class="inline-flex items-center justify-center size-3.5 shrink-0" set:html={sparkSvg} />
-              <span class="min-w-0 text-center">
-                <span class="uppercase tracking-[0.06em] sm:tracking-[0.08em]">New</span>
-                {' · '}
-                {latestPost.title}
-              </span>
+            {/* Title + arrow. One line; ellipsis on narrow screens so the
+                arrow stays visible. Full title is on `title` for hover. */}
+            <span class="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full bg-[var(--surface-strong)] px-3 py-1 text-foreground text-xs font-medium leading-none transition-colors hover:bg-[var(--hairline-strong)]">
+              <span class="min-w-0 truncate">{latestPost.title}</span>
+              <span class="shrink-0" set:html={arrowSvg} />
             </span>
           </a>
         )

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -63,6 +63,8 @@ describe('hero pill links to the latest published blog post', () => {
     expect(hero).toContain('data-hero-latest-post')
     expect(hero).toContain('href={latestPost.href}')
     expect(hero).toContain('{latestPost.title}')
+    expect(hero).toContain('truncate')
+    expect(hero).not.toMatch(/>New</)
     expect(hero).not.toContain('data-hero-oss')
     expect(hero).not.toContain('https://github.com/chmonitor/chmonitor')
   })

--- a/apps/landing/src/layouts/mobile-landing.test.ts
+++ b/apps/landing/src/layouts/mobile-landing.test.ts
@@ -94,16 +94,19 @@ describe('mobile nav: open menu shows X + dim, tap targets ≥44px', () => {
   })
 })
 
-describe('hero latest-post pill: compact, wrap-friendly, 12px type', () => {
-  test('does not truncate; title may wrap on narrow screens', () => {
+describe('hero latest-post pill: title + arrow, truncates when tight', () => {
+  test('shows the post title and a trailing arrow, no New prefix', () => {
     const idx = hero.indexOf('data-hero-latest-post')
     expect(idx).toBeGreaterThan(-1)
     const start = hero.lastIndexOf('<a', idx)
     const pill = hero.slice(start, hero.indexOf('</a>', idx))
     expect(pill).toContain('{latestPost.title}')
     expect(pill).toContain('{latestPost.href}')
-    expect(pill).not.toMatch(/class="[^"]*\btruncate\b/)
-    expect(pill).not.toMatch(/whitespace-nowrap/)
+    expect(pill).toContain('title={latestPost.title}')
+    expect(pill).toContain('truncate')
+    expect(pill).toContain('shrink-0')
+    expect(pill).not.toMatch(/>New</)
+    expect(pill).not.toContain('sparkSvg')
   })
 
   test('type is at least 12px (text-xs), not a squeeze below that', () => {


### PR DESCRIPTION
## Summary

Hero latest-post pill is now the post title plus an arrow — no icon, no "New ·" prefix. Long titles ellipsis on narrow screens so the arrow stays visible; hover shows the full title.

## Changes

- Pill copy: `{title} →`
- `truncate` + `min-w-0` on the title; arrow is `shrink-0`
- `title` attribute for the full string when truncated
- Tests and the post-build structure check now expect truncate instead of forbidding it

## Test plan

- [x] `bun test` homepage + mobile landing tests
- [ ] Check the hero on phone width (~320–375) and desktop after preview deploy