### PR TITLE
docs(blog): intro v0.3.4 with agent days and demo links

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -1,14 +1,17 @@
 ---
 title: "chmonitor v0.3.4 — Tools, Schema Compare, workspace roles"
-description: "A Tools menu, per-browser workspace roles, Schema Compare, Settings Diff, TTL inventory, What's new, and self-hosted licenses."
+description: "After four days of agents working day and night — 106 PRs, 267 comments — v0.3.4 ships a Tools menu, workspace roles, Schema Compare, Settings Diff, TTL inventory, What's new, and self-hosted licenses."
 date: 2026-08-20
 tag: Release
 version: v0.3.4
 ---
 
-chmonitor **v0.3.4** is the tag for everything that landed on `main` after
-v0.3.3. Tools, workspace roles, Schema Compare, Settings Diff, TTL inventory,
-and self-hosted licenses are in this release.
+After **four days** of agents working day and night — **106 pull requests** and
+**267 comments** on GitHub — chmonitor **v0.3.4** is the tag for everything that
+landed on `main` after v0.3.3. Tools, workspace roles, Schema Compare, Settings
+Diff, TTL inventory, and self-hosted licenses are in this release.
+
+Every path below opens the live demo: [dash.chmonitor.dev](https://dash.chmonitor.dev).
 
 <div class="hl-grid">
   <div class="hl"><b>Tools menu</b><span>SQL Console, Explorer, Explain, Advisor, Chart Builder, Schema Compare, Settings Diff — last group in Main.</span></div>
@@ -23,9 +26,14 @@ and self-hosted licenses are in this release.
 
 ### Tools and workspace
 
-- **Tools** sidebar group: SQL Console, Data Explorer, Explain, Advisor, Chart
-  Builder, Schema Compare, Settings Diff. Last group in Main. Postgres hosts
-  do not see it.
+- **Tools** sidebar group: [SQL Console](https://dash.chmonitor.dev/sql),
+  [Data Explorer](https://dash.chmonitor.dev/explorer),
+  [Explain](https://dash.chmonitor.dev/explain),
+  [Advisor](https://dash.chmonitor.dev/advisor),
+  [Chart Builder](https://dash.chmonitor.dev/dashboard),
+  [Schema Compare](https://dash.chmonitor.dev/schema-diff),
+  [Settings Diff](https://dash.chmonitor.dev/settings-diff). Last group in Main.
+  Postgres hosts do not see it.
 - **Workspace roles** in Settings: Full, DBA, Engineer, SRE. Pick a role and
   the Navigation tree remounts collapsed.
 - Customize the sidebar from the Settings menu tree.
@@ -39,29 +47,30 @@ and self-hosted licenses are in this release.
 [DBA workflows](https://docs.chmonitor.dev/guide/guides/dba-workflows) is the
 map.
 
-- **Schema Compare** (`/schema-diff`) diffs `CREATE TABLE` across saved
-  connections or replica nodes. One host is not enough — add a second, or
-  compare nodes on this cluster. The plan is copy-only.
-- **Settings Diff** (`/settings-diff`) diffs `system.settings` and
-  `system.merge_tree_settings`. Filter to differences, or to values changed
-  from default. When every setting matches: **All matched**.
+- **[Schema Compare](https://dash.chmonitor.dev/schema-diff)** diffs `CREATE TABLE`
+  across saved connections or replica nodes. One host is not enough — add a
+  second, or compare nodes on this cluster. The plan is copy-only.
+- **[Settings Diff](https://dash.chmonitor.dev/settings-diff)** diffs
+  `system.settings` and `system.merge_tree_settings`. Filter to differences, or
+  to values changed from default. When every setting matches: **All matched**.
 - Advisor findings can emit a **local** statement plus an `ON CLUSTER` variant
-  when topology is known.
+  when topology is known. Try [Advisor](https://dash.chmonitor.dev/advisor).
 
 ### Cluster ops
 
-- **TTL and partition health** at `/ttl-partition-health` — inventory of
-  MergeTree TTL and `PARTITION BY`, with partition and part counts. Tables
-  without TTL still appear. Recommend-only: this page does not run `ALTER TTL`
-  or `DROP PARTITION`.
-- Schema lint on Explorer table Overview (same recommend-only engine as
-  Advisor).
+- **[TTL and partition health](https://dash.chmonitor.dev/ttl-partition-health)**
+  — inventory of MergeTree TTL and `PARTITION BY`, with partition and part
+  counts. Tables without TTL still appear. Recommend-only: this page does not
+  run `ALTER TTL` or `DROP PARTITION`.
+- Schema lint on [Explorer](https://dash.chmonitor.dev/explorer) table Overview
+  (same recommend-only engine as Advisor).
 - **What's new** dialog next to Settings — notes from `docs/whats-new/` for
   each tagged version. Auto-opens once after an upgrade.
 
 ### Agent
 
-- Cloud demo **guests can chat** (still under the v0.3.3 guest cap).
+- Cloud demo **[guests can chat](https://dash.chmonitor.dev/agents)** (still
+  under the v0.3.3 guest cap).
 - Keyless **Firecrawl MCP** is connected by default (`CHM_AGENT_FIRECRAWL_MCP`,
   opt-out).
 - Follow-up suggestions are tool-aware and sit on the composer.
@@ -85,6 +94,7 @@ Self-hosters: pull the image you already run.
 docker pull ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Cloud (`dash.chmonitor.dev`) already has this. Nothing to migrate.
+Cloud ([dash.chmonitor.dev](https://dash.chmonitor.dev)) already has this.
+Nothing to migrate.
 
 The full commit list is in [PR #3035](https://github.com/chmonitor/chmonitor/pull/3035).


### PR DESCRIPTION
## Summary

The v0.3.4 post now opens with the four-day agent sprint (106 PRs, 267 GitHub comments) and every example path links to the live demo on dash.chmonitor.dev.

## Changes

- Lede: after four days of agents working day and night — 106 PRs, 267 comments
- Schema Compare, Settings Diff, TTL, SQL Console, Explorer, Explain, Advisor, Chart Builder, Agent → `https://dash.chmonitor.dev/...` (verified HTTP 200)

Counts are from GitHub for `merged:>=2026-08-16` (v0.3.3 → v0.3.4): 106 merged PRs, 267 issue comments.

## Test plan

- [x] Demo paths return 200 on dash.chmonitor.dev
- [ ] `pnpm run lint` / blog CI
- [x] Docs updated in `apps/blog/src/content/blog/`

---

Co-Authored-By: duyetbot <bot@duyet.net>