### PR TITLE
feat(blog): recap 0.3.x patches and what is next

### DIFF
--- a/apps/blog/CONTENT-CALENDAR.md
+++ b/apps/blog/CONTENT-CALENDAR.md
@@ -50,9 +50,10 @@ published (`draft: false`, merged to main)
 | 9 | how-to | Self-hosting chmonitor on Kubernetes | clickhouse monitoring kubernetes | `/operate/deploy/k8s` | done (`clickhouse-monitoring-kubernetes.md`, published 2026-07-10) |
 | 10 | troubleshooting | Debugging `system.errors` spikes | clickhouse system errors | `/guide/features/health` | done (`clickhouse-system-errors-spikes.md`, published 2026-07-10) |
 | 11 | case-study | Capacity planning with the TTL and disk-growth advisor | clickhouse capacity planning ttl | `/guide/ai-agent` (advisor tools) | done (`clickhouse-capacity-planning-ttl.md`, published 2026-07-10) |
-| 12 | release | (scaffold from the next GitHub release when it ships) | — | `/reference/releases` | planned |
+| 12 | release | What's new in chmonitor 0.3.x | clickhouse monitoring dashboard 0.3 | `/guide/getting-started` | done (`chmonitor-0-3-x.md` → `/v0.3.3/`, published 2026-08-19) |
 | 13 | troubleshooting | ClickHouse disk is full — what to do right now | clickhouse disk full emergency | `/guide/features` | done (`clickhouse-disk-full-emergency.md`, published 2026-07-10) |
 | 14 | product | A DBA, an SRE, and an engineer should not share a sidebar | customize clickhouse monitoring dashboard | `/reference/settings` | done (`customize-dashboard.md`, published 2026-08-19) |
+| 15 | update | What's next in 0.3.x | clickhouse monitoring tools schema compare | `/guide/guides/dba-workflows` | done (`whats-next-0-3-x.md`, published 2026-08-19) |
 
 ## Published this cycle (homepage redesign + SEO expansion)
 

