### PR TITLE
fix(compare): show listing loading when switching scope

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -114,7 +114,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   differences first) live on that sidebar — not the host toolbar.
   When Differences is on and there are no diffs, still list identical
   tables with a green `CheckCircle2` (`--chart-green`) — click a row
-  to select it on the right. A matching selection is **All matched** / **This
+  to select it on the right. Switching Connections / Replica nodes
+  keeps the toolbar and shows a listing loading state (not a full-page
+  empty load). A matching selection is **All matched** / **This
   table matches** (`MatchOk`), never EmptyState "no data" or
   "Select a table". Keep "No tables match" only for a name-filter
   miss.

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.test.tsx
@@ -756,4 +756,43 @@ describe('Schema Compare two-host path', () => {
       await cleanup()
     }
   })
+
+  test('scope switch keeps the toolbar and shows listing loading', async () => {
+    const { SchemaDiffView } = await import('./schema-diff-view')
+    const data = twoHostPayload()
+
+    const { cleanup } = await renderInto(
+      <SchemaDiffView
+        data={{
+          ...data,
+          nodes: [
+            { id: 10, name: 'clickhouse-0' },
+            { id: 11, name: 'clickhouse-1' },
+          ],
+        }}
+        sourceId={0}
+        targetId={1}
+        scope="hosts"
+        peers={data.hosts}
+        hostCount={2}
+        nodeCount={2}
+        listingLoading
+        onPairChange={() => {}}
+        onScopeChange={() => {}}
+      />
+    )
+
+    try {
+      expect(document.body.textContent).toContain('Replica nodes')
+      expect(document.body.textContent).toContain('staging')
+      expect(
+        document.querySelector('[data-testid="schema-diff-listing-loading"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="schema-diff-table-list"]')
+      ).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
 })

--- a/apps/dashboard/src/components/schema-diff/schema-diff-page.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-page.tsx
@@ -46,7 +46,7 @@ export function SchemaDiffPage() {
   const scopeParam = search.scope
   const hostKey = mergedHosts.map((h) => `${h.source}:${h.id}`).join('|')
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isFetching, isPlaceholderData, error } = useQuery({
     queryKey: [
       'schema-diff',
       hostId,
@@ -73,7 +73,9 @@ export function SchemaDiffPage() {
     },
     enabled: !hostsLoading,
     staleTime: 60_000,
+    placeholderData: (previous) => previous,
   })
+  const listingLoading = isFetching && isPlaceholderData
 
   const example = useMemo(() => buildExampleSchemaDiff(), [])
   const exampleRows = useMemo(
@@ -97,7 +99,7 @@ export function SchemaDiffPage() {
     })
   }
 
-  if (hostsLoading || isLoading) {
+  if ((hostsLoading || isLoading) && !data) {
     return (
       <div className="flex flex-col gap-4">
         <PageHeader title="Schema Compare" description={PAGE_DESCRIPTION} />
@@ -208,6 +210,7 @@ export function SchemaDiffPage() {
         hostCount={hostCount}
         nodeCount={nodeCount}
         nameFilterPlaceholder={scope === 'nodes' ? 'Filter tables…' : undefined}
+        listingLoading={listingLoading}
         onPairChange={(source, target) => setPair(source, target, scope)}
         onScopeChange={(next) => {
           const nextPeers = next === 'nodes' ? nodes : hosts

--- a/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
+++ b/apps/dashboard/src/components/schema-diff/schema-diff-view.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon, PanelLeftIcon } from 'lucide-react'
+import { CopyIcon, Loader2Icon, PanelLeftIcon } from 'lucide-react'
 
 import type { ComparePeer, CompareScope } from '@/lib/compare/scope'
 import type { SchemaDiffResponse, TableDiff } from '@/lib/schema-diff'
@@ -33,6 +33,7 @@ export interface SchemaDiffViewProps {
   onScopeChange?: (scope: CompareScope) => void
   nameFilterPlaceholder?: string
   example?: boolean
+  listingLoading?: boolean
 }
 
 export function SchemaDiffView({
@@ -47,6 +48,7 @@ export function SchemaDiffView({
   onScopeChange,
   nameFilterPlaceholder,
   example = false,
+  listingLoading = false,
 }: SchemaDiffViewProps) {
   const [showDiffsOnly, setShowDiffsOnly] = useState(true)
   const [nameFilter, setNameFilter] = useState('')
@@ -97,12 +99,21 @@ export function SchemaDiffView({
       <CompareToolbar
         tabs={
           onScopeChange ? (
-            <CompareScopeToggle
-              value={scope}
-              onChange={onScopeChange}
-              hostCount={hostCount}
-              nodeCount={nodeCount}
-            />
+            <div className="flex items-center gap-2">
+              <CompareScopeToggle
+                value={scope}
+                onChange={onScopeChange}
+                hostCount={hostCount}
+                nodeCount={nodeCount}
+              />
+              {listingLoading ? (
+                <Loader2Icon
+                  className="size-3.5 animate-spin text-muted-foreground motion-reduce:animate-none"
+                  strokeWidth={1.5}
+                  aria-hidden
+                />
+              ) : null}
+            </div>
           ) : null
         }
       >
@@ -121,7 +132,7 @@ export function SchemaDiffView({
                         variant="outline"
                         size="sm"
                         onClick={copySafe}
-                        disabled={!hasSafeStatements}
+                        disabled={!hasSafeStatements || listingLoading}
                         aria-label="Copy recommended SQL"
                         className="h-8 text-[13px]"
                       >
@@ -142,70 +153,87 @@ export function SchemaDiffView({
         />
       </CompareToolbar>
 
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-        {sidebarOpen ? (
-          <div className="w-full shrink-0 lg:w-[22rem]">
-            <TableList
-              rows={rows}
-              selectedKey={selected?.key ?? null}
-              onSelect={setSelectedKey}
-              example={example}
-              nameFilter={nameFilter}
-              onNameFilterChange={setNameFilter}
-              nameFilterPlaceholder={nameFilterPlaceholder}
-              showDiffsOnly={showDiffsOnly}
-              onShowDiffsOnlyChange={setShowDiffsOnly}
-              onCollapse={() => setSidebarOpen(false)}
-            />
-          </div>
-        ) : (
-          <Button
-            type="button"
-            variant="outline"
-            size="icon-sm"
-            onClick={() => setSidebarOpen(true)}
-            className="size-8 shrink-0 text-muted-foreground hover:text-foreground"
-            aria-label="Show table list"
-            data-testid="schema-diff-sidebar-expand"
-          >
-            <PanelLeftIcon className="size-3.5" strokeWidth={1.5} />
-          </Button>
-        )}
-
-        <div className="flex min-w-0 flex-1 flex-col gap-4">
-          {selected ? (
-            <>
-              {selectedMatches ? (
-                <MatchOk
-                  title={allMatched ? 'All matched' : 'This table matches'}
-                  description={
-                    allMatched
-                      ? 'Every table schema is identical on source and target.'
-                      : 'Source and target DDL are identical. No recommended statements.'
-                  }
-                />
-              ) : null}
-              <DdlPair selected={selected} />
-              {selectedMatches ? null : <PlanList items={selectedPlan} />}
-            </>
-          ) : allMatched && !hasNameFilter ? (
-            <MatchOk
-              title="All matched"
-              description="Every table schema is identical on source and target."
-            />
-          ) : (
-            <EmptyState
-              variant={hasNameFilter ? 'filtered-empty' : 'no-data'}
-              title={hasNameFilter ? 'No tables match' : 'Select a table'}
-              description={
-                hasNameFilter
-                  ? 'Try a different filter or switch to All.'
-                  : 'Pick a table on the left to see side-by-side DDL and a copyable plan.'
-              }
-            />
-          )}
+      {listingLoading ? (
+        <div
+          className="flex min-h-64 items-center justify-center rounded-xl border bg-card shadow-sm"
+          data-testid="schema-diff-listing-loading"
+          role="status"
+          aria-busy="true"
+          aria-label="Loading comparison"
+        >
+          <EmptyState
+            variant="loading"
+            compact
+            title="Loading comparison"
+            description="Fetching schemas for the selected pair."
+          />
         </div>
-      </div>
+      ) : (
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          {sidebarOpen ? (
+            <div className="w-full shrink-0 lg:w-[22rem]">
+              <TableList
+                rows={rows}
+                selectedKey={selected?.key ?? null}
+                onSelect={setSelectedKey}
+                example={example}
+                nameFilter={nameFilter}
+                onNameFilterChange={setNameFilter}
+                nameFilterPlaceholder={nameFilterPlaceholder}
+                showDiffsOnly={showDiffsOnly}
+                onShowDiffsOnlyChange={setShowDiffsOnly}
+                onCollapse={() => setSidebarOpen(false)}
+              />
+            </div>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              onClick={() => setSidebarOpen(true)}
+              className="size-8 shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="Show table list"
+              data-testid="schema-diff-sidebar-expand"
+            >
+              <PanelLeftIcon className="size-3.5" strokeWidth={1.5} />
+            </Button>
+          )}
+
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            {selected ? (
+              <>
+                {selectedMatches ? (
+                  <MatchOk
+                    title={allMatched ? 'All matched' : 'This table matches'}
+                    description={
+                      allMatched
+                        ? 'Every table schema is identical on source and target.'
+                        : 'Source and target DDL are identical. No recommended statements.'
+                    }
+                  />
+                ) : null}
+                <DdlPair selected={selected} />
+                {selectedMatches ? null : <PlanList items={selectedPlan} />}
+              </>
+            ) : allMatched && !hasNameFilter ? (
+              <MatchOk
+                title="All matched"
+                description="Every table schema is identical on source and target."
+              />
+            ) : (
+              <EmptyState
+                variant={hasNameFilter ? 'filtered-empty' : 'no-data'}
+                title={hasNameFilter ? 'No tables match' : 'Select a table'}
+                description={
+                  hasNameFilter
+                    ? 'Try a different filter or switch to All.'
+                    : 'Pick a table on the left to see side-by-side DDL and a copyable plan.'
+                }
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -1,3 +1,4 @@
+import { Loader2Icon } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 
@@ -53,7 +54,7 @@ export function SettingsDiffPage() {
   const viewParam = search.view
   const hostKey = mergedHosts.map((h) => `${h.source}:${h.id}`).join('|')
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isFetching, isPlaceholderData, error } = useQuery({
     queryKey: [
       'settings-diff',
       hostId,
@@ -82,7 +83,9 @@ export function SettingsDiffPage() {
     },
     enabled: !hostsLoading,
     staleTime: 60_000,
+    placeholderData: (previous) => previous,
   })
+  const listingLoading = isFetching && isPlaceholderData
 
   const setSearch = (next: {
     source?: number
@@ -106,7 +109,7 @@ export function SettingsDiffPage() {
     })
   }
 
-  if (hostsLoading || isLoading) {
+  if ((hostsLoading || isLoading) && !data) {
     return (
       <div className="flex flex-col gap-4">
         <PageHeader title="Settings Diff" description={PAGE_DESCRIPTION} />
@@ -218,22 +221,31 @@ export function SettingsDiffPage() {
       <CompareToolbar
         tabs={
           <>
-            <CompareScopeToggle
-              value={scope}
-              onChange={(next) => {
-                const nextPeers = next === 'nodes' ? nodes : hosts
-                const nextPair = resolvePair(nextPeers)
-                if (!nextPair) return
-                setSearch({
-                  source: nextPair.sourceId,
-                  target: nextPair.targetId,
-                  scope: next,
-                  view: next === 'hosts' ? view : undefined,
-                })
-              }}
-              hostCount={hostCount}
-              nodeCount={nodeCount}
-            />
+            <div className="flex items-center gap-2">
+              <CompareScopeToggle
+                value={scope}
+                onChange={(next) => {
+                  const nextPeers = next === 'nodes' ? nodes : hosts
+                  const nextPair = resolvePair(nextPeers)
+                  if (!nextPair) return
+                  setSearch({
+                    source: nextPair.sourceId,
+                    target: nextPair.targetId,
+                    scope: next,
+                    view: next === 'hosts' ? view : undefined,
+                  })
+                }}
+                hostCount={hostCount}
+                nodeCount={nodeCount}
+              />
+              {listingLoading ? (
+                <Loader2Icon
+                  className="size-3.5 animate-spin text-muted-foreground motion-reduce:animate-none"
+                  strokeWidth={1.5}
+                  aria-hidden
+                />
+              ) : null}
+            </div>
             {scope === 'hosts' ? (
               <SettingsViewToggle
                 value={view}
@@ -305,19 +317,38 @@ export function SettingsDiffPage() {
         )}
       </CompareToolbar>
 
-      <SettingsDiffTable
-        columns={columns}
-        rows={filteredRows}
-        nameFilter={nameFilter}
-        onNameFilterChange={setNameFilter}
-      />
+      {listingLoading ? (
+        <div
+          className="flex min-h-64 items-center justify-center rounded-xl border bg-card shadow-sm"
+          data-testid="settings-diff-listing-loading"
+          role="status"
+          aria-busy="true"
+          aria-label="Loading comparison"
+        >
+          <EmptyState
+            variant="loading"
+            compact
+            title="Loading comparison"
+            description="Fetching settings for the selected pair."
+          />
+        </div>
+      ) : (
+        <>
+          <SettingsDiffTable
+            columns={columns}
+            rows={filteredRows}
+            nameFilter={nameFilter}
+            onNameFilterChange={setNameFilter}
+          />
 
-      <p className="text-xs text-muted-foreground">
-        {filteredRows.length.toLocaleString()} row
-        {filteredRows.length !== 1 ? 's' : ''}
-        {filteredRows.length !== (data?.rows?.length ?? 0) &&
-          ` (filtered from ${(data?.rows?.length ?? 0).toLocaleString()})`}
-      </p>
+          <p className="text-xs text-muted-foreground">
+            {filteredRows.length.toLocaleString()} row
+            {filteredRows.length !== 1 ? 's' : ''}
+            {filteredRows.length !== (data?.rows?.length ?? 0) &&
+              ` (filtered from ${(data?.rows?.length ?? 0).toLocaleString()})`}
+          </p>
+        </>
+      )}
     </div>
   )
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -672,7 +672,8 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   `ChmonitorLogo` + version/uptime/status like HostSwitcher).
   Differences / All and table sort are icon-only controls on the
   table sidebar (with the name search), not the host toolbar.
-  Scope toggle (only when both hostCount and
+  Switching Connections / Replica nodes keeps the toolbar and shows a
+  listing loading state. Scope toggle (only when both hostCount and
   nodeCount are ≥ 2) writes `?scope=hosts|nodes` and remounts the pair
   from that peer list.
   The table catalog is a collapsible left sidebar grouped


### PR DESCRIPTION
## Summary

Switching Schema Compare / Settings Diff between Connections and Replica nodes keeps the toolbar and shows a listing loading state, instead of replacing the whole page with an empty load.

## Changes

- Keep previous query data as placeholder while the new scope pair fetches
- Spinner next to the scope toggle
- Listing card: "Loading comparison"
- Tests cover toolbar-still-visible + listing loading

## Test plan

- [x] Schema Compare unit tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

---

Co-Authored-By: duyetbot <bot@duyet.net>