### PR TITLE
fix(schema-diff): move diffs filter and sort onto the table sidebar

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -106,13 +106,15 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   **Replica nodes**, `SegmentedControl size="sm"`), then Source /
   Target searchable comboboxes (`ComparePeerSelect`: Command +
   Popover, sorted by name, `ChmonitorLogo` plus version/uptime/status
-  like HostSwitcher — never a native Select), then **Differences** /
-  **All**. Copy recommended SQL sits on that row. The table catalog
-  is a collapsible left sidebar grouped **database → table** (folder
-  row + nested table name, search in the sidebar). When Differences
-  is on and there are no diffs, still list identical tables with a
-  green `CheckCircle2` (`--chart-green`) — click a row to select it
-  on the right. A matching selection is **All matched** / **This
+  like HostSwitcher — never a native Select). Copy recommended SQL
+  sits on that row. The table catalog is a collapsible left sidebar
+  grouped **database → table** (folder row + nested table name).
+  Search, **Differences / All** (icon-only `GitCompareArrows` /
+  `List`), and sort (icon-only `ArrowDownAZ` menu: A–Z, Z–A,
+  differences first) live on that sidebar — not the host toolbar.
+  When Differences is on and there are no diffs, still list identical
+  tables with a green `CheckCircle2` (`--chart-green`) — click a row
+  to select it on the right. A matching selection is **All matched** / **This
   table matches** (`MatchOk`), never EmptyState "no data" or
   "Select a table". Keep "No tables match" only for a name-filter
   miss.

--- a/apps/dashboard/src/components/compare/host-pair-filter.tsx
+++ b/apps/dashboard/src/components/compare/host-pair-filter.tsx
@@ -10,10 +10,10 @@ interface HostPairFilterProps {
   hosts: ComparePeer[]
   sourceHostId: number
   targetHostId: number
-  showDiffsOnly: boolean
+  showDiffsOnly?: boolean
   diffsOnlyLabel?: string
   onPairChange: (source: number, target: number) => void
-  onShowDiffsOnlyChange: (value: boolean) => void
+  onShowDiffsOnlyChange?: (value: boolean) => void
   extraFilters?: ReactNode
 }
 
