### PR TITLE
fix(settings-diff): show All matched when nothing differs

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -107,7 +107,12 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   connections vs nodes in this cluster). When Differences only is on,
   zero diffs, and no name filter, the table list is
   `EmptyState variant="no-data"` titled **Schemas match** — keep
-  "No tables match" only for a name-filter miss.
+  "No tables match" only for a name-filter miss. Settings Diff
+  (`/settings-diff`) with diffs-only and zero deltas is
+  `EmptyState` titled **All matched** plus a green check
+  (`CheckCircle2Icon` + `--chart-green`) and **Show matching
+  settings** (turns diffs-only off). "No settings match" is only
+  a name/changed-from-default filter miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).
@@ -207,7 +212,8 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   one saved host uses a real `EmptyState` (Add host via `AddHostDialog`, same
   as HostSwitcher) plus a faded `TableList` + `DdlPair` example. Settings Diff
   with one host keeps the live vs-default table and a banner (`AddHostButton`,
-  `data-testid="add-host"`). Pair ids include user connections.
+  `data-testid="add-host"`). Pair ids include user connections. Diffs-only
+  with zero deltas is **All matched** (green check) + Show matching settings.
 - **Base UI primitives** (`components/ui/*` = shadcn Base UI, not Radix): style
   overlays off `data-open`/`data-closed`/`data-orientation` (needs the
   `@custom-variant data-horizontal|vertical` in `styles.css`) and Base UI CSS

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
@@ -142,6 +142,55 @@ describe('Settings Diff one-host vs default', () => {
   })
 })
 
