### PR TITLE
feat(peerdb): group jobs by prefix and cache fleet totals

### DIFF
--- a/apps/dashboard/src/components/peerdb/counting-number.tsx
+++ b/apps/dashboard/src/components/peerdb/counting-number.tsx
@@ -1,0 +1,79 @@
+import { pdbFmtNum } from './peerdb-utils'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+const ANIMATION_DURATION = 700
+
+function easeOutQuad(t: number): number {
+  return t * (2 - t)
+}
+
+interface CountingNumberProps {
+  value: number
+  /** Still aggregating — pulse so the operator can see the total is in flight. */
+  counting?: boolean
+  /** Last-known snapshot, not this session's live fetch. */
+  cached?: boolean
+  format?: (n: number) => string
+  className?: string
+}
+
+/**
+ * Animates a KPI from its previous value to `value`, formatting with
+ * `pdbFmtNum` so compact suffixes (18.4M) stay stable while the underlying
+ * count is still climbing.
+ */
+export function CountingNumber({
+  value,
+  counting,
+  cached,
+  format = pdbFmtNum,
+  className,
+}: CountingNumberProps) {
+  const target = Number.isFinite(value) ? value : 0
+  const [display, setDisplay] = useState(target)
+  const prevRef = useRef(target)
+  const frameRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const prev = prevRef.current
+    if (prev === target) {
+      setDisplay(target)
+      return
+    }
+
+    const start = performance.now()
+    const from = prev
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / ANIMATION_DURATION, 1)
+      const current = from + (target - from) * easeOutQuad(progress)
+      setDisplay(current)
+      if (progress < 1) {
+        frameRef.current = requestAnimationFrame(tick)
+      } else {
+        prevRef.current = target
+        setDisplay(target)
+      }
+    }
+
+    frameRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (frameRef.current != null) cancelAnimationFrame(frameRef.current)
+    }
+  }, [target])
+
+  return (
+    <span
+      className={cn(
+        'tabular-nums',
+        counting && 'motion-safe:animate-pulse motion-reduce:animate-none',
+        cached && !counting && 'text-muted-foreground',
+        className
+      )}
+      title={cached ? 'Cached from last visit' : undefined}
+    >
+      {format(display)}
+    </span>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/group-by-prefix.test.ts
+++ b/apps/dashboard/src/components/peerdb/group-by-prefix.test.ts
@@ -1,0 +1,148 @@
+import {
+  groupBySmartPrefix,
+  isVolatileToken,
+  splitName,
+  wildcardFor,
+} from './group-by-prefix'
+import { describe, expect, test } from 'bun:test'
+
+describe('splitName', () => {
+  test('splits on underscore, hyphen, dot, slash', () => {
+    expect(splitName('qrep_sg_fleetreporting1_202608')).toEqual({
+      tokens: ['qrep', 'sg', 'fleetreporting1', '202608'],
+      seps: ['_', '_', '_'],
+    })
+    expect(splitName('cdc-prod.orders/v2')).toEqual({
+      tokens: ['cdc', 'prod', 'orders', 'v2'],
+      seps: ['-', '.', '/'],
+    })
+  })
+
+  test('a name with no separators is a single token', () => {
+    expect(splitName('orders')).toEqual({ tokens: ['orders'], seps: [] })
+  })
+})
+
+describe('isVolatileToken', () => {
+  test('dates, versions, hashes, long ids', () => {
+    expect(isVolatileToken('202608')).toBe(true)
+    expect(isVolatileToken('20260819')).toBe(true)
+    expect(isVolatileToken('2026-08')).toBe(true)
+    expect(isVolatileToken('2026-08-19')).toBe(true)
+    expect(isVolatileToken('v2')).toBe(true)
+    expect(isVolatileToken('v1.4.2')).toBe(true)
+    expect(isVolatileToken('deadbeef')).toBe(true)
+    expect(isVolatileToken('10001')).toBe(true)
+  })
+
+  test('stable job tokens stay as names, not suffixes', () => {
+    expect(isVolatileToken('fleetreporting1')).toBe(false)
+    expect(isVolatileToken('orders')).toBe(false)
+    expect(isVolatileToken('cdc')).toBe(false)
+    expect(isVolatileToken('sg')).toBe(false)
+  })
+})
+
+describe('wildcardFor', () => {
+  test('uses the original separator before the collapsed suffix', () => {
+    const split = splitName('qrep_sg_fleetreporting1_202608')
+    expect(wildcardFor(split, 3)).toBe('qrep_sg_fleetreporting1_*')
+    expect(wildcardFor(splitName('job-202608'), 1)).toBe('job-*')
+  })
+})
+
+describe('groupBySmartPrefix', () => {
+  const names = (list: string[]) =>
+    groupBySmartPrefix(
+      list.map((name) => ({ name })),
+      (m) => m.name
+    )
+
+  test('date-suffixed QRep jobs group at the longest shared prefix', () => {
+    const result = names([
+      'qrep_sg_fleetreporting1_202606',
+      'qrep_sg_fleetreporting1_202607',
+      'qrep_sg_fleetreporting1_202608',
+      'qrep_sg_orders_202607',
+      'qrep_sg_orders_202608',
+      'orders_cdc',
+    ])
+    expect(result.groups.map((g) => g.wildcard)).toEqual([
+      'qrep_sg_fleetreporting1_*',
+      'qrep_sg_orders_*',
+    ])
+    expect(result.groups[0].items.map((m) => m.name)).toEqual([
+      'qrep_sg_fleetreporting1_202606',
+      'qrep_sg_fleetreporting1_202607',
+      'qrep_sg_fleetreporting1_202608',
+    ])
+    expect(result.ungrouped.map((m) => m.name)).toEqual(['orders_cdc'])
+  })
+
+  test('does not collapse distinct families into a coarse qrep_* bucket', () => {
+    const result = names([
+      'qrep_sg_fleetreporting1_202608',
+      'qrep_sg_fleetreporting1_202609',
+      'qrep_sg_orders_202608',
+      'qrep_sg_orders_202609',
+    ])
+    expect(result.groups.map((g) => g.wildcard)).toEqual([
+      'qrep_sg_fleetreporting1_*',
+      'qrep_sg_orders_*',
+    ])
+    expect(result.ungrouped).toEqual([])
+  })
+
+  test('a single job stays ungrouped', () => {
+    const result = names(['qrep_sg_fleetreporting1_202608', 'orders_cdc'])
+    expect(result.groups).toEqual([])
+    expect(result.ungrouped.map((m) => m.name)).toEqual([
+      'qrep_sg_fleetreporting1_202608',
+      'orders_cdc',
+    ])
+  })
+
+  test('empty input', () => {
+    expect(names([])).toEqual({ groups: [], ungrouped: [] })
+  })
+
+  test('names without separators stay ungrouped', () => {
+    const result = names(['orders', 'users', 'payments'])
+    expect(result.groups).toEqual([])
+    expect(result.ungrouped).toHaveLength(3)
+  })
+
+  test('version suffixes group (v1 / v2)', () => {
+    const result = names(['catalog_sync_v1', 'catalog_sync_v2'])
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].wildcard).toBe('catalog_sync_*')
+  })
+
+  test('depth-1 groups only when the next token is volatile', () => {
+    const volatile = names(['job_202608', 'job_202609', 'job_202610'])
+    expect(volatile.groups.map((g) => g.wildcard)).toEqual(['job_*'])
+
+    const stable = names(['job_orders', 'job_users', 'job_payments'])
+    expect(stable.groups).toEqual([])
+    expect(stable.ungrouped).toHaveLength(3)
+  })
+
+  test('respects minGroupSize', () => {
+    const result = groupBySmartPrefix(
+      [
+        { name: 'qrep_sg_orders_202607' },
+        { name: 'qrep_sg_orders_202608' },
+        { name: 'qrep_sg_orders_202609' },
+      ],
+      (m) => m.name,
+      { minGroupSize: 4 }
+    )
+    expect(result.groups).toEqual([])
+    expect(result.ungrouped).toHaveLength(3)
+  })
+
+  test('hyphenated date suffixes keep the hyphen in the wildcard', () => {
+    const result = names(['mirror-prod-202608', 'mirror-prod-202609'])
+    expect(result.groups.map((g) => g.wildcard)).toEqual(['mirror-prod-*'])
+  })
+})

--- a/apps/dashboard/src/components/peerdb/group-by-prefix.ts
+++ b/apps/dashboard/src/components/peerdb/group-by-prefix.ts
@@ -1,0 +1,141 @@
+/**
+ * Smart prefix grouping for named jobs (PeerDB mirrors).
+ *
+ * Splits names on `_` / `-` / `.` / `/` and groups items that share a token
+ * prefix, preferring the longest prefix whose remaining suffix looks volatile
+ * (dates like `202608`, ISO dates, `v2`, hashes, numeric ids). Display uses a
+ * wildcard: `qrep_sg_fleetreporting1_*`.
+ *
+ * Depth-1 groups (`qrep_*`) are skipped unless the next token is volatile, so
+ * a fleet of `qrep_sg_orders_*` + `qrep_sg_users_*` does not collapse into one
+ * coarse `qrep_*` bucket.
+ */
+
+export interface PrefixGroup<T> {
+  /** Display wildcard, e.g. `qrep_sg_fleetreporting1_*`. */
+  wildcard: string
+  /** Shared prefix without the trailing separator, e.g. `qrep_sg_fleetreporting1`. */
+  prefix: string
+  items: T[]
+}
+
+export interface PrefixGrouping<T> {
+  groups: PrefixGroup<T>[]
+  ungrouped: T[]
+}
+
+export interface SplitName {
+  tokens: string[]
+  /** Separator that followed tokens[i]; seps.length === tokens.length - 1 when well-formed. */
+  seps: string[]
+}
+
+export function splitName(name: string): SplitName {
+  const tokens: string[] = []
+  const seps: string[] = []
+  let buf = ''
+  for (const ch of name) {
+    if (ch === '_' || ch === '-' || ch === '.' || ch === '/') {
+      if (buf.length > 0) {
+        tokens.push(buf)
+        seps.push(ch)
+        buf = ''
+      }
+    } else {
+      buf += ch
+    }
+  }
+  if (buf.length > 0) tokens.push(buf)
+  return { tokens, seps }
+}
+
+/**
+ * True when a token is a date, version, hash, or long numeric id — the kind of
+ * suffix that should collapse into a `prefix_*` group rather than stay as a
+ * distinct job name.
+ */
+export function isVolatileToken(token: string): boolean {
+  return /^(?:\d{6,8}|\d{4}-\d{2}(?:-\d{2})?|v?\d+(?:\.\d+)*|[0-9a-f]{8,}|\d{4,})$/i.test(
+    token
+  )
+}
+
+function joinPrefix(split: SplitName, depth: number): string {
+  let prefix = split.tokens[0] ?? ''
+  for (let i = 1; i < depth; i++) {
+    prefix += (split.seps[i - 1] ?? '_') + split.tokens[i]
+  }
+  return prefix
+}
+
+export function wildcardFor(split: SplitName, depth: number): string {
+  const prefix = joinPrefix(split, depth)
+  const sep = split.seps[depth - 1] ?? '_'
+  return `${prefix}${sep}*`
+}
+
+export function groupBySmartPrefix<T>(
+  items: T[],
+  nameOf: (item: T) => string,
+  options?: { minGroupSize?: number }
+): PrefixGrouping<T> {
+  const minGroupSize = options?.minGroupSize ?? 2
+  const named = items.map((item) => ({
+    item,
+    split: splitName(nameOf(item)),
+  }))
+
+  type Candidate = {
+    key: string
+    depth: number
+    volatile: boolean
+    members: typeof named
+  }
+
+  const buckets = new Map<string, typeof named>()
+  for (const row of named) {
+    const { tokens } = row.split
+    for (let depth = 1; depth < tokens.length; depth++) {
+      const key = `${depth}:${tokens.slice(0, depth).join('\0')}`
+      const list = buckets.get(key)
+      if (list) list.push(row)
+      else buckets.set(key, [row])
+    }
+  }
+
+  const candidates: Candidate[] = []
+  for (const [key, members] of buckets) {
+    if (members.length < minGroupSize) continue
+    const depth = Number(key.slice(0, key.indexOf(':')))
+    const volatile = members.every((m) =>
+      isVolatileToken(m.split.tokens[depth] ?? '')
+    )
+    if (depth < 2 && !volatile) continue
+    candidates.push({ key, depth, volatile, members })
+  }
+
+  candidates.sort((a, b) => {
+    if (a.volatile !== b.volatile) return a.volatile ? -1 : 1
+    if (b.depth !== a.depth) return b.depth - a.depth
+    return b.members.length - a.members.length
+  })
+
+  const assigned = new Set<T>()
+  const groups: PrefixGroup<T>[] = []
+
+  for (const c of candidates) {
+    const free = c.members.filter((m) => !assigned.has(m.item))
+    if (free.length < minGroupSize) continue
+    const sample = free[0].split
+    groups.push({
+      wildcard: wildcardFor(sample, c.depth),
+      prefix: joinPrefix(sample, c.depth),
+      items: free.map((m) => m.item),
+    })
+    for (const m of free) assigned.add(m.item)
+  }
+
+  groups.sort((a, b) => a.wildcard.localeCompare(b.wildcard))
+  const ungrouped = items.filter((it) => !assigned.has(it))
+  return { groups, ungrouped }
+}

