### PR TITLE
docs(blog): rewrite v0.3.3 with agent-days intro and demo links

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-0-3-x.md
+++ b/apps/blog/src/content/blog/chmonitor-0-3-x.md
@@ -1,13 +1,17 @@
 ---
 title: "chmonitor v0.3.3 — guest AI caps, alert templates, favorites"
-description: "Cloud guest AI is capped and metered. Alerts use templates. Pinned favorites drag to reorder. Settings sits next to Sign in."
+description: "After four days of agents working day and night — 50 PRs, 83 comments — v0.3.3 caps Cloud guest AI, adds alert templates, and lets you drag pinned favorites."
 date: 2026-08-16
 tag: Release
 version: v0.3.3
 ---
 
-chmonitor **v0.3.3** is the 16 Aug 2026 tag. Guest AI on Cloud is capped, alerts
-start from templates, and pinned sidebar favorites drag to reorder.
+After **four days** of agents working day and night — **50 pull requests** and
+**83 comments** on GitHub (33 of 50 commits after hours) — chmonitor **v0.3.3**
+is the 16 Aug 2026 tag. Guest AI on Cloud is capped, alerts start from
+templates, and pinned sidebar favorites drag to reorder.
+
+Every path below opens the live demo: [dash.chmonitor.dev](https://dash.chmonitor.dev).
 
 <div class="hl-grid">
   <div class="hl"><b>Guest AI caps</b><span>Cloud demo chat is metered so a public guest cannot run unbounded tool loops.</span></div>
@@ -16,36 +20,36 @@ start from templates, and pinned sidebar favorites drag to reorder.
   <div class="hl"><b>Settings</b><span>The gear sits next to Sign in. Changes stay in this browser.</span></div>
 </div>
 
-## Guest AI on Cloud
+## What shipped
+
+### Guest AI on Cloud
 
 Anonymous visitors on [dash.chmonitor.dev](https://dash.chmonitor.dev) can still
-try the agent. Usage is **capped and tracked**, so a public demo cannot burn
-unbounded tool calls.
+try the [agent](https://dash.chmonitor.dev/agents). Usage is **capped and
+tracked**, so a public demo cannot burn unbounded tool calls.
 
 You pick models dynamically: AnyRouter presets, plus a custom model field. The
 AnyRouter sign-in prompt only shows when no `ANYROUTER_API_KEY` is set.
 
 Self-hosted builds are unchanged — guest caps are Cloud-only.
 
-## Alert templates
+### Alert templates
 
-[Alert settings](https://docs.chmonitor.dev/guide/features/health) use
-**templates and presets** instead of a wall of empty threshold forms. Pick a
-starting point, then edit.
+[Alert settings](https://dash.chmonitor.dev/alert-settings) use **templates and
+presets** instead of a wall of empty threshold forms. Pick a starting point,
+then edit. Docs: [Health](https://docs.chmonitor.dev/guide/features/health).
 
-## Favorites, Settings, Merges
+### Favorites, Settings, Merges
 
 Pinned sidebar favorites **drag to reorder**. Pin and grip icons stay on hover
 so they do not sit on top of the row.
 
-**Settings** opens from the gear next to Sign in (or the avatar). Theme,
-timezone, units, and workspace stay **local to this browser**.
+**Settings** opens from the gear next to Sign in (or the avatar) on
+[dash.chmonitor.dev](https://dash.chmonitor.dev). Theme, timezone, units, and
+workspace stay **local to this browser**.
 
-When no merges are running, the Merges page shows the **last completed ones** so
-the page is not empty.
-
-[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.3) ·
-16 Aug 2026.
+When no merges are running, [Merges](https://dash.chmonitor.dev/merges) shows
+the **last completed ones** so the page is not empty.
 
 ## Upgrade
 
@@ -55,4 +59,8 @@ Self-hosters: pull the image you already run.
 docker pull ghcr.io/chmonitor/chmonitor:v0.3.3
 ```
 
-Cloud (`dash.chmonitor.dev`) already tracks this tag. Nothing to migrate.
+Cloud ([dash.chmonitor.dev](https://dash.chmonitor.dev)) already tracks this
+tag. Nothing to migrate.
+
+The full changelog is in the
+[GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.3).


### PR DESCRIPTION
## Summary

Rewrite `/v0.3.3/` the same way as v0.3.4: agent sprint intro, live demo links, versioned Docker tag, GitHub release changelog.

Sprint numbers come from the published v0.3.3 GitHub release recap: 4 days, 50 PRs, 83 comments (33 of 50 commits after hours).

Demo paths (HTTP 200): `/agents`, `/alert-settings`, `/merges`.

## Test plan

- [x] Paths 200 on dash.chmonitor.dev
- [ ] blog CI

---

Co-Authored-By: duyetbot <bot@duyet.net>