+describe('Settings Diff all-matched empty', () => {
+  test('shows a green All matched state when diffs-only has nothing to list', async () => {
+    const { SettingsDiffTable } = await import('./settings-diff-table')
+    let showedMatching = false
+
+    const { cleanup } = await renderInto(
+      <SettingsDiffTable
+        columns={[
+          { id: 0, name: 'clickhouse-0' },
+          { id: 1, name: 'clickhouse-1' },
+        ]}
+        rows={[]}
+        allMatched
+        onShowMatching={() => {
+          showedMatching = true
+        }}
+      />
+    )
+
+    try {
+      expect(document.body.textContent).toContain('All matched')
+      expect(document.body.textContent).not.toContain(
+        'No settings match the current filters'
+      )
+      const button = document.body.querySelector('button')
+      expect(button?.textContent).toContain('Show matching settings')
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      expect(showedMatching).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('a name-filter miss still says No settings match', async () => {
+    const { SettingsDiffTable } = await import('./settings-diff-table')
+
+    const { cleanup } = await renderInto(
+      <SettingsDiffTable columns={[{ id: 0, name: 'prod' }]} rows={[]} />
+    )
+
+    try {
+      expect(document.body.textContent).toContain('No settings match')
+      expect(document.body.textContent).not.toContain('All matched')
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
 describe('Settings Diff pair ids include user connections', () => {
   test('resolvePair accepts negative database and browser ids', async () => {
     const { resolvePair } = await import('@/lib/compare/scope')

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -24,7 +24,10 @@ import {
   fetchCompareDiff,
 } from '@/lib/compare/fetch-diff-request'
 import { resolveCompareScope, resolvePair } from '@/lib/compare/scope'
-import { filterSettingsDiffRows } from '@/lib/settings-diff/filter'
+import {
+  filterSettingsDiffRows,
+  isSettingsDiffAllMatchedEmpty,
+} from '@/lib/settings-diff/filter'
 import { useHostId } from '@/lib/swr/use-host'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
@@ -181,13 +184,22 @@ export function SettingsDiffPage() {
       ? peers.filter((p) => p.id === pair.sourceId || p.id === pair.targetId)
       : hosts
 
+  const diffsOnly = hostCount === 1 ? false : showDiffsOnly
+  const totalRows = data.rows?.length ?? 0
   const filteredRows = filterSettingsDiffRows(data.rows ?? [], {
-    showDiffsOnly: hostCount === 1 ? false : showDiffsOnly,
+    showDiffsOnly: diffsOnly,
     showChangedOnly,
     nameFilter,
   })
   const diffCount = (data.rows ?? []).filter((r) => r.hasDiff).length
   const oneHostVsDefault = hostCount === 1 && scope === 'hosts'
+  const allMatched = isSettingsDiffAllMatchedEmpty({
+    totalRows,
+    diffCount,
+    showDiffsOnly: diffsOnly,
+    showChangedOnly,
+    nameFilter,
+  })
 
   return (
     <div className="flex flex-col gap-4">
@@ -307,7 +319,12 @@ export function SettingsDiffPage() {
         </label>
       </div>
 
-      <SettingsDiffTable columns={columns} rows={filteredRows} />
+      <SettingsDiffTable
+        columns={columns}
+        rows={filteredRows}
+        allMatched={allMatched}
+        onShowMatching={() => setShowDiffsOnly(false)}
+      />
 
       <p className="text-xs text-muted-foreground">
         {filteredRows.length.toLocaleString()} row

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -1,4 +1,5 @@
 import { DownloadIcon } from '@radix-ui/react-icons'
+import { CheckCircle2Icon } from 'lucide-react'
 
 import type {
   SettingsDiffHostInfo,
@@ -8,6 +9,7 @@ import type {
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { EmptyState } from '@/components/ui/empty-state'
 import {
   Table,
   TableBody,
@@ -63,9 +65,16 @@ export function exportSettingsCsv(
 interface SettingsDiffTableProps {
   columns: SettingsDiffHostInfo[]
   rows: SettingsDiffRow[]
+  allMatched?: boolean
+  onShowMatching?: () => void
 }
 
-export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
+export function SettingsDiffTable({
+  columns,
+  rows,
+  allMatched = false,
+  onShowMatching,
+}: SettingsDiffTableProps) {
   return (
     <Card>
       <CardContent className="p-0">
@@ -88,11 +97,35 @@ export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
             <TableBody>
               {rows.length === 0 ? (
                 <TableRow>
-                  <TableCell
-                    colSpan={3 + columns.length}
-                    className="py-12 text-center text-sm text-muted-foreground"
-                  >
-                    No settings match the current filters.
+                  <TableCell colSpan={3 + columns.length} className="py-10">
+                    {allMatched ? (
+                      <EmptyState
+                        variant="no-data"
+                        title="All matched"
+                        description="No setting differences between source and target. Turn off Show diffs only to list every setting."
+                        icon={
+                          <CheckCircle2Icon
+                            className="size-6 text-[var(--chart-green)]"
+                            strokeWidth={1.5}
+                          />
+                        }
+                        action={
+                          onShowMatching
+                            ? {
+                                label: 'Show matching settings',
+                                onClick: onShowMatching,
+                              }
+                            : undefined
+                        }
+                      />
+                    ) : (
+                      <EmptyState
+                        variant="filtered-empty"
+                        compact
+                        title="No settings match"
+                        description="Try a different name filter or turn off Show diffs only."
+                      />
+                    )}
                   </TableCell>
                 </TableRow>
               ) : (

--- a/apps/dashboard/src/lib/settings-diff/filter.ts
+++ b/apps/dashboard/src/lib/settings-diff/filter.ts
@@ -12,3 +12,20 @@ export function filterSettingsDiffRows(
     return true
   })
 }
+
+/** Diffs-only with zero deltas and no other filter — show "All matched", not a filter miss. */
+export function isSettingsDiffAllMatchedEmpty(opts: {
+  totalRows: number
+  diffCount: number
+  showDiffsOnly: boolean
+  showChangedOnly: boolean
+  nameFilter: string
+}): boolean {
+  return (
+    opts.showDiffsOnly &&
+    opts.diffCount === 0 &&
+    opts.totalRows > 0 &&
+    !opts.showChangedOnly &&
+    opts.nameFilter.trim() === ''
+  )
+}

--- a/apps/dashboard/src/lib/settings-diff/search.test.ts
+++ b/apps/dashboard/src/lib/settings-diff/search.test.ts
@@ -1,4 +1,4 @@
-import { filterSettingsDiffRows } from './filter'
+import { filterSettingsDiffRows, isSettingsDiffAllMatchedEmpty } from './filter'
 import { mergeSettingsDiff } from './merge'
 import { buildSettingsDiffRequest, validateSettingsDiffSearch } from './search'
 import { describe, expect, test } from 'bun:test'
@@ -130,5 +130,58 @@ describe('settings-diff node pair filter', () => {
       nameFilter: '',
     })
     expect(filtered.map((r) => r.name)).toEqual(['max_threads'])
+  })
+})
+
+describe('settings-diff all-matched empty', () => {
+  test('is true when diffs-only hides a full matching catalog', () => {
+    expect(
+      isSettingsDiffAllMatchedEmpty({
+        totalRows: 40,
+        diffCount: 0,
+        showDiffsOnly: true,
+        showChangedOnly: false,
+        nameFilter: '',
+      })
+    ).toBe(true)
+  })
+
+  test('is false when there are diffs, a name filter, or diffs-only is off', () => {
+    expect(
+      isSettingsDiffAllMatchedEmpty({
+        totalRows: 40,
+        diffCount: 1,
+        showDiffsOnly: true,
+        showChangedOnly: false,
+        nameFilter: '',
+      })
+    ).toBe(false)
+    expect(
+      isSettingsDiffAllMatchedEmpty({
+        totalRows: 40,
+        diffCount: 0,
+        showDiffsOnly: false,
+        showChangedOnly: false,
+        nameFilter: '',
+      })
+    ).toBe(false)
+    expect(
+      isSettingsDiffAllMatchedEmpty({
+        totalRows: 40,
+        diffCount: 0,
+        showDiffsOnly: true,
+        showChangedOnly: false,
+        nameFilter: 'max_threads',
+      })
+    ).toBe(false)
+    expect(
+      isSettingsDiffAllMatchedEmpty({
+        totalRows: 0,
+        diffCount: 0,
+        showDiffsOnly: true,
+        showChangedOnly: false,
+        nameFilter: '',
+      })
+    ).toBe(false)
   })
 })

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -676,7 +676,10 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   with one host keeps the live vs-default matrix and a banner to add
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair
-  mode (`HostPairFilter` + URL `source`/`target`). Compare APIs resolve
+  mode (`HostPairFilter` + URL `source`/`target`). Diffs-only with zero
+  deltas is **All matched** (green check, `--chart-green`) plus **Show
+  matching settings** to turn the toggle off; "No settings match" is
+  only a name/changed-from-default filter miss. Compare APIs resolve
   merged hosts the same way charts do (`resolve-host-fetch.ts` /
   `use-merged-hosts.ts`).
 - Overflow strip: for a single-row scroller that must not wrap, use


### PR DESCRIPTION
## Summary
- When Show diffs only is on and every setting matches, Settings Diff now shows a green check and **All matched** instead of an empty table that looks like a filter miss.
- **Show matching settings** turns the toggle off so identical rows can still be listed. A real name/filter miss still says **No settings match**.

## Test plan
- [x] `bun test` settings-diff page + filter tests
- [ ] After deploy, open `/settings-diff?host=0` with matching replica nodes: All matched + toggle lists settings