--- a/apps/dashboard/src/components/peerdb/job-analytics.test.ts
+++ b/apps/dashboard/src/components/peerdb/job-analytics.test.ts
@@ -1,0 +1,80 @@
+import { jobPartitionAnalytics, partitionState } from './job-analytics'
+import { describe, expect, test } from 'bun:test'
+
+describe('partitionState', () => {
+  test('queued / running / done / error', () => {
+    expect(partitionState({})).toBe('queued')
+    expect(partitionState({ startTime: '2026-08-18T00:00:00Z' })).toBe(
+      'running'
+    )
+    expect(
+      partitionState({
+        startTime: '2026-08-18T00:00:00Z',
+        endTime: '2026-08-18T00:00:05Z',
+        rowsInPartition: 10,
+        rowsSynced: 10,
+      })
+    ).toBe('done')
+    expect(
+      partitionState({
+        startTime: '2026-08-18T00:00:00Z',
+        endTime: '2026-08-18T00:00:05Z',
+        rowsInPartition: 10,
+        rowsSynced: 4,
+      })
+    ).toBe('error')
+  })
+})
+
+describe('jobPartitionAnalytics', () => {
+  test('empty partitions', () => {
+    expect(jobPartitionAnalytics([])).toEqual({
+      total: 0,
+      done: 0,
+      running: 0,
+      queued: 0,
+      error: 0,
+      rowsIn: 0,
+      rowsSynced: 0,
+      avgDurationSec: null,
+    })
+  })
+
+  test('counts done / running / queued / error and averages duration', () => {
+    const stats = jobPartitionAnalytics([
+      {
+        partitionId: 'a',
+        startTime: '2026-08-18T08:17:52.000Z',
+        endTime: '2026-08-18T08:17:57.000Z',
+        rowsInPartition: 515,
+        rowsSynced: 515,
+      },
+      {
+        partitionId: 'b',
+        startTime: '2026-08-18T08:18:00.000Z',
+        rowsInPartition: 800,
+        rowsSynced: 240,
+      },
+      {
+        partitionId: 'c',
+        rowsInPartition: 100,
+        rowsSynced: 0,
+      },
+      {
+        partitionId: 'd',
+        startTime: '2026-08-18T08:19:00.000Z',
+        endTime: '2026-08-18T08:19:10.000Z',
+        rowsInPartition: 100,
+        rowsSynced: 40,
+      },
+    ])
+    expect(stats.total).toBe(4)
+    expect(stats.done).toBe(1)
+    expect(stats.running).toBe(1)
+    expect(stats.queued).toBe(1)
+    expect(stats.error).toBe(1)
+    expect(stats.rowsIn).toBe(1515)
+    expect(stats.rowsSynced).toBe(795)
+    expect(stats.avgDurationSec).toBe(5)
+  })
+})

--- a/apps/dashboard/src/components/peerdb/job-analytics.ts
+++ b/apps/dashboard/src/components/peerdb/job-analytics.ts
@@ -1,0 +1,74 @@
+import type { QRepPartition } from '@/lib/peerdb/types'
+
+import { durationMs, toNumber } from './peerdb-utils'
+
+export function partitionState(
+  p: QRepPartition
+): 'done' | 'running' | 'queued' | 'error' {
+  if (p.endTime) {
+    const synced = toNumber(p.rowsSynced)
+    const total = toNumber(p.rowsInPartition ?? p.numRows)
+    // If endTime is set but rowsSynced < rowsInPartition, the partition failed.
+    if (total > 0 && synced > 0 && synced < total) return 'error'
+    return 'done'
+  }
+  // A partition that has started (has a startTime) or already synced rows is
+  // in flight; only un-started partitions are queued.
+  if (p.startTime || toNumber(p.rowsSynced) > 0) return 'running'
+  return 'queued'
+}
+
+export interface JobPartitionAnalytics {
+  total: number
+  done: number
+  running: number
+  queued: number
+  error: number
+  rowsIn: number
+  rowsSynced: number
+  /** Mean duration of finished partitions, seconds. Null when none have ended. */
+  avgDurationSec: number | null
+}
+
+/**
+ * Aggregate QRep / initial-load partition stats for the job header. Pure so
+ * the list, expanded row, and detail page share one definition of "done".
+ */
+export function jobPartitionAnalytics(
+  partitions: QRepPartition[]
+): JobPartitionAnalytics {
+  let done = 0
+  let running = 0
+  let queued = 0
+  let error = 0
+  let rowsIn = 0
+  let rowsSynced = 0
+  let durationSum = 0
+  let durationN = 0
+
+  for (const p of partitions) {
+    const state = partitionState(p)
+    if (state === 'done') done++
+    else if (state === 'running') running++
+    else if (state === 'error') error++
+    else queued++
+    rowsIn += toNumber(p.rowsInPartition ?? p.numRows)
+    rowsSynced += toNumber(p.rowsSynced)
+    const dur = durationMs(p.startTime, p.endTime ?? p.pullEndTime)
+    if (dur != null && state === 'done') {
+      durationSum += dur
+      durationN++
+    }
+  }
+
+  return {
+    total: partitions.length,
+    done,
+    running,
+    queued,
+    error,
+    rowsIn,
+    rowsSynced,
+    avgDurationSec: durationN > 0 ? durationSum / durationN / 1000 : null,
+  }
+}

--- a/apps/dashboard/src/components/peerdb/kpi-card.tsx
+++ b/apps/dashboard/src/components/peerdb/kpi-card.tsx
@@ -4,6 +4,7 @@
 import type { ReactNode } from 'react'
 
 import { PdbSparkline } from './pdb-charts'
+import { cn } from '@/lib/utils'
 
 interface KpiCardProps {
   label: string
@@ -14,6 +15,8 @@ interface KpiCardProps {
   pulse?: boolean
   sparkData?: number[]
   sparkColor?: string
+  /** Totals still aggregating — keep the card visually "in progress". */
+  counting?: boolean
 }
 
 /** KPI stat card with a status dot and optional inline sparkline (PdbKpi). */
@@ -26,6 +29,7 @@ export function KpiCard({
   pulse,
   sparkData,
   sparkColor,
+  counting,
 }: KpiCardProps) {
   return (
     <div className="flex flex-col gap-2.5 rounded-xl border border-border bg-card p-3.5 transition-colors hover:border-foreground/20">
@@ -67,7 +71,12 @@ export function KpiCard({
           {value}
         </span>
         {sub && (
-          <span className="ml-auto text-[11px] leading-tight text-muted-foreground">
+          <span
+            className={cn(
+              'ml-auto text-[11px] leading-tight text-muted-foreground',
+              counting && 'motion-safe:animate-pulse motion-reduce:animate-none'
+            )}
+          >
             {sub}
           </span>
         )}

--- a/apps/dashboard/src/components/peerdb/metrics-cache.test.ts
+++ b/apps/dashboard/src/components/peerdb/metrics-cache.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the compact PeerDB KPI snapshot. Stubs window.localStorage the
+ * same way fleet-helpers.test.ts does (bun test has no DOM).
+ */
+
+import {
+  METRICS_CACHE_KEY_PREFIX,
+  METRICS_CACHE_MAX_AGE_MS,
+  metricsCacheKey,
+  metricsFromSnapshot,
+  parseMetricsCache,
+  readMetricsCache,
+  writeMetricsCache,
+} from './metrics-cache'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+function makeLocalStorageStub() {
+  const store: Record<string, string> = {}
+  return {
+    store,
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+  }
+}
+
+function setWindowLocalStorage(localStorage: unknown) {
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage },
+    writable: true,
+    configurable: true,
+  })
+}
+
+beforeEach(() => {
+  setWindowLocalStorage(makeLocalStorageStub())
+})
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  })
+})
+
+describe('metricsCacheKey', () => {
+  test('env-wide vs per-connection', () => {
+    expect(metricsCacheKey('')).toBe(`${METRICS_CACHE_KEY_PREFIX}:env`)
+    expect(metricsCacheKey('abc')).toBe(`${METRICS_CACHE_KEY_PREFIX}:abc`)
+  })
+})
+
+describe('parseMetricsCache', () => {
+  test('rejects junk, missing version, and stale snapshots', () => {
+    expect(parseMetricsCache(null)).toBeNull()
+    expect(parseMetricsCache('not-json')).toBeNull()
+    expect(
+      parseMetricsCache(JSON.stringify({ v: 2, at: Date.now(), metrics: {} }))
+    ).toBeNull()
+    expect(
+      parseMetricsCache(
+        JSON.stringify({
+          v: 1,
+          at: Date.now() - METRICS_CACHE_MAX_AGE_MS - 1,
+          metrics: {
+            a: { rowsPerSec: 1, rowsSynced: 2, trend: [], lagSec: null },
+          },
+        })
+      )
+    ).toBeNull()
+  })
+
+  test('accepts a fresh v1 snapshot', () => {
+    const snap = parseMetricsCache(
+      JSON.stringify({
+        v: 1,
+        at: Date.now(),
+        metrics: {
+          orders_cdc: {
+            rowsPerSec: 10,
+            rowsSynced: 100,
+            trend: [1, 2],
+            lagSec: 3,
+          },
+        },
+      })
+    )
+    expect(snap?.metrics.orders_cdc.rowsSynced).toBe(100)
+  })
+})
+
+describe('read / write round-trip', () => {
+  test('writes compact numbers and reads them back tagged as cache', () => {
+    writeMetricsCache('env', {
+      orders_cdc: {
+        rowsPerSec: 2840,
+        rowsSynced: 18_412_603,
+        trend: [1, 2, 3],
+        lagSec: 3.2,
+        source: 'live',
+      },
+    })
+    const snap = readMetricsCache('env')
+    expect(snap?.metrics.orders_cdc.rowsSynced).toBe(18_412_603)
+    const seeded = metricsFromSnapshot(snap)
+    expect(seeded.orders_cdc.source).toBe('cache')
+    expect(seeded.orders_cdc.rowsPerSec).toBe(2840)
+  })
+
+  test('write is a no-op when localStorage throws', () => {
+    setWindowLocalStorage({
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('quota')
+      },
+    })
+    expect(() =>
+      writeMetricsCache('env', {
+        a: { rowsPerSec: 1, rowsSynced: 1, trend: [], lagSec: null },
+      })
+    ).not.toThrow()
+    expect(readMetricsCache('env')).toBeNull()
+  })
+})

