### PR TITLE
fix(dashboard): polish compare toolbar tabs and filters

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -101,18 +101,19 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
 - **Schema Compare (`/schema-diff`):** one static `PageHeader` ("Schema
   Compare" + recommend-only description). Pair identity lives in the
   Source/Target selects — no second "Comparing X → Y — N tables differ"
-  line. Toolbar is one wrapping row: pair + filter + Differences only on
-  the left; scope toggle + "Copy recommended SQL" on the right. Scope
-  labels are **Connections** / **Replica nodes** (tooltips: saved
-  connections vs nodes in this cluster). When Differences only is on,
-  zero diffs, and no name filter, the table list is
-  `EmptyState variant="no-data"` titled **Schemas match** — keep
-  "No tables match" only for a name-filter miss. Settings Diff
-  (`/settings-diff`) with diffs-only and zero deltas is
-  `EmptyState` titled **All matched** plus a green check
-  (`CheckCircle2Icon` + `--chart-green`) and **Show matching
-  settings** (turns diffs-only off). "No settings match" is only
-  a name/changed-from-default filter miss.
+  line. Compare tools wrap filters in `CompareToolbar` (`rounded-xl
+  border bg-card p-4`): tabs on top (**Connections** / **Replica
+  nodes**, `SegmentedControl size="default"`), then stacked Source /
+  Target selects (peer **name**, never a raw id) with a Filter field,
+  then **Differences** / **All**. Copy recommended SQL sits on that
+  filter row. When Differences is on, zero diffs, and no name filter,
+  the table list is `EmptyState variant="no-data"` titled **Schemas
+  match** — keep "No tables match" only for a name-filter miss.
+  Settings Diff (`/settings-diff`) uses the same toolbar; diffs-only
+  with zero deltas is **All matched** plus a green check and **Show
+  matching settings**. "Changed from default" is a pressable chip, not
+  a second switch. "No settings match" is only a name/changed-from-default
+  filter miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).

