### PR TITLE
fix(compare): keep the name filter on the listing panel

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -116,7 +116,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   table matches** (`MatchOk`), never EmptyState "no data" or
   "Select a table". Keep "No tables match" only for a name-filter
   miss.
-  Settings Diff (`/settings-diff`) uses the same toolbar. Diffs-only
+  Settings Diff (`/settings-diff`) uses the same toolbar. The name
+  filter sits on the listing panel (schema-diff table sidebar,
+  settings-diff table card) — not next to Source/Target. Diffs-only
   with zero deltas still lists matching settings, each with a green
   `CheckCircle2` in a Match column (`--chart-green`). "Changed from
   default" is a pressable chip, not a second switch. "No settings

--- a/apps/dashboard/src/components/compare/host-pair-filter.tsx
+++ b/apps/dashboard/src/components/compare/host-pair-filter.tsx
@@ -5,18 +5,14 @@ import type { ComparePeer } from '@/lib/compare/scope'
 
 import { ComparePeerSelect } from './compare-peer-select'
 import { SegmentedControl } from '@/components/filters/segmented-control'
-import { Input } from '@/components/ui/input'
 
 interface HostPairFilterProps {
   hosts: ComparePeer[]
   sourceHostId: number
   targetHostId: number
-  nameFilter?: string
-  nameFilterPlaceholder?: string
   showDiffsOnly: boolean
   diffsOnlyLabel?: string
   onPairChange: (source: number, target: number) => void
-  onNameFilterChange?: (value: string) => void
   onShowDiffsOnlyChange: (value: boolean) => void
   extraFilters?: ReactNode
 }
