### PR TITLE
docs(blog): pin upgrade pulls to the release image tag

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-0-3-x.md
+++ b/apps/blog/src/content/blog/chmonitor-0-3-x.md
@@ -52,7 +52,7 @@ the page is not empty.
 Self-hosters: pull the image you already run.
 
 ```bash
-docker pull ghcr.io/chmonitor/chmonitor:latest
+docker pull ghcr.io/chmonitor/chmonitor:v0.3.3
 ```
 
 Cloud (`dash.chmonitor.dev`) already tracks this tag. Nothing to migrate.

--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -91,7 +91,7 @@ map.
 Self-hosters: pull the image you already run.
 
 ```bash
-docker pull ghcr.io/chmonitor/chmonitor:latest
+docker pull ghcr.io/chmonitor/chmonitor:v0.3.4
 ```
 
 Cloud ([dash.chmonitor.dev](https://dash.chmonitor.dev)) already has this.


### PR DESCRIPTION
## Summary

v0.3.4 and v0.3.3 upgrade snippets now pull `ghcr.io/chmonitor/chmonitor:v0.3.4` / `:v0.3.3` instead of `:latest`.

## Test plan

- [x] Release posts match the version in frontmatter
- [ ] blog CI

---

Co-Authored-By: duyetbot <bot@duyet.net>