### PR TITLE
fix(landing): loop the hero intro video

### DIFF
--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -82,6 +82,18 @@ if (!latestChunk.includes('blog.chmonitor.dev')) {
   console.log('OK: hero pill links to the latest blog post (truncates)')
 }
 
+const introIdx = html.indexOf('data-hero-intro')
+const videoStart = introIdx === -1 ? -1 : html.lastIndexOf('<video', introIdx)
+const videoEnd = introIdx === -1 ? -1 : html.indexOf('>', introIdx)
+const videoTag =
+  videoStart === -1 || videoEnd === -1 ? '' : html.slice(videoStart, videoEnd)
+if (!/\bloop\b/.test(videoTag)) {
+  console.error('MISSING loop on [data-hero-intro] video')
+  failed = true
+} else {
+  console.log('OK: hero video loops')
+}
+
 for (const text of forbidden) {
   if (html.includes(text)) {
     console.error(`FORBIDDEN on homepage: ${text}`)

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -107,7 +107,7 @@ const arrowSvg = `<svg class="size-3.5 shrink-0" viewBox="0 0 24 24" fill="none"
     </div>
 
     {/* Launch film as the hero intro. Poster is the LCP image; the video
-        autoplays muted once when motion is allowed. Reduced-motion and
+        autoplays muted and loops when motion is allowed. Reduced-motion and
         failed playback keep the poster. */}
     <div
       class="mt-12 sm:mt-16 overflow-hidden rounded-xl hero-shot-frame"
@@ -120,6 +120,7 @@ const arrowSvg = `<svg class="size-3.5 shrink-0" viewBox="0 0 24 24" fill="none"
         height="1126"
         autoplay
         muted
+        loop
         playsinline
         preload="metadata"
         disablepictureinpicture

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -69,3 +69,15 @@ describe('hero pill links to the latest published blog post', () => {
     expect(hero).not.toContain('https://github.com/chmonitor/chmonitor')
   })
 })
+
+describe('hero video', () => {
+  test('autoplays muted and loops', () => {
+    const idx = hero.indexOf('data-hero-intro')
+    expect(idx).toBeGreaterThan(-1)
+    const start = hero.lastIndexOf('<video', idx)
+    const tag = hero.slice(start, hero.indexOf('>', idx))
+    expect(tag).toMatch(/\bautoplay\b/)
+    expect(tag).toMatch(/\bmuted\b/)
+    expect(tag).toMatch(/\bloop\b/)
+  })
+})


### PR DESCRIPTION
## Summary

Hero intro video now loops instead of playing once. Still muted autoplay; reduced-motion and failed playback keep the poster.

## Test plan

- [x] Homepage source test asserts `autoplay`, `muted`, and `loop` on `[data-hero-intro]`
- [ ] Confirm the film repeats on the landing preview