@@ -25,11 +21,8 @@ export function HostPairFilter({
   hosts,
   sourceHostId,
   targetHostId,
-  nameFilter,
-  nameFilterPlaceholder = 'Filter tables…',
   showDiffsOnly,
   onPairChange,
-  onNameFilterChange,
   onShowDiffsOnlyChange,
   extraFilters,
 }: HostPairFilterProps) {
@@ -63,19 +56,6 @@ export function HostPairFilter({
             onPairChange(nextSource, next)
           }}
         />
-        {onNameFilterChange ? (
-          <label className="flex min-w-48 flex-1 flex-col gap-1 sm:max-w-72">
-            <span className="text-[11px] font-medium text-muted-foreground">
-              Filter
-            </span>
-            <Input
-              placeholder={nameFilterPlaceholder}
-              value={nameFilter ?? ''}
-              onChange={(e) => onNameFilterChange(e.target.value)}
-              className="h-11"
-            />
-          </label>
-        ) : null}
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <SegmentedControl

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -571,10 +571,15 @@ describe('Schema Compare two-host path', () => {
     )
 
     try {
-      const input = document.querySelector(
-        'input[placeholder="Filter tables…"]'
+      const list = document.querySelector(
+        '[data-testid="schema-diff-table-list"]'
+      )
+      expect(list).not.toBeNull()
+      const input = list?.querySelector(
+        '[data-testid="schema-diff-table-filter"]'
       ) as HTMLInputElement
       expect(input).not.toBeNull()
+      expect(input.placeholder).toBe('Filter tables…')
       await setInputValue(input, 'no-such-table')
       expect(document.body.textContent).toContain('No tables match')
       expect(document.body.textContent).not.toContain('Schemas match')

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -115,6 +115,7 @@ export function TableList({
               onChange={(e) => onNameFilterChange(e.target.value)}
               placeholder={nameFilterPlaceholder}
               className="h-8 pl-7 text-[13px]"
+              data-testid="schema-diff-table-filter"
             />
           </div>
         ) : null}

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
@@ -278,10 +278,21 @@ describe('Settings Diff matching rows', () => {
     const { SettingsDiffTable } = await import('./settings-diff-table')
 
     const { cleanup } = await renderInto(
-      <SettingsDiffTable columns={[{ id: 0, name: 'prod' }]} rows={[]} />
+      <SettingsDiffTable
+        columns={[{ id: 0, name: 'prod' }]}
+        rows={[]}
+        nameFilter="no-such"
+        onNameFilterChange={() => {}}
+      />
     )
 
     try {
+      const table = document.querySelector(
+        '[data-testid="settings-diff-table"]'
+      )
+      expect(
+        table?.querySelector('[data-testid="settings-diff-table-filter"]')
+      ).not.toBeNull()
       expect(document.body.textContent).toContain('No settings match')
       expect(document.body.textContent).not.toContain('All matched')
     } finally {

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -20,7 +20,6 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
-import { Input } from '@/components/ui/input'
 import {
   collectBrowserDiffSessions,
   fetchCompareDiff,
@@ -267,8 +266,6 @@ export function SettingsDiffPage() {
             hosts={peers}
             sourceHostId={pair.sourceId}
             targetHostId={pair.targetId}
-            nameFilter={nameFilter}
-            nameFilterPlaceholder="Filter by name…"
             showDiffsOnly={showDiffsOnly}
             onPairChange={(source, target) =>
               setSearch({
@@ -278,7 +275,6 @@ export function SettingsDiffPage() {
                 view: scope === 'hosts' ? 'pair' : undefined,
               })
             }
-            onNameFilterChange={setNameFilter}
             onShowDiffsOnlyChange={setShowDiffsOnly}
             extraFilters={
               <ChangedFromDefaultChip
@@ -288,41 +284,33 @@ export function SettingsDiffPage() {
             }
           />
         ) : (
-          <div className="flex flex-col gap-4">
-            <label className="flex min-w-48 max-w-72 flex-col gap-1.5">
-              <span className="text-xs font-medium text-muted-foreground">
-                Filter
-              </span>
-              <Input
-                placeholder="Filter by name…"
-                value={nameFilter}
-                onChange={(e) => setNameFilter(e.target.value)}
-                className="h-9"
+          <div className="flex flex-wrap items-center gap-2">
+            {hostCount > 1 ? (
+              <SegmentedControl
+                size="sm"
+                ariaLabel="Show differences or all rows"
+                value={showDiffsOnly ? 'diffs' : 'all'}
+                onChange={(next) => setShowDiffsOnly(next === 'diffs')}
+                options={[
+                  { label: 'Differences', value: 'diffs' },
+                  { label: 'All', value: 'all' },
+                ]}
               />
-            </label>
-            <div className="flex flex-wrap items-center gap-2">
-              {hostCount > 1 ? (
-                <SegmentedControl
-                  size="default"
-                  ariaLabel="Show differences or all rows"
-                  value={showDiffsOnly ? 'diffs' : 'all'}
-                  onChange={(next) => setShowDiffsOnly(next === 'diffs')}
-                  options={[
-                    { label: 'Differences', value: 'diffs' },
-                    { label: 'All', value: 'all' },
-                  ]}
-                />
-              ) : null}
-              <ChangedFromDefaultChip
-                pressed={showChangedOnly}
-                onPressedChange={setShowChangedOnly}
-              />
-            </div>
+            ) : null}
+            <ChangedFromDefaultChip
+              pressed={showChangedOnly}
+              onPressedChange={setShowChangedOnly}
+            />
           </div>
         )}
       </CompareToolbar>
 
-      <SettingsDiffTable columns={columns} rows={filteredRows} />
+      <SettingsDiffTable
+        columns={columns}
+        rows={filteredRows}
+        nameFilter={nameFilter}
+        onNameFilterChange={setNameFilter}
+      />
 
       <p className="text-xs text-muted-foreground">
         {filteredRows.length.toLocaleString()} row

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -1,5 +1,5 @@
 import { DownloadIcon } from '@radix-ui/react-icons'
-import { CheckCircle2Icon } from 'lucide-react'
+import { CheckCircle2Icon, SearchIcon } from 'lucide-react'
 
 import type {
   SettingsDiffHostInfo,
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { EmptyState } from '@/components/ui/empty-state'
+import { Input } from '@/components/ui/input'
 import {
   Table,
   TableBody,
@@ -65,14 +66,37 @@ export function exportSettingsCsv(
 interface SettingsDiffTableProps {
   columns: SettingsDiffHostInfo[]
   rows: SettingsDiffRow[]
+  nameFilter?: string
+  onNameFilterChange?: (value: string) => void
+  nameFilterPlaceholder?: string
 }
 
-export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
+export function SettingsDiffTable({
+  columns,
+  rows,
+  nameFilter,
+  onNameFilterChange,
+  nameFilterPlaceholder = 'Filter by name…',
+}: SettingsDiffTableProps) {
   const showMatchColumn = columns.length > 1
   const colSpan = (showMatchColumn ? 4 : 3) + columns.length
 
   return (
-    <Card>
+    <Card data-testid="settings-diff-table">
+      {onNameFilterChange ? (
+        <div className="border-b border-border px-3 py-2">
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={nameFilter ?? ''}
+              onChange={(e) => onNameFilterChange(e.target.value)}
+              placeholder={nameFilterPlaceholder}
+              className="h-8 pl-7 text-[13px]"
+              data-testid="settings-diff-table-filter"
+            />
+          </div>
+        </div>
+      ) : null}
       <CardContent className="p-0">
         <div className="overflow-x-auto">
           <Table>

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -685,7 +685,9 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   with one host keeps the live vs-default matrix and a banner to add
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair
-  mode (`HostPairFilter` + URL `source`/`target`). Diffs-only with zero
+  mode (`HostPairFilter` + URL `source`/`target`). Name filter lives
+  on the listing panel (schema-diff sidebar, settings-diff table),
+  not the host toolbar. Diffs-only with zero
   deltas still lists matching settings with a green `CheckCircle2` in
   a Match column (`--chart-green`); "No settings match" is only a
   name/changed-from-default filter miss. Compare APIs resolve


### PR DESCRIPTION
## Summary

The table/name filter sits on the listing panel: Schema Compare search is in the Tables sidebar, Settings Diff search is on the table card. It is no longer next to Source/Target.

## Changes

- Removed the Filter field from `HostPairFilter`
- Settings Diff name search is on `SettingsDiffTable`
- Schema Compare filter stays in `TableList` (`data-testid="schema-diff-table-filter"`)
- Tests assert the filter is inside the listing panel

## Test plan

- [x] Schema Compare + Settings Diff unit tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

---

Co-Authored-By: duyetbot <bot@duyet.net>