### PR TITLE
fix(schema-diff): list matching tables with green checks

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -106,9 +106,13 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   nodes**, `SegmentedControl size="default"`), then stacked Source /
   Target selects (peer **name**, never a raw id) with a Filter field,
   then **Differences** / **All**. Copy recommended SQL sits on that
-  filter row. When Differences is on, zero diffs, and no name filter,
-  the table list is `EmptyState variant="no-data"` titled **Schemas
-  match** — keep "No tables match" only for a name-filter miss.
+  filter row. The table catalog is a collapsible left sidebar
+  (`PanelLeftClose` / `PanelLeft`). When Differences is on and there
+  are no diffs, still list identical tables with a green
+  `CheckCircle2` (`--chart-green`) — click a row to select it on the
+  right. A matching selection is **All matched** / **This table
+  matches** (`MatchOk`), never EmptyState "no data" or "Select a
+  table". Keep "No tables match" only for a name-filter miss.
   Settings Diff (`/settings-diff`) uses the same toolbar; diffs-only
   with zero deltas is **All matched** plus a green check and **Show
   matching settings**. "Changed from default" is a pressable chip, not

--- a/apps/dashboard/src/components/schema-diff/match-ok.tsx
+++ b/apps/dashboard/src/components/schema-diff/match-ok.tsx
@@ -1,0 +1,29 @@
+import { CheckCircle2Icon } from 'lucide-react'
+
+import { Card, CardContent } from '@/components/ui/card'
+
+interface MatchOkProps {
+  title: string
+  description: string
+}
+
+export function MatchOk({ title, description }: MatchOkProps) {
+  return (
+    <Card
+      className="rounded-xl border bg-card py-0 shadow-sm"
+      data-testid="schema-diff-match-ok"
+    >
+      <CardContent className="flex items-start gap-3 p-4">
+        <CheckCircle2Icon
+          className="mt-0.5 size-5 shrink-0 text-[var(--chart-green)]"
+          strokeWidth={1.5}
+          aria-hidden
+        />
+        <div>
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -157,11 +157,28 @@ function matchingHostPayload(): SchemaDiffResponse {
         create_table_query:
           'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree ORDER BY id',
       },
+      {
+        database: 'app',
+        table: 'users',
+        engine: 'MergeTree',
+        sorting_key: 'id',
+        partition_key: '',
+        primary_key: 'id',
+        create_table_query:
+          'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id',
+      },
     ],
     [
       {
         database: 'app',
         table: 'events',
+        name: 'id',
+        type: 'UInt64',
+        codec: '',
+      },
+      {
+        database: 'app',
+        table: 'users',
         name: 'id',
         type: 'UInt64',
         codec: '',
@@ -393,7 +410,7 @@ describe('Schema Compare two-host path', () => {
     }
   })
 
-  test('matching schemas with Differences only says Schemas match', async () => {
+  test('matching schemas list tables with checks and a green All matched pane', async () => {
     const { SchemaDiffView } = await import('./schema-diff-view')
     const data = matchingHostPayload()
 
@@ -411,14 +428,85 @@ describe('Schema Compare two-host path', () => {
     )
 
     try {
-      expect(document.body.textContent).toContain('Schemas match')
-      expect(document.body.textContent).toContain(
-        'Switch to All to list every table.'
-      )
+      expect(document.body.textContent).toContain('app.events')
+      expect(document.body.textContent).toContain('app.users')
+      expect(document.body.textContent).toContain('All matched')
+      expect(document.body.textContent).toContain('Source DDL')
+      expect(
+        document.querySelector('[data-testid="schema-diff-match-ok"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelectorAll('[data-testid="schema-diff-matched-icon"]')
+          .length
+      ).toBe(2)
+      expect(document.body.textContent).not.toContain('Schemas match')
+      expect(document.body.textContent).not.toContain('Select a table')
       expect(document.body.textContent).not.toContain('No tables match')
+      expect(document.body.textContent).not.toContain(
+        'No recommended statements'
+      )
       expect(document.body.textContent).not.toMatch(
         /Comparing .+ tables differ/
       )
+
+      const { act } = await import('react')
+      const users = [...document.querySelectorAll('button')].find((el) =>
+        el.textContent?.includes('app.users')
+      ) as HTMLButtonElement
+      expect(users).not.toBeNull()
+      await act(async () => {
+        users.click()
+      })
+      expect(users.getAttribute('aria-current')).toBe('true')
+      expect(document.body.textContent).toContain(
+        'CREATE TABLE app.users (id UInt64)'
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('table list sidebar can collapse and expand', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = matchingHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-list"]')
+      ).not.toBeNull()
+      const { act } = await import('react')
+      const collapse = document.querySelector(
+        '[data-testid="schema-diff-sidebar-collapse"]'
+      ) as HTMLButtonElement
+      await act(async () => {
+        collapse.click()
+      })
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-list"]')
+      ).toBeNull()
+      const expand = document.querySelector(
+        '[data-testid="schema-diff-sidebar-expand"]'
+      ) as HTMLButtonElement
+      expect(expand).not.toBeNull()
+      await act(async () => {
+        expand.click()
+      })
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-list"]')
+      ).not.toBeNull()
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -1,9 +1,10 @@
-import { CopyIcon } from 'lucide-react'
+import { CopyIcon, PanelLeftIcon } from 'lucide-react'
 
 import type { ComparePeer, CompareScope } from '@/lib/compare/scope'
 import type { SchemaDiffResponse, TableDiff } from '@/lib/schema-diff'
 
 import { DdlPair } from './ddl-pair'
+import { MatchOk } from './match-ok'
 import { PlanList } from './plan-list'
 import { TableList } from './table-list'
 import { useMemo, useState } from 'react'
@@ -51,14 +52,24 @@ export function SchemaDiffView({
   const [nameFilter, setNameFilter] = useState('')
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [copiedSafe, setCopiedSafe] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+
+  const diffCount =
+    data.diff.onlySource.length +
+    data.diff.onlyTarget.length +
+    data.diff.changed.length
+  const allMatched = diffCount === 0 && data.diff.identical.length > 0
 
   const rows: TableDiff[] = useMemo(() => {
-    const all = [
+    const diffs = [
       ...data.diff.onlySource,
       ...data.diff.onlyTarget,
       ...data.diff.changed,
-      ...(showDiffsOnly ? [] : data.diff.identical),
     ]
+    // Differences with zero deltas still lists matching tables so the
+    // sidebar is a real catalog, not an empty "no data" card.
+    const includeIdentical = !showDiffsOnly || diffs.length === 0
+    const all = includeIdentical ? [...diffs, ...data.diff.identical] : diffs
     if (!nameFilter) return all
     const q = nameFilter.toLowerCase()
     return all.filter((row) => row.key.toLowerCase().includes(q))
@@ -68,14 +79,9 @@ export function SchemaDiffView({
   const selectedPlan = (data.plan.items ?? []).filter(
     (item) => item.tableKey === selected?.key
   )
+  const selectedMatches = selected?.kind === 'identical'
 
-  const diffCount =
-    data.diff.onlySource.length +
-    data.diff.onlyTarget.length +
-    data.diff.changed.length
   const hasNameFilter = nameFilter.trim().length > 0
-  const schemasMatchEmpty =
-    rows.length === 0 && showDiffsOnly && diffCount === 0 && !hasNameFilter
   const hasSafeStatements = data.plan.safeStatements.length > 0
 
   const copySafe = async () => {
@@ -141,33 +147,61 @@ export function SchemaDiffView({
         />
       </CompareToolbar>
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,22rem)_minmax(0,1fr)]">
-        <TableList
-          rows={rows}
-          selectedKey={selected?.key ?? null}
-          onSelect={setSelectedKey}
-          example={example}
-          emptyTitle={schemasMatchEmpty ? 'Schemas match' : undefined}
-          emptyDescription={
-            schemasMatchEmpty
-              ? 'No table differences between source and target. Switch to All to list every table.'
-              : undefined
-          }
-          emptyVariant={schemasMatchEmpty ? 'no-data' : undefined}
-          emptyCompact={!schemasMatchEmpty}
-        />
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        {sidebarOpen ? (
+          <div className="w-full shrink-0 lg:w-[22rem]">
+            <TableList
+              rows={rows}
+              selectedKey={selected?.key ?? null}
+              onSelect={setSelectedKey}
+              example={example}
+              onCollapse={() => setSidebarOpen(false)}
+            />
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            onClick={() => setSidebarOpen(true)}
+            className="size-8 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="Show table list"
+            data-testid="schema-diff-sidebar-expand"
+          >
+            <PanelLeftIcon className="size-3.5" strokeWidth={1.5} />
+          </Button>
+        )}
 
-        <div className="flex flex-col gap-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
           {selected ? (
             <>
+              {selectedMatches ? (
+                <MatchOk
+                  title={allMatched ? 'All matched' : 'This table matches'}
+                  description={
+                    allMatched
+                      ? 'Every table schema is identical on source and target.'
+                      : 'Source and target DDL are identical. No recommended statements.'
+                  }
+                />
+              ) : null}
               <DdlPair selected={selected} />
-              <PlanList items={selectedPlan} />
+              {selectedMatches ? null : <PlanList items={selectedPlan} />}
             </>
+          ) : allMatched && !hasNameFilter ? (
+            <MatchOk
+              title="All matched"
+              description="Every table schema is identical on source and target."
+            />
           ) : (
             <EmptyState
-              variant="no-data"
-              title="Select a table"
-              description="Pick a table on the left to see side-by-side DDL and a copyable plan."
+              variant={hasNameFilter ? 'filtered-empty' : 'no-data'}
+              title={hasNameFilter ? 'No tables match' : 'Select a table'}
+              description={
+                hasNameFilter
+                  ? 'Try a different filter or switch to All.'
+                  : 'Pick a table on the left to see side-by-side DDL and a copyable plan.'
+              }
             />
           )}
         </div>

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -1,9 +1,13 @@
+import { CheckCircle2Icon, PanelLeftCloseIcon } from 'lucide-react'
+
 import type { EmptyStateVariant } from '@/components/ui/empty-state'
 import type { TableDiff } from '@/lib/schema-diff'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
+import { cn } from '@/lib/utils'
 
 interface TableListProps {
   rows: TableDiff[]
@@ -14,6 +18,7 @@ interface TableListProps {
   emptyDescription?: string
   emptyVariant?: EmptyStateVariant
   emptyCompact?: boolean
+  onCollapse?: () => void
 }
 
 function kindLabel(kind: TableDiff['kind']): string {
@@ -32,11 +37,38 @@ export function TableList({
   emptyDescription = 'Try a different filter or switch to All.',
   emptyVariant = 'filtered-empty',
   emptyCompact = true,
+  onCollapse,
 }: TableListProps) {
   return (
-    <Card className="rounded-xl border bg-card shadow-sm">
+    <Card
+      className="gap-0 rounded-xl border bg-card py-0 shadow-sm"
+      data-testid="schema-diff-table-list"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <h2 className="text-sm font-medium text-foreground">
+          Tables
+          {rows.length > 0 ? (
+            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+              {rows.length}
+            </span>
+          ) : null}
+        </h2>
+        {onCollapse ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onCollapse}
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="Hide table list"
+            data-testid="schema-diff-sidebar-collapse"
+          >
+            <PanelLeftCloseIcon className="size-3.5" strokeWidth={1.5} />
+          </Button>
+        ) : null}
+      </div>
       <CardContent className="p-0">
-        <ul className="divide-y divide-border">
+        <ul className="max-h-[min(36rem,70vh)] divide-y divide-border overflow-y-auto">
           {rows.length === 0 ? (
             <li className="p-4">
               <EmptyState
@@ -51,9 +83,11 @@ export function TableList({
               <li key={row.key}>
                 <button
                   type="button"
-                  className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] hover:bg-muted ${
-                    selectedKey === row.key ? 'bg-muted' : ''
-                  }`}
+                  className={cn(
+                    'flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] hover:bg-muted',
+                    selectedKey === row.key && 'bg-muted'
+                  )}
+                  aria-current={selectedKey === row.key ? 'true' : undefined}
                   onClick={() => onSelect(row.key)}
                 >
                   <span className="truncate font-mono">{row.key}</span>
@@ -66,9 +100,21 @@ export function TableList({
                         Example
                       </Badge>
                     ) : null}
-                    <Badge variant="outline" className="text-muted-foreground">
-                      {kindLabel(row.kind)}
-                    </Badge>
+                    {row.kind === 'identical' ? (
+                      <CheckCircle2Icon
+                        className="size-3.5 text-[var(--chart-green)]"
+                        strokeWidth={1.5}
+                        aria-label="matched"
+                        data-testid="schema-diff-matched-icon"
+                      />
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="text-muted-foreground"
+                      >
+                        {kindLabel(row.kind)}
+                      </Badge>
+                    )}
                   </span>
                 </button>
               </li>

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -671,9 +671,14 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   then Differences / All. Scope toggle (only when both hostCount and
   nodeCount are ≥ 2) writes `?scope=hosts|nodes` and remounts the pair
   from that peer list.
-  Differences-only with zero diffs and no name filter is
-  `EmptyState variant="no-data"` titled **Schemas match**; "No tables
-  match" is only for a name-filter miss. Settings Diff (`/settings-diff`)
+  The table catalog is a collapsible left sidebar (`TableList` +
+  `PanelLeftClose` / `PanelLeft`). Differences-only with zero diffs
+  still lists identical tables with a green `CheckCircle2`
+  (`--chart-green`); clicking a row selects it on the right. A
+  matching table's detail is **All matched** / **This table matches**
+  (`MatchOk`) plus side-by-side DDL — never EmptyState "no data" /
+  "Select a table" / "No recommended statements". "No tables match"
+  is only for a name-filter miss. Settings Diff (`/settings-diff`)
   with one host keeps the live vs-default matrix and a banner to add
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair


### PR DESCRIPTION
## Summary

When Schema Compare finds no diffs, still list every table in a collapsible sidebar with green checks. Clicking a row selects it on the right and shows a green All matched confirmation plus side-by-side DDL, instead of the empty "Schemas match" / "Select a table" cards.

## Changes

- Differences with zero diffs now includes identical tables in `TableList`, each with a green `CheckCircle2`
- Table catalog is a collapsible left sidebar (`PanelLeftClose` / `PanelLeft`)
- Matching selection uses `MatchOk` ("All matched" / "This table matches") instead of EmptyState "no data"
- Clicking a table row still opens its DDL on the right
- Tests cover the matched list, click-to-select, and sidebar toggle
- Product-design skill + knowledge doc updated

## Test plan

- [x] Schema Compare unit tests (`schema-diff-page.test.tsx`) pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

"No tables match" is still only a name-filter miss. Differences with actual diffs still hides identical tables.

---

Co-Authored-By: duyetbot <bot@duyet.net>