--- a/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
+++ b/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
@@ -19,6 +19,7 @@ export function CompareScopeToggle({
 
   return (
     <SegmentedControl
+      size="default"
       ariaLabel="Compare saved connections or replica nodes"
       value={value}
       onChange={(next) => {

--- a/apps/dashboard/src/components/compare/compare-toolbar.tsx
+++ b/apps/dashboard/src/components/compare/compare-toolbar.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface CompareToolbarProps {
+  tabs?: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+/** Shared compare-tools chrome: padded card, tabs on top, fields below. */
+export function CompareToolbar({
+  tabs,
+  children,
+  className,
+}: CompareToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-4 rounded-xl border bg-card p-4 shadow-sm',
+        className
+      )}
+    >
+      {tabs ? (
+        <div className="flex flex-wrap items-center gap-2">{tabs}</div>
+      ) : null}
+      {children}
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/compare/host-pair-filter.tsx
+++ b/apps/dashboard/src/components/compare/host-pair-filter.tsx
@@ -1,5 +1,9 @@
+import { ArrowRightIcon } from 'lucide-react'
+
+import type { ReactNode } from 'react'
 import type { ComparePeer } from '@/lib/compare/scope'
 
+import { SegmentedControl } from '@/components/filters/segmented-control'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -8,7 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Switch } from '@/components/ui/switch'
 
 interface HostPairFilterProps {
   hosts: ComparePeer[]
@@ -21,6 +24,7 @@ interface HostPairFilterProps {
   onPairChange: (source: number, target: number) => void
   onNameFilterChange: (value: string) => void
   onShowDiffsOnlyChange: (value: boolean) => void
+  extraFilters?: ReactNode
 }
 
 export function HostPairFilter({
@@ -30,86 +34,114 @@ export function HostPairFilter({
   nameFilter,
   nameFilterPlaceholder = 'Filter tables…',
   showDiffsOnly,
-  diffsOnlyLabel = 'Differences only',
   onPairChange,
   onNameFilterChange,
   onShowDiffsOnlyChange,
+  extraFilters,
 }: HostPairFilterProps) {
   const hostItems = Object.fromEntries(hosts.map((h) => [String(h.id), h.name]))
 
   return (
-    <div className="flex flex-wrap items-center gap-3 sm:gap-4">
-      <label className="flex items-center gap-2 text-[13px]">
-        <span className="text-muted-foreground">Source</span>
-        <Select
-          value={String(sourceHostId)}
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <PeerSelect
+          label="Source"
+          testId="compare-source"
+          value={sourceHostId}
+          hosts={hosts}
           items={hostItems}
-          onValueChange={(value) => {
-            if (value == null) return
-            const next = Number(value)
+          onChange={(next) => {
             const nextTarget =
               next === targetHostId ? sourceHostId : targetHostId
             onPairChange(next, nextTarget)
           }}
-        >
-          <SelectTrigger
-            size="sm"
-            className="h-8 min-w-40 text-[13px]"
-            data-testid="compare-source"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {hosts.map((h) => (
-              <SelectItem key={h.id} value={String(h.id)}>
-                {h.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </label>
-      <label className="flex items-center gap-2 text-[13px]">
-        <span className="text-muted-foreground">Target</span>
-        <Select
-          value={String(targetHostId)}
+        />
+        <ArrowRightIcon
+          className="mb-2 hidden size-4 shrink-0 text-muted-foreground sm:block"
+          strokeWidth={1.5}
+          aria-hidden
+        />
+        <PeerSelect
+          label="Target"
+          testId="compare-target"
+          value={targetHostId}
+          hosts={hosts}
           items={hostItems}
-          onValueChange={(value) => {
-            if (value == null) return
-            const next = Number(value)
+          onChange={(next) => {
             const nextSource =
               next === sourceHostId ? targetHostId : sourceHostId
             onPairChange(nextSource, next)
           }}
-        >
-          <SelectTrigger
-            size="sm"
-            className="h-8 min-w-40 text-[13px]"
-            data-testid="compare-target"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {hosts.map((h) => (
-              <SelectItem key={h.id} value={String(h.id)}>
-                {h.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </label>
-      <Input
-        placeholder={nameFilterPlaceholder}
-        value={nameFilter}
-        onChange={(e) => onNameFilterChange(e.target.value)}
-        className="h-8 w-full sm:w-64"
-      />
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <Switch
-          checked={showDiffsOnly}
-          onCheckedChange={onShowDiffsOnlyChange}
         />
-        {diffsOnlyLabel}
-      </label>
+        <label className="flex min-w-48 flex-1 flex-col gap-1.5 sm:max-w-72">
+          <span className="text-xs font-medium text-muted-foreground">
+            Filter
+          </span>
+          <Input
+            placeholder={nameFilterPlaceholder}
+            value={nameFilter}
+            onChange={(e) => onNameFilterChange(e.target.value)}
+            className="h-9"
+          />
+        </label>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <SegmentedControl
+          size="default"
+          ariaLabel="Show differences or all rows"
+          value={showDiffsOnly ? 'diffs' : 'all'}
+          onChange={(next) => onShowDiffsOnlyChange(next === 'diffs')}
+          options={[
+            { label: 'Differences', value: 'diffs' },
+            { label: 'All', value: 'all' },
+          ]}
+        />
+        {extraFilters}
+      </div>
     </div>
+  )
+}
+
+function PeerSelect({
+  label,
+  testId,
+  value,
+  hosts,
+  items,
+  onChange,
+}: {
+  label: string
+  testId: string
+  value: number
+  hosts: ComparePeer[]
+  items: Record<string, string>
+  onChange: (next: number) => void
+}) {
+  return (
+    <label className="flex min-w-48 flex-col gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <Select
+        value={String(value)}
+        items={items}
+        onValueChange={(next) => {
+          if (next == null) return
+          onChange(Number(next))
+        }}
+      >
+        <SelectTrigger
+          className="h-9 min-w-48 text-[13px] font-medium"
+          data-testid={testId}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {hosts.map((h) => (
+            <SelectItem key={h.id} value={String(h.id)}>
+              {h.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </label>
   )
 }

--- a/apps/dashboard/src/components/compare/settings-view-toggle.tsx
+++ b/apps/dashboard/src/components/compare/settings-view-toggle.tsx
@@ -16,17 +16,17 @@ export function SettingsViewToggle({
   if (hostCount < 2) return null
 
   return (
-    <div aria-label="All hosts matrix or pair">
-      <SegmentedControl
-        value={value}
-        onChange={(next) => {
-          if (next === 'matrix' || next === 'pair') onChange(next)
-        }}
-        options={[
-          { label: 'All hosts', value: 'matrix' },
-          { label: 'Pair', value: 'pair' },
-        ]}
-      />
-    </div>
+    <SegmentedControl
+      size="default"
+      ariaLabel="All hosts matrix or pair"
+      value={value}
+      onChange={(next) => {
+        if (next === 'matrix' || next === 'pair') onChange(next)
+      }}
+      options={[
+        { label: 'All hosts', value: 'matrix' },
+        { label: 'Pair', value: 'pair' },
+      ]}
+    />
   )
 }

--- a/apps/dashboard/src/components/filters/segmented-control.tsx
+++ b/apps/dashboard/src/components/filters/segmented-control.tsx
@@ -22,6 +22,8 @@ interface SegmentedControlProps {
   /** Optional className for styling */
   className?: string
   ariaLabel?: string
+  /** `sm` is the dense query-filter pill. `default` is the compare toolbar tab. */
+  size?: 'sm' | 'default'
 }
 
 /**
@@ -36,11 +38,14 @@ export function SegmentedControl({
   placeholder,
   className,
   ariaLabel = 'Segmented control',
+  size = 'sm',
 }: SegmentedControlProps) {
+  const isDefault = size === 'default'
   const group = (
     <div
       className={cn(
-        'inline-flex items-center gap-0.5 rounded-lg border border-border/60 bg-muted/20 p-0.5',
+        'inline-flex items-center gap-0.5 rounded-lg border border-border/60 bg-muted/20',
+        isDefault ? 'p-1' : 'p-0.5',
         className
       )}
       role="group"
@@ -58,10 +63,13 @@ export function SegmentedControl({
           variant: (isActive ? 'secondary' : 'ghost') as 'secondary' | 'ghost',
           size: 'sm' as const,
           className: cn(
-            'gap-1.5 px-2.5 text-xs h-7 rounded-md transition-all',
+            'rounded-md font-medium transition-all',
+            isDefault
+              ? 'h-8 min-w-28 px-3 text-[13px]'
+              : 'h-7 gap-1.5 px-2.5 text-xs',
             isActive
-              ? 'bg-background shadow-sm border border-border/50 font-medium'
-              : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+              ? 'border border-border/50 bg-background shadow-sm'
+              : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'
           ),
           'aria-pressed': isActive,
           onClick: () => onChange(option.value),

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -413,7 +413,7 @@ describe('Schema Compare two-host path', () => {
     try {
       expect(document.body.textContent).toContain('Schemas match')
       expect(document.body.textContent).toContain(
-        'Turn off Differences only to list every table.'
+        'Switch to All to list every table.'
       )
       expect(document.body.textContent).not.toContain('No tables match')
       expect(document.body.textContent).not.toMatch(

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -8,6 +8,7 @@ import { PlanList } from './plan-list'
 import { TableList } from './table-list'
 import { useMemo, useState } from 'react'
 import { CompareScopeToggle } from '@/components/compare/compare-scope-toggle'
+import { CompareToolbar } from '@/components/compare/compare-toolbar'
 import { HostPairFilter } from '@/components/compare/host-pair-filter'
 import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
@@ -87,7 +88,18 @@ export function SchemaDiffView({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <CompareToolbar
+        tabs={
+          onScopeChange ? (
+            <CompareScopeToggle
+              value={scope}
+              onChange={onScopeChange}
+              hostCount={hostCount}
+              nodeCount={nodeCount}
+            />
+          ) : null
+        }
+      >
         <HostPairFilter
           hosts={peers}
           sourceHostId={sourceId}
@@ -98,43 +110,36 @@ export function SchemaDiffView({
           onPairChange={onPairChange}
           onNameFilterChange={setNameFilter}
           onShowDiffsOnlyChange={setShowDiffsOnly}
+          extraFilters={
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span className="inline-flex">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={copySafe}
+                        disabled={!hasSafeStatements}
+                        aria-label="Copy recommended SQL"
+                        className="h-8 text-[13px]"
+                      >
+                        <CopyIcon className="mr-2 size-3.5" strokeWidth={1.5} />
+                        {copiedSafe ? 'Copied' : 'Copy recommended SQL'}
+                      </Button>
+                    </span>
+                  }
+                />
+                <TooltipContent side="top" className="max-w-xs">
+                  {hasSafeStatements
+                    ? 'Copy recommended ALTER/CREATE statements. Nothing is applied.'
+                    : 'No recommended SQL — schemas match or every change is a manual rewrite.'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          }
         />
-        <div className="flex flex-wrap items-center gap-2">
-          {onScopeChange ? (
-            <CompareScopeToggle
-              value={scope}
-              onChange={onScopeChange}
-              hostCount={hostCount}
-              nodeCount={nodeCount}
-            />
-          ) : null}
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <span className="inline-flex">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={copySafe}
-                      disabled={!hasSafeStatements}
-                      aria-label="Copy recommended SQL"
-                    >
-                      <CopyIcon className="mr-2 size-3.5" strokeWidth={1.5} />
-                      {copiedSafe ? 'Copied' : 'Copy recommended SQL'}
-                    </Button>
-                  </span>
-                }
-              />
-              <TooltipContent side="top" className="max-w-xs">
-                {hasSafeStatements
-                  ? 'Copy recommended ALTER/CREATE statements. Nothing is applied.'
-                  : 'No recommended SQL — schemas match or every change is a manual rewrite.'}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      </div>
+      </CompareToolbar>
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
         <TableList
@@ -145,7 +150,7 @@ export function SchemaDiffView({
           emptyTitle={schemasMatchEmpty ? 'Schemas match' : undefined}
           emptyDescription={
             schemasMatchEmpty
-              ? 'No table differences between source and target. Turn off Differences only to list every table.'
+              ? 'No table differences between source and target. Switch to All to list every table.'
               : undefined
           }
           emptyVariant={schemasMatchEmpty ? 'no-data' : undefined}

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -29,7 +29,7 @@ export function TableList({
   onSelect,
   example = false,
   emptyTitle = 'No tables match',
-  emptyDescription = 'Try a different filter or turn off differences only.',
+  emptyDescription = 'Try a different filter or switch to All.',
   emptyVariant = 'filtered-empty',
   emptyCompact = true,
 }: TableListProps) {

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -11,14 +11,16 @@ import { SettingsCsvButton, SettingsDiffTable } from './settings-diff-table'
 import { useState } from 'react'
 import { AddHostButton } from '@/components/compare/add-host-button'
 import { CompareScopeToggle } from '@/components/compare/compare-scope-toggle'
+import { CompareToolbar } from '@/components/compare/compare-toolbar'
 import { HostPairFilter } from '@/components/compare/host-pair-filter'
 import { SettingsViewToggle } from '@/components/compare/settings-view-toggle'
+import { SegmentedControl } from '@/components/filters/segmented-control'
 import { PageHeader } from '@/components/layout/page-header'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
-import { Switch } from '@/components/ui/switch'
 import {
   collectBrowserDiffSessions,
   fetchCompareDiff,
@@ -208,13 +210,7 @@ export function SettingsDiffPage() {
         description={
           oneHostVsDefault
             ? 'Comparing this host against setting defaults'
-            : scope === 'nodes' && pair
-              ? `Comparing cluster nodes — ${diffCount} setting${diffCount !== 1 ? 's' : ''} differ`
-              : hosts.length > 1 && view === 'pair' && pair
-                ? `Comparing ${hosts.find((h) => h.id === pair.sourceId)?.name ?? pair.sourceId} → ${hosts.find((h) => h.id === pair.targetId)?.name ?? pair.targetId} — ${diffCount} setting${diffCount !== 1 ? 's' : ''} differ`
-                : hosts.length > 1
-                  ? `Comparing ${hosts.length} hosts — ${diffCount} setting${diffCount !== 1 ? 's' : ''} differ`
-                  : PAGE_DESCRIPTION
+            : PAGE_DESCRIPTION
         }
         actions={<SettingsCsvButton columns={columns} rows={filteredRows} />}
       />
@@ -232,45 +228,52 @@ export function SettingsDiffPage() {
         </Alert>
       ) : null}
 
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <CompareScopeToggle
-            value={scope}
-            onChange={(next) => {
-              const nextPeers = next === 'nodes' ? nodes : hosts
-              const nextPair = resolvePair(nextPeers)
-              if (!nextPair) return
-              setSearch({
-                source: nextPair.sourceId,
-                target: nextPair.targetId,
-                scope: next,
-                view: next === 'hosts' ? view : undefined,
-              })
-            }}
-            hostCount={hostCount}
-            nodeCount={nodeCount}
-          />
-          {scope === 'hosts' ? (
-            <SettingsViewToggle
-              value={view}
-              hostCount={hostCount}
+      <CompareToolbar
+        tabs={
+          <>
+            <CompareScopeToggle
+              value={scope}
               onChange={(next) => {
-                if (next === 'pair') {
-                  const nextPair = resolvePair(hosts, sourceParam, targetParam)
-                  if (!nextPair) return
-                  setSearch({
-                    source: nextPair.sourceId,
-                    target: nextPair.targetId,
-                    scope: 'hosts',
-                    view: 'pair',
-                  })
-                  return
-                }
-                setSearch({ scope: 'hosts', view: 'matrix' })
+                const nextPeers = next === 'nodes' ? nodes : hosts
+                const nextPair = resolvePair(nextPeers)
+                if (!nextPair) return
+                setSearch({
+                  source: nextPair.sourceId,
+                  target: nextPair.targetId,
+                  scope: next,
+                  view: next === 'hosts' ? view : undefined,
+                })
               }}
+              hostCount={hostCount}
+              nodeCount={nodeCount}
             />
-          ) : null}
-        </div>
+            {scope === 'hosts' ? (
+              <SettingsViewToggle
+                value={view}
+                hostCount={hostCount}
+                onChange={(next) => {
+                  if (next === 'pair') {
+                    const nextPair = resolvePair(
+                      hosts,
+                      sourceParam,
+                      targetParam
+                    )
+                    if (!nextPair) return
+                    setSearch({
+                      source: nextPair.sourceId,
+                      target: nextPair.targetId,
+                      scope: 'hosts',
+                      view: 'pair',
+                    })
+                    return
+                  }
+                  setSearch({ scope: 'hosts', view: 'matrix' })
+                }}
+              />
+            ) : null}
+          </>
+        }
+      >
         {pairMode && pair ? (
           <HostPairFilter
             hosts={peers}
@@ -279,7 +282,6 @@ export function SettingsDiffPage() {
             nameFilter={nameFilter}
             nameFilterPlaceholder="Filter by name…"
             showDiffsOnly={showDiffsOnly}
-            diffsOnlyLabel="Show diffs only"
             onPairChange={(source, target) =>
               setSearch({
                 source,
@@ -290,34 +292,47 @@ export function SettingsDiffPage() {
             }
             onNameFilterChange={setNameFilter}
             onShowDiffsOnlyChange={setShowDiffsOnly}
+            extraFilters={
+              <ChangedFromDefaultChip
+                pressed={showChangedOnly}
+                onPressedChange={setShowChangedOnly}
+              />
+            }
           />
         ) : (
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-            <Input
-              placeholder="Filter by name…"
-              value={nameFilter}
-              onChange={(e) => setNameFilter(e.target.value)}
-              className="h-8 w-full sm:w-64"
-            />
-            {hostCount > 1 ? (
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
-                <Switch
-                  checked={showDiffsOnly}
-                  onCheckedChange={setShowDiffsOnly}
+          <div className="flex flex-col gap-4">
+            <label className="flex min-w-48 max-w-72 flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Filter
+              </span>
+              <Input
+                placeholder="Filter by name…"
+                value={nameFilter}
+                onChange={(e) => setNameFilter(e.target.value)}
+                className="h-9"
+              />
+            </label>
+            <div className="flex flex-wrap items-center gap-2">
+              {hostCount > 1 ? (
+                <SegmentedControl
+                  size="default"
+                  ariaLabel="Show differences or all rows"
+                  value={showDiffsOnly ? 'diffs' : 'all'}
+                  onChange={(next) => setShowDiffsOnly(next === 'diffs')}
+                  options={[
+                    { label: 'Differences', value: 'diffs' },
+                    { label: 'All', value: 'all' },
+                  ]}
                 />
-                Show diffs only
-              </label>
-            ) : null}
+              ) : null}
+              <ChangedFromDefaultChip
+                pressed={showChangedOnly}
+                onPressedChange={setShowChangedOnly}
+              />
+            </div>
           </div>
         )}
-        <label className="flex cursor-pointer items-center gap-2 text-sm">
-          <Switch
-            checked={showChangedOnly}
-            onCheckedChange={setShowChangedOnly}
-          />
-          Show changed from default only
-        </label>
-      </div>
+      </CompareToolbar>
 
       <SettingsDiffTable
         columns={columns}
@@ -333,5 +348,26 @@ export function SettingsDiffPage() {
           ` (filtered from ${(data?.rows?.length ?? 0).toLocaleString()})`}
       </p>
     </div>
+  )
+}
+
+function ChangedFromDefaultChip({
+  pressed,
+  onPressedChange,
+}: {
+  pressed: boolean
+  onPressedChange: (next: boolean) => void
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant={pressed ? 'secondary' : 'outline'}
+      aria-pressed={pressed}
+      className="h-8 rounded-md text-[13px]"
+      onClick={() => onPressedChange(!pressed)}
+    >
+      Changed from default
+    </Button>
   )
 }

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -102,7 +102,7 @@ export function SettingsDiffTable({
                       <EmptyState
                         variant="no-data"
                         title="All matched"
-                        description="No setting differences between source and target. Turn off Show diffs only to list every setting."
+                        description="No setting differences between source and target. Switch to All to list every setting."
                         icon={
                           <CheckCircle2Icon
                             className="size-6 text-[var(--chart-green)]"
@@ -123,7 +123,7 @@ export function SettingsDiffTable({
                         variant="filtered-empty"
                         compact
                         title="No settings match"
-                        description="Try a different name filter or turn off Show diffs only."
+                        description="Try a different name filter or switch to All."
                       />
                     )}
                   </TableCell>

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -666,10 +666,11 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   `DdlPair` with placeholder names. Two or more peers keep a **static**
   PageHeader (title + recommend-only description) — do not add a dynamic
   "Comparing X → Y — N tables differ" sentence; the pair is the Source /
-  Target selects. Toolbar is one wrapping row (pair + filter + Differences
-  only left; Connections / Replica nodes toggle + Copy recommended SQL
-  right). Scope toggle (only when both hostCount and nodeCount are ≥ 2)
-  writes `?scope=hosts|nodes` and remounts the pair from that peer list.
+  Target selects. Toolbar is `CompareToolbar` (`p-4` card): Connections /
+  Replica nodes tabs, then stacked Source / Target (peer name) + Filter,
+  then Differences / All. Scope toggle (only when both hostCount and
+  nodeCount are ≥ 2) writes `?scope=hosts|nodes` and remounts the pair
+  from that peer list.
   Differences-only with zero diffs and no name filter is
   `EmptyState variant="no-data"` titled **Schemas match**; "No tables
   match" is only for a name-filter miss. Settings Diff (`/settings-diff`)


### PR DESCRIPTION
## Summary
- Compare tools (Settings Diff, Schema Compare) now use a padded `CompareToolbar` card.
- Tabs are taller **Connections / Replica nodes** (and All hosts / Pair).
- Source and Target are stacked labeled dropdowns showing node names, not `0` / `1`.
- **Differences / All** replaces the switch; **Changed from default** is a chip.

## Test plan
- [x] schema-diff + settings-diff unit tests
- [ ] After deploy, `/settings-diff?host=0` toolbar: names, tabs, padding, chips