### PR TITLE
fix(schema-diff): show peer names and fix compare toolbar

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -94,8 +94,20 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
 - **Base UI Select labels:** pass `items={{ value: 'Human label' }}` on
   `Select` (the Root) so `SelectValue` shows the label, not the raw value.
   `placeholder` only appears when nothing is selected — a selected `24` /
-  `__all__` otherwise renders as those strings. See
-  `components/agents/advisor-query-picker.tsx`.
+  `__all__` otherwise renders as those strings. Same map on compare
+  Source/Target (`HostPairFilter` — id → `h.name`, never a raw `0`). See
+  `components/agents/advisor-query-picker.tsx` and
+  `components/compare/host-pair-filter.tsx`.
+- **Schema Compare (`/schema-diff`):** one static `PageHeader` ("Schema
+  Compare" + recommend-only description). Pair identity lives in the
+  Source/Target selects — no second "Comparing X → Y — N tables differ"
+  line. Toolbar is one wrapping row: pair + filter + Differences only on
+  the left; scope toggle + "Copy recommended SQL" on the right. Scope
+  labels are **Connections** / **Replica nodes** (tooltips: saved
+  connections vs nodes in this cluster). When Differences only is on,
+  zero diffs, and no name filter, the table list is
+  `EmptyState variant="no-data"` titled **Schemas match** — keep
+  "No tables match" only for a name-filter miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).

