### PR TITLE
fix(landing): drop 01 / 08 section index labels

### DIFF
--- a/apps/landing/src/components/FeatureShowcase.astro
+++ b/apps/landing/src/components/FeatureShowcase.astro
@@ -33,20 +33,14 @@ const icons: Record<string, string> = {
 
     <div class="mt-16 sm:mt-20 flex flex-col gap-20 sm:gap-[80px]">
       {
-        FEATURE_SECTIONS.map((section, i) => (
+        FEATURE_SECTIONS.map((section) => (
           <article id={section.id} class="scroll-mt-6">
             {/* Copy sits above the shot so the screenshot gets the full
                 column instead of half of it. `reverse` alternates which side
                 the bullet list lands on. */}
             <div class="grid gap-6 md:grid-cols-2 md:items-end md:gap-16">
               <div class={section.reverse ? 'md:order-2' : 'md:order-1'}>
-                <div class="flex items-center gap-3">
-                  <span class="inline-flex size-11 items-center justify-center rounded-xl bg-[var(--surface-strong)] [&_svg]:text-foreground" set:html={icons[section.icon]} />
-                  <span class="font-mono text-sm tabular-nums text-muted-foreground">
-                    {String(i + 1).padStart(2, '0')}
-                    <span class="text-[var(--muted-soft)]"> / {String(FEATURE_SECTIONS.length).padStart(2, '0')}</span>
-                  </span>
-                </div>
+                <span class="inline-flex size-11 items-center justify-center rounded-xl bg-[var(--surface-strong)] [&_svg]:text-foreground" set:html={icons[section.icon]} />
                 <p class="mt-4 font-mono text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--brand-ink)]">
                   {section.eyebrow}
                 </p>

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -10,6 +10,8 @@ const home = read('src/pages/index.astro')
 const nav = read('src/components/Nav.astro')
 const footer = read('src/components/Footer.astro')
 const hero = read('src/components/Hero.astro')
+const showcase = read('src/components/FeatureShowcase.astro')
+const featurePage = read('src/pages/features/[slug].astro')
 
 describe('homepage hides Pricing and the Always shipping band', () => {
   test('does not import or render Pricing or ChangelogBand', () => {
@@ -67,6 +69,18 @@ describe('hero pill links to the latest published blog post', () => {
     expect(hero).not.toMatch(/>New</)
     expect(hero).not.toContain('data-hero-oss')
     expect(hero).not.toContain('https://github.com/chmonitor/chmonitor')
+  })
+})
+
+describe('feature sections have no 01 / 08 index labels', () => {
+  test('homepage showcase does not number every block', () => {
+    expect(showcase).not.toContain('padStart')
+    expect(showcase).not.toContain('FEATURE_SECTIONS.length).padStart')
+  })
+
+  test('feature pages keep the eyebrow without a 01 · prefix', () => {
+    expect(featurePage).toContain('{section.eyebrow}')
+    expect(featurePage).not.toContain('padStart')
   })
 })
 

--- a/apps/landing/src/pages/features/[slug].astro
+++ b/apps/landing/src/pages/features/[slug].astro
@@ -107,13 +107,12 @@ const faqJsonLd = {
       </div>
     </section>
 
-    <!-- numbered deep-dive sections -->
     {sections.map((section, i) => (
       <section class={`band${i % 2 === 1 ? ' band-soft' : ''}`}>
         <div class="wrap">
           <div class={`fp-section${section.reverse ? ' fp-reverse' : ''}`}>
             <div class="fp-copy reveal">
-              <span class="eyebrow">{String(i + 1).padStart(2, '0')} · {section.eyebrow}</span>
+              <span class="eyebrow">{section.eyebrow}</span>
               <h2>{section.title}</h2>
               <p>{section.body}</p>
               {section.bullets && (


### PR DESCRIPTION
## Summary

Remove the numbered \`01 / 08\` labels on every homepage feature block, and the matching \`01 ·\` prefixes on feature pages. Keep the icon, eyebrow, and heading.

## Test plan

- [x] Homepage tests assert \`padStart\` is gone from the showcase and feature pages
- [ ] Confirm feature blocks on the landing preview no longer show a counter