### PR TITLE
fix(schema-diff): group tables in a tree and compact host pickers

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -95,24 +95,27 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `Select` (the Root) so `SelectValue` shows the label, not the raw value.
   `placeholder` only appears when nothing is selected — a selected `24` /
   `__all__` otherwise renders as those strings. Same map on compare
-  Source/Target (`HostPairFilter` — id → `h.name`, never a raw `0`). See
+  Source/Target (`ComparePeerSelect` — id → `h.name`, never a raw `0`). See
   `components/agents/advisor-query-picker.tsx` and
-  `components/compare/host-pair-filter.tsx`.
+  `components/compare/compare-peer-select.tsx`.
 - **Schema Compare (`/schema-diff`):** one static `PageHeader` ("Schema
   Compare" + recommend-only description). Pair identity lives in the
-  Source/Target selects — no second "Comparing X → Y — N tables differ"
-  line. Compare tools wrap filters in `CompareToolbar` (`rounded-xl
-  border bg-card p-4`): tabs on top (**Connections** / **Replica
-  nodes**, `SegmentedControl size="default"`), then stacked Source /
-  Target selects (peer **name**, never a raw id) with a Filter field,
-  then **Differences** / **All**. Copy recommended SQL sits on that
-  filter row. The table catalog is a collapsible left sidebar
-  (`PanelLeftClose` / `PanelLeft`). When Differences is on and there
-  are no diffs, still list identical tables with a green
-  `CheckCircle2` (`--chart-green`) — click a row to select it on the
-  right. A matching selection is **All matched** / **This table
-  matches** (`MatchOk`), never EmptyState "no data" or "Select a
-  table". Keep "No tables match" only for a name-filter miss.
+  Source/Target comboboxes — no second "Comparing X → Y — N tables differ"
+  line. Compare tools wrap filters in compact `CompareToolbar`
+  (`rounded-xl border bg-card p-3`): tabs on top (**Connections** /
+  **Replica nodes**, `SegmentedControl size="sm"`), then Source /
+  Target searchable comboboxes (`ComparePeerSelect`: Command +
+  Popover, sorted by name, `ChmonitorLogo` plus version/uptime/status
+  like HostSwitcher — never a native Select), then **Differences** /
+  **All**. Copy recommended SQL sits on that row. The table catalog
+  is a collapsible left sidebar grouped **database → table** (folder
+  row + nested table name, search in the sidebar). When Differences
+  is on and there are no diffs, still list identical tables with a
+  green `CheckCircle2` (`--chart-green`) — click a row to select it
+  on the right. A matching selection is **All matched** / **This
+  table matches** (`MatchOk`), never EmptyState "no data" or
+  "Select a table". Keep "No tables match" only for a name-filter
+  miss.
   Settings Diff (`/settings-diff`) uses the same toolbar. Diffs-only
   with zero deltas still lists matching settings, each with a green
   `CheckCircle2` in a Match column (`--chart-green`). "Changed from

--- a/apps/dashboard/src/components/compare/compare-peer-select.tsx
+++ b/apps/dashboard/src/components/compare/compare-peer-select.tsx
@@ -1,0 +1,151 @@
+import { Check, ChevronsUpDown } from 'lucide-react'
+
+import type { ComparePeer } from '@/lib/compare/scope'
+
+import { useMemo, useState } from 'react'
+import { HostMenuRow } from '@/components/host/host-menu-row'
+import { HostVersionWithStatus } from '@/components/host/host-version-status'
+import { ChmonitorLogo } from '@/components/icons/chmonitor-logo'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { isServerHost, useMergedHosts } from '@/lib/swr/use-merged-hosts'
+import { cn } from '@/lib/utils'
+
+interface ComparePeerSelectProps {
+  label: string
+  testId: string
+  value: number
+  hosts: ComparePeer[]
+  onChange: (next: number) => void
+}
+
+export function ComparePeerSelect({
+  label,
+  testId,
+  value,
+  hosts,
+  onChange,
+}: ComparePeerSelectProps) {
+  const [open, setOpen] = useState(false)
+  const { hosts: merged } = useMergedHosts()
+  const selected = hosts.find((h) => h.id === value) ?? hosts[0]
+  const mergedSelected = merged.find((h) => h.id === value)
+  const showLiveStatus = Boolean(
+    mergedSelected && isServerHost(mergedSelected.source)
+  )
+
+  const sorted = useMemo(
+    () => [...hosts].sort((a, b) => a.name.localeCompare(b.name)),
+    [hosts]
+  )
+
+  return (
+    <label className="flex min-w-56 flex-1 flex-col gap-1">
+      <span className="text-[11px] font-medium text-muted-foreground">
+        {label}
+      </span>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={open}
+              data-testid={testId}
+              className="h-auto min-h-11 w-full justify-start gap-2 px-2.5 py-1.5 font-normal"
+            />
+          }
+        >
+          <ChmonitorLogo width={20} height={20} className="size-5 shrink-0" />
+          <span className="grid min-w-0 flex-1 text-left leading-tight">
+            <span className="truncate text-[13px] font-medium">
+              {selected?.name ?? ''}
+            </span>
+            {showLiveStatus && selected ? (
+              <HostVersionWithStatus hostId={selected.id} />
+            ) : (
+              <span className="truncate text-xs text-muted-foreground">
+                {mergedSelected?.source === 'database'
+                  ? 'Saved to server'
+                  : mergedSelected?.source === 'browser'
+                    ? 'Saved in browser'
+                    : 'Connection'}
+              </span>
+            )}
+          </span>
+          <ChevronsUpDown className="ml-auto size-3.5 shrink-0 opacity-50" />
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-(--anchor-width) min-w-64 p-0"
+        >
+          <Command>
+            <CommandInput placeholder="Search hosts…" className="h-9" />
+            <CommandList className="max-h-72">
+              <CommandEmpty>No host found.</CommandEmpty>
+              <CommandGroup>
+                {sorted.map((host) => {
+                  const mergedHost = merged.find((h) => h.id === host.id)
+                  const live = Boolean(
+                    mergedHost && isServerHost(mergedHost.source)
+                  )
+                  return (
+                    <CommandItem
+                      key={host.id}
+                      value={`${host.name} ${host.id}`}
+                      onSelect={() => {
+                        onChange(host.id)
+                        setOpen(false)
+                      }}
+                      className="gap-2 p-2"
+                    >
+                      <ChmonitorLogo
+                        width={16}
+                        height={16}
+                        className="size-4 shrink-0"
+                      />
+                      {live ? (
+                        <div className="min-w-0 flex-1">
+                          <HostMenuRow
+                            hostId={host.id}
+                            hostName={host.name}
+                            isActive={host.id === value}
+                          />
+                        </div>
+                      ) : (
+                        <>
+                          <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                            {host.name}
+                          </span>
+                          <Check
+                            className={cn(
+                              'size-4 shrink-0 text-muted-foreground',
+                              host.id === value ? 'opacity-100' : 'opacity-0'
+                            )}
+                          />
+                        </>
+                      )}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </label>
+  )
+}

--- a/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
+++ b/apps/dashboard/src/components/compare/compare-scope-toggle.tsx
@@ -19,7 +19,7 @@ export function CompareScopeToggle({
 
   return (
     <SegmentedControl
-      size="default"
+      size="sm"
       ariaLabel="Compare saved connections or replica nodes"
       value={value}
       onChange={(next) => {

--- a/apps/dashboard/src/components/compare/compare-toolbar.tsx
+++ b/apps/dashboard/src/components/compare/compare-toolbar.tsx
@@ -17,7 +17,7 @@ export function CompareToolbar({
   return (
     <div
       className={cn(
-        'flex flex-col gap-4 rounded-xl border bg-card p-4 shadow-sm',
+        'flex flex-col gap-3 rounded-xl border bg-card p-3 shadow-sm',
         className
       )}
     >

--- a/apps/dashboard/src/components/compare/host-pair-filter.tsx
+++ b/apps/dashboard/src/components/compare/host-pair-filter.tsx
@@ -3,26 +3,20 @@ import { ArrowRightIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 import type { ComparePeer } from '@/lib/compare/scope'
 
+import { ComparePeerSelect } from './compare-peer-select'
 import { SegmentedControl } from '@/components/filters/segmented-control'
 import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 
 interface HostPairFilterProps {
   hosts: ComparePeer[]
   sourceHostId: number
   targetHostId: number
-  nameFilter: string
+  nameFilter?: string
   nameFilterPlaceholder?: string
   showDiffsOnly: boolean
   diffsOnlyLabel?: string
   onPairChange: (source: number, target: number) => void
-  onNameFilterChange: (value: string) => void
+  onNameFilterChange?: (value: string) => void
   onShowDiffsOnlyChange: (value: boolean) => void
   extraFilters?: ReactNode
 }
@@ -39,17 +33,14 @@ export function HostPairFilter({
   onShowDiffsOnlyChange,
   extraFilters,
 }: HostPairFilterProps) {
-  const hostItems = Object.fromEntries(hosts.map((h) => [String(h.id), h.name]))
-
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-end gap-3">
-        <PeerSelect
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <ComparePeerSelect
           label="Source"
           testId="compare-source"
           value={sourceHostId}
           hosts={hosts}
-          items={hostItems}
           onChange={(next) => {
             const nextTarget =
               next === targetHostId ? sourceHostId : targetHostId
@@ -57,37 +48,38 @@ export function HostPairFilter({
           }}
         />
         <ArrowRightIcon
-          className="mb-2 hidden size-4 shrink-0 text-muted-foreground sm:block"
+          className="mb-3 hidden size-4 shrink-0 text-muted-foreground sm:block"
           strokeWidth={1.5}
           aria-hidden
         />
-        <PeerSelect
+        <ComparePeerSelect
           label="Target"
           testId="compare-target"
           value={targetHostId}
           hosts={hosts}
-          items={hostItems}
           onChange={(next) => {
             const nextSource =
               next === sourceHostId ? targetHostId : sourceHostId
             onPairChange(nextSource, next)
           }}
         />
-        <label className="flex min-w-48 flex-1 flex-col gap-1.5 sm:max-w-72">
-          <span className="text-xs font-medium text-muted-foreground">
-            Filter
-          </span>
-          <Input
-            placeholder={nameFilterPlaceholder}
-            value={nameFilter}
-            onChange={(e) => onNameFilterChange(e.target.value)}
-            className="h-9"
-          />
-        </label>
+        {onNameFilterChange ? (
+          <label className="flex min-w-48 flex-1 flex-col gap-1 sm:max-w-72">
+            <span className="text-[11px] font-medium text-muted-foreground">
+              Filter
+            </span>
+            <Input
+              placeholder={nameFilterPlaceholder}
+              value={nameFilter ?? ''}
+              onChange={(e) => onNameFilterChange(e.target.value)}
+              className="h-11"
+            />
+          </label>
+        ) : null}
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <SegmentedControl
-          size="default"
+          size="sm"
           ariaLabel="Show differences or all rows"
           value={showDiffsOnly ? 'diffs' : 'all'}
           onChange={(next) => onShowDiffsOnlyChange(next === 'diffs')}
@@ -99,49 +91,5 @@ export function HostPairFilter({
         {extraFilters}
       </div>
     </div>
-  )
-}
-
-function PeerSelect({
-  label,
-  testId,
-  value,
-  hosts,
-  items,
-  onChange,
-}: {
-  label: string
-  testId: string
-  value: number
-  hosts: ComparePeer[]
-  items: Record<string, string>
-  onChange: (next: number) => void
-}) {
-  return (
-    <label className="flex min-w-48 flex-col gap-1.5">
-      <span className="text-xs font-medium text-muted-foreground">{label}</span>
-      <Select
-        value={String(value)}
-        items={items}
-        onValueChange={(next) => {
-          if (next == null) return
-          onChange(Number(next))
-        }}
-      >
-        <SelectTrigger
-          className="h-9 min-w-48 text-[13px] font-medium"
-          data-testid={testId}
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {hosts.map((h) => (
-            <SelectItem key={h.id} value={String(h.id)}>
-              {h.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </label>
   )
 }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -26,6 +26,28 @@ mock.module('@/components/connections', () => ({
     open ? <div data-testid="add-host-dialog">Add host dialog</div> : null,
 }))
 
+mock.module('@/lib/swr/use-merged-hosts', () => ({
+  useMergedHosts: () => ({
+    hosts: [],
+    error: null,
+    isUnauthorized: false,
+    isLoading: false,
+    getConnectionByHostId: () => undefined,
+    cloudMode: false,
+    isSignedIn: false,
+  }),
+  isServerHost: (source: string) => source === 'env' || source === 'demo',
+}))
+
+mock.module('@/lib/swr/use-host-status', () => ({
+  useHostStatus: () => ({
+    data: null,
+    error: null,
+    isLoading: false,
+    isOnline: false,
+  }),
+}))
+
 beforeAll(() => {
   GlobalRegistrator.register()
   ;(
@@ -265,7 +287,13 @@ describe('Schema Compare one-host empty state', () => {
       expect(document.body.textContent).toContain('Need two saved connections')
       expect(document.body.textContent).toContain('staging vs prod')
       expect(document.body.textContent).toContain('Example')
-      expect(document.body.textContent).toContain('analytics.events')
+      expect(
+        document.querySelector(
+          '[data-testid="schema-diff-table-analytics.events"]'
+        )
+      ).not.toBeNull()
+      expect(document.body.textContent).toContain('analytics')
+      expect(document.body.textContent).toContain('events')
       expect(document.body.textContent).toContain('Source DDL')
       const faded = document.querySelector(
         '[data-testid="compare-example-preview"]'
@@ -347,7 +375,11 @@ describe('Schema Compare two-host path', () => {
     try {
       expect(document.body.textContent).toContain('staging')
       expect(document.body.textContent).toContain('production')
-      expect(document.body.textContent).toContain('app.events')
+      expect(document.body.textContent).toContain('app')
+      expect(document.body.textContent).toContain('events')
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.events"]')
+      ).not.toBeNull()
       expect(document.body.textContent).not.toContain('Host A')
       expect(document.body.textContent).not.toMatch(
         /Comparing .+ tables differ/
@@ -396,15 +428,15 @@ describe('Schema Compare two-host path', () => {
 
     try {
       const sourceValue = document.querySelector(
-        '[data-testid="compare-source"] [data-slot="select-value"]'
+        '[data-testid="compare-source"]'
       )
       const targetValue = document.querySelector(
-        '[data-testid="compare-target"] [data-slot="select-value"]'
+        '[data-testid="compare-target"]'
       )
-      expect(sourceValue?.textContent).toBe('staging')
-      expect(targetValue?.textContent).toBe('production')
-      expect(sourceValue?.textContent).not.toBe('0')
-      expect(targetValue?.textContent).not.toBe('1')
+      expect(sourceValue?.textContent).toContain('staging')
+      expect(targetValue?.textContent).toContain('production')
+      expect(sourceValue?.textContent).not.toMatch(/^0/)
+      expect(targetValue?.textContent).not.toMatch(/^1/)
     } finally {
       await cleanup()
     }
@@ -428,8 +460,17 @@ describe('Schema Compare two-host path', () => {
     )
 
     try {
-      expect(document.body.textContent).toContain('app.events')
-      expect(document.body.textContent).toContain('app.users')
+      expect(
+        document.querySelector('[data-testid="schema-diff-db-app"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.events"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.users"]')
+      ).not.toBeNull()
+      expect(document.body.textContent).toContain('events')
+      expect(document.body.textContent).toContain('users')
       expect(document.body.textContent).toContain('All matched')
       expect(document.body.textContent).toContain('Source DDL')
       expect(
@@ -450,8 +491,8 @@ describe('Schema Compare two-host path', () => {
       )
 
       const { act } = await import('react')
-      const users = [...document.querySelectorAll('button')].find((el) =>
-        el.textContent?.includes('app.users')
+      const users = document.querySelector(
+        '[data-testid="schema-diff-table-app.users"]'
       ) as HTMLButtonElement
       expect(users).not.toBeNull()
       await act(async () => {

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -110,11 +110,8 @@ export function SchemaDiffView({
           hosts={peers}
           sourceHostId={sourceId}
           targetHostId={targetId}
-          nameFilter={nameFilter}
-          nameFilterPlaceholder={nameFilterPlaceholder}
           showDiffsOnly={showDiffsOnly}
           onPairChange={onPairChange}
-          onNameFilterChange={setNameFilter}
           onShowDiffsOnlyChange={setShowDiffsOnly}
           extraFilters={
             <TooltipProvider>
@@ -155,6 +152,9 @@ export function SchemaDiffView({
               selectedKey={selected?.key ?? null}
               onSelect={setSelectedKey}
               example={example}
+              nameFilter={nameFilter}
+              onNameFilterChange={setNameFilter}
+              nameFilterPlaceholder={nameFilterPlaceholder}
               onCollapse={() => setSidebarOpen(false)}
             />
           </div>

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -1,12 +1,25 @@
-import { CheckCircle2Icon, PanelLeftCloseIcon } from 'lucide-react'
+import {
+  CheckCircle2Icon,
+  ChevronRightIcon,
+  DatabaseIcon,
+  PanelLeftCloseIcon,
+  SearchIcon,
+} from 'lucide-react'
 
-import type { EmptyStateVariant } from '@/components/ui/empty-state'
 import type { TableDiff } from '@/lib/schema-diff'
 
+import { useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
+import { groupDiffsByDatabase, tableNameOf } from '@/lib/schema-diff/group'
 import { cn } from '@/lib/utils'
 
 interface TableListProps {
@@ -14,10 +27,9 @@ interface TableListProps {
   selectedKey: string | null
   onSelect: (key: string) => void
   example?: boolean
-  emptyTitle?: string
-  emptyDescription?: string
-  emptyVariant?: EmptyStateVariant
-  emptyCompact?: boolean
+  nameFilter?: string
+  onNameFilterChange?: (value: string) => void
+  nameFilterPlaceholder?: string
   onCollapse?: () => void
 }
 
@@ -28,99 +40,175 @@ function kindLabel(kind: TableDiff['kind']): string {
   return 'same'
 }
 
+function KindMark({ row, example }: { row: TableDiff; example: boolean }) {
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {example ? (
+        <Badge variant="secondary" className="font-normal text-[10px]">
+          Example
+        </Badge>
+      ) : null}
+      {row.kind === 'identical' ? (
+        <CheckCircle2Icon
+          className="size-3.5 text-[var(--chart-green)]"
+          strokeWidth={1.5}
+          aria-label="matched"
+          data-testid="schema-diff-matched-icon"
+        />
+      ) : (
+        <Badge variant="outline" className="text-muted-foreground">
+          {kindLabel(row.kind)}
+        </Badge>
+      )}
+    </span>
+  )
+}
+
 export function TableList({
   rows,
   selectedKey,
   onSelect,
   example = false,
-  emptyTitle = 'No tables match',
-  emptyDescription = 'Try a different filter or switch to All.',
-  emptyVariant = 'filtered-empty',
-  emptyCompact = true,
+  nameFilter = '',
+  onNameFilterChange,
+  nameFilterPlaceholder = 'Filter tables…',
   onCollapse,
 }: TableListProps) {
+  const groups = useMemo(() => groupDiffsByDatabase(rows), [rows])
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+  const filtering = nameFilter.trim().length > 0
+
   return (
     <Card
       className="gap-0 rounded-xl border bg-card py-0 shadow-sm"
       data-testid="schema-diff-table-list"
     >
-      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
-        <h2 className="text-sm font-medium text-foreground">
-          Tables
-          {rows.length > 0 ? (
-            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-              {rows.length}
-            </span>
+      <div className="flex flex-col gap-2 border-b border-border px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-sm font-medium text-foreground">
+            Tables
+            {rows.length > 0 ? (
+              <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                {rows.length}
+              </span>
+            ) : null}
+          </h2>
+          {onCollapse ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={onCollapse}
+              className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="Hide table list"
+              data-testid="schema-diff-sidebar-collapse"
+            >
+              <PanelLeftCloseIcon className="size-3.5" strokeWidth={1.5} />
+            </Button>
           ) : null}
-        </h2>
-        {onCollapse ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onCollapse}
-            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
-            aria-label="Hide table list"
-            data-testid="schema-diff-sidebar-collapse"
-          >
-            <PanelLeftCloseIcon className="size-3.5" strokeWidth={1.5} />
-          </Button>
+        </div>
+        {onNameFilterChange ? (
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={nameFilter}
+              onChange={(e) => onNameFilterChange(e.target.value)}
+              placeholder={nameFilterPlaceholder}
+              className="h-8 pl-7 text-[13px]"
+            />
+          </div>
         ) : null}
       </div>
       <CardContent className="p-0">
-        <ul className="max-h-[min(36rem,70vh)] divide-y divide-border overflow-y-auto">
-          {rows.length === 0 ? (
-            <li className="p-4">
-              <EmptyState
-                variant={emptyVariant}
-                compact={emptyCompact}
-                title={emptyTitle}
-                description={emptyDescription}
-              />
-            </li>
-          ) : (
-            rows.map((row) => (
-              <li key={row.key}>
-                <button
-                  type="button"
-                  className={cn(
-                    'flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[13px] hover:bg-muted',
-                    selectedKey === row.key && 'bg-muted'
-                  )}
-                  aria-current={selectedKey === row.key ? 'true' : undefined}
-                  onClick={() => onSelect(row.key)}
+        {rows.length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              variant="filtered-empty"
+              compact
+              title="No tables match"
+              description="Try a different filter or switch to All."
+            />
+          </div>
+        ) : (
+          <div
+            className="max-h-[min(36rem,70vh)] overflow-y-auto py-1"
+            role="tree"
+            aria-label="Tables by database"
+          >
+            {groups.map((group) => {
+              const open = filtering || !collapsed.has(group.database)
+              return (
+                <Collapsible
+                  key={group.database}
+                  open={open}
+                  onOpenChange={(next) => {
+                    setCollapsed((prev) => {
+                      const copy = new Set(prev)
+                      if (next) copy.delete(group.database)
+                      else copy.add(group.database)
+                      return copy
+                    })
+                  }}
                 >
-                  <span className="truncate font-mono">{row.key}</span>
-                  <span className="flex shrink-0 items-center gap-1">
-                    {example ? (
-                      <Badge
-                        variant="secondary"
-                        className="font-normal text-[10px]"
-                      >
-                        Example
-                      </Badge>
-                    ) : null}
-                    {row.kind === 'identical' ? (
-                      <CheckCircle2Icon
-                        className="size-3.5 text-[var(--chart-green)]"
-                        strokeWidth={1.5}
-                        aria-label="matched"
-                        data-testid="schema-diff-matched-icon"
+                  <CollapsibleTrigger
+                    render={
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[13px] font-medium hover:bg-muted"
+                        data-testid={`schema-diff-db-${group.database}`}
                       />
-                    ) : (
-                      <Badge
-                        variant="outline"
-                        className="text-muted-foreground"
-                      >
-                        {kindLabel(row.kind)}
-                      </Badge>
-                    )}
-                  </span>
-                </button>
-              </li>
-            ))
-          )}
-        </ul>
+                    }
+                  >
+                    <ChevronRightIcon
+                      className={cn(
+                        'size-3.5 shrink-0 text-muted-foreground transition-transform',
+                        open && 'rotate-90'
+                      )}
+                      strokeWidth={1.5}
+                    />
+                    <DatabaseIcon
+                      className="size-3.5 shrink-0 text-muted-foreground"
+                      strokeWidth={1.5}
+                    />
+                    <span className="min-w-0 truncate">{group.database}</span>
+                    <span className="ml-auto text-xs font-normal text-muted-foreground">
+                      {group.tables.length}
+                    </span>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <ul>
+                      {group.tables.map((row) => {
+                        const table = tableNameOf(row)
+                        return (
+                          <li key={row.key}>
+                            <button
+                              type="button"
+                              className={cn(
+                                'flex w-full items-center justify-between gap-2 py-1 pr-2 pl-7 text-left text-[13px] hover:bg-muted',
+                                selectedKey === row.key && 'bg-muted'
+                              )}
+                              aria-current={
+                                selectedKey === row.key ? 'true' : undefined
+                              }
+                              aria-label={row.key}
+                              data-testid={`schema-diff-table-${row.key}`}
+                              onClick={() => onSelect(row.key)}
+                            >
+                              <span className="truncate font-mono">
+                                {table}
+                              </span>
+                              <KindMark row={row} example={example} />
+                            </button>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </CollapsibleContent>
+                </Collapsible>
+              )
+            })}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/dashboard/src/lib/schema-diff/group.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/group.test.ts
@@ -1,0 +1,49 @@
+import { assembleCatalog } from './catalog'
+import { compareCatalogs } from './compare'
+import { groupDiffsByDatabase, tableNameOf } from './group'
+import { describe, expect, test } from 'bun:test'
+
+describe('groupDiffsByDatabase', () => {
+  test('nests tables under a sorted database folder', () => {
+    const catalog = assembleCatalog(
+      [
+        {
+          database: 'zeta',
+          table: 'b',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE zeta.b (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+        {
+          database: 'app',
+          table: 'users',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+        {
+          database: 'app',
+          table: 'events',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+      ],
+      []
+    )
+    const diff = compareCatalogs(catalog, catalog)
+    const groups = groupDiffsByDatabase(diff.identical)
+    expect(groups.map((g) => g.database)).toEqual(['app', 'zeta'])
+    expect(groups[0].tables.map(tableNameOf)).toEqual(['events', 'users'])
+    expect(groups[1].tables.map(tableNameOf)).toEqual(['b'])
+  })
+})

--- a/apps/dashboard/src/lib/schema-diff/group.ts
+++ b/apps/dashboard/src/lib/schema-diff/group.ts
@@ -1,0 +1,39 @@
+import type { TableDiff } from './types'
+
+export function tableNameOf(row: TableDiff): string {
+  return row.source?.table ?? row.target?.table ?? lastSegment(row.key)
+}
+
+export function databaseNameOf(row: TableDiff): string {
+  return row.source?.database ?? row.target?.database ?? firstSegment(row.key)
+}
+
+function firstSegment(key: string): string {
+  const i = key.indexOf('.')
+  return i === -1 ? key : key.slice(0, i)
+}
+
+function lastSegment(key: string): string {
+  const i = key.indexOf('.')
+  return i === -1 ? key : key.slice(i + 1)
+}
+
+export function groupDiffsByDatabase(
+  rows: TableDiff[]
+): { database: string; tables: TableDiff[] }[] {
+  const map = new Map<string, TableDiff[]>()
+  for (const row of rows) {
+    const database = databaseNameOf(row)
+    const list = map.get(database)
+    if (list) list.push(row)
+    else map.set(database, [row])
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([database, tables]) => ({
+      database,
+      tables: [...tables].sort((a, b) =>
+        tableNameOf(a).localeCompare(tableNameOf(b))
+      ),
+    }))
+}

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -666,13 +666,16 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   `DdlPair` with placeholder names. Two or more peers keep a **static**
   PageHeader (title + recommend-only description) — do not add a dynamic
   "Comparing X → Y — N tables differ" sentence; the pair is the Source /
-  Target selects. Toolbar is `CompareToolbar` (`p-4` card): Connections /
-  Replica nodes tabs, then stacked Source / Target (peer name) + Filter,
-  then Differences / All. Scope toggle (only when both hostCount and
+  Target comboboxes. Toolbar is compact `CompareToolbar` (`p-3` card):
+  Connections / Replica nodes tabs (`size="sm"`), then Source / Target
+  searchable comboboxes (`ComparePeerSelect`, sorted by name,
+  `ChmonitorLogo` + version/uptime/status like HostSwitcher), then
+  Differences / All. Scope toggle (only when both hostCount and
   nodeCount are ≥ 2) writes `?scope=hosts|nodes` and remounts the pair
   from that peer list.
-  The table catalog is a collapsible left sidebar (`TableList` +
-  `PanelLeftClose` / `PanelLeft`). Differences-only with zero diffs
+  The table catalog is a collapsible left sidebar grouped
+  database → table (`TableList` + `PanelLeftClose` / `PanelLeft`,
+  search in the sidebar). Differences-only with zero diffs
   still lists identical tables with a green `CheckCircle2`
   (`--chart-green`); clicking a row selects it on the right. A
   matching table's detail is **All matched** / **This table matches**


### PR DESCRIPTION
## Summary

Schema Compare sidebar is now a database → table tree instead of a flat `db.table` list. The toolbar is denser, and Source/Target are searchable sorted comboboxes with logo plus host status like Host Switcher.

## Changes

- Table list groups by database (collapsible folder + nested table name, search in the sidebar)
- `ComparePeerSelect` replaces native Select: Command + Popover, sorted by name, `ChmonitorLogo`, version/uptime/status
- Compact `CompareToolbar` (`p-3`) and `size="sm"` segmented tabs
- Product-design skill + knowledge doc updated
- Tests for grouping, click-to-select, and combobox labels

## Test plan

- [x] Schema Compare + group unit tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Settings Diff pair mode shares `HostPairFilter`, so it gets the same host combobox.

---

Co-Authored-By: duyetbot <bot@duyet.net>