--- a/apps/dashboard/src/components/peerdb/metrics-cache.ts
+++ b/apps/dashboard/src/components/peerdb/metrics-cache.ts
@@ -1,0 +1,106 @@
+/**
+ * Compact last-known PeerDB KPI snapshot.
+ *
+ * TanStack Query already persists successful queries (see QueryProvider), but
+ * per-mirror `/mirrors/status` payloads are too large to keep on disk (hundreds
+ * of QRep partitions). This store keeps only the numbers the fleet page needs
+ * so the KPI row and per-row totals paint from cache on the next visit, then
+ * count up to live values as probes finish.
+ */
+
+import type { MirrorMetricsSummary } from './use-mirror-metrics'
+
+export const METRICS_CACHE_KEY_PREFIX = 'chm-peerdb-metrics-v1'
+export const METRICS_CACHE_MAX_AGE_MS = 24 * 60 * 60_000
+export const METRICS_CACHE_MAX_ENTRIES = 500
+export const METRICS_CACHE_TREND_CAP = 48
+
+export interface CachedMirrorMetrics extends MirrorMetricsSummary {
+  source: 'cache'
+}
+
+export interface MetricsCacheSnapshot {
+  v: 1
+  at: number
+  metrics: Record<string, MirrorMetricsSummary>
+}
+
+export function metricsCacheKey(connection: string): string {
+  return `${METRICS_CACHE_KEY_PREFIX}:${connection || 'env'}`
+}
+
+function capSummary(summary: MirrorMetricsSummary): MirrorMetricsSummary {
+  const trend = summary.trend.slice(-METRICS_CACHE_TREND_CAP)
+  return {
+    rowsPerSec: summary.rowsPerSec,
+    rowsSynced: summary.rowsSynced,
+    lagSec: summary.lagSec,
+    trend,
+  }
+}
+
+export function parseMetricsCache(
+  raw: string | null
+): MetricsCacheSnapshot | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<MetricsCacheSnapshot>
+    if (parsed.v !== 1 || typeof parsed.at !== 'number' || !parsed.metrics) {
+      return null
+    }
+    if (Date.now() - parsed.at > METRICS_CACHE_MAX_AGE_MS) return null
+    return {
+      v: 1,
+      at: parsed.at,
+      metrics: parsed.metrics,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function readMetricsCache(
+  connection: string
+): MetricsCacheSnapshot | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return parseMetricsCache(
+      window.localStorage.getItem(metricsCacheKey(connection))
+    )
+  } catch {
+    return null
+  }
+}
+
+export function writeMetricsCache(
+  connection: string,
+  metrics: Record<string, MirrorMetricsSummary>
+): void {
+  if (typeof window === 'undefined') return
+  const entries = Object.entries(metrics).slice(0, METRICS_CACHE_MAX_ENTRIES)
+  const snapshot: MetricsCacheSnapshot = {
+    v: 1,
+    at: Date.now(),
+    metrics: Object.fromEntries(entries.map(([k, v]) => [k, capSummary(v)])),
+  }
+  try {
+    window.localStorage.setItem(
+      metricsCacheKey(connection),
+      JSON.stringify(snapshot)
+    )
+  } catch {
+    // Quota / private mode — the live query persist path still covers lists.
+  }
+}
+
+/** Seed page-level totals from a snapshot, tagged so the UI can show "cached". */
+export function metricsFromSnapshot(
+  snapshot: MetricsCacheSnapshot | null
+): Record<string, MirrorMetricsSummary> {
+  if (!snapshot) return {}
+  const out: Record<string, MirrorMetricsSummary> = {}
+  for (const [name, summary] of Object.entries(snapshot.metrics)) {
+    out[name] = { ...capSummary(summary), source: 'cache' }
+  }
+  return out
+}

--- a/apps/dashboard/src/components/peerdb/mirror-group-header.tsx
+++ b/apps/dashboard/src/components/peerdb/mirror-group-header.tsx
@@ -1,0 +1,149 @@
+import { ChevronDownIcon } from 'lucide-react'
+
+import type { MirrorListItem } from '@/lib/peerdb/types'
+import type { PrefixGroup } from './group-by-prefix'
+import type { MirrorMetricsSummary } from './use-mirror-metrics'
+
+import { CountingNumber } from './counting-number'
+import { PdbSparkline } from './pdb-charts'
+import {
+  DESIGN_STATUS_META,
+  type DesignStatus,
+  pdbFmtLag,
+  pdbFmtNum,
+  toDesignStatus,
+} from './peerdb-utils'
+import { cn } from '@/lib/utils'
+
+function groupAnalytics(
+  items: MirrorListItem[],
+  metrics: Record<string, MirrorMetricsSummary>
+) {
+  const counts: Record<DesignStatus, number> = {
+    running: 0,
+    snapshotting: 0,
+    paused: 0,
+    failed: 0,
+  }
+  let rowsPerSec = 0
+  let rowsSynced = 0
+  let lagSec: number | null = null
+  let trendLen = 0
+  let measured = 0
+  let cached = 0
+  for (const m of items) {
+    counts[toDesignStatus(m.status)]++
+    const v = metrics[m.name]
+    if (!v) continue
+    measured++
+    if (v.source === 'cache') cached++
+    rowsPerSec += v.rowsPerSec
+    rowsSynced += v.rowsSynced
+    trendLen = Math.max(trendLen, v.trend.length)
+    if (v.lagSec != null)
+      lagSec = lagSec == null ? v.lagSec : Math.max(lagSec, v.lagSec)
+  }
+  const trend = Array.from({ length: trendLen }, (_, i) =>
+    items.reduce((a, m) => a + (metrics[m.name]?.trend[i] ?? 0), 0)
+  )
+  return { counts, rowsPerSec, rowsSynced, lagSec, trend, measured, cached }
+}
+
+interface MirrorGroupHeaderProps {
+  group: PrefixGroup<MirrorListItem>
+  expanded: boolean
+  onToggle: () => void
+  metrics: Record<string, MirrorMetricsSummary>
+  counting: boolean
+}
+
+/** Collapsible prefix-group row: wildcard name + aggregated job analytics. */
+export function MirrorGroupHeader({
+  group,
+  expanded,
+  onToggle,
+  metrics,
+  counting,
+}: MirrorGroupHeaderProps) {
+  const agg = groupAnalytics(group.items, metrics)
+  const cached = agg.cached > 0 && agg.cached === agg.measured
+  const statusBits = (
+    ['running', 'snapshotting', 'paused', 'failed'] as DesignStatus[]
+  ).filter((k) => agg.counts[k] > 0)
+
+  return (
+    <tr className="border-b border-border bg-muted/30">
+      <td colSpan={8} className="p-0">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          className="flex w-full flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2 text-left hover:bg-muted/50"
+        >
+          <ChevronDownIcon
+            className={cn(
+              'size-3.5 shrink-0 text-muted-foreground transition-transform',
+              !expanded && '-rotate-90'
+            )}
+          />
+          <span className="font-mono text-[12.5px] font-semibold">
+            {group.wildcard}
+          </span>
+          <span className="inline-flex items-center rounded-md border border-border bg-card px-1.5 py-0.5 font-mono text-[10.5px] text-muted-foreground">
+            {group.items.length} jobs
+          </span>
+          <span className="flex items-center gap-1.5">
+            {statusBits.map((k) => (
+              <span
+                key={k}
+                className="inline-flex items-center gap-1 text-[10.5px] tabular-nums text-muted-foreground"
+              >
+                <span
+                  className="size-1.5 rounded-full"
+                  style={{ background: DESIGN_STATUS_META[k].dot }}
+                />
+                {agg.counts[k]}
+              </span>
+            ))}
+          </span>
+          <span className="ml-auto flex flex-wrap items-center gap-4 text-[11.5px] tabular-nums">
+            <span className="hidden sm:inline text-muted-foreground">
+              lag{' '}
+              <span className="font-medium text-foreground">
+                {pdbFmtLag(agg.lagSec)}
+              </span>
+            </span>
+            <span className="text-muted-foreground">
+              <CountingNumber
+                value={agg.rowsPerSec}
+                counting={counting}
+                cached={cached}
+                className="font-medium text-foreground"
+              />
+              <span className="ml-0.5">/s</span>
+            </span>
+            <span className="text-muted-foreground">
+              <CountingNumber
+                value={agg.rowsSynced}
+                counting={counting}
+                cached={cached}
+                format={pdbFmtNum}
+                className="font-medium text-foreground"
+              />{' '}
+              rows
+            </span>
+            {agg.trend.length > 1 && (
+              <PdbSparkline
+                data={agg.trend}
+                color={DESIGN_STATUS_META.running.dot}
+                width={72}
+                height={20}
+                fill={0.22}
+              />
+            )}
+          </span>
+        </button>
+      </td>
+    </tr>
+  )
+}

--- a/apps/dashboard/src/components/peerdb/mirror-metrics-probe.tsx
+++ b/apps/dashboard/src/components/peerdb/mirror-metrics-probe.tsx
@@ -1,0 +1,45 @@
+import type { MirrorMetricsSummary } from './use-mirror-metrics'
+
+import { useMirrorMetrics } from './use-mirror-metrics'
+import { useEffect } from 'react'
+
+/**
+ * Headless per-mirror metrics fetch. Mounted for the eager KPI budget so
+ * collapsed prefix groups still contribute to page totals without rendering
+ * a table row (and so we can unmount collapsed rows without dropping KPIs).
+ */
+export function MirrorMetricsProbe({
+  name,
+  isCdc,
+  onMetrics,
+}: {
+  name: string
+  isCdc: boolean
+  onMetrics: (name: string, summary: MirrorMetricsSummary) => void
+}) {
+  const metrics = useMirrorMetrics(name, isCdc, true)
+  const trendKey = metrics.trend.join(',')
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trend tracked via trendKey
+  useEffect(() => {
+    if (metrics.source !== 'live') return
+    onMetrics(name, {
+      rowsPerSec: metrics.rowsPerSec,
+      rowsSynced: metrics.rowsSynced,
+      trend: metrics.trend,
+      lagSec: metrics.lagSec,
+      source: 'live',
+    })
+  }, [
+    name,
+    metrics.rowsPerSec,
+    metrics.rowsSynced,
+    trendKey,
+    metrics.lagSec,
+    metrics.loading,
+    metrics.source,
+    onMetrics,
+  ])
+
+  return null
+}

