### PR TITLE
fix(settings-diff): list matching settings with green checks

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -113,11 +113,11 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   right. A matching selection is **All matched** / **This table
   matches** (`MatchOk`), never EmptyState "no data" or "Select a
   table". Keep "No tables match" only for a name-filter miss.
-  Settings Diff (`/settings-diff`) uses the same toolbar; diffs-only
-  with zero deltas is **All matched** plus a green check and **Show
-  matching settings**. "Changed from default" is a pressable chip, not
-  a second switch. "No settings match" is only a name/changed-from-default
-  filter miss.
+  Settings Diff (`/settings-diff`) uses the same toolbar. Diffs-only
+  with zero deltas still lists matching settings, each with a green
+  `CheckCircle2` in a Match column (`--chart-green`). "Changed from
+  default" is a pressable chip, not a second switch. "No settings
+  match" is only a name/changed-from-default filter miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).
@@ -218,7 +218,7 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   as HostSwitcher) plus a faded `TableList` + `DdlPair` example. Settings Diff
   with one host keeps the live vs-default table and a banner (`AddHostButton`,
   `data-testid="add-host"`). Pair ids include user connections. Diffs-only
-  with zero deltas is **All matched** (green check) + Show matching settings.
+  with zero deltas still lists matching settings with a green Match check.
 - **Base UI primitives** (`components/ui/*` = shadcn Base UI, not Radix): style
   overlays off `data-open`/`data-closed`/`data-orientation` (needs the
   `@custom-variant data-horizontal|vertical` in `styles.css`) and Base UI CSS

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
@@ -142,10 +142,51 @@ describe('Settings Diff one-host vs default', () => {
   })
 })
 
