### PR TITLE
docs(blog): point v0.3.4 changelog at the GitHub release

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -97,4 +97,5 @@ docker pull ghcr.io/chmonitor/chmonitor:v0.3.4
 Cloud ([dash.chmonitor.dev](https://dash.chmonitor.dev)) already has this.
 Nothing to migrate.
 
-The full commit list is in [PR #3035](https://github.com/chmonitor/chmonitor/pull/3035).
+The full changelog is in the
+[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4).


### PR DESCRIPTION
## Summary

v0.3.4 no longer points at PR #3035. The changelog link is the GitHub release URL for the tag (`/releases/tag/v0.3.4`). The release is not cut yet; the URL is the one that tag will use.

## Test plan

- [x] Link matches the release-post template and the v0.3.3 post
- [ ] blog CI

---

Co-Authored-By: duyetbot <bot@duyet.net>