--- a/apps/dashboard/src/components/peerdb/mirror-row.tsx
+++ b/apps/dashboard/src/components/peerdb/mirror-row.tsx
@@ -29,6 +29,8 @@ interface MirrorRowProps {
   /** Fetch live metrics even when collapsed (eager for small lists). */
   loadMetrics?: boolean
   onMetrics?: (name: string, summary: MirrorMetricsSummary) => void
+  /** Last-known numbers while the live probe is still in flight. */
+  cachedMetrics?: MirrorMetricsSummary
 }
 
 export function MirrorRow({
@@ -37,21 +39,45 @@ export function MirrorRow({
   onToggle,
   loadMetrics = false,
   onMetrics,
+  cachedMetrics,
 }: MirrorRowProps) {
   // Treat undefined `isCdc` as CDC consistently so labels and metrics agree.
   const isCdc = mirror.isCdc !== false
   const type = isCdc ? 'CDC' : 'QRep'
   const meta = DESIGN_STATUS_META[toDesignStatus(mirror.status)]
   const metrics = useMirrorMetrics(mirror.name, isCdc, loadMetrics || expanded)
-  const { trend, rowsPerSec, rowsSynced, lagSec, partitions } = metrics
+  const waiting = metrics.loading && metrics.source !== 'live'
+  const trend = waiting && cachedMetrics ? cachedMetrics.trend : metrics.trend
+  const rowsPerSec =
+    waiting && cachedMetrics ? cachedMetrics.rowsPerSec : metrics.rowsPerSec
+  const rowsSynced =
+    waiting && cachedMetrics ? cachedMetrics.rowsSynced : metrics.rowsSynced
+  const lagSec =
+    waiting && cachedMetrics ? cachedMetrics.lagSec : metrics.lagSec
+  const partitions = metrics.partitions
   const panelId = useId()
 
-  const trendKey = trend.join(',')
+  const trendKey = metrics.trend.join(',')
   // Report metrics up so the page can aggregate KPI totals + lag triage (deduped fetch).
   // biome-ignore lint/correctness/useExhaustiveDependencies: trend tracked via trendKey
   useEffect(() => {
-    onMetrics?.(mirror.name, { rowsPerSec, rowsSynced, trend, lagSec })
-  }, [mirror.name, rowsPerSec, rowsSynced, trendKey, lagSec, onMetrics])
+    if (waiting || metrics.source !== 'live') return
+    onMetrics?.(mirror.name, {
+      rowsPerSec: metrics.rowsPerSec,
+      rowsSynced: metrics.rowsSynced,
+      trend: metrics.trend,
+      lagSec: metrics.lagSec,
+      source: 'live',
+    })
+  }, [
+    mirror.name,
+    metrics.rowsPerSec,
+    metrics.rowsSynced,
+    trendKey,
+    metrics.lagSec,
+    waiting,
+    onMetrics,
+  ])
 
   const lagAccent =
     lagSec == null
@@ -136,7 +162,12 @@ export function MirrorRow({
         </td>
 
         <td className="hidden px-3 py-2.5 text-right lg:table-cell">
-          <div className="font-mono text-[12px] tabular-nums">
+          <div
+            className={cn(
+              'font-mono text-[12px] tabular-nums',
+              waiting && 'motion-safe:animate-pulse motion-reduce:animate-none'
+            )}
+          >
             {rowsPerSec > 0 ? (
               pdbFmtNum(rowsPerSec)
             ) : (
@@ -151,7 +182,13 @@ export function MirrorRow({
         <td className="px-3 py-2.5">
           <div className="flex items-center justify-end gap-3">
             <div className="text-right">
-              <div className="font-mono text-[12.5px] font-semibold leading-tight tabular-nums">
+              <div
+                className={cn(
+                  'font-mono text-[12.5px] font-semibold leading-tight tabular-nums',
+                  waiting &&
+                    'motion-safe:animate-pulse motion-reduce:animate-none'
+                )}
+              >
                 {pdbFmtNum(rowsSynced)}
               </div>
               <div className="text-[10px] leading-tight tabular-nums text-muted-foreground">

--- a/apps/dashboard/src/components/peerdb/qrep-partitions.tsx
+++ b/apps/dashboard/src/components/peerdb/qrep-partitions.tsx
@@ -1,5 +1,8 @@
+import { SearchIcon, XIcon } from 'lucide-react'
+
 import type { QRepPartition } from '@/lib/peerdb/types'
 
+import { jobPartitionAnalytics, partitionState } from './job-analytics'
 import {
   durationMs,
   pdbFmtClock,
@@ -7,22 +10,9 @@ import {
   pdbFmtNum,
   toNumber,
 } from './peerdb-utils'
+import { useMemo, useState } from 'react'
 
-export function partitionState(
-  p: QRepPartition
-): 'done' | 'running' | 'queued' | 'error' {
-  if (p.endTime) {
-    const synced = toNumber(p.rowsSynced)
-    const total = toNumber(p.rowsInPartition ?? p.numRows)
-    // If endTime is set but rowsSynced < rowsInPartition, the partition failed.
-    if (total > 0 && synced > 0 && synced < total) return 'error'
-    return 'done'
-  }
-  // A partition that has started (has a startTime) or already synced rows is
-  // in flight; only un-started partitions are queued.
-  if (p.startTime || toNumber(p.rowsSynced) > 0) return 'running'
-  return 'queued'
-}
+export { partitionState } from './job-analytics'
 
 const PART_TONE: Record<string, string> = {
   done: '#10b981',
@@ -56,50 +46,102 @@ export function buildSyncHistory(
     }))
 }
 
-/** QRep partition sync-progress table (first 12 partitions). */
+const DEFAULT_PAGE_SIZE = 25
+
+/** QRep partition sync-progress table with search, paging, and totals. */
 export function QRepPartitions({
   partitions,
+  pageSize = DEFAULT_PAGE_SIZE,
 }: {
   partitions: QRepPartition[]
+  pageSize?: number
 }) {
-  const done = partitions.filter((p) => partitionState(p) === 'done').length
-  const errored = partitions.filter((p) => partitionState(p) === 'error').length
-  const running = partitions.filter(
-    (p) => partitionState(p) === 'running'
-  ).length
-  const queued = partitions.filter((p) => partitionState(p) === 'queued').length
+  const [query, setQuery] = useState('')
+  const [page, setPage] = useState(0)
+  const stats = jobPartitionAnalytics(partitions)
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const list = q
+      ? partitions.filter((p) =>
+          (p.partitionId ?? '').toLowerCase().includes(q)
+        )
+      : partitions
+    return [...list].sort((a, b) => {
+      const at = Date.parse(a.startTime ?? '') || 0
+      const bt = Date.parse(b.startTime ?? '') || 0
+      return bt - at
+    })
+  }, [partitions, query])
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize))
+  const safePage = Math.min(page, pageCount - 1)
+  const slice = filtered.slice(safePage * pageSize, (safePage + 1) * pageSize)
+  const from = filtered.length === 0 ? 0 : safePage * pageSize + 1
+  const to = Math.min(filtered.length, (safePage + 1) * pageSize)
+
   return (
     <div className="overflow-hidden rounded-md border border-border bg-card">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-muted/40 px-3 py-2">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-            QRep partitions
+            Progress
           </span>
           <span className="text-[11px] tabular-nums">
             <span className="font-semibold text-emerald-600 dark:text-emerald-400">
-              {done}
+              {stats.done}
             </span>
             <span className="text-muted-foreground"> done</span>
             <span className="mx-1.5 text-muted-foreground">·</span>
             <span className="font-semibold text-blue-600 dark:text-blue-400">
-              {running}
+              {stats.running}
             </span>
             <span className="text-muted-foreground"> in flight</span>
             <span className="mx-1.5 text-muted-foreground">·</span>
             <span className="font-semibold text-muted-foreground">
-              {queued}
+              {stats.queued}
             </span>
             <span className="text-muted-foreground"> queued</span>
-            {errored > 0 && (
+            {stats.error > 0 && (
               <>
                 <span className="mx-1.5 text-muted-foreground">·</span>
                 <span className="font-semibold text-rose-600 dark:text-rose-400">
-                  {errored}
+                  {stats.error}
                 </span>
                 <span className="text-muted-foreground"> error</span>
               </>
             )}
           </span>
+          <span className="text-[11px] tabular-nums text-muted-foreground">
+            · {pdbFmtNum(stats.rowsSynced)} / {pdbFmtNum(stats.rowsIn)} rows
+            {stats.avgDurationSec != null && (
+              <> · avg {pdbFmtDuration(stats.avgDurationSec)}</>
+            )}
+          </span>
+        </div>
+        <div className="flex h-7 w-[220px] items-center gap-1.5 rounded-md border border-border bg-card px-2">
+          <SearchIcon className="size-3 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setPage(0)
+            }}
+            placeholder="Search by partition"
+            className="min-w-0 flex-1 bg-transparent text-[11.5px] outline-none placeholder:text-muted-foreground"
+          />
+          {query && (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('')
+                setPage(0)
+              }}
+              className="text-muted-foreground"
+            >
+              <XIcon className="size-3" />
+            </button>
+          )}
         </div>
       </div>
       <div className="overflow-x-auto">
@@ -124,7 +166,7 @@ export function QRepPartitions({
             </tr>
           </thead>
           <tbody>
-            {partitions.slice(0, 12).map((p, i) => {
+            {slice.map((p, i) => {
               const st = partitionState(p)
               const tone = PART_TONE[st]
               const rowsIn = toNumber(p.rowsInPartition ?? p.numRows)
@@ -140,7 +182,7 @@ export function QRepPartitions({
                   className="border-b border-border last:border-b-0 hover:bg-muted/40"
                 >
                   <td className="px-2.5 py-1.5 font-mono tabular-nums text-muted-foreground">
-                    {i + 1}
+                    {from + i}
                   </td>
                   <td className="px-2.5 py-1.5">
                     <span className="font-mono text-[10.5px]" title={uuid}>
@@ -196,6 +238,35 @@ export function QRepPartitions({
             })}
           </tbody>
         </table>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border px-3 py-1.5 text-[11px] text-muted-foreground">
+        <span className="tabular-nums">
+          {from === 0 ? '0 of 0' : `${from}–${to} of ${filtered.length}`}
+          {filtered.length !== partitions.length
+            ? ` (filtered from ${partitions.length})`
+            : ''}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            disabled={safePage <= 0}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            className="rounded-md border border-border px-2 py-0.5 disabled:opacity-40"
+          >
+            Prev
+          </button>
+          <span className="tabular-nums">
+            {safePage + 1} / {pageCount}
+          </span>
+          <button
+            type="button"
+            disabled={safePage >= pageCount - 1}
+            onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+            className="rounded-md border border-border px-2 py-0.5 disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/apps/dashboard/src/components/peerdb/use-mirror-metrics.ts
+++ b/apps/dashboard/src/components/peerdb/use-mirror-metrics.ts
@@ -18,6 +18,7 @@ export interface DerivedMetrics {
   batches: CDCBatch[]
   errorMessage?: string
   loading: boolean
+  source?: 'live' | 'cache'
 }
 
 /** Summary surfaced to the page so it can aggregate KPI totals + lag triage. */
@@ -26,6 +27,8 @@ export interface MirrorMetricsSummary {
   rowsSynced: number
   trend: number[]
   lagSec: number | null
+  /** `cache` = last snapshot; `live` = this session's PeerDB fetch. */
+  source?: 'live' | 'cache'
 }
 
 /**
@@ -86,6 +89,10 @@ export function useMirrorMetrics(
     if (end != null) lagSec = Math.max(0, (Date.now() - end) / 1000)
   }
 
+  const loading = enabled && (status.isLoading || graph.isLoading)
+  const live =
+    enabled && !loading && (status.data != null || graph.data != null)
+
   return {
     trend,
     rowsPerSec,
@@ -94,6 +101,7 @@ export function useMirrorMetrics(
     partitions,
     batches,
     errorMessage: status.data?.errorMessage,
-    loading: status.isLoading || graph.isLoading,
+    loading,
+    source: live ? 'live' : undefined,
   }
 }

--- a/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
+++ b/apps/dashboard/src/lib/query/__tests__/provider.test.tsx
@@ -53,9 +53,7 @@ describe('invalidateActiveQueriesInBatches', () => {
     })
 
     type InvalidateArg = { type?: string; queryKey?: readonly unknown[] }
-    const calls = invalidateSpy.mock.calls.map(
-      (c) => (c as [InvalidateArg])[0]
-    )
+    const calls = invalidateSpy.mock.calls.map((c) => (c as [InvalidateArg])[0])
     expect(calls.some((arg) => arg && arg.type === 'active')).toBe(false)
     expect(invalidateSpy).toHaveBeenCalledTimes(20)
 
@@ -137,5 +135,33 @@ describe('shouldDehydrateQuery persistence exclusions', () => {
   // it out of the persisted cache is what preserves the single source of truth.
   it('never persists user-settings, so localStorage stays authoritative', () => {
     expect(shouldDehydrateQuery(q(USER_SETTINGS_QUERY_KEY))).toBe(false)
+  })
+
+  it('persists compact PeerDB list/peers queries for a fast first paint', () => {
+    expect(
+      shouldDehydrateQuery(q(['peerdb', '/mirrors/list', 'GET', '', '']))
+    ).toBe(true)
+    expect(
+      shouldDehydrateQuery(q(['peerdb', '/peers/list', 'GET', '', '']))
+    ).toBe(true)
+  })
+
+  it('skips bulky per-mirror PeerDB payloads (status/batches/logs)', () => {
+    expect(
+      shouldDehydrateQuery(q(['peerdb', '/mirrors/status', 'POST', '{}', '']))
+    ).toBe(false)
+    expect(
+      shouldDehydrateQuery(
+        q(['peerdb', '/mirrors/cdc/batches', 'POST', '{}', ''])
+      )
+    ).toBe(false)
+    expect(
+      shouldDehydrateQuery(q(['peerdb', '/mirrors/logs', 'POST', '{}', '']))
+    ).toBe(false)
+    expect(
+      shouldDehydrateQuery(
+        q(['peerdb', '/mirrors/cdc/table_total_counts/orders', 'GET', '', ''])
+      )
+    ).toBe(false)
   })
 })

--- a/apps/dashboard/src/lib/query/provider.tsx
+++ b/apps/dashboard/src/lib/query/provider.tsx
@@ -69,6 +69,28 @@ const NEVER_PERSIST_QUERY_KEYS = new Set<string>([
  * Decide whether a query may be written to the persisted cache. Exported so the
  * exclusions can be tested without rendering the provider.
  */
+/**
+ * PeerDB `/mirrors/status`, batches, logs, and per-table counts are large
+ * (hundreds of QRep partitions). Persisting them blows the ~5 MB localStorage
+ * budget and slows first paint. Compact KPI numbers live in
+ * `chm-peerdb-metrics-v1` instead; list/peers/graph still persist here.
+ */
+const BULKY_PEERDB_PATHS = new Set([
+  '/mirrors/status',
+  '/mirrors/cdc/batches',
+  '/mirrors/logs',
+])
+
+function isBulkyPeerDBQuery(queryKey: readonly unknown[]): boolean {
+  if (queryKey[0] !== 'peerdb') return false
+  const path = String(queryKey[1] ?? '')
+  if (BULKY_PEERDB_PATHS.has(path)) return true
+  return (
+    path.startsWith('/mirrors/cdc/table_total_counts/') ||
+    path.startsWith('/mirrors/cdc/initial_load/')
+  )
+}
+
 export function shouldDehydrateQuery(query: {
   state: { status: string }
   queryKey: readonly unknown[]
@@ -80,6 +102,7 @@ export function shouldDehydrateQuery(query: {
   // Never persist per-user server connections — would leak across accounts.
   if (query.queryKey[0] === USER_CONNECTIONS_QUERY_PREFIX) return false
   if (NEVER_PERSIST_QUERY_KEYS.has(String(query.queryKey[0]))) return false
+  if (isBulkyPeerDBQuery(query.queryKey)) return false
   return true
 }
 

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/index.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   ExternalLinkIcon,
+  LayersIcon,
   NetworkIcon,
   RefreshCwIcon,
   SearchIcon,
@@ -10,19 +11,31 @@ import {
 import { toast } from 'sonner'
 import { createFileRoute } from '@tanstack/react-router'
 
+import type { ReactNode } from 'react'
+import type { PrefixGroup } from '@/components/peerdb/group-by-prefix'
 import type { MirrorMetricsSummary } from '@/components/peerdb/mirror-row'
-import type { ListMirrorsResponse, ListPeersResponse } from '@/lib/peerdb/types'
+import type {
+  ListMirrorsResponse,
+  ListPeersResponse,
+  MirrorListItem,
+} from '@/lib/peerdb/types'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { CountingNumber } from '@/components/peerdb/counting-number'
 import { FleetLagTriage } from '@/components/peerdb/fleet-lag-triage'
 import { FleetLogsFeed } from '@/components/peerdb/fleet-logs-feed'
+import { groupBySmartPrefix } from '@/components/peerdb/group-by-prefix'
 import { KpiCard } from '@/components/peerdb/kpi-card'
+import {
+  metricsFromSnapshot,
+  readMetricsCache,
+  writeMetricsCache,
+} from '@/components/peerdb/metrics-cache'
+import { MirrorGroupHeader } from '@/components/peerdb/mirror-group-header'
+import { MirrorMetricsProbe } from '@/components/peerdb/mirror-metrics-probe'
 import { MirrorRow } from '@/components/peerdb/mirror-row'
 import { PeerGraph } from '@/components/peerdb/peer-graph'
-import {
-  EAGER_METRICS_LIMIT,
-  shouldEagerLoadMetrics,
-} from '@/components/peerdb/peerdb-derive'
+import { EAGER_METRICS_LIMIT } from '@/components/peerdb/peerdb-derive'
 import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
   DESIGN_STATUS_META,
@@ -32,6 +45,8 @@ import {
   toDesignStatus,
 } from '@/components/peerdb/peerdb-utils'
 import { usePeerDBStatus } from '@/components/peerdb/use-peerdb-status'
+import { useUrlSearchParams } from '@/hooks/use-url-search-params'
+import { PEERDB_CONNECTION_PARAM } from '@/lib/peerdb/peerdb-auth'
 import { usePeerDB } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
@@ -49,8 +64,42 @@ const FILTERS: { k: DesignStatus | 'all'; label: string }[] = [
 
 /** Rows rendered before "Show more" — windows huge fleets so the DOM stays light. */
 const PAGE_SIZE = 60
+const GROUP_ON_KEY = 'chm-peerdb-group-by-prefix'
+const GROUP_COLLAPSE_KEY = 'chm-peerdb-group-collapsed'
+/** Groups this large start collapsed unless the user has toggled them. */
+const DEFAULT_COLLAPSE_AT = 4
+
+type CollapseMap = Record<string, boolean>
+
+function readCollapseMap(): CollapseMap {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(GROUP_COLLAPSE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as CollapseMap
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function isGroupCollapsed(
+  wildcard: string,
+  size: number,
+  map: CollapseMap
+): boolean {
+  if (wildcard in map) return map[wildcard]
+  return size >= DEFAULT_COLLAPSE_AT
+}
+
+type ListEntry =
+  | { kind: 'group'; group: PrefixGroup<MirrorListItem> }
+  | { kind: 'mirror'; mirror: MirrorListItem }
 
 function PeerDBMirrorsPage() {
+  const searchParams = useUrlSearchParams()
+  const connection = searchParams.get(PEERDB_CONNECTION_PARAM) ?? ''
+
   const {
     data,
     error,
@@ -90,7 +139,6 @@ function PeerDBMirrorsPage() {
     }
   }
 
-  // Trigger sonner toast notifications on fetching errors
   useEffect(() => {
     if (error) {
       toast.error(`Mirrors API Error: ${error.message}`)
@@ -118,8 +166,41 @@ function PeerDBMirrorsPage() {
   const [metrics, setMetrics] = useState<Record<string, MirrorMetricsSummary>>(
     {}
   )
+  const [groupOn, setGroupOn] = useState(true)
+  const [collapseMap, setCollapseMap] = useState<CollapseMap>({})
 
-  const onMetrics = (name: string, m: MirrorMetricsSummary) => {
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(GROUP_ON_KEY) === '0') setGroupOn(false)
+    } catch {
+      // private mode
+    }
+    setCollapseMap(readCollapseMap())
+  }, [])
+
+  useEffect(() => {
+    const snap = readMetricsCache(connection)
+    if (!snap) return
+    setMetrics((prev) => {
+      const seeded = metricsFromSnapshot(snap)
+      const next = { ...seeded }
+      for (const [name, cur] of Object.entries(prev)) {
+        if (cur.source === 'live') next[name] = cur
+      }
+      return next
+    })
+  }, [connection])
+
+  useEffect(() => {
+    if (Object.keys(metrics).length === 0) return
+    const t = window.setTimeout(
+      () => writeMetricsCache(connection, metrics),
+      400
+    )
+    return () => window.clearTimeout(t)
+  }, [connection, metrics])
+
+  const onMetrics = useCallback((name: string, m: MirrorMetricsSummary) => {
     setMetrics((prev) => {
       const cur = prev[name]
       const sameTrend =
@@ -131,13 +212,14 @@ function PeerDBMirrorsPage() {
         cur.rowsPerSec === m.rowsPerSec &&
         cur.rowsSynced === m.rowsSynced &&
         cur.lagSec === m.lagSec &&
+        cur.source === m.source &&
         sameTrend
       ) {
         return prev
       }
       return { ...prev, [name]: m }
     })
-  }
+  }, [])
 
   const mirrors = data?.mirrors ?? []
   const peers = (() => {
@@ -171,10 +253,12 @@ function PeerDBMirrorsPage() {
     let rowsSynced = 0
     let trendLen = 0
     let measured = 0
+    let cached = 0
     for (const m of mirrors) {
       const v = metrics[m.name]
       if (!v) continue
       measured++
+      if (v.source === 'cache') cached++
       rowsPerSec += v.rowsPerSec
       rowsSynced += v.rowsSynced
       trendLen = Math.max(trendLen, v.trend.length)
@@ -182,7 +266,7 @@ function PeerDBMirrorsPage() {
     const aggTrend = Array.from({ length: trendLen }, (_, i) =>
       mirrors.reduce((a, m) => a + (metrics[m.name]?.trend[i] ?? 0), 0)
     )
-    return { rowsPerSec, rowsSynced, aggTrend, measured }
+    return { rowsPerSec, rowsSynced, aggTrend, measured, cached }
   })()
 
   const filtered = mirrors.filter((m) => {
@@ -198,24 +282,66 @@ function PeerDBMirrorsPage() {
     return true
   })
 
+  const grouping = useMemo(
+    () =>
+      groupOn
+        ? groupBySmartPrefix(filtered, (m) => m.name)
+        : { groups: [], ungrouped: filtered },
+    [filtered, groupOn]
+  )
+
+  const entries: ListEntry[] = useMemo(() => {
+    if (!groupOn) {
+      return filtered.map((mirror) => ({ kind: 'mirror' as const, mirror }))
+    }
+    return [
+      ...grouping.groups.map((group) => ({ kind: 'group' as const, group })),
+      ...grouping.ungrouped.map((mirror) => ({
+        kind: 'mirror' as const,
+        mirror,
+      })),
+    ]
+  }, [filtered, groupOn, grouping])
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: deliberate reset triggers
   useEffect(() => {
     setVisibleCount(PAGE_SIZE)
-  }, [statusFilter, search])
+  }, [statusFilter, search, groupOn])
 
-  const visible = filtered.slice(0, visibleCount)
+  const visibleEntries = entries.slice(0, visibleCount)
 
   if (isPeerDBNotConfigured(error)) {
     return <PeerDBNotConfigured />
   }
 
-  // The first EAGER_METRICS_LIMIT rows always load metrics on mount so the
-  // header KPIs, sparklines, and lag triage are populated before any row is
-  // expanded; the rest load lazily on expand to cap the PeerDB API fan-out.
-  // `eagerMetrics` here means "the whole fleet fits the eager budget" and only
-  // drives the KPI sub-label (all vs partial), not the per-row gating.
+  const eagerSlice = mirrors.slice(0, EAGER_METRICS_LIMIT)
+  const liveCount = eagerSlice.filter(
+    (m) => metrics[m.name]?.source === 'live'
+  ).length
+  const counting = eagerSlice.length > 0 && liveCount < eagerSlice.length
+  const usingCache = totals.cached > 0
   const eagerMetrics =
     mirrors.length > 0 && mirrors.length <= EAGER_METRICS_LIMIT
+
+  const throughputSub = counting
+    ? usingCache
+      ? `counting ${liveCount}/${eagerSlice.length} · cached`
+      : `counting ${liveCount}/${eagerSlice.length}`
+    : eagerMetrics
+      ? usingCache
+        ? 'rows/s · cached'
+        : 'rows/s · all mirrors'
+      : `rows/s · ${totals.measured}/${mirrors.length} loaded`
+
+  const syncedSub = counting
+    ? usingCache
+      ? `counting ${liveCount}/${eagerSlice.length} · cached`
+      : `counting ${liveCount}/${eagerSlice.length}`
+    : eagerMetrics
+      ? usingCache
+        ? 'cumulative · cached'
+        : 'cumulative all-time'
+      : `cumulative · ${totals.measured}/${mirrors.length} loaded`
 
   const toggleRow = (id: string) =>
     setExpanded((prev) => {
@@ -223,6 +349,28 @@ function PeerDBMirrorsPage() {
       next.has(id) ? next.delete(id) : next.add(id)
       return next
     })
+
+  const toggleGroup = (wildcard: string, size: number) => {
+    setCollapseMap((prev) => {
+      const currently = isGroupCollapsed(wildcard, size, prev)
+      const next = { ...prev, [wildcard]: !currently }
+      try {
+        window.localStorage.setItem(GROUP_COLLAPSE_KEY, JSON.stringify(next))
+      } catch {
+        // private mode
+      }
+      return next
+    })
+  }
+
+  const setGrouping = (on: boolean) => {
+    setGroupOn(on)
+    try {
+      window.localStorage.setItem(GROUP_ON_KEY, on ? '1' : '0')
+    } catch {
+      // private mode
+    }
+  }
 
   const connected = status?.state === 'connected'
   const chipTone = connected
@@ -236,8 +384,31 @@ function PeerDBMirrorsPage() {
       ? '#f59e0b'
       : '#94a3b8'
 
+  const renderMirror = (m: MirrorListItem) => (
+    <MirrorRow
+      key={m.name}
+      mirror={m}
+      expanded={expanded.has(m.name)}
+      onToggle={() => toggleRow(m.name)}
+      loadMetrics={expanded.has(m.name)}
+      onMetrics={onMetrics}
+      cachedMetrics={
+        metrics[m.name]?.source === 'cache' ? metrics[m.name] : undefined
+      }
+    />
+  )
+
   return (
     <div className="max-w-[1640px] px-3 py-4 sm:px-4 sm:py-5 md:px-6">
+      {eagerSlice.map((m) => (
+        <MirrorMetricsProbe
+          key={m.name}
+          name={m.name}
+          isCdc={m.isCdc !== false}
+          onMetrics={onMetrics}
+        />
+      ))}
+
       {/* header */}
       <div className="mb-1 flex flex-wrap items-start justify-between gap-3 sm:items-center">
         <div className="flex min-w-0 items-center gap-2">
@@ -247,6 +418,11 @@ function PeerDBMirrorsPage() {
           <span className="ml-1 inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-muted-foreground">
             {mirrors.length} mirrors
           </span>
+          {groupOn && grouping.groups.length > 0 && (
+            <span className="inline-flex items-center rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[10.5px] font-medium text-muted-foreground">
+              {grouping.groups.length} groups
+            </span>
+          )}
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
           <span
@@ -273,10 +449,12 @@ function PeerDBMirrorsPage() {
               {status?.host ?? '—'}
             </span>
           </span>
-          {isRefreshing && (
+          {(isRefreshing || counting) && (
             <span className="mr-1 inline-flex animate-pulse items-center gap-1.5 text-[11px] text-muted-foreground">
               <span className="size-1.5 rounded-full bg-primary" />
-              Syncing in background...
+              {counting
+                ? `Counting ${liveCount}/${eagerSlice.length} jobs…`
+                : 'Syncing in background...'}
             </span>
           )}
           <button
@@ -314,7 +492,6 @@ function PeerDBMirrorsPage() {
         <span className="font-mono">/v1/mirrors/list</span>.
       </p>
 
-      {/* API connection error warning banner */}
       {(error || peersError || statusError) && (
         <div className="mb-4 animate-in fade-in slide-in-from-top-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-destructive/20 bg-destructive/10 px-4 py-3 text-[12.5px] text-destructive shadow-sm duration-300">
           <div className="flex items-center gap-2">
@@ -369,31 +546,36 @@ function PeerDBMirrorsPage() {
         />
         <KpiCard
           label="Throughput"
-          value={pdbFmtNum(totals.rowsPerSec)}
-          sub={
-            eagerMetrics
-              ? 'rows/s · all mirrors'
-              : `rows/s · ${totals.measured}/${mirrors.length} loaded`
+          value={
+            <CountingNumber
+              value={totals.rowsPerSec}
+              counting={counting}
+              cached={usingCache && counting}
+            />
           }
+          sub={throughputSub}
+          counting={counting}
           dotColor="#6366f1"
           sparkData={totals.aggTrend}
           sparkColor="#6366f1"
         />
         <KpiCard
           label="Rows synced"
-          value={pdbFmtNum(totals.rowsSynced)}
-          sub={
-            eagerMetrics
-              ? 'cumulative all-time'
-              : `cumulative · ${totals.measured}/${mirrors.length} loaded`
+          value={
+            <CountingNumber
+              value={totals.rowsSynced}
+              counting={counting}
+              cached={usingCache && counting}
+              format={pdbFmtNum}
+            />
           }
+          sub={syncedSub}
+          counting={counting}
         />
       </div>
 
-      {/* lag triage strip — worst-lag mirrors (quiet when the fleet is healthy) */}
       <FleetLagTriage mirrors={mirrors} metrics={metrics} />
 
-      {/* topology card — expand button centered on bottom border */}
       <div className="relative mb-6">
         <div className="overflow-hidden rounded-xl border border-border bg-card">
           <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
@@ -432,9 +614,7 @@ function PeerDBMirrorsPage() {
         </div>
       </div>
 
-      {/* mirror table card */}
       <div className="overflow-hidden rounded-xl border border-border bg-card">
-        {/* toolbar */}
         <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2.5">
           <div className="flex h-8 min-w-[200px] max-w-[360px] flex-1 items-center gap-1.5 rounded-md border border-border bg-card px-2.5">
             <SearchIcon className="size-3 text-muted-foreground" />
@@ -479,6 +659,21 @@ function PeerDBMirrorsPage() {
               )
             })}
           </div>
+          <button
+            type="button"
+            onClick={() => setGrouping(!groupOn)}
+            aria-pressed={groupOn}
+            className={cn(
+              'inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-[12px] font-medium',
+              groupOn
+                ? 'border-border bg-card text-foreground shadow-sm'
+                : 'border-transparent text-muted-foreground hover:bg-muted'
+            )}
+            title="Group jobs that share a name prefix (qrep_sg_fleetreporting1_*)"
+          >
+            <LayersIcon className="size-3.5" />
+            <span className="hidden sm:inline">Group by prefix</span>
+          </button>
           <div className="flex-1" />
         </div>
 
@@ -522,16 +717,30 @@ function PeerDBMirrorsPage() {
               </tr>
             </thead>
             <tbody>
-              {visible.map((m, i) => (
-                <MirrorRow
-                  key={m.name}
-                  mirror={m}
-                  expanded={expanded.has(m.name)}
-                  onToggle={() => toggleRow(m.name)}
-                  loadMetrics={shouldEagerLoadMetrics(i)}
-                  onMetrics={onMetrics}
-                />
-              ))}
+              {visibleEntries.map((entry) => {
+                if (entry.kind === 'mirror') {
+                  return renderMirror(entry.mirror)
+                }
+                const { group } = entry
+                const collapsed = isGroupCollapsed(
+                  group.wildcard,
+                  group.items.length,
+                  collapseMap
+                )
+                return (
+                  <FragmentGroup
+                    key={group.wildcard}
+                    group={group}
+                    collapsed={collapsed}
+                    onToggle={() =>
+                      toggleGroup(group.wildcard, group.items.length)
+                    }
+                    metrics={metrics}
+                    counting={counting}
+                    renderMirror={renderMirror}
+                  />
+                )
+              })}
               {filtered.length === 0 && (
                 <tr>
                   <td
@@ -546,15 +755,15 @@ function PeerDBMirrorsPage() {
           </table>
         </div>
 
-        {visible.length < filtered.length && (
+        {visibleEntries.length < entries.length && (
           <div className="border-t border-border px-3 py-2 text-center">
             <button
               type="button"
               onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
               className="text-[12px] font-medium text-muted-foreground hover:text-foreground"
             >
-              Show {Math.min(PAGE_SIZE, filtered.length - visible.length)} more
-              mirrors
+              Show {Math.min(PAGE_SIZE, entries.length - visibleEntries.length)}{' '}
+              more {groupOn ? 'groups' : 'mirrors'}
             </button>
           </div>
         )}
@@ -563,13 +772,15 @@ function PeerDBMirrorsPage() {
           <div>
             Showing{' '}
             <span className="font-medium tabular-nums text-foreground">
-              {visible.length}
-            </span>{' '}
-            of {filtered.length}
+              {filtered.length}
+            </span>
             {filtered.length !== mirrors.length
-              ? ` (filtered from ${mirrors.length})`
+              ? ` of ${mirrors.length} filtered`
               : ''}{' '}
             mirrors
+            {groupOn && grouping.groups.length > 0
+              ? ` · ${grouping.groups.length} prefix groups`
+              : ''}
           </div>
           <div className="flex items-center gap-2">
             <RefreshCwIcon className="size-3" />
@@ -578,8 +789,6 @@ function PeerDBMirrorsPage() {
         </div>
       </div>
 
-      {/* fleet logs & alerts — collapsed by default; mounted only when open so
-          the per-mirror log fetchers don't poll in the background. */}
       {mirrors.length > 0 && (
         <div className="mt-4">
           <button
@@ -598,5 +807,34 @@ function PeerDBMirrorsPage() {
         </div>
       )}
     </div>
+  )
+}
+
+function FragmentGroup({
+  group,
+  collapsed,
+  onToggle,
+  metrics,
+  counting,
+  renderMirror,
+}: {
+  group: PrefixGroup<MirrorListItem>
+  collapsed: boolean
+  onToggle: () => void
+  metrics: Record<string, MirrorMetricsSummary>
+  counting: boolean
+  renderMirror: (m: MirrorListItem) => ReactNode
+}) {
+  return (
+    <>
+      <MirrorGroupHeader
+        group={group}
+        expanded={!collapsed}
+        onToggle={onToggle}
+        metrics={metrics}
+        counting={counting}
+      />
+      {!collapsed && group.items.map((m) => renderMirror(m))}
+    </>
   )
 }

--- a/apps/dashboard/src/routes/(peerdb)/peerdb/mirror.tsx
+++ b/apps/dashboard/src/routes/(peerdb)/peerdb/mirror.tsx
@@ -9,17 +9,25 @@ import type {
   TotalRowsSyncedResponse,
 } from '@/lib/peerdb/types'
 
-import { Suspense } from 'react'
+import { type ReactNode, Suspense } from 'react'
 import { CdcBatchHistory } from '@/components/peerdb/cdc-batch-history'
+import { CountingNumber } from '@/components/peerdb/counting-number'
+import { jobPartitionAnalytics } from '@/components/peerdb/job-analytics'
 import { MirrorStatusBadge } from '@/components/peerdb/mirror-status-badge'
 import { OperationMixChart } from '@/components/peerdb/operation-mix-chart'
-import { PartitionTable } from '@/components/peerdb/partition-table'
+import { PdbBarChart } from '@/components/peerdb/pdb-charts'
 import { PeerDBNotConfigured } from '@/components/peerdb/peerdb-not-configured'
 import {
   formatDateTime,
   isPeerDBNotConfigured,
+  pdbFmtDuration,
+  pdbFmtNum,
   toNumber,
 } from '@/components/peerdb/peerdb-utils'
+import {
+  buildSyncHistory,
+  QRepPartitions,
+} from '@/components/peerdb/qrep-partitions'
 import { RowsSyncedChart } from '@/components/peerdb/rows-synced-chart'
 import { SnapshotProgress } from '@/components/peerdb/snapshot-progress'
 import { AppLink } from '@/components/ui/app-link'
@@ -39,12 +47,28 @@ export const Route = createFileRoute('/(peerdb)/peerdb/mirror')({
   component: PeerDBMirrorDetailPage,
 })
 
-function StatCard({ label, value }: { label: string; value: string }) {
+function StatCard({
+  label,
+  value,
+  counting,
+}: {
+  label: string
+  value: ReactNode
+  counting?: boolean
+}) {
   return (
     <Card>
       <CardContent className="flex flex-col gap-1 p-4">
         <span className="text-xs text-muted-foreground">{label}</span>
-        <span className="text-xl font-semibold tabular-nums">{value}</span>
+        <span
+          className={`text-xl font-semibold tabular-nums ${
+            counting
+              ? 'motion-safe:animate-pulse motion-reduce:animate-none'
+              : ''
+          }`}
+        >
+          {value}
+        </span>
       </CardContent>
     </Card>
   )
@@ -105,6 +129,7 @@ function MirrorDetailContent() {
   const qrep = data?.qrepStatus
   const isCdc = !qrep
   const partitions = qrep?.partitions ?? []
+  const partStats = jobPartitionAnalytics(partitions)
   const tables = tableCounts.data?.tablesData ?? []
   const errors = logs.data?.errors ?? []
   const batches = batchesReq.data?.cdcBatches ?? cdc?.cdcBatches ?? []
@@ -115,8 +140,17 @@ function MirrorDetailContent() {
   const rowsSynced =
     authoritativeTotal != null
       ? toNumber(authoritativeTotal)
-      : toNumber(cdc?.rowsSynced)
-  const hasRowsSynced = authoritativeTotal != null || cdc?.rowsSynced != null
+      : qrep
+        ? partStats.rowsSynced
+        : toNumber(cdc?.rowsSynced)
+  const hasRowsSynced =
+    authoritativeTotal != null ||
+    cdc?.rowsSynced != null ||
+    (qrep != null && partitions.length > 0)
+  const counting =
+    status.isLoading ||
+    totalSynced.isLoading ||
+    (qrep != null && status.isLoading)
 
   return (
     <div className="flex flex-col gap-4">
@@ -140,22 +174,72 @@ function MirrorDetailContent() {
         </div>
       ) : null}
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
         <StatCard
           label="Rows synced (total)"
-          value={hasRowsSynced ? formatReadableQuantity(rowsSynced) : '—'}
-        />
-        <StatCard
-          label="Tables"
-          value={String(tables.length || partitions.length || 0)}
-        />
-        <StatCard
-          label="Total (graph)"
+          counting={counting}
           value={
-            graph.data
-              ? formatReadableQuantity(toNumber(graph.data.totalRows))
-              : '—'
+            hasRowsSynced ? (
+              <CountingNumber
+                value={rowsSynced}
+                counting={counting}
+                format={(n) => formatReadableQuantity(n)}
+              />
+            ) : (
+              '—'
+            )
           }
+        />
+        {qrep ? (
+          <>
+            <StatCard
+              label="Partitions"
+              counting={counting}
+              value={`${partStats.done} / ${partStats.total}`}
+            />
+            <StatCard
+              label="Rows in partitions"
+              counting={counting}
+              value={
+                <CountingNumber
+                  value={partStats.rowsIn}
+                  counting={counting}
+                  format={pdbFmtNum}
+                />
+              }
+            />
+            <StatCard
+              label="Avg partition"
+              value={
+                partStats.avgDurationSec != null
+                  ? pdbFmtDuration(partStats.avgDurationSec)
+                  : '—'
+              }
+            />
+          </>
+        ) : (
+          <>
+            <StatCard label="Tables" value={String(tables.length || 0)} />
+            <StatCard
+              label="Total (graph)"
+              counting={graph.isLoading}
+              value={
+                graph.data ? (
+                  <CountingNumber
+                    value={toNumber(graph.data.totalRows)}
+                    counting={graph.isLoading}
+                    format={(n) => formatReadableQuantity(n)}
+                  />
+                ) : (
+                  '—'
+                )
+              }
+            />
+          </>
+        )}
+        <StatCard
+          label="Created"
+          value={data?.createdAt ? formatDateTime(data.createdAt) : '—'}
         />
       </div>
 
@@ -178,10 +262,26 @@ function MirrorDetailContent() {
         </section>
       ) : null}
 
+      {qrep && partitions.length > 0 ? (
+        <section className="flex flex-col gap-2 rounded-lg border p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold">Partition sync history</h2>
+            <span className="text-[11px] text-muted-foreground">
+              Rows synced at a point in time
+            </span>
+          </div>
+          <PdbBarChart
+            data={buildSyncHistory(partitions)}
+            color="#3b82f6"
+            height={200}
+            valueFormatter={pdbFmtNum}
+          />
+        </section>
+      ) : null}
+
       {partitions.length > 0 ? (
         <section className="flex flex-col gap-2">
-          <h2 className="text-sm font-semibold">Partitions</h2>
-          <PartitionTable partitions={partitions} />
+          <QRepPartitions partitions={partitions} pageSize={50} />
         </section>
       ) : null}
 

--- a/docs/content/guide/features/peerdb.mdx
+++ b/docs/content/guide/features/peerdb.mdx
@@ -23,8 +23,8 @@ Monitor PeerDB replication mirrors and peers without leaving chmonitor — an op
 
 When you set `PEERDB_API_URL`, chmonitor adds a PeerDB section to the navigation. It proxies read-only calls to the PeerDB API so you can monitor replication without leaving the chmonitor UI.
 
-- **Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state, plus a fleet **lag-triage strip** (worst-lag mirrors) and a collapsible **logs & alerts feed** aggregated across every mirror.
-- **Mirror detail** (`/peerdb/mirror?name=…`) adds **snapshot / initial-load progress** (per-table partition completion, fetch/consolidate phase, avg time per partition), **CDC batch history** (rows per batch, LSN range, duration), a per-table **operation mix** (insert/update/delete), and an authoritative rows-synced total.
+- **Mirrors** (`/peerdb`) shows all configured replication mirrors with status, throughput, and per-table sync state, plus a fleet **lag-triage strip** (worst-lag mirrors) and a collapsible **logs & alerts feed** aggregated across every mirror. Jobs that share a name prefix (date/version suffixes such as `qrep_sg_fleetreporting1_202608`) **group under a `prefix_*` wildcard** you can collapse; each group shows aggregated lag, rows/s, and rows synced. Header totals **count up** while per-job metrics are still loading, and last-known numbers are **cached** so the page paints immediately on revisit.
+- **Mirror detail** (`/peerdb/mirror?name=…`) adds **snapshot / initial-load progress** (per-table partition completion, fetch/consolidate phase, avg time per partition), **CDC batch history** (rows per batch, LSN range, duration), a per-table **operation mix** (insert/update/delete), an authoritative rows-synced total, and for QRep jobs a searchable, paged **partition progress** table (UUID, duration, start/end, rows in partition vs synced) plus partition-sync history.
 - **Peers** (`/peerdb/peers`) lists source and destination peers, a **replication slot health** table (lag, active state, WAL status classified ok / warn / critical), and a mirror connectivity graph.
 - **Peer detail** (`/peerdb/peer?name=…`) shows the peer's redacted config and server version, its replication slots, slot-lag history, and active queries.
 
@@ -36,8 +36,8 @@ The PeerDB section does not appear in the navigation when `PEERDB_API_URL` is un
 
 | Page | Route | What it shows | System tables |
 |---|---|---|---|
-| Mirrors | `/peerdb` | Mirror status, throughput, lag triage, fleet logs feed | — (PeerDB API) |
-| Mirror detail | `/peerdb/mirror` | Snapshot progress, CDC batch history, operation mix, rows-synced total | — (PeerDB API) |
+| Mirrors | `/peerdb` | Mirror status, prefix groups, throughput, lag triage, fleet logs feed | — (PeerDB API) |
+| Mirror detail | `/peerdb/mirror` | Snapshot progress, CDC batch history, QRep partition search/pager, operation mix, rows-synced total | — (PeerDB API) |
 | Peers | `/peerdb/peers` | Peer list, slot health, mirror graph | — (PeerDB API) |
 | Peer detail | `/peerdb/peer` | Peer info + version, slots, slot-lag history, active queries | — (PeerDB API) |
 
@@ -132,7 +132,7 @@ access = "authenticated"
     PEERDB_API_URL: { type: "string", description: "PeerDB API base URL. Include the /api suffix for the UI API (e.g. https://peerdb.example.com/api). When unset, the PeerDB section is hidden entirely. Default: unset." },
     PEERDB_PASSWORD: { type: "string", description: "Auth secret. Used as the HTTP Basic password (empty username) by default, or as the Bearer token when PEERDB_AUTH_SCHEME=bearer. Default: unset." },
     PEERDB_AUTH_SCHEME: { type: "string", description: "Auth scheme for PEERDB_PASSWORD: 'basic' (empty-user HTTP Basic, the default) or 'bearer' (Authorization: Bearer <token>) for deployments behind an auth proxy (PeerDB Enterprise / BYOC). Default: basic." },
-    PEERDB_CACHE_TTL_MS: { type: "number", description: "Response cache TTL in milliseconds. Default: 10000." },
+    PEERDB_CACHE_TTL_MS: { type: "number", description: "Server-side response cache TTL in milliseconds. Default: 10000. The browser also persists mirror list/peers queries and a compact KPI snapshot (`chm-peerdb-metrics-v1`) so the fleet page paints last-known numbers immediately." },
     PEERDB_CACHE_MAX_ENTRIES: { type: "number", description: "Maximum number of cached responses. Default: 500." },
     PEERDB_FETCH_TIMEOUT_MS: { type: "number", description: "Timeout for proxied PeerDB API requests. Default: 10000." },
   }}

--- a/docs/content/operate/advanced/peerdb-monitoring.mdx
+++ b/docs/content/operate/advanced/peerdb-monitoring.mdx
@@ -24,8 +24,8 @@ Open it at `/peerdb` once configured. The section is hidden until
 
 | View | Where | Highlights |
 |---|---|---|
-| Mirrors fleet | `/peerdb` | Status KPIs, per-mirror throughput, a **lag-triage strip** (worst-lag mirrors), and a collapsible **logs & alerts feed** aggregated across every mirror with error/warn/info filters. |
-| Snapshot progress | mirror detail | Per-table initial-load progress from `initial_load` — partitions completed, rows synced, avg time per partition, and fetch/consolidate phase badges. Fills the gap for snapshotting mirrors. |
+| Mirrors fleet | `/peerdb` | Status KPIs (count-up while still aggregating, last-known numbers cached), per-mirror throughput, **prefix groups** (`qrep_sg_fleetreporting1_*`) you can collapse, a **lag-triage strip** (worst-lag mirrors), and a collapsible **logs & alerts feed** aggregated across every mirror with error/warn/info filters. |
+| Snapshot / QRep progress | mirror detail | Per-table initial-load progress from `initial_load` — partitions completed, rows synced, avg time per partition, and fetch/consolidate phase badges. QRep jobs add searchable, paged partition progress (UUID, duration, start/end, rows in partition vs synced) and a partition-sync history chart. |
 | CDC batch history | mirror detail | Recent CDC batches (id, LSN range, rows, duration) plus a rows-per-batch chart. |
 | Operation mix | mirror detail | Per-table insert / update / delete split from `table_total_counts`. |
 | Slot health | `/peerdb/peers` | Replication slots across Postgres peers classified **ok / warn / critical** by lag, active state, and WAL status; worst-first. |

--- a/scripts/peerdb-mock-server.ts
+++ b/scripts/peerdb-mock-server.ts
@@ -155,6 +155,96 @@ const MIRRORS: MirrorFixture[] = [
     errorMessage:
       "replication slot 'pgmirror_slot_legacy' is approaching max_wal_size (98.4% · 4180 MiB) — destination consumer is not draining; check ch-archive ingestion rate",
   },
+  {
+    name: 'qrep_sg_fleetreporting1_202606',
+    isCdc: false,
+    source: 'pg-prod',
+    sourceType: 'POSTGRES',
+    destination: 'ch-analytics',
+    destinationType: 'CLICKHOUSE',
+    status: 'STATUS_RUNNING',
+    createdAgoHours: 720,
+    rowsSynced: 41_220_118,
+    rowsPerSec: 0,
+    lagSec: null,
+    tables: ['reporting.fleet_events'],
+    workflowId: 'qrep-fleetreporting1-202606',
+  },
+  {
+    name: 'qrep_sg_fleetreporting1_202607',
+    isCdc: false,
+    source: 'pg-prod',
+    sourceType: 'POSTGRES',
+    destination: 'ch-analytics',
+    destinationType: 'CLICKHOUSE',
+    status: 'STATUS_RUNNING',
+    createdAgoHours: 380,
+    rowsSynced: 38_104_902,
+    rowsPerSec: 0,
+    lagSec: null,
+    tables: ['reporting.fleet_events'],
+    workflowId: 'qrep-fleetreporting1-202607',
+  },
+  {
+    name: 'qrep_sg_fleetreporting1_202608',
+    isCdc: false,
+    source: 'pg-prod',
+    sourceType: 'POSTGRES',
+    destination: 'ch-analytics',
+    destinationType: 'CLICKHOUSE',
+    status: 'STATUS_SNAPSHOT',
+    createdAgoHours: 36,
+    rowsSynced: 12_408_551,
+    rowsPerSec: 18_400,
+    lagSec: null,
+    tables: ['reporting.fleet_events'],
+    workflowId: 'qrep-fleetreporting1-202608',
+  },
+  {
+    name: 'qrep_sg_orders_202607',
+    isCdc: false,
+    source: 'pg-staging',
+    sourceType: 'POSTGRES',
+    destination: 's3-datalake',
+    destinationType: 'S3',
+    status: 'STATUS_RUNNING',
+    createdAgoHours: 400,
+    rowsSynced: 9_104_220,
+    rowsPerSec: 0,
+    lagSec: null,
+    tables: ['public.orders'],
+    workflowId: 'qrep-orders-202607',
+  },
+  {
+    name: 'qrep_sg_orders_202608',
+    isCdc: false,
+    source: 'pg-staging',
+    sourceType: 'POSTGRES',
+    destination: 's3-datalake',
+    destinationType: 'S3',
+    status: 'STATUS_RUNNING',
+    createdAgoHours: 48,
+    rowsSynced: 2_880_412,
+    rowsPerSec: 6_200,
+    lagSec: null,
+    tables: ['public.orders'],
+    workflowId: 'qrep-orders-202608',
+  },
+  {
+    name: 'qrep_sg_orders_202609',
+    isCdc: false,
+    source: 'pg-staging',
+    sourceType: 'POSTGRES',
+    destination: 's3-datalake',
+    destinationType: 'S3',
+    status: 'STATUS_SETUP',
+    createdAgoHours: 2,
+    rowsSynced: 120_440,
+    rowsPerSec: 2_800,
+    lagSec: null,
+    tables: ['public.orders'],
+    workflowId: 'qrep-orders-202609',
+  },
 ]
 
 function mirror(name: string): MirrorFixture | undefined {
@@ -226,15 +316,17 @@ function cdcBatches(m: MirrorFixture) {
 
 function partitions(m: MirrorFixture) {
   const now = Date.now()
-  const total = 45
-  const doneN = 28
+  const total = m.name.startsWith('qrep_sg_fleetreporting1') ? 80 : 45
+  const doneN =
+    m.status === 'STATUS_SETUP' ? 4 : m.status === 'STATUS_SNAPSHOT' ? 42 : 62
+  const doneClamped = Math.min(doneN, total - 2)
   const start0 = now - m.createdAgoHours * HOUR
   return Array.from({ length: total }, (_, i) => {
     const dur = Math.round(18_000 + seeded(i + 10) * 64_000)
     const start = start0 + i * (dur + 1200)
     const rows = Math.round(9_400_000 + seeded(i + 20) * 2_400_000)
-    const done = i < doneN
-    const inFlight = i >= doneN && i < doneN + 2
+    const done = i < doneClamped
+    const inFlight = i >= doneClamped && i < doneClamped + 2
     return {
       partitionId: `0a${(0xb1c2d3e4 + i).toString(16).padStart(8, '0')}-${(0x4f50 + i).toString(16)}-9c2a-${(0x1100 + i).toString(16)}-${(0xa1b2c3d40000 + i).toString(16)}`,
       startTime: new Date(start).toISOString(),


### PR DESCRIPTION
## Summary

PeerDB job lists now group similarly named jobs under a collapsible `prefix_*` wildcard, show live totals that count up while metrics are still loading, and paint last-known numbers from cache on revisit. QRep job detail shows searchable, paged partition progress.

## Changes

- Smart prefix grouping (`qrep_sg_fleetreporting1_*`) with collapse state and group-level lag / rows/s / rows-synced totals
- Header KPIs animate while still counting, seeded from a compact `chm-peerdb-metrics-v1` snapshot
- Persist Query cache keeps list/peers for first paint; bulky per-mirror status/batches/logs stay off disk
- QRep job detail: partition search, pager, row-in vs synced totals, partition-sync history
- Mock fixtures for date-suffixed QRep families; unit tests for grouping, cache, and analytics

## Test plan

- [x] Focused unit tests for grouping, metrics cache, job analytics, persist exclusions
- [x] Biome check on changed files
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Grouping prefers the longest prefix whose remaining suffix looks volatile (dates, versions, hashes). Depth-1 buckets like `qrep_*` are skipped unless that next token is volatile. Collapsed groups still contribute to page KPIs via a headless metrics probe so hiding rows does not zero the totals.

---

Co-Authored-By: duyetbot <bot@duyet.net>