### PR TITLE
fix(blog): hide Features/Open source/RSS and show GitHub stars

### DIFF
--- a/apps/blog/astro.config.mjs
+++ b/apps/blog/astro.config.mjs
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import sitemap from '@astrojs/sitemap'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'astro/config'
@@ -7,5 +8,7 @@ export default defineConfig({
   integrations: [sitemap()],
   vite: {
     plugins: [tailwindcss()],
+    // Nav reuses landing's GitHub stars helper (one fetch, fail-open).
+    server: { fs: { allow: [fileURLToPath(new URL('../..', import.meta.url))] } },
   },
 })

--- a/apps/blog/src/chrome.test.ts
+++ b/apps/blog/src/chrome.test.ts
@@ -30,14 +30,16 @@ describe('blog chrome matches landing shadcn tokens', () => {
     expect(nav).toContain('border-border')
   })
 
-  test('Nav links stay on one line and do not pack Open source / Pricing / RSS', () => {
+  test('Nav drops Features / Open source / RSS and shows the real star count', () => {
     const nav = read('src/components/Nav.astro')
     expect(nav).toContain('whitespace-nowrap')
-    expect(nav).toContain('overflow-hidden')
+    expect(nav).toContain('getGitHubStats')
+    expect(nav).toContain('starLabel')
+    expect(nav).toContain('Stars')
+    expect(nav).not.toContain('#features')
     expect(nav).not.toContain('#open-source')
-    expect(nav).not.toContain('#pricing')
     expect(nav).not.toContain('/rss.xml')
-    expect(nav).toContain('>Features<')
+    expect(nav).not.toContain('>Features<')
     expect(nav).toContain('>Docs<')
     expect(nav).toContain('>Changelog<')
     expect(nav).toContain('>Blog<')

--- a/apps/blog/src/components/Nav.astro
+++ b/apps/blog/src/components/Nav.astro
@@ -1,6 +1,10 @@
 ---
+import { formatCount, getGitHubStats } from '../../../landing/src/lib/github-stars'
 import { btnOutline, btnPrimary } from '../lib/button-classes'
 import ThemeToggle from './ThemeToggle.astro'
+
+const { stars } = await getGitHubStats()
+const starLabel = formatCount(stars)
 
 const navLink =
   'inline-flex h-9 shrink-0 items-center whitespace-nowrap rounded-md px-2.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
@@ -15,7 +19,6 @@ const navLink =
       <span class="ml-0.5 rounded-full border border-border px-2 py-px text-xs font-semibold text-muted-foreground">Blog</span>
     </a>
     <nav class="nav-links hidden min-w-0 items-center justify-end gap-0.5 overflow-hidden lg:flex">
-      <a class={navLink} href="https://chmonitor.dev/#features">Features</a>
       <a class={navLink} href="https://docs.chmonitor.dev">Docs</a>
       <a class={navLink} href="https://chmonitor.dev/changelog">Changelog</a>
       <a class={navLink} href="/">Blog</a>
@@ -25,7 +28,7 @@ const navLink =
       <span class="nav-cta-star">
         <a class={btnOutline} href="https://github.com/chmonitor/chmonitor" target="_blank" rel="noopener">
           <svg class="size-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.84 9.73.5.1.68-.22.68-.49l-.01-1.9c-2.78.62-3.37-1.2-3.37-1.2-.45-1.18-1.11-1.5-1.11-1.5-.91-.64.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.56 2.34 1.11 2.91.85.09-.66.35-1.11.63-1.36-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.27 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.32 2.75-1.05 2.75-1.05.55 1.41.2 2.45.1 2.71.64.72 1.03 1.63 1.03 2.75 0 3.94-2.35 4.8-4.58 5.06.36.32.68.94.68 1.9l-.01 2.82c0 .27.18.6.69.49A10.03 10.03 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>
-          Star
+          {starLabel ? <><span class="tabular-nums">{starLabel}</span> Stars</> : 'Star'}
         </a>
       </span>
       <a class={btnPrimary} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary

Blog header no longer lists Features, Open source, or RSS. The GitHub button uses the same build-time star count as the landing page (\`N Stars\`, or \`Star\` if the fetch fails).

Docs, Changelog, and Blog stay in the bar. Footer still has Features, Pricing, and RSS.

## Test plan

- [x] Blog chrome tests
- [ ] Confirm the Star button shows a number after the blog deploy