--- a/apps/blog/src/content/blog/chmonitor-0-3-x.md
+++ b/apps/blog/src/content/blog/chmonitor-0-3-x.md
@@ -1,0 +1,85 @@
+---
+title: "What's new in chmonitor 0.3.x"
+description: "Three patch releases since the v0.3 rebuild: interactive topology, a live MCP playground, guest AI caps, simpler alerts, and a sidebar you can pin and reorder."
+date: 2026-08-19
+tag: Release
+version: v0.3.3
+---
+
+chmonitor **v0.3** was the rebuild. **v0.3.1**, **v0.3.2**, and **v0.3.3** are
+what we shipped on top of it — three tagged releases in August, all GPL-3.0,
+same Docker image, same Cloud app.
+
+If you last looked at the [v0.3 launch post](/v0.3/), this is the recap.
+
+<div class="hl-grid">
+  <div class="hl"><b>v0.3.1</b><span>Drag-and-inspect cluster topology. The agent picks models from real usage, not a static list.</span></div>
+  <div class="hl"><b>v0.3.2</b><span>Fleet strip with sparklines, a live MCP Playground, and alert channels that start from what you already configured.</span></div>
+  <div class="hl"><b>v0.3.3</b><span>Guest AI caps on Cloud, alert templates, drag-to-reorder favorites, Settings next to Sign in.</span></div>
+</div>
+
+## v0.3.1 — topology you can actually use
+
+[Cluster topology](https://docs.chmonitor.dev/guide/features/topology) is no
+longer a static drawing. Drag nodes, click a glyph, inspect latency and
+membership. On ClickHouse 26.2+ the parts page also says **why** a part was
+postponed instead of leaving you to guess.
+
+The AI agent auto-picks [AnyRouter](https://docs.chmonitor.dev/guide/ai-agent)
+models from usage, not a hard-coded roster.
+
+[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.1) ·
+11 Aug 2026.
+
+## v0.3.2 — fleet, MCP, alerts
+
+A **fleet** strip sits on the host switcher: metrics and sparklines for every
+saved connection, so you see the noisy node before you click into it.
+
+The [MCP](https://docs.chmonitor.dev/guide/ai-agent) page has a real Playground
+client (2026-07-28 spec), not a copy-paste blob.
+
+Alert settings lead with **channels you already configured**. The rest stay
+behind Add channel — no wall of empty forms.
+
+Explorer table Overview is denser and engine-aware, with highlighted DDL. The
+query-activity heatmap picks a month window that fits the screen.
+
+[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.2) ·
+12 Aug 2026.
+
+## v0.3.3 — caps, templates, favorites
+
+Cloud **guest AI** is capped and metered so a public demo cannot run unbounded
+tool loops. You pick models dynamically, including AnyRouter presets and a
+custom model field.
+
+Alerts use **templates and presets** instead of a threshold spreadsheet.
+
+Pinned sidebar favorites drag to reorder. Settings opens from the gear next to
+Sign in — local to this browser. When no merges are running, the Merges page
+shows the last completed ones so the page is not empty.
+
+[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.3) ·
+16 Aug 2026.
+
+## Upgrade
+
+Self-hosters: pull the image you already run.
+
+```bash
+docker pull ghcr.io/chmonitor/chmonitor:latest
+```
+
+Cloud (`dash.chmonitor.dev`) already tracks these tags. Nothing to migrate.
+
+## What's next
+
+The next 0.3.x tag is not cut yet. Tools, workspace roles, Schema Compare, and
+Settings Diff are already on `main` — see [What's next in 0.3.x](/whats-next-0-3-x/).
+
+## Related
+
+- [chmonitor v0.3 — a full rebuild](/v0.3/)
+- Docs: [Getting started](https://docs.chmonitor.dev/guide/getting-started)
+- [All GitHub releases](https://github.com/chmonitor/chmonitor/releases)

--- a/apps/blog/src/content/blog/chmonitor-v0-3.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3.md
@@ -195,7 +195,8 @@ All configuration variables are now unified under the standard `CHM_` prefix (e.
 | Performance | 13 perf wins — pooling, memoization, cache limits, hidden-chart unmounting |
 
 See the full commit-level history in the
-[GitHub releases](https://github.com/chmonitor/chmonitor/releases).
+[GitHub releases](https://github.com/chmonitor/chmonitor/releases). Patch
+releases since this post: [What's new in chmonitor 0.3.x](/v0.3.3/).
 
 ---
 

--- a/apps/blog/src/content/blog/whats-next-0-3-x.md
+++ b/apps/blog/src/content/blog/whats-next-0-3-x.md
@@ -1,0 +1,76 @@
+---
+title: "What's next in 0.3.x: Tools, workspace roles, Schema Compare"
+description: "Already on main and Cloud — a Tools menu, per-browser workspace roles, Schema Compare, Settings Diff, and a What's new dialog. The next 0.3.x tag will include them."
+date: 2026-08-19
+tag: Update
+---
+
+These are **not a tagged GitHub release yet**. They are on `main` and on
+[dash.chmonitor.dev](https://dash.chmonitor.dev). The next **0.3.x** tag will
+pick them up. Self-hosters on `:latest` built from `main` already have them.
+
+<div class="hl-grid">
+  <div class="hl"><b>Tools menu</b><span>SQL Console, Explorer, Explain, Advisor, Chart Builder, Schema Compare, Settings Diff — last group in Main.</span></div>
+  <div class="hl"><b>Workspace roles</b><span>Full / DBA / Engineer / SRE. Hide and pin pages locally. The sidebar follows this browser.</span></div>
+  <div class="hl"><b>Schema Compare</b><span>Table DDL across hosts or replica nodes. Recommend-only plan — copy statements, never apply.</span></div>
+  <div class="hl"><b>Settings Diff</b><span>system.settings and merge_tree_settings, pair or matrix. All matched when nothing differs.</span></div>
+</div>
+
+## Tools, at the end of Main
+
+Interactive work used to live under Queries, Tables, and Operations. It now
+lives in **Tools** — last group in Main, after Logs.
+
+SQL Console, Data Explorer, Explain, Advisor, Chart Builder, Schema Compare,
+Settings Diff. **AI Agent** stays its own group. Postgres hosts do not see
+Tools (ClickHouse-family only).
+
+The longer write-up is [A DBA, an SRE, and an engineer should not share a
+sidebar](/customize-dashboard/).
+
+## Schema Compare and Settings Diff
+
+[DBA workflows](https://docs.chmonitor.dev/guide/guides/dba-workflows) is the
+map.
+
+**Schema Compare** (`/schema-diff`) diffs `CREATE TABLE` across saved connections
+or replica nodes. One host is not enough — add a second, or compare nodes on
+this cluster. The plan is copy-only. Advisor findings can also emit a local
+statement plus an `ON CLUSTER` variant when topology is known.
+
+**Settings Diff** (`/settings-diff`) diffs `system.settings` and
+`system.merge_tree_settings`. Filter to differences, or to values changed from
+default. When every setting matches: green check, **All matched**, then **All**
+to list them anyway.
+
+## What's new, next to Settings
+
+The newspaper icon next to the Settings gear opens **What's new** — notes from
+`docs/whats-new/` for each tagged version, newest first. It auto-opens once
+after an upgrade.
+
+## Also on this train
+
+- **TTL and partition health** at `/ttl-partition-health` — inventory, not just
+  move history on Storage Economics.
+- Schema lint on Explorer table Overview (same recommend-only engine as
+  Advisor).
+- [Self-hosted commercial licenses](/self-hosted-licenses/) — host-count
+  invoice, no key in the binary.
+- Advisor: copyable local vs `ON CLUSTER` DDL.
+
+## What this is not
+
+It is not v0.3.4 until [release-please](https://github.com/chmonitor/chmonitor/releases)
+cuts the tag. Do not treat this post as a changelog for a version number that
+does not exist yet.
+
+When that tag ships, we will scaffold a normal [release post](/v0.3.3/). Until
+then: Cloud has it, `main` has it, `:latest` has it if you build from `main`.
+
+## Related
+
+- Recap: [What's new in chmonitor 0.3.x](/v0.3.3/)
+- [Customize the dashboard](/customize-dashboard/)
+- Docs: [DBA workflows](https://docs.chmonitor.dev/guide/guides/dba-workflows),
+  [Settings](https://docs.chmonitor.dev/guide/features/settings)

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -24,6 +24,8 @@ function fmtDate(d: Date) {
 const CATEGORY_ORDER = [
   'Release',
   'Feature',
+  'Product',
+  'Update',
   'How-to',
   'Performance',
   'Monitoring',
@@ -35,6 +37,8 @@ const CATEGORY_ORDER = [
 const CATEGORY_TAGLINE = {
   Release: 'New versions, features, and fixes shipped to chmonitor.',
   Feature: 'New product surfaces in the dashboard.',
+  Product: 'How we sell, license, and shape the product.',
+  Update: 'What shipped between tags, and what is on main next.',
   Howto: 'Step-by-step guides to get more from your dashboard.',
   Performance: 'Tune ClickHouse — indexes, parts, queries, and profiling that actually move latency.',
   Monitoring: 'The dashboards and system-table signals every ClickHouse cluster needs.',

--- a/docs/content/guide/features/explorer.mdx
+++ b/docs/content/guide/features/explorer.mdx
@@ -90,7 +90,7 @@ CLICKHOUSE_MAX_EXECUTION_TIME=60
 ## Related
 
 <Cards>
-  <Card title="DBA workflows" href="/guide/guides/dba-workflows" description="Single-host Explorer DDL vs planned cross-host schema compare." />
+  <Card title="DBA workflows" href="/guide/guides/dba-workflows" description="Explorer DDL vs Schema Compare across hosts or replica nodes." />
   <Card title="Tables & storage" href="/guide/features/tables" description="Storage, parts, and replication for the tables you explore." />
   <Card title="Authentication" href="/operate/authentication" description="Who can sign in and what each visitor may access." />
   <Card title="Settings reference" href="/reference/settings" description="Environment variables and in-app configuration." />

--- a/docs/content/guide/features/settings.mdx
+++ b/docs/content/guide/features/settings.mdx
@@ -95,4 +95,5 @@ No feature-specific environment variables. The pages are read-only — chmonitor
   <Card title="Feature permissions" href="/operate/advanced/feature-permissions" description="Gate or disable features per section." />
   <Card title="ClickHouse system.settings" href="https://clickhouse.com/docs/en/operations/system-tables/settings" description="Upstream reference for server settings." />
   <Card title="ClickHouse system.merge_tree_settings" href="https://clickhouse.com/docs/en/operations/system-tables/merge_tree_settings" description="Upstream reference for MergeTree settings." />
+  <Card title="What's next in 0.3.x" href="https://blog.chmonitor.dev/whats-next-0-3-x/" description="Settings Diff, Schema Compare, and the Tools menu — already on main." />
 </Cards>

--- a/docs/content/guide/guides/dba-workflows.mdx
+++ b/docs/content/guide/guides/dba-workflows.mdx
@@ -79,4 +79,5 @@ Until those exist, use `/schema-diff`, `/settings-diff`, `/advisor`, `/storage-e
   <Card title="Data explorer" href="/guide/features/explorer" description="Single-host DDL, columns, indexes, and projections." />
   <Card title="Tables & storage" href="/guide/features/tables" description="Table sizes, parts, and replication pages." />
   <Card title="ClickHouse query optimization" href="/guide/guides/clickhouse-query-optimization" description="The six areas the query advisor reasons about." />
+  <Card title="What's next in 0.3.x" href="https://blog.chmonitor.dev/whats-next-0-3-x/" description="Tools, workspace roles, Schema Compare, Settings Diff — on main, next tag." />
 </Cards>


### PR DESCRIPTION
## Summary
- New Release post: [What's new in chmonitor 0.3.x](https://blog.chmonitor.dev/v0.3.3/) covering v0.3.1–v0.3.3.
- New Update post: [What's next in 0.3.x](https://blog.chmonitor.dev/whats-next-0-3-x/) for Tools, workspace roles, Schema Compare, Settings Diff — on main, not a tag yet.
- Docs backlinks from DBA workflows, Settings, Explorer.

## Test plan
- [x] Posts use published dates (not future)
- [x] Upcoming post does not claim a v0.3.4 tag
- [ ] After blog deploy, both URLs return 200