### PR TITLE
fix(blog): publish customize-dashboard on 2026-08-19

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -52,7 +52,7 @@ published (`draft: false`, merged to main)
 | 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-07-10) |
 | 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
 | 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-07-10) |
-| 14 | product | A DBA, an SRE, and an engineer should not share a sidebar | customize clickhouse monitoring dashboard | `/reference/settings` | done (`customize-dashboard.md`, published 2026-08-20) |
+| 14 | product | A DBA, an SRE, and an engineer should not share a sidebar | customize clickhouse monitoring dashboard | `/reference/settings` | done (`customize-dashboard.md`, published 2026-08-19) |
 
 ## Published this cycle (homepage redesign + SEO expansion)
 

--- a/apps/blog/src/content/blog/customize-dashboard.md
+++ b/apps/blog/src/content/blog/customize-dashboard.md
@@ -1,7 +1,7 @@
 ---
 title: "A DBA, an SRE, and an engineer should not share a sidebar"
 description: "Pick a workspace role, hide pages you never open, pin the ones you do — the sidebar follows this browser, not the whole team."
-date: 2026-08-20
+date: 2026-08-19
 tag: Product
 ---
 


### PR DESCRIPTION
## Summary

The customize-dashboard post is in git but 404 on production. \`date: 2026-08-20\` is still in the future for UTC CI, so \`isPublished()\` dropped it from the Astro build.

Set the date to 2026-08-19 (the merge day). After this deploys, https://blog.chmonitor.dev/customize-dashboard/ should be live and the landing hero pill should point at it.

## Test plan

- [ ] https://blog.chmonitor.dev/customize-dashboard/ returns 200
- [ ] Homepage / RSS list the post
- [ ] Landing hero pill links to it