### PR TITLE
fix(menu): list Data Explorer under both Tools and Tables

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -386,8 +386,8 @@ module snapshot in `lib/format-settings.ts`; palette/density →
 2. Add a `QueryConfig` in `src/lib/query-config/` if it needs data.
 3. Register in `src/menu/` (with feature gate / `tableCheck` if optional).
    Interactive utilities (SQL, explorer, explain, compare, builder) go in
-   `menu/tools.ts` — not under Queries/Tables/Operations/System. System-table
-   views stay in their domain file. Tools is the last Main group, composed
+   `menu/tools.ts`. Data Explorer (`/explorer`) is also listed under
+   Tables. Other system-table views stay in their domain file. Tools is the last Main group, composed
    after Logs and before the About footer in `menu/index.ts` — do not put
    it after Overview / before AI Agent. The Tools parent must not set
    `permission`; copy the child's existing feature onto the leaf. Leave

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
@@ -129,6 +129,21 @@ describe('derivePaletteGroups', () => {
     expect(tableResult.quickNav.isTableName).toBe(true)
   })
 
+  test('Data Explorer is listed under both Tools and Tables', () => {
+    const result = derivePaletteGroups({
+      menuItems: menuItemsConfig,
+      favoriteMenuItems: [],
+      tableRows: [],
+      hosts: [],
+      currentHostId: 0,
+      query: '',
+    })
+    const tools = result.sectionedItems.find((item) => item.title === 'Tools')
+    const tables = result.sectionedItems.find((item) => item.title === 'Tables')
+    expect(tools?.items?.map((item) => item.href)).toContain('/explorer')
+    expect(tables?.items?.map((item) => item.href)).toContain('/explorer')
+  })
+
   test('Inbound Events is under Health, not a top-level Go-to leaf (#3134)', () => {
     const result = derivePaletteGroups({
       menuItems: menuItemsConfig,

--- a/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
+++ b/apps/dashboard/src/lib/menu/__tests__/__snapshots__/menu-config-snapshot.test.ts.snap
@@ -202,6 +202,12 @@ exports[`menuItemsConfig snapshot flattened menu structure (titles, hrefs, order
   },
   {
     "depth": 1,
+    "href": "/explorer",
+    "section": undefined,
+    "title": "Data Explorer",
+  },
+  {
+    "depth": 1,
     "href": "/tables-overview",
     "section": undefined,
     "title": "Tables Overview",

--- a/apps/dashboard/src/lib/menu/__tests__/breadcrumb.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/breadcrumb.test.ts
@@ -72,6 +72,13 @@ describe('getBreadcrumbPath (Inbound Events under Health, #3134)', () => {
 })
 
 describe('getBreadcrumbPath (Tools regroup)', () => {
+  test('Data Explorer breadcrumbs go through Tables (first parent; also listed under Tools)', () => {
+    expect(getBreadcrumbPath('/explorer')).toEqual([
+      { title: 'Tables', href: '/tables' },
+      { title: 'Data Explorer', href: '/explorer' },
+    ])
+  })
+
   test('SQL Console breadcrumbs go through Tools, not Tables', () => {
     expect(getBreadcrumbPath('/sql')).toEqual([
       { title: 'Tools', href: '' },

--- a/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/menu-config-invariants.test.ts
@@ -5,11 +5,12 @@
  * href (its actual navigational destination) and a sibling group's titles
  * (what a user sees listed together in one dropdown).
  *
- * Known-legitimate exception, not a bug: a group parent may repeat its first
- * child's href (e.g. "Merges" both links directly to /merges AND lists
- * /merges again inside its own dropdown with a description) — that's a
- * container mirroring its own landing page. Only *leaf* items (no nested
- * `items`) are required to have a distinct href.
+ * Known-legitimate exceptions, not bugs:
+ * - A group parent may repeat its first child's href (e.g. "Merges" both
+ *   links directly to /merges AND lists /merges again inside its own
+ *   dropdown) — that's a container mirroring its own landing page. Only
+ *   *leaf* items (no nested `items`) are required to have a distinct href.
+ * - Data Explorer (`/explorer`) is listed under both Tools and Tables.
  */
 
 import { RssIcon } from 'lucide-react'
@@ -53,10 +54,20 @@ describe('menu.ts structural invariants', () => {
       titles.push(item.title)
       titlesByHref.set(item.href, titles)
     }
+    const allowedDupHrefs = new Set(['/explorer'])
     const duplicates = [...titlesByHref.entries()].filter(
-      ([, titles]) => titles.length > 1
+      ([href, titles]) => titles.length > 1 && !allowedDupHrefs.has(href)
     )
     expect(duplicates).toEqual([])
+  })
+
+  test('Data Explorer is listed under both Tools and Tables', () => {
+    const hrefsOf = (title: string) =>
+      menuItemsConfig
+        .find((item) => item.title === title)
+        ?.items?.map((item) => item.href) ?? []
+    expect(hrefsOf('Tools')).toContain('/explorer')
+    expect(hrefsOf('Tables')).toContain('/explorer')
   })
 
   test('sibling titles are unique within each dropdown / list', () => {
@@ -222,7 +233,7 @@ describe('Tools group (interactive utilities)', () => {
         ?.items?.map((item) => item.href) ?? []
 
     expect(hrefsOf('Tables')).not.toContain('/sql')
-    expect(hrefsOf('Tables')).not.toContain('/explorer')
+    expect(hrefsOf('Tables')).toContain('/explorer')
     expect(hrefsOf('Queries')).not.toContain('/explain')
     expect(hrefsOf('Queries')).not.toContain('/advisor')
     expect(hrefsOf('Operations')).not.toContain('/dashboard')

--- a/apps/dashboard/src/menu/data-explorer.ts
+++ b/apps/dashboard/src/menu/data-explorer.ts
@@ -1,0 +1,16 @@
+import { TableIcon } from 'lucide-react'
+
+import type { MenuItem } from '@/components/menu/types'
+
+/** Shared leaf so Data Explorer can sit under both Tools and Tables. */
+export const dataExplorerItem: MenuItem = {
+  title: 'Data Explorer',
+  href: '/explorer',
+  description: 'Interactive database schema browser with metadata',
+  countKey: 'tables-explorer',
+  countLabel: 'tables',
+  icon: TableIcon,
+  docs: 'https://clickhouse.com/docs/en/operations/system-tables/databases', // pragma: allowlist secret
+  tableCheck: ['system.databases', 'system.tables'],
+  permission: { feature: 'tables' },
+}

--- a/apps/dashboard/src/menu/tables.ts
+++ b/apps/dashboard/src/menu/tables.ts
@@ -17,6 +17,8 @@ import {
 
 import type { MenuItem } from '@/components/menu/types'
 
+import { dataExplorerItem } from './data-explorer'
+
 export const tablesItems: MenuItem[] = [
   {
     title: 'Tables',
@@ -25,6 +27,7 @@ export const tablesItems: MenuItem[] = [
     section: 'main',
     permission: { feature: 'tables' },
     items: [
+      dataExplorerItem,
       {
         title: 'Tables Overview',
         href: '/tables-overview',

--- a/apps/dashboard/src/menu/tools.ts
+++ b/apps/dashboard/src/menu/tools.ts
@@ -1,13 +1,14 @@
 import { DashboardIcon, InfoCircledIcon } from '@radix-ui/react-icons'
 import {
   GitCompareArrowsIcon,
-  TableIcon,
   TerminalIcon,
   WandSparklesIcon,
   WrenchIcon,
 } from 'lucide-react'
 
 import type { MenuItem } from '@/components/menu/types'
+
+import { dataExplorerItem } from './data-explorer'
 
 export const toolsItems: MenuItem[] = [
   {
@@ -39,17 +40,7 @@ export const toolsItems: MenuItem[] = [
         docs: 'https://clickhouse.com/docs/en/sql-reference/statements/select', // pragma: allowlist secret
         permission: { feature: 'tables' },
       },
-      {
-        title: 'Data Explorer',
-        href: '/explorer',
-        description: 'Interactive database schema browser with metadata',
-        countKey: 'tables-explorer',
-        countLabel: 'tables',
-        icon: TableIcon,
-        docs: 'https://clickhouse.com/docs/en/operations/system-tables/databases', // pragma: allowlist secret
-        tableCheck: ['system.databases', 'system.tables'],
-        permission: { feature: 'tables' },
-      },
+      dataExplorerItem,
       {
         title: 'Explain',
         href: '/explain',

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -740,8 +740,10 @@ Logs in `menu/index.ts`, before the About footer and System / Cluster /
 Operations. Current leaves, most-used first: SQL Console (`/sql`), Data
 Explorer (`/explorer`), Explain (`/explain`), Advisor (`/advisor`,
 recommend-only), Chart Builder (`/dashboard`), Schema Compare
-(`/schema-diff`), Settings Diff (`/settings-diff`). AI Agent stays its own
-flagship group. Postgres-only items stay engine-gated and are not moved here.
+(`/schema-diff`), Settings Diff (`/settings-diff`). Data Explorer is
+**also** listed under Tables (`menu/data-explorer.ts` shared leaf).
+AI Agent stays its own flagship group. Postgres-only items stay
+engine-gated and are not moved here.
 
 Leave `engines` **absent** on the Tools parent and children. Absent already
 means the default source-engine family, so `filterMenuItemsByEngine` drops


### PR DESCRIPTION
## Summary

Data Explorer (`/explorer`) stays under Tools and is also listed again as the first child of Tables, using one shared menu leaf.

## Changes

- Extract `dataExplorerItem` to `menu/data-explorer.ts`
- Keep it in `menu/tools.ts` and add it as the first Tables child
- Allow `/explorer` as the only duplicate leaf href
- Update the menu snapshot, breadcrumbs, command palette, and product-design notes

## Test plan

- [x] `bun test src/lib/menu src/components/controls/command-palette/__tests__/use-palette-groups.test.ts --isolate` (120 pass)
- [ ] `pnpm run lint` (CI)
- [ ] `pnpm run build` (CI)
- [ ] `pnpm run test:unit` (CI)

## Notes for reviewer

Hiding `/explorer` still hides both listings because hide is href-based. Breadcrumbs use the first parent (Tables).

---

Co-Authored-By: duyetbot <bot@duyet.net>