### PR TITLE
fix(blog): move postgres monitoring beta into Feature

### DIFF
--- a/apps/blog/src/content/blog/postgres-monitoring-beta.md
+++ b/apps/blog/src/content/blog/postgres-monitoring-beta.md
@@ -2,7 +2,7 @@
 title: "Postgres as a monitored source (beta)"
 description: "chmonitor now monitors Postgres alongside ClickHouse — read-only query insights, running queries, and AI agent tools. Beta, free on every plan."
 date: 2026-07-11
-tag: Release
+tag: Feature
 ---
 
 chmonitor started as a ClickHouse dashboard. Today it monitors **Postgres** too —

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -23,6 +23,7 @@ function fmtDate(d: Date) {
 // alphabetical order so a new tag always gets a card.
 const CATEGORY_ORDER = [
   'Release',
+  'Feature',
   'How-to',
   'Performance',
   'Monitoring',
@@ -33,6 +34,7 @@ const CATEGORY_ORDER = [
 
 const CATEGORY_TAGLINE = {
   Release: 'New versions, features, and fixes shipped to chmonitor.',
+  Feature: 'New product surfaces in the dashboard.',
   Howto: 'Step-by-step guides to get more from your dashboard.',
   Performance: 'Tune ClickHouse — indexes, parts, queries, and profiling that actually move latency.',
   Monitoring: 'The dashboards and system-table signals every ClickHouse cluster needs.',


### PR DESCRIPTION
## Summary

Move [Postgres as a monitored source (beta)](https://blog.chmonitor.dev/postgres-monitoring-beta/) from Release to Feature, next to the other Feature posts. Put Feature in the homepage category order.

## Test plan

- [ ] Post shows Feature in the byline
- [ ] Homepage Feature card includes this post; Release no longer does