--- a/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
+++ b/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
@@ -18,17 +18,24 @@ export function CompareScopeToggle({
   if (hostCount < 2 || nodeCount < 2) return null
 
   return (
-    <div aria-label="Compare saved hosts or cluster nodes">
-      <SegmentedControl
-        value={value}
-        onChange={(next) => {
-          if (next === 'hosts' || next === 'nodes') onChange(next)
-        }}
-        options={[
-          { label: 'Saved hosts', value: 'hosts' },
-          { label: 'Cluster nodes', value: 'nodes' },
-        ]}
-      />
-    </div>
+    <SegmentedControl
+      ariaLabel="Compare saved connections or replica nodes"
+      value={value}
+      onChange={(next) => {
+        if (next === 'hosts' || next === 'nodes') onChange(next)
+      }}
+      options={[
+        {
+          label: 'Connections',
+          value: 'hosts',
+          tooltip: 'Saved ClickHouse connections',
+        },
+        {
+          label: 'Replica nodes',
+          value: 'nodes',
+          tooltip: 'Nodes in this cluster',
+        },
+      ]}
+    />
   )
 }

--- a/apps/dashboard/src/components/compare/host-pair-filter.tsx
+++ b/apps/dashboard/src/components/compare/host-pair-filter.tsx
@@ -35,12 +35,15 @@ export function HostPairFilter({
   onNameFilterChange,
   onShowDiffsOnlyChange,
 }: HostPairFilterProps) {
+  const hostItems = Object.fromEntries(hosts.map((h) => [String(h.id), h.name]))
+
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+    <div className="flex flex-wrap items-center gap-3 sm:gap-4">
       <label className="flex items-center gap-2 text-[13px]">
         <span className="text-muted-foreground">Source</span>
         <Select
           value={String(sourceHostId)}
+          items={hostItems}
           onValueChange={(value) => {
             if (value == null) return
             const next = Number(value)
@@ -49,7 +52,11 @@ export function HostPairFilter({
             onPairChange(next, nextTarget)
           }}
         >
-          <SelectTrigger size="sm" className="h-8 min-w-40 text-[13px]">
+          <SelectTrigger
+            size="sm"
+            className="h-8 min-w-40 text-[13px]"
+            data-testid="compare-source"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -65,6 +72,7 @@ export function HostPairFilter({
         <span className="text-muted-foreground">Target</span>
         <Select
           value={String(targetHostId)}
+          items={hostItems}
           onValueChange={(value) => {
             if (value == null) return
             const next = Number(value)
@@ -73,7 +81,11 @@ export function HostPairFilter({
             onPairChange(nextSource, next)
           }}
         >
-          <SelectTrigger size="sm" className="h-8 min-w-40 text-[13px]">
+          <SelectTrigger
+            size="sm"
+            className="h-8 min-w-40 text-[13px]"
+            data-testid="compare-target"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/apps/dashboard/src/components/filters/segmented-control.tsx
+++ b/apps/dashboard/src/components/filters/segmented-control.tsx
@@ -1,9 +1,16 @@
 import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 export interface SegmentedOption {
   label: string
   value: string
+  tooltip?: string
 }
 
 interface SegmentedControlProps {
@@ -14,6 +21,7 @@ interface SegmentedControlProps {
   placeholder?: string
   /** Optional className for styling */
   className?: string
+  ariaLabel?: string
 }
 
 /**
@@ -27,15 +35,16 @@ export function SegmentedControl({
   onChange,
   placeholder,
   className,
+  ariaLabel = 'Segmented control',
 }: SegmentedControlProps) {
-  return (
+  const group = (
     <div
       className={cn(
         'inline-flex items-center gap-0.5 rounded-lg border border-border/60 bg-muted/20 p-0.5',
         className
       )}
       role="group"
-      aria-label="Segmented control"
+      aria-label={ariaLabel}
     >
       {placeholder && value === '' && (
         <div className="px-2.5 text-xs text-muted-foreground/70">
@@ -44,25 +53,41 @@ export function SegmentedControl({
       )}
       {options.map((option) => {
         const isActive = value === option.value
+        const buttonProps = {
+          type: 'button' as const,
+          variant: (isActive ? 'secondary' : 'ghost') as 'secondary' | 'ghost',
+          size: 'sm' as const,
+          className: cn(
+            'gap-1.5 px-2.5 text-xs h-7 rounded-md transition-all',
+            isActive
+              ? 'bg-background shadow-sm border border-border/50 font-medium'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+          ),
+          'aria-pressed': isActive,
+          onClick: () => onChange(option.value),
+        }
+        if (!option.tooltip) {
+          return (
+            <Button key={option.value} {...buttonProps}>
+              <span>{option.label}</span>
+            </Button>
+          )
+        }
         return (
-          <Button
-            key={option.value}
-            type="button"
-            variant={isActive ? 'secondary' : 'ghost'}
-            size="sm"
-            className={cn(
-              'gap-1.5 px-2.5 text-xs h-7 rounded-md transition-all',
-              isActive
-                ? 'bg-background shadow-sm border border-border/50 font-medium'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
-            )}
-            aria-pressed={isActive}
-            onClick={() => onChange(option.value)}
-          >
-            <span>{option.label}</span>
-          </Button>
+          <Tooltip key={option.value}>
+            <TooltipTrigger render={<Button {...buttonProps} />}>
+              <span>{option.label}</span>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              {option.tooltip}
+            </TooltipContent>
+          </Tooltip>
         )
       })}
     </div>
   )
+
+  if (!options.some((option) => option.tooltip)) return group
+
+  return <TooltipProvider>{group}</TooltipProvider>
 }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -144,6 +144,58 @@ function twoHostPayload(): SchemaDiffResponse {
   }
 }
 
+function matchingHostPayload(): SchemaDiffResponse {
+  const catalog = assembleCatalog(
+    [
+      {
+        database: 'app',
+        table: 'events',
+        engine: 'MergeTree',
+        sorting_key: 'id',
+        partition_key: '',
+        primary_key: 'id',
+        create_table_query:
+          'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree ORDER BY id',
+      },
+    ],
+    [
+      {
+        database: 'app',
+        table: 'events',
+        name: 'id',
+        type: 'UInt64',
+        codec: '',
+      },
+    ]
+  )
+  const diff = compareCatalogs(catalog, catalog)
+  return {
+    success: true,
+    hosts: [
+      { id: 0, name: 'clickhouse-0' },
+      { id: 1, name: 'clickhouse-1' },
+    ],
+    nodes: [],
+    scope: 'hosts',
+    sourceHostId: 0,
+    targetHostId: 1,
+    diff,
+    plan: buildChangePlan(diff),
+  }
+}
+
+async function setInputValue(input: HTMLInputElement, value: string) {
+  const { act } = await import('react')
+  await act(async () => {
+    const proto = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )
+    proto?.set?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
 describe('Schema Compare one-host empty state', () => {
   test('shows empty copy, Add host, and a faded TableList + DdlPair example', async () => {
     const { ExamplePreviewChrome } = await import(
@@ -280,10 +332,169 @@ describe('Schema Compare two-host path', () => {
       expect(document.body.textContent).toContain('production')
       expect(document.body.textContent).toContain('app.events')
       expect(document.body.textContent).not.toContain('Host A')
+      expect(document.body.textContent).not.toMatch(
+        /Comparing .+ tables differ/
+      )
+      const source = document.querySelector(
+        '[data-testid="compare-source"]'
+      ) as HTMLElement
+      const target = document.querySelector(
+        '[data-testid="compare-target"]'
+      ) as HTMLElement
+      expect(source?.textContent).toContain('staging')
+      expect(target?.textContent).toContain('production')
+      expect(source?.textContent).not.toMatch(/^0/)
+      expect(target?.textContent).not.toMatch(/^1/)
+      const copy = document.querySelector(
+        '[aria-label="Copy recommended SQL"]'
+      ) as HTMLButtonElement
+      expect(copy).not.toBeNull()
+      expect(copy.disabled).toBe(true)
+      expect(copy.textContent).toContain('Copy recommended SQL')
       const exampleBadges = [...document.querySelectorAll('span')].filter(
         (el) => el.textContent === 'Example'
       )
       expect(exampleBadges).toHaveLength(0)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('Select closed value shows peer names, not numeric ids', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = twoHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      const sourceValue = document.querySelector(
+        '[data-testid="compare-source"] [data-slot="select-value"]'
+      )
+      const targetValue = document.querySelector(
+        '[data-testid="compare-target"] [data-slot="select-value"]'
+      )
+      expect(sourceValue?.textContent).toBe('staging')
+      expect(targetValue?.textContent).toBe('production')
+      expect(sourceValue?.textContent).not.toBe('0')
+      expect(targetValue?.textContent).not.toBe('1')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('matching schemas with Differences only says Schemas match', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = matchingHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      expect(document.body.textContent).toContain('Schemas match')
+      expect(document.body.textContent).toContain(
+        'Turn off Differences only to list every table.'
+      )
+      expect(document.body.textContent).not.toContain('No tables match')
+      expect(document.body.textContent).not.toMatch(
+        /Comparing .+ tables differ/
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('name filter miss still says No tables match', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = twoHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      const input = document.querySelector(
+        'input[placeholder="Filter tables…"]'
+      ) as HTMLInputElement
+      expect(input).not.toBeNull()
+      await setInputValue(input, 'no-such-table')
+      expect(document.body.textContent).toContain('No tables match')
+      expect(document.body.textContent).not.toContain('Schemas match')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('scope toggle changes scope from hosts to replica nodes', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = twoHostPayload()
+    const seen: string[] = []
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={{
+          ...data,
+          nodes: [
+            { id: 10, name: 'clickhouse-0' },
+            { id: 11, name: 'clickhouse-1' },
+          ],
+        }}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={2}
+        onPairChange={() => {}}
+        onScopeChange={(next) => {
+          seen.push(next)
+        }}
+      />
+    )
+
+    try {
+      const group = document.querySelector(
+        '[aria-label="Compare saved connections or replica nodes"]'
+      )
+      expect(group).not.toBeNull()
+      const replica = [...document.querySelectorAll('button')].find(
+        (el) => el.textContent === 'Replica nodes'
+      ) as HTMLButtonElement
+      expect(replica).not.toBeNull()
+      const { act } = await import('react')
+      await act(async () => {
+        replica.click()
+      })
+      expect(seen).toEqual(['nodes'])
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -11,6 +11,12 @@ import { CompareScopeToggle } from '@/components/compare/compare-scope-toggle'
 import { HostPairFilter } from '@/components/compare/host-pair-filter'
 import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { copyToClipboard } from '@/lib/utils/clipboard'
 
 export interface SchemaDiffViewProps {
@@ -62,12 +68,14 @@ export function SchemaDiffView({
     (item) => item.tableKey === selected?.key
   )
 
-  const sourceHost = peers.find((h) => h.id === sourceId)
-  const targetHost = peers.find((h) => h.id === targetId)
   const diffCount =
     data.diff.onlySource.length +
     data.diff.onlyTarget.length +
     data.diff.changed.length
+  const hasNameFilter = nameFilter.trim().length > 0
+  const schemasMatchEmpty =
+    rows.length === 0 && showDiffsOnly && diffCount === 0 && !hasNameFilter
+  const hasSafeStatements = data.plan.safeStatements.length > 0
 
   const copySafe = async () => {
     const text = data.plan.safeStatements.join(';\n\n')
@@ -79,13 +87,18 @@ export function SchemaDiffView({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-muted-foreground">
-          Comparing {sourceHost?.name ?? sourceId} →{' '}
-          {targetHost?.name ?? targetId} — {diffCount} table
-          {diffCount !== 1 ? 's' : ''} differ. Recommend only; copy statements,
-          never apply.
-        </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <HostPairFilter
+          hosts={peers}
+          sourceHostId={sourceId}
+          targetHostId={targetId}
+          nameFilter={nameFilter}
+          nameFilterPlaceholder={nameFilterPlaceholder}
+          showDiffsOnly={showDiffsOnly}
+          onPairChange={onPairChange}
+          onNameFilterChange={setNameFilter}
+          onShowDiffsOnlyChange={setShowDiffsOnly}
+        />
         <div className="flex flex-wrap items-center gap-2">
           {onScopeChange ? (
             <CompareScopeToggle
@@ -95,29 +108,33 @@ export function SchemaDiffView({
               nodeCount={nodeCount}
             />
           ) : null}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={copySafe}
-            disabled={data.plan.safeStatements.length === 0}
-          >
-            <CopyIcon className="mr-2 size-3.5" strokeWidth={1.5} />
-            {copiedSafe ? 'Copied' : 'Copy safe statements'}
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span className="inline-flex">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={copySafe}
+                      disabled={!hasSafeStatements}
+                      aria-label="Copy recommended SQL"
+                    >
+                      <CopyIcon className="mr-2 size-3.5" strokeWidth={1.5} />
+                      {copiedSafe ? 'Copied' : 'Copy recommended SQL'}
+                    </Button>
+                  </span>
+                }
+              />
+              <TooltipContent side="top" className="max-w-xs">
+                {hasSafeStatements
+                  ? 'Copy recommended ALTER/CREATE statements. Nothing is applied.'
+                  : 'No recommended SQL — schemas match or every change is a manual rewrite.'}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
-
-      <HostPairFilter
-        hosts={peers}
-        sourceHostId={sourceId}
-        targetHostId={targetId}
-        nameFilter={nameFilter}
-        nameFilterPlaceholder={nameFilterPlaceholder}
-        showDiffsOnly={showDiffsOnly}
-        onPairChange={onPairChange}
-        onNameFilterChange={setNameFilter}
-        onShowDiffsOnlyChange={setShowDiffsOnly}
-      />
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
         <TableList
@@ -125,6 +142,14 @@ export function SchemaDiffView({
           selectedKey={selected?.key ?? null}
           onSelect={setSelectedKey}
           example={example}
+          emptyTitle={schemasMatchEmpty ? 'Schemas match' : undefined}
+          emptyDescription={
+            schemasMatchEmpty
+              ? 'No table differences between source and target. Turn off Differences only to list every table.'
+              : undefined
+          }
+          emptyVariant={schemasMatchEmpty ? 'no-data' : undefined}
+          emptyCompact={!schemasMatchEmpty}
         />
 
         <div className="flex flex-col gap-4">

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -1,3 +1,4 @@
+import type { EmptyStateVariant } from '@/components/ui/empty-state'
 import type { TableDiff } from '@/lib/schema-diff'
 
 import { Badge } from '@/components/ui/badge'
@@ -9,6 +10,10 @@ interface TableListProps {
   selectedKey: string | null
   onSelect: (key: string) => void
   example?: boolean
+  emptyTitle?: string
+  emptyDescription?: string
+  emptyVariant?: EmptyStateVariant
+  emptyCompact?: boolean
 }
 
 function kindLabel(kind: TableDiff['kind']): string {
@@ -23,6 +28,10 @@ export function TableList({
   selectedKey,
   onSelect,
   example = false,
+  emptyTitle = 'No tables match',
+  emptyDescription = 'Try a different filter or turn off differences only.',
+  emptyVariant = 'filtered-empty',
+  emptyCompact = true,
 }: TableListProps) {
   return (
     <Card className="rounded-xl border bg-card shadow-sm">
@@ -31,10 +40,10 @@ export function TableList({
           {rows.length === 0 ? (
             <li className="p-4">
               <EmptyState
-                variant="filtered-empty"
-                compact
-                title="No tables match"
-                description="Try a different filter or turn off differences only."
+                variant={emptyVariant}
+                compact={emptyCompact}
+                title={emptyTitle}
+                description={emptyDescription}
               />
             </li>
           ) : (

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-19
+updated: 2026-08-20
 tags:
   - design-system
   - ui
@@ -219,7 +219,9 @@ caused a class of silent runtime breakage in #2361/#2363/#2364:
   `{ value: label }` record or `{ value, label }[]`) on `Select.Root`, or
   a render-function child. `placeholder` is empty-only — selected `24` /
   `__all__` otherwise paint those strings in the trigger. Incident: the
-  Advisor pick-query dialog (#3139).
+  Advisor pick-query dialog (#3139). Compare Source/Target
+  (`HostPairFilter`) must pass `items` as id → peer name so the closed
+  trigger shows `clickhouse-0`, never `0`.
 - Ground-truth attribute/var names live in
   `node_modules/@base-ui/react/**/*DataAttributes.js` / `*CssVars.js`.
 
@@ -661,12 +663,22 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   `lib/insights/mock-preview.ts`. Schema Compare (`/schema-diff`) with one
   saved host uses a real `EmptyState` (Add host opens `AddHostDialog`, same
   as HostSwitcher / first-run) plus a faded EXAMPLE of `TableList` +
-  `DdlPair` with placeholder names. Settings Diff (`/settings-diff`) with one
-  host keeps the live vs-default matrix and a banner to add another host;
-  two or more merged hosts (env + database + browser, including negative
-  ids) keep an All-hosts matrix with an optional pair mode (`HostPairFilter`
-  + URL `source`/`target`). Compare APIs resolve merged hosts the same way
-  charts do (`resolve-host-fetch.ts` / `use-merged-hosts.ts`).
+  `DdlPair` with placeholder names. Two or more peers keep a **static**
+  PageHeader (title + recommend-only description) — do not add a dynamic
+  "Comparing X → Y — N tables differ" sentence; the pair is the Source /
+  Target selects. Toolbar is one wrapping row (pair + filter + Differences
+  only left; Connections / Replica nodes toggle + Copy recommended SQL
+  right). Scope toggle (only when both hostCount and nodeCount are ≥ 2)
+  writes `?scope=hosts|nodes` and remounts the pair from that peer list.
+  Differences-only with zero diffs and no name filter is
+  `EmptyState variant="no-data"` titled **Schemas match**; "No tables
+  match" is only for a name-filter miss. Settings Diff (`/settings-diff`)
+  with one host keeps the live vs-default matrix and a banner to add
+  another host; two or more merged hosts (env + database + browser,
+  including negative ids) keep an All-hosts matrix with an optional pair
+  mode (`HostPairFilter` + URL `source`/`target`). Compare APIs resolve
+  merged hosts the same way charts do (`resolve-host-fetch.ts` /
+  `use-merged-hosts.ts`).
 - Overflow strip: for a single-row scroller that must not wrap, use
   `scrollbar-hide overflow-x-auto` (util in `styles.css`; also on the overview
   tab bar) with `py-*` so card shadows/accents/focus rings aren't clipped


### PR DESCRIPTION
## Summary

Fix Schema Compare at `/schema-diff` so Source/Target show host names, the heading stays static, and the copy/scope/empty states say what they do.

## Changes

- Pass a Base UI `items` map on Source/Target selects so the closed trigger shows `clickhouse-0`, never `0`
- Keep one PageHeader; remove the extra "Comparing X → Y — N tables differ" line
- Relabel scope toggle to Connections / Replica nodes with tooltips; clicking still writes `?scope=`
- Relabel copy to "Copy recommended SQL" with enabled/disabled tooltips
- Differences-only + zero diffs + no name filter: **Schemas match**; name-filter miss still **No tables match**
- Record the Select `items` map and Schemas match empty in the product-design skill + knowledge doc

## Test plan

- [x] `bun test src/components/schema-diff --isolate` (7 pass)
- [x] `bun test src/components/settings-diff --isolate` (2 pass; shared HostPairFilter)
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [x] Schema Compare unit tests cover names, heading, copy label, empty states, scope click
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Pair identity lives in the Source/Target controls. Settings Diff only picks up the shared select `items` map and scope-toggle labels — no Settings Diff redesign.

---

Co-Authored-By: duyetbot <bot@duyet.net>