### PR TITLE
fix(blog): stop header nav links wrapping and overflowing

### DIFF
--- a/apps/blog/src/chrome.test.ts
+++ b/apps/blog/src/chrome.test.ts
@@ -30,6 +30,19 @@ describe('blog chrome matches landing shadcn tokens', () => {
     expect(nav).toContain('border-border')
   })
 
+  test('Nav links stay on one line and do not pack Open source / Pricing / RSS', () => {
+    const nav = read('src/components/Nav.astro')
+    expect(nav).toContain('whitespace-nowrap')
+    expect(nav).toContain('overflow-hidden')
+    expect(nav).not.toContain('#open-source')
+    expect(nav).not.toContain('#pricing')
+    expect(nav).not.toContain('/rss.xml')
+    expect(nav).toContain('>Features<')
+    expect(nav).toContain('>Docs<')
+    expect(nav).toContain('>Changelog<')
+    expect(nav).toContain('>Blog<')
+  })
+
   test('Footer uses semantic token classes', () => {
     const footer = read('src/components/Footer.astro')
     expect(footer).toContain('text-muted-foreground')

--- a/apps/blog/src/components/Nav.astro
+++ b/apps/blog/src/components/Nav.astro
@@ -3,10 +3,10 @@ import { btnOutline, btnPrimary } from '../lib/button-classes'
 import ThemeToggle from './ThemeToggle.astro'
 
 const navLink =
-  'inline-flex h-9 items-center rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+  'inline-flex h-9 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
 ---
 <header class="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-md">
-  <div class="mx-auto flex h-16 w-full max-w-[1080px] items-center justify-between gap-7 px-6">
+  <div class="mx-auto flex h-16 w-full max-w-[1080px] items-center justify-between gap-4 overflow-hidden px-4 sm:px-6">
     <a class="flex shrink-0 items-center gap-2.5 text-[15px] font-semibold tracking-tight" href="https://chmonitor.dev">
       <span class="mark" aria-hidden="true">
         <img src="/brand/logo-chmonitor.svg" alt="chmonitor" />
@@ -14,14 +14,11 @@ const navLink =
       chmonitor
       <span class="ml-0.5 rounded-full border border-border px-2 py-px text-xs font-semibold text-muted-foreground">Blog</span>
     </a>
-    <nav class="nav-links hidden items-center gap-1 lg:flex">
+    <nav class="nav-links hidden min-w-0 items-center justify-end gap-0.5 overflow-hidden lg:flex">
       <a class={navLink} href="https://chmonitor.dev/#features">Features</a>
-      <a class={navLink} href="https://chmonitor.dev/#open-source">Open source</a>
-      <a class={navLink} href="https://chmonitor.dev/#pricing">Pricing</a>
       <a class={navLink} href="https://docs.chmonitor.dev">Docs</a>
       <a class={navLink} href="https://chmonitor.dev/changelog">Changelog</a>
       <a class={navLink} href="/">Blog</a>
-      <a class={navLink} href="/rss.xml">RSS</a>
     </nav>
     <div class="flex shrink-0 items-center gap-2.5">
       <ThemeToggle />


### PR DESCRIPTION
## Summary

Blog header links no longer wrap or overflow. \"Open source\" was stacking on two lines inside the 64px bar.

## Changes

- \`whitespace-nowrap\` + \`shrink-0\` on header links
- Slim the desktop nav to Features / Docs / Changelog / Blog (Pricing, Open source, RSS stay in the footer)
- Tighter row gap and \`overflow-hidden\` so the bar cannot grow or collide

## Test plan

- [x] Blog chrome tests
- [ ] Check the blog header around 1024–1280px after preview deploy