@@ -26,6 +26,9 @@ export function HostPairFilter({
   onShowDiffsOnlyChange,
   extraFilters,
 }: HostPairFilterProps) {
+  const showDiffsToggle =
+    showDiffsOnly !== undefined && onShowDiffsOnlyChange !== undefined
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-end gap-2">
@@ -57,19 +60,23 @@ export function HostPairFilter({
           }}
         />
       </div>
-      <div className="flex flex-wrap items-center gap-2">
-        <SegmentedControl
-          size="sm"
-          ariaLabel="Show differences or all rows"
-          value={showDiffsOnly ? 'diffs' : 'all'}
-          onChange={(next) => onShowDiffsOnlyChange(next === 'diffs')}
-          options={[
-            { label: 'Differences', value: 'diffs' },
-            { label: 'All', value: 'all' },
-          ]}
-        />
-        {extraFilters}
-      </div>
+      {showDiffsToggle || extraFilters ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {showDiffsToggle ? (
+            <SegmentedControl
+              size="sm"
+              ariaLabel="Show differences or all rows"
+              value={showDiffsOnly ? 'diffs' : 'all'}
+              onChange={(next) => onShowDiffsOnlyChange(next === 'diffs')}
+              options={[
+                { label: 'Differences', value: 'diffs' },
+                { label: 'All', value: 'all' },
+              ]}
+            />
+          ) : null}
+          {extraFilters}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -223,6 +223,19 @@ function matchingHostPayload(): SchemaDiffResponse {
   }
 }
 
+function mixedHostPayload(): SchemaDiffResponse {
+  const changed = twoHostPayload()
+  const matching = matchingHostPayload()
+  const users = matching.diff.identical.find((row) => row.key === 'app.users')
+  return {
+    ...changed,
+    diff: {
+      ...changed.diff,
+      identical: users ? [users] : [],
+    },
+  }
+}
+
 async function setInputValue(input: HTMLInputElement, value: string) {
   const { act } = await import('react')
   await act(async () => {
@@ -583,6 +596,116 @@ describe('Schema Compare two-host path', () => {
       await setInputValue(input, 'no-such-table')
       expect(document.body.textContent).toContain('No tables match')
       expect(document.body.textContent).not.toContain('Schemas match')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('sidebar icon switches Differences and All, and sorts Z to A', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = matchingHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      const list = document.querySelector(
+        '[data-testid="schema-diff-table-list"]'
+      )
+      expect(
+        list?.querySelector('[data-testid="schema-diff-filter-diffs"]')
+      ).not.toBeNull()
+      expect(
+        list?.querySelector('[data-testid="schema-diff-filter-all"]')
+      ).not.toBeNull()
+      expect(document.body.textContent).not.toContain('Differences')
+
+      const names = () =>
+        [
+          ...document.querySelectorAll(
+            '[data-testid^="schema-diff-table-app."]'
+          ),
+        ].map((el) => el.getAttribute('data-testid'))
+      expect(names()).toEqual([
+        'schema-diff-table-app.events',
+        'schema-diff-table-app.users',
+      ])
+
+      const { act } = await import('react')
+      const sort = document.querySelector(
+        '[data-testid="schema-diff-sort"]'
+      ) as HTMLButtonElement
+      await act(async () => {
+        sort.click()
+      })
+      const za = document.querySelector(
+        '[data-testid="schema-diff-sort-za"]'
+      ) as HTMLElement
+      expect(za).not.toBeNull()
+      await act(async () => {
+        za.click()
+      })
+      expect(names()).toEqual([
+        'schema-diff-table-app.users',
+        'schema-diff-table-app.events',
+      ])
+
+      const all = document.querySelector(
+        '[data-testid="schema-diff-filter-all"]'
+      ) as HTMLButtonElement
+      await act(async () => {
+        all.click()
+      })
+      expect(all.getAttribute('aria-pressed')).toBe('true')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('Differences icon hides matching tables when there are diffs', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = mixedHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={data}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={0}
+        onPairChange={() => {}}
+      />
+    )
+
+    try {
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.events"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.users"]')
+      ).toBeNull()
+      const { act } = await import('react')
+      const all = document.querySelector(
+        '[data-testid="schema-diff-filter-all"]'
+      ) as HTMLButtonElement
+      await act(async () => {
+        all.click()
+      })
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-app.users"]')
+      ).not.toBeNull()
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -110,9 +110,7 @@ export function SchemaDiffView({
           hosts={peers}
           sourceHostId={sourceId}
           targetHostId={targetId}
-          showDiffsOnly={showDiffsOnly}
           onPairChange={onPairChange}
-          onShowDiffsOnlyChange={setShowDiffsOnly}
           extraFilters={
             <TooltipProvider>
               <Tooltip>
@@ -155,6 +153,8 @@ export function SchemaDiffView({
               nameFilter={nameFilter}
               onNameFilterChange={setNameFilter}
               nameFilterPlaceholder={nameFilterPlaceholder}
+              showDiffsOnly={showDiffsOnly}
+              onShowDiffsOnlyChange={setShowDiffsOnly}
               onCollapse={() => setSidebarOpen(false)}
             />
           </div>

--- a/apps/dashboard/src/components/schema-diff/table-list.tsx
+++ b/apps/dashboard/src/components/schema-diff/table-list.tsx
@@ -1,12 +1,19 @@
 import {
+  ArrowDownAZIcon,
+  ArrowDownWideNarrowIcon,
+  ArrowUpZAIcon,
   CheckCircle2Icon,
   ChevronRightIcon,
   DatabaseIcon,
+  GitCompareArrowsIcon,
+  ListIcon,
   PanelLeftCloseIcon,
   SearchIcon,
 } from 'lucide-react'
 
+import type { ReactNode } from 'react'
 import type { TableDiff } from '@/lib/schema-diff'
+import type { TableSort } from '@/lib/schema-diff/group'
 
 import { useMemo, useState } from 'react'
 import { Badge } from '@/components/ui/badge'
@@ -17,8 +24,20 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Input } from '@/components/ui/input'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { groupDiffsByDatabase, tableNameOf } from '@/lib/schema-diff/group'
 import { cn } from '@/lib/utils'
 
@@ -30,6 +49,8 @@ interface TableListProps {
   nameFilter?: string
   onNameFilterChange?: (value: string) => void
   nameFilterPlaceholder?: string
+  showDiffsOnly?: boolean
+  onShowDiffsOnlyChange?: (value: boolean) => void
   onCollapse?: () => void
 }
 
@@ -64,6 +85,42 @@ function KindMark({ row, example }: { row: TableDiff; example: boolean }) {
   )
 }
 
+function IconToolButton({
+  label,
+  pressed,
+  testId,
+  onClick,
+  children,
+}: {
+  label: string
+  pressed?: boolean
+  testId: string
+  onClick?: () => void
+  children: ReactNode
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            variant={pressed ? 'secondary' : 'ghost'}
+            size="icon-sm"
+            aria-label={label}
+            aria-pressed={pressed}
+            data-testid={testId}
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+            onClick={onClick}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function TableList({
   rows,
   selectedKey,
@@ -72,54 +129,129 @@ export function TableList({
   nameFilter = '',
   onNameFilterChange,
   nameFilterPlaceholder = 'Filter tables…',
+  showDiffsOnly,
+  onShowDiffsOnlyChange,
   onCollapse,
 }: TableListProps) {
-  const groups = useMemo(() => groupDiffsByDatabase(rows), [rows])
+  const [sort, setSort] = useState<TableSort>('name-asc')
+  const groups = useMemo(() => groupDiffsByDatabase(rows, sort), [rows, sort])
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
   const filtering = nameFilter.trim().length > 0
+  const SortIcon =
+    sort === 'name-desc'
+      ? ArrowUpZAIcon
+      : sort === 'kind'
+        ? ArrowDownWideNarrowIcon
+        : ArrowDownAZIcon
 
   return (
     <Card
       className="gap-0 rounded-xl border bg-card py-0 shadow-sm"
       data-testid="schema-diff-table-list"
     >
-      <div className="flex flex-col gap-2 border-b border-border px-3 py-2">
-        <div className="flex items-center justify-between gap-2">
-          <h2 className="text-sm font-medium text-foreground">
-            Tables
-            {rows.length > 0 ? (
-              <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-                {rows.length}
-              </span>
-            ) : null}
-          </h2>
-          {onCollapse ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={onCollapse}
-              className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
-              aria-label="Hide table list"
-              data-testid="schema-diff-sidebar-collapse"
-            >
-              <PanelLeftCloseIcon className="size-3.5" strokeWidth={1.5} />
-            </Button>
+      <TooltipProvider>
+        <div className="flex flex-col gap-2 border-b border-border px-3 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-sm font-medium text-foreground">
+              Tables
+              {rows.length > 0 ? (
+                <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                  {rows.length}
+                </span>
+              ) : null}
+            </h2>
+            <div className="flex items-center gap-0.5">
+              {onShowDiffsOnlyChange ? (
+                <div className="mr-0.5 inline-flex rounded-md border border-border/60 p-0.5">
+                  <IconToolButton
+                    label="Differences"
+                    pressed={showDiffsOnly}
+                    testId="schema-diff-filter-diffs"
+                    onClick={() => onShowDiffsOnlyChange(true)}
+                  >
+                    <GitCompareArrowsIcon
+                      className="size-3.5"
+                      strokeWidth={1.5}
+                    />
+                  </IconToolButton>
+                  <IconToolButton
+                    label="All tables"
+                    pressed={!showDiffsOnly}
+                    testId="schema-diff-filter-all"
+                    onClick={() => onShowDiffsOnlyChange(false)}
+                  >
+                    <ListIcon className="size-3.5" strokeWidth={1.5} />
+                  </IconToolButton>
+                </div>
+              ) : null}
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Sort tables"
+                      title="Sort"
+                      data-testid="schema-diff-sort"
+                      className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+                    />
+                  }
+                >
+                  <SortIcon className="size-3.5" strokeWidth={1.5} />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-40">
+                  <DropdownMenuItem
+                    onClick={() => setSort('name-asc')}
+                    data-testid="schema-diff-sort-az"
+                  >
+                    <ArrowDownAZIcon className="size-3.5" strokeWidth={1.5} />A
+                    to Z
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setSort('name-desc')}
+                    data-testid="schema-diff-sort-za"
+                  >
+                    <ArrowUpZAIcon className="size-3.5" strokeWidth={1.5} />Z to
+                    A
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setSort('kind')}
+                    data-testid="schema-diff-sort-kind"
+                  >
+                    <ArrowDownWideNarrowIcon
+                      className="size-3.5"
+                      strokeWidth={1.5}
+                    />
+                    Differences first
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {onCollapse ? (
+                <IconToolButton
+                  label="Hide table list"
+                  testId="schema-diff-sidebar-collapse"
+                  onClick={onCollapse}
+                >
+                  <PanelLeftCloseIcon className="size-3.5" strokeWidth={1.5} />
+                </IconToolButton>
+              ) : null}
+            </div>
+          </div>
+          {onNameFilterChange ? (
+            <div className="relative">
+              <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={nameFilter}
+                onChange={(e) => onNameFilterChange(e.target.value)}
+                placeholder={nameFilterPlaceholder}
+                className="h-8 pl-7 text-[13px]"
+                data-testid="schema-diff-table-filter"
+              />
+            </div>
           ) : null}
         </div>
-        {onNameFilterChange ? (
-          <div className="relative">
-            <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={nameFilter}
-              onChange={(e) => onNameFilterChange(e.target.value)}
-              placeholder={nameFilterPlaceholder}
-              className="h-8 pl-7 text-[13px]"
-              data-testid="schema-diff-table-filter"
-            />
-          </div>
-        ) : null}
-      </div>
+      </TooltipProvider>
       <CardContent className="p-0">
         {rows.length === 0 ? (
           <div className="p-4">
@@ -127,7 +259,7 @@ export function TableList({
               variant="filtered-empty"
               compact
               title="No tables match"
-              description="Try a different filter or switch to All."
+              description="Try a different filter or show all tables."
             />
           </div>
         ) : (

--- a/apps/dashboard/src/lib/schema-diff/group.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/group.test.ts
@@ -46,4 +46,127 @@ describe('groupDiffsByDatabase', () => {
     expect(groups[0].tables.map(tableNameOf)).toEqual(['events', 'users'])
     expect(groups[1].tables.map(tableNameOf)).toEqual(['b'])
   })
+
+  test('name-desc reverses database and table order', () => {
+    const catalog = assembleCatalog(
+      [
+        {
+          database: 'app',
+          table: 'users',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+        {
+          database: 'app',
+          table: 'events',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+      ],
+      []
+    )
+    const diff = compareCatalogs(catalog, catalog)
+    const groups = groupDiffsByDatabase(diff.identical, 'name-desc')
+    expect(groups[0].tables.map(tableNameOf)).toEqual(['users', 'events'])
+  })
+
+  test('kind sort puts changed tables before identical', () => {
+    const source = assembleCatalog(
+      [
+        {
+          database: 'app',
+          table: 'events',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.events (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+        {
+          database: 'app',
+          table: 'users',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+      ],
+      [
+        {
+          database: 'app',
+          table: 'events',
+          name: 'id',
+          type: 'UInt64',
+          codec: '',
+        },
+        {
+          database: 'app',
+          table: 'users',
+          name: 'id',
+          type: 'UInt64',
+          codec: '',
+        },
+      ]
+    )
+    const target = assembleCatalog(
+      [
+        {
+          database: 'app',
+          table: 'events',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.events (id UInt32) ENGINE = MergeTree ORDER BY id',
+        },
+        {
+          database: 'app',
+          table: 'users',
+          engine: 'MergeTree',
+          sorting_key: 'id',
+          partition_key: '',
+          primary_key: 'id',
+          create_table_query:
+            'CREATE TABLE app.users (id UInt64) ENGINE = MergeTree ORDER BY id',
+        },
+      ],
+      [
+        {
+          database: 'app',
+          table: 'events',
+          name: 'id',
+          type: 'UInt32',
+          codec: '',
+        },
+        {
+          database: 'app',
+          table: 'users',
+          name: 'id',
+          type: 'UInt64',
+          codec: '',
+        },
+      ]
+    )
+    const diff = compareCatalogs(source, target)
+    const groups = groupDiffsByDatabase(
+      [...diff.changed, ...diff.identical],
+      'kind'
+    )
+    expect(groups[0].tables.map((row) => row.kind)).toEqual([
+      'changed',
+      'identical',
+    ])
+  })
 })

--- a/apps/dashboard/src/lib/schema-diff/group.ts
+++ b/apps/dashboard/src/lib/schema-diff/group.ts
@@ -1,4 +1,6 @@
-import type { TableDiff } from './types'
+import type { TableDiff, TableDiffKind } from './types'
+
+export type TableSort = 'name-asc' | 'name-desc' | 'kind'
 
 export function tableNameOf(row: TableDiff): string {
   return row.source?.table ?? row.target?.table ?? lastSegment(row.key)
@@ -18,8 +20,16 @@ function lastSegment(key: string): string {
   return i === -1 ? key : key.slice(i + 1)
 }
 
+const KIND_ORDER: Record<TableDiffKind, number> = {
+  changed: 0,
+  only_source: 1,
+  only_target: 2,
+  identical: 3,
+}
+
 export function groupDiffsByDatabase(
-  rows: TableDiff[]
+  rows: TableDiff[],
+  sort: TableSort = 'name-asc'
 ): { database: string; tables: TableDiff[] }[] {
   const map = new Map<string, TableDiff[]>()
   for (const row of rows) {
@@ -28,12 +38,22 @@ export function groupDiffsByDatabase(
     if (list) list.push(row)
     else map.set(database, [row])
   }
+
+  const nameCmp = (a: string, b: string) => {
+    const n = a.localeCompare(b)
+    return sort === 'name-desc' ? -n : n
+  }
+
   return [...map.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => nameCmp(a, b))
     .map(([database, tables]) => ({
       database,
-      tables: [...tables].sort((a, b) =>
-        tableNameOf(a).localeCompare(tableNameOf(b))
-      ),
+      tables: [...tables].sort((a, b) => {
+        if (sort === 'kind') {
+          const k = KIND_ORDER[a.kind] - KIND_ORDER[b.kind]
+          if (k !== 0) return k
+        }
+        return nameCmp(tableNameOf(a), tableNameOf(b))
+      }),
     }))
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -669,8 +669,10 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   Target comboboxes. Toolbar is compact `CompareToolbar` (`p-3` card):
   Connections / Replica nodes tabs (`size="sm"`), then Source / Target
   searchable comboboxes (`ComparePeerSelect`, sorted by name,
-  `ChmonitorLogo` + version/uptime/status like HostSwitcher), then
-  Differences / All. Scope toggle (only when both hostCount and
+  `ChmonitorLogo` + version/uptime/status like HostSwitcher).
+  Differences / All and table sort are icon-only controls on the
+  table sidebar (with the name search), not the host toolbar.
+  Scope toggle (only when both hostCount and
   nodeCount are ≥ 2) writes `?scope=hosts|nodes` and remounts the pair
   from that peer list.
   The table catalog is a collapsible left sidebar grouped


### PR DESCRIPTION
## Summary

Differences vs All and table sorting live on the Schema Compare table sidebar as icon-only controls, next to the search field.

## Changes

- Sidebar header: Differences (`GitCompareArrows`) / All (`List`) icon pair, sort menu (`ArrowDownAZ`: A–Z, Z–A, differences first), collapse
- Search stays on the listing panel
- Host toolbar no longer has the Differences/All segmented control (Settings Diff pair mode still does)
- Tests cover icon filter, hiding matches when there are diffs, and Z–A sort

## Test plan

- [x] Schema Compare + group unit tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

---

Co-Authored-By: duyetbot <bot@duyet.net>