-describe('Settings Diff all-matched empty', () => {
-  test('shows a green All matched state when diffs-only has nothing to list', async () => {
+describe('Settings Diff matching rows', () => {
+  test('lists matching settings with a green check instead of an empty All matched card', async () => {
     const { SettingsDiffTable } = await import('./settings-diff-table')
-    let showedMatching = false
+    const rows = mergeSettingsDiff([
+      {
+        peerId: 0,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+          {
+            name: 'max_memory_usage',
+            value: '0',
+            changed: 1,
+            description: '',
+            defaultValue: '0',
+          },
+        ],
+      },
+      {
+        peerId: 1,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+          {
+            name: 'max_memory_usage',
+            value: '10G',
+            changed: 1,
+            description: '',
+            defaultValue: '0',
+          },
+        ],
+      },
+    ])
 
     const { cleanup } = await renderInto(
       <SettingsDiffTable
@@ -153,23 +194,81 @@ describe('Settings Diff all-matched empty', () => {
           { id: 0, name: 'clickhouse-0' },
           { id: 1, name: 'clickhouse-1' },
         ]}
-        rows={[]}
-        allMatched
-        onShowMatching={() => {
-          showedMatching = true
-        }}
+        rows={filterSettingsDiffRows(rows, {
+          showDiffsOnly: false,
+          showChangedOnly: false,
+          nameFilter: '',
+        })}
       />
     )
 
     try {
-      expect(document.body.textContent).toContain('All matched')
-      expect(document.body.textContent).not.toContain(
-        'No settings match the current filters'
-      )
-      const button = document.body.querySelector('button')
-      expect(button?.textContent).toContain('Show matching settings')
-      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-      expect(showedMatching).toBe(true)
+      expect(document.body.textContent).toContain('max_memory_usage')
+      expect(document.body.textContent).toContain('max_threads')
+      expect(
+        document.querySelectorAll('[data-testid="settings-diff-matched-icon"]')
+          .length
+      ).toBe(1)
+      expect(document.body.textContent).not.toContain('All matched')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('diffs-only with no deltas still lists every setting with a check', async () => {
+    const { SettingsDiffTable } = await import('./settings-diff-table')
+    const rows = mergeSettingsDiff([
+      {
+        peerId: 0,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+        ],
+      },
+      {
+        peerId: 1,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+        ],
+      },
+    ])
+
+    const { cleanup } = await renderInto(
+      <SettingsDiffTable
+        columns={[
+          { id: 0, name: 'clickhouse-0' },
+          { id: 1, name: 'clickhouse-1' },
+        ]}
+        rows={filterSettingsDiffRows(rows, {
+          showDiffsOnly: true,
+          showChangedOnly: false,
+          nameFilter: '',
+        })}
+      />
+    )
+
+    try {
+      expect(document.body.textContent).toContain('max_threads')
+      expect(
+        document.querySelectorAll('[data-testid="settings-diff-matched-icon"]')
+          .length
+      ).toBe(1)
+      expect(document.body.textContent).not.toContain('All matched')
+      expect(document.body.textContent).not.toContain('No settings match')
+      expect(document.body.textContent).not.toContain('Show matching settings')
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -26,10 +26,7 @@ import {
   fetchCompareDiff,
 } from '@/lib/compare/fetch-diff-request'
 import { resolveCompareScope, resolvePair } from '@/lib/compare/scope'
-import {
-  filterSettingsDiffRows,
-  isSettingsDiffAllMatchedEmpty,
-} from '@/lib/settings-diff/filter'
+import { filterSettingsDiffRows } from '@/lib/settings-diff/filter'
 import { useHostId } from '@/lib/swr/use-host'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl } from '@/lib/url/url-builder'
@@ -187,21 +184,12 @@ export function SettingsDiffPage() {
       : hosts
 
   const diffsOnly = hostCount === 1 ? false : showDiffsOnly
-  const totalRows = data.rows?.length ?? 0
   const filteredRows = filterSettingsDiffRows(data.rows ?? [], {
     showDiffsOnly: diffsOnly,
     showChangedOnly,
     nameFilter,
   })
-  const diffCount = (data.rows ?? []).filter((r) => r.hasDiff).length
   const oneHostVsDefault = hostCount === 1 && scope === 'hosts'
-  const allMatched = isSettingsDiffAllMatchedEmpty({
-    totalRows,
-    diffCount,
-    showDiffsOnly: diffsOnly,
-    showChangedOnly,
-    nameFilter,
-  })
 
   return (
     <div className="flex flex-col gap-4">
@@ -334,12 +322,7 @@ export function SettingsDiffPage() {
         )}
       </CompareToolbar>
 
-      <SettingsDiffTable
-        columns={columns}
-        rows={filteredRows}
-        allMatched={allMatched}
-        onShowMatching={() => setShowDiffsOnly(false)}
-      />
+      <SettingsDiffTable columns={columns} rows={filteredRows} />
 
       <p className="text-xs text-muted-foreground">
         {filteredRows.length.toLocaleString()} row

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -65,16 +65,12 @@ export function exportSettingsCsv(
 interface SettingsDiffTableProps {
   columns: SettingsDiffHostInfo[]
   rows: SettingsDiffRow[]
-  allMatched?: boolean
-  onShowMatching?: () => void
 }
 
-export function SettingsDiffTable({
-  columns,
-  rows,
-  allMatched = false,
-  onShowMatching,
-}: SettingsDiffTableProps) {
+export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
+  const showMatchColumn = columns.length > 1
+  const colSpan = (showMatchColumn ? 4 : 3) + columns.length
+
   return (
     <Card>
       <CardContent className="p-0">
@@ -82,6 +78,11 @@ export function SettingsDiffTable({
           <Table>
             <TableHeader>
               <TableRow>
+                {showMatchColumn ? (
+                  <TableHead className="w-8 px-2">
+                    <span className="sr-only">Match</span>
+                  </TableHead>
+                ) : null}
                 <TableHead className="w-64 min-w-48">Name</TableHead>
                 <TableHead className="w-40">Table</TableHead>
                 <TableHead className="w-36 text-muted-foreground">
@@ -97,35 +98,13 @@ export function SettingsDiffTable({
             <TableBody>
               {rows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={3 + columns.length} className="py-10">
-                    {allMatched ? (
-                      <EmptyState
-                        variant="no-data"
-                        title="All matched"
-                        description="No setting differences between source and target. Switch to All to list every setting."
-                        icon={
-                          <CheckCircle2Icon
-                            className="size-6 text-[var(--chart-green)]"
-                            strokeWidth={1.5}
-                          />
-                        }
-                        action={
-                          onShowMatching
-                            ? {
-                                label: 'Show matching settings',
-                                onClick: onShowMatching,
-                              }
-                            : undefined
-                        }
-                      />
-                    ) : (
-                      <EmptyState
-                        variant="filtered-empty"
-                        compact
-                        title="No settings match"
-                        description="Try a different name filter or switch to All."
-                      />
-                    )}
+                  <TableCell colSpan={colSpan} className="py-10">
+                    <EmptyState
+                      variant="filtered-empty"
+                      compact
+                      title="No settings match"
+                      description="Try a different name filter or switch to All."
+                    />
                   </TableCell>
                 </TableRow>
               ) : (
@@ -143,6 +122,18 @@ export function SettingsDiffTable({
                           : undefined
                       }
                     >
+                      {showMatchColumn ? (
+                        <TableCell className="w-8 px-2">
+                          {row.hasDiff ? null : (
+                            <CheckCircle2Icon
+                              className="size-3.5 text-[var(--chart-green)]"
+                              strokeWidth={1.5}
+                              aria-label="matched"
+                              data-testid="settings-diff-matched-icon"
+                            />
+                          )}
+                        </TableCell>
+                      ) : null}
                       <TableCell className="font-mono text-xs">
                         <div className="flex items-center gap-2">
                           {row.name}

--- a/apps/dashboard/src/lib/settings-diff/filter.ts
+++ b/apps/dashboard/src/lib/settings-diff/filter.ts
@@ -5,27 +5,14 @@ export function filterSettingsDiffRows(
   opts: { showDiffsOnly: boolean; showChangedOnly: boolean; nameFilter: string }
 ): SettingsDiffRow[] {
   const q = opts.nameFilter.toLowerCase()
+  // Differences with zero deltas still lists matching rows so the table
+  // is a real catalog, not an empty "All matched" card.
+  const hasAnyDiff = rows.some((row) => row.hasDiff)
+  const hideMatched = opts.showDiffsOnly && hasAnyDiff
   return rows.filter((row) => {
-    if (opts.showDiffsOnly && !row.hasDiff) return false
+    if (hideMatched && !row.hasDiff) return false
     if (opts.showChangedOnly && !row.changedFromDefault) return false
     if (q && !row.name.toLowerCase().includes(q)) return false
     return true
   })
-}
-
-/** Diffs-only with zero deltas and no other filter — show "All matched", not a filter miss. */
-export function isSettingsDiffAllMatchedEmpty(opts: {
-  totalRows: number
-  diffCount: number
-  showDiffsOnly: boolean
-  showChangedOnly: boolean
-  nameFilter: string
-}): boolean {
-  return (
-    opts.showDiffsOnly &&
-    opts.diffCount === 0 &&
-    opts.totalRows > 0 &&
-    !opts.showChangedOnly &&
-    opts.nameFilter.trim() === ''
-  )
 }

--- a/apps/dashboard/src/lib/settings-diff/search.test.ts
+++ b/apps/dashboard/src/lib/settings-diff/search.test.ts
@@ -1,4 +1,4 @@
-import { filterSettingsDiffRows, isSettingsDiffAllMatchedEmpty } from './filter'
+import { filterSettingsDiffRows } from './filter'
 import { mergeSettingsDiff } from './merge'
 import { buildSettingsDiffRequest, validateSettingsDiffSearch } from './search'
 import { describe, expect, test } from 'bun:test'
@@ -133,55 +133,59 @@ describe('settings-diff node pair filter', () => {
   })
 })
 
-describe('settings-diff all-matched empty', () => {
-  test('is true when diffs-only hides a full matching catalog', () => {
-    expect(
-      isSettingsDiffAllMatchedEmpty({
-        totalRows: 40,
-        diffCount: 0,
-        showDiffsOnly: true,
-        showChangedOnly: false,
-        nameFilter: '',
-      })
-    ).toBe(true)
-  })
-
-  test('is false when there are diffs, a name filter, or diffs-only is off', () => {
-    expect(
-      isSettingsDiffAllMatchedEmpty({
-        totalRows: 40,
-        diffCount: 1,
-        showDiffsOnly: true,
-        showChangedOnly: false,
-        nameFilter: '',
-      })
-    ).toBe(false)
-    expect(
-      isSettingsDiffAllMatchedEmpty({
-        totalRows: 40,
-        diffCount: 0,
-        showDiffsOnly: false,
-        showChangedOnly: false,
-        nameFilter: '',
-      })
-    ).toBe(false)
-    expect(
-      isSettingsDiffAllMatchedEmpty({
-        totalRows: 40,
-        diffCount: 0,
-        showDiffsOnly: true,
-        showChangedOnly: false,
-        nameFilter: 'max_threads',
-      })
-    ).toBe(false)
-    expect(
-      isSettingsDiffAllMatchedEmpty({
-        totalRows: 0,
-        diffCount: 0,
-        showDiffsOnly: true,
-        showChangedOnly: false,
-        nameFilter: '',
-      })
-    ).toBe(false)
+describe('settings-diff matching catalog', () => {
+  test('diffs-only with no deltas still lists matching rows', () => {
+    const rows = mergeSettingsDiff([
+      {
+        peerId: 0,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+          {
+            name: 'use_uncompressed_cache',
+            value: '0',
+            changed: 0,
+            description: '',
+            defaultValue: '0',
+          },
+        ],
+      },
+      {
+        peerId: 1,
+        table: 'settings',
+        rows: [
+          {
+            name: 'max_threads',
+            value: '8',
+            changed: 0,
+            description: '',
+            defaultValue: '8',
+          },
+          {
+            name: 'use_uncompressed_cache',
+            value: '0',
+            changed: 0,
+            description: '',
+            defaultValue: '0',
+          },
+        ],
+      },
+    ])
+    const filtered = filterSettingsDiffRows(rows, {
+      showDiffsOnly: true,
+      showChangedOnly: false,
+      nameFilter: '',
+    })
+    expect(filtered.map((r) => r.name).sort()).toEqual([
+      'max_threads',
+      'use_uncompressed_cache',
+    ])
+    expect(filtered.every((r) => r.hasDiff === false)).toBe(true)
   })
 })

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -683,9 +683,9 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair
   mode (`HostPairFilter` + URL `source`/`target`). Diffs-only with zero
-  deltas is **All matched** (green check, `--chart-green`) plus **Show
-  matching settings** to turn the toggle off; "No settings match" is
-  only a name/changed-from-default filter miss. Compare APIs resolve
+  deltas still lists matching settings with a green `CheckCircle2` in
+  a Match column (`--chart-green`); "No settings match" is only a
+  name/changed-from-default filter miss. Compare APIs resolve
   merged hosts the same way charts do (`resolve-host-fetch.ts` /
   `use-merged-hosts.ts`).
 - Overflow strip: for a single-row scroller that must not wrap, use


### PR DESCRIPTION
## Summary

When Settings Diff finds no differences, still list every setting instead of the empty All matched card. Matched rows get a small green check in a Match column.

## Changes

- Differences with zero deltas still returns matching rows (`filterSettingsDiffRows`)
- Two-or-more host tables add a Match column with a green `CheckCircle2` (`--chart-green`) on `!hasDiff` rows
- Removed the empty All matched / Show matching settings state
- "No settings match" is only a name / changed-from-default filter miss
- Tests + product-design skill/docs updated

## Test plan

- [x] Settings Diff unit tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Differences with actual diffs still hides matched rows. Switch to All to see checks on matching settings next to amber diff rows.

---

Co-Authored-By: duyetbot <bot@duyet.net>