### PR TITLE
fix(landing): rebuild hero when the latest blog post changes

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -36,7 +36,9 @@ permissions:
 # `bug-handler`. Without filtering, every push to main and every PR rebuilt &
 # redeployed all 6. Each job now runs a `filter` step and gates its own
 # build/deploy steps so a worker is touched ONLY when its own app dir (or a
-# shared dep — packages/**, root lockfile, this workflow) changed.
+# shared dep — packages/**, root lockfile, this workflow) changed. Landing also
+# rebuilds when `apps/blog/src/content/blog/**` changes: the hero pill is the
+# newest published post, inlined at Astro build time.
 #
 # Conservative by design (never skip a needed deploy):
 #   • The filter only runs on pull_request and pushes to a branch (main).
@@ -601,6 +603,8 @@ jobs:
           filters: |
             landing:
               - 'apps/landing/**'
+              # Hero latest-post pill is baked at Astro build from blog markdown.
+              - 'apps/blog/src/content/blog/**'
               - 'scripts/**'
               - 'assets/**'
               - 'bun.lock'

--- a/apps/landing/src/lib/latest-blog-post.test.ts
+++ b/apps/landing/src/lib/latest-blog-post.test.ts
@@ -1,6 +1,6 @@
 import { BLOG_ORIGIN, getLatestBlogPost } from './latest-blog-post'
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -121,6 +121,18 @@ describe('getLatestBlogPost', () => {
     })
     expect(latest?.slug).toBe('v0.3')
     expect(latest?.href).toBe(`${BLOG_ORIGIN}/v0.3/`)
+  })
+
+  test('landing deploy filter includes blog markdown so the hero pill stays current', () => {
+    const yml = readFileSync(
+      join(import.meta.dir, '../../../../.github/workflows/cloudflare.yml'),
+      'utf8'
+    )
+    const landingPaths = yml.indexOf("- 'apps/landing/**'")
+    expect(landingPaths).toBeGreaterThan(-1)
+    expect(yml.slice(landingPaths, landingPaths + 500)).toContain(
+      "apps/blog/src/content/blog/**"
+    )
   })
 
   test('returns null when the directory has no published posts', () => {

--- a/apps/landing/src/lib/latest-blog-post.ts
+++ b/apps/landing/src/lib/latest-blog-post.ts
@@ -28,6 +28,9 @@ export type LatestBlogPostOptions = {
  * Published = not `draft` and `date <= now`, matching the blog app's
  * `isPublished` / `postSlug` (version frontmatter wins over filename id).
  * Parses YAML frontmatter locally — do not import `astro:content` from blog.
+ *
+ * This is build-time. The Cloudflare landing job must rebuild when blog
+ * markdown changes (see `.github/workflows/cloudflare.yml` landing filter).
  */
 export function getLatestBlogPost(
   options: LatestBlogPostOptions = {}


### PR DESCRIPTION
## Summary

The homepage hero pill is baked at landing build from blog markdown. After v0.3.4 shipped, production still linked the licenses post because landing did not rebuild. Include blog content in the landing deploy filter so the pill always points at the latest post.

## Changes

- Cloudflare landing job also deploys when `apps/blog/src/content/blog/**` changes.
- Guard the filter in `latest-blog-post.test.ts`.

## Test plan

- [x] `bun test` in `apps/landing` (`latest-blog-post`, `homepage`)
- [ ] Landing production deploy after merge — pill href is `https://blog.chmonitor.dev/v0.3.4/`

## Notes for reviewer

Live `chmonitor.dev` currently shows the licenses post. Helper locally already returns v0.3.4.

---

Co-Authored-By: duyetbot <bot@duyet.net>