### PR TITLE
feat(cli): chm rewrite with auth, channels, and self-hosted device login

### DIFF
--- a/.claude/skills/cloud-saas-mode/SKILL.md
+++ b/.claude/skills/cloud-saas-mode/SKILL.md
@@ -69,10 +69,10 @@ on mismatch. The reverse (cloud build, runtime unset) is safe — fail-closed.
 | Anonymous | env hosts | the demo |
 | Signed-in | env hosts | demo HIDDEN → own D1 connections; zero → welcome/setup |
 | Agent (anon) | Clerk-gated if access=authenticated | reachable on demo host via `authorizeAgentApiRequest` guest wrapper (not `CHM_FEATURE_AGENT_ACCESS=public`); daily cap 3 + RL 5/min; D1 `guest:<ip-hash>`; deploy `ANYROUTER_API_KEY` + `anyrouter:auto` |
+| CLI device login (`CHM_DEVICE_LOGIN`) | **off** by default (`auto`); set `true` for device-only tokens when `auth=none` (trusted LAN) | **on** when `CHM_API_KEY_SECRET` is set; `/device` needs Clerk session |
 
-Implemented in `lib/swr/use-merged-hosts.ts` (tag demo, hide-when-signed-in;
-returns `cloudMode`/`isSignedIn`). Switcher badges + `demo`-as-`env` status in
-`components/host/host-switcher.tsx`.
+Resolver: `lib/auth/device-login-config.ts`. Store: D1 or in-memory
+(`lib/auth/device-code-store.ts`). See `docs/knowledge/standalone-cli.md`.
 
 ## Welcome / setup page
 

--- a/.github/workflows/cli-rust-release.yml
+++ b/.github/workflows/cli-rust-release.yml
@@ -9,7 +9,17 @@ on:
         type: string
   push:
     tags:
-      - 'chm-v*'
+      # Stable only — exclude beta tags created by main pushes so they do not
+      # re-trigger this workflow as a second (stable) build.
+      - 'chm-v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+    paths:
+      - 'rust/ch-monitor-cli/**'
+      - 'rust/Cargo.lock'
+      - 'rust/Cargo.toml'
+      - '.github/workflows/cli-rust-release.yml'
+      - 'scripts/install.sh'
 
 permissions:
   contents: write
@@ -37,7 +47,34 @@ jobs:
         with:
           # On tag push this is the tag itself; on dispatch, check out the
           # requested tag so the built binary matches the release version.
+          # On main push this is refs/heads/main (beta prerelease build).
           ref: ${{ inputs.tag || github.ref }}
+      - name: Release meta
+        id: meta
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' rust/ch-monitor-cli/Cargo.toml | head -n1)"
+            if [ -z "$version" ]; then
+              echo "failed to read version from rust/ch-monitor-cli/Cargo.toml" >&2
+              exit 1
+            fi
+            case "$version" in
+              0.1.*) ;;
+              *)
+                echo "refusing to ship beta from unexpected Cargo.toml version '$version' (expected 0.1.x)" >&2
+                exit 1
+                ;;
+            esac
+            echo "tag=chm-v${version}-beta.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "channel=beta" >> "$GITHUB_OUTPUT"
+          else
+            tag="${{ inputs.tag || github.ref_name }}"
+            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "channel=stable" >> "$GITHUB_OUTPUT"
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -64,7 +101,13 @@ jobs:
           cd dist
           shasum -a 256 ${{ matrix.bin }}-${{ matrix.target }} > ${{ matrix.bin }}-${{ matrix.target }}.sha256
       - uses: softprops/action-gh-release@v3
-        if: github.ref_type == 'tag' || inputs.tag != ''
+        if: >-
+          github.ref_type == 'tag' ||
+          inputs.tag != '' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           files: dist/*
+          generate_release_notes: true

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -15,6 +15,15 @@ CLICKHOUSE_PASSWORD=
 # CHM_AUTH_PROVIDER=none
 # CHM_CLERK_PUBLISHABLE_KEY=pk_...
 # CLERK_SECRET_KEY=sk_...
+# Signing secret for chm_ API keys (MCP / CLI). Also required to enable device login.
+# CHM_API_KEY_SECRET=
+# CLI device login (chm auth login). auto | true | false — default auto:
+#   cloud → on when CHM_API_KEY_SECRET is set; self-hosted/OSS → off (trusted LAN).
+# Set true on self-hosted to opt in. With CHM_AUTH_PROVIDER=none this is
+# device-only approve (no Clerk) — anyone who can open /device can mint a token.
+# CHM_DEVICE_LOGIN=auto
+# Subject embedded in device-only tokens (auth=none). Default: self-hosted
+# CHM_DEVICE_LOGIN_SUBJECT=self-hosted
 
 # ── Agent / LLM ─────────────────────────────────────────────────────────────
 # ANYROUTER_API_KEY=

--- a/apps/dashboard/src/db/conversations-migrations/0030_oauth_device_codes.sql
+++ b/apps/dashboard/src/db/conversations-migrations/0030_oauth_device_codes.sql
@@ -1,0 +1,22 @@
+-- OAuth device-code grant store for `chm auth login` (RFC 8628).
+-- Lives in CHM_CLOUD_D1 alongside conversations / slack installs.
+-- Optional: without D1 the device-login endpoints return 503 and the CLI
+-- falls back to a manually issued API key.
+
+CREATE TABLE IF NOT EXISTS oauth_device_codes (
+  device_code   TEXT PRIMARY KEY,
+  user_code     TEXT NOT NULL UNIQUE,  -- stored UPPERCASE (e.g. ABCD-EFGH)
+  client_id     TEXT NOT NULL,
+  created_at    INTEGER NOT NULL,      -- unix ms
+  expires_at    INTEGER NOT NULL,      -- unix ms
+  interval_sec  INTEGER NOT NULL DEFAULT 5,
+  approved_at   INTEGER,              -- unix ms when the user approved
+  user_id       TEXT,                 -- Clerk/proxy subject that approved
+  consumed_at   INTEGER               -- unix ms when token was issued
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_device_codes_user_code
+  ON oauth_device_codes (user_code);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_device_codes_expires
+  ON oauth_device_codes (expires_at);

--- a/apps/dashboard/src/lib/api/openapi-spec.ts
+++ b/apps/dashboard/src/lib/api/openapi-spec.ts
@@ -593,7 +593,7 @@ function buildOperations(
         tags: ['Auth'],
         summary: 'Issue an API key',
         description:
-          'Mints a signed `chm_` API key. Authorize with `Authorization: Bearer` set to `CHM_API_KEY_SECRET` (the issuance secret, not an existing key). Returns 503 when the secret is unset.',
+          'Mints a signed `chm_` API key. Authorize with `Authorization: Bearer` set to `CHM_API_KEY_SECRET`, or with an authenticated Clerk/proxy session (user-scoped). Optional `scopes` in the body. Returns 503 when the secret is unset.',
         operationId: 'issueApiKey',
         security: REQUIRED_AUTH,
         requestBody: {
@@ -610,8 +610,56 @@ function buildOperations(
             content: jsonContent(ref('ErrorBody')),
           },
           '401': {
-            description: 'Bearer token is not CHM_API_KEY_SECRET',
+            description: 'Missing secret Bearer or signed-in session',
             content: jsonContent(ref('ErrorBody')),
+          },
+          '503': {
+            description: 'CHM_API_KEY_SECRET is not configured',
+            content: jsonContent(ref('ErrorBody')),
+          },
+        },
+      },
+    },
+    '/api/v1/auth/device/code': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Start device-code login',
+        description:
+          'RFC 8628 device authorization. Public. Creates a pending device/user code pair for `chm auth login`. Returns 503 when D1 is unavailable.',
+        operationId: 'deviceCode',
+        security: [{}],
+        responses: {
+          '200': {
+            description: 'Device and user codes',
+            content: jsonContent(ref('DeviceCodeResponse')),
+          },
+          '503': {
+            description: 'D1 / device login unavailable',
+            content: jsonContent(ref('ErrorBody')),
+          },
+        },
+      },
+    },
+    '/api/v1/auth/token': {
+      post: {
+        tags: ['Auth'],
+        summary: 'Exchange device code for access token',
+        description:
+          'Polls a pending device_code. Returns `authorization_pending` (400) until the user approves at `/device`, then mints a `chm_` API key.',
+        operationId: 'deviceToken',
+        security: [{}],
+        requestBody: {
+          required: true,
+          content: jsonContent(ref('DeviceTokenRequest')),
+        },
+        responses: {
+          '200': {
+            description: 'Access token issued',
+            content: jsonContent(ref('DeviceTokenResponse')),
+          },
+          '400': {
+            description: 'authorization_pending or other OAuth error',
+            content: jsonContent(ref('OAuthError')),
           },
           '503': {
             description: 'CHM_API_KEY_SECRET is not configured',
@@ -825,6 +873,12 @@ const SCHEMAS: Record<string, JsonSchema> = {
         default: 30,
         description: 'Key lifetime in days.',
       },
+      scopes: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Optional scopes. Empty/omitted stamps all scopes (back-compat).',
+      },
     },
   },
   IssueApiKeyResponse: {
@@ -833,11 +887,67 @@ const SCHEMAS: Record<string, JsonSchema> = {
     properties: {
       data: {
         type: 'object',
-        required: ['apiKey'],
+        required: ['apiKey', 'sub', 'scopes', 'expiresInDays'],
         properties: {
           apiKey: { type: 'string' },
+          sub: { type: 'string' },
+          scopes: { type: 'array', items: { type: 'string' } },
+          expiresInDays: { type: 'integer' },
         },
       },
+    },
+  },
+  DeviceCodeResponse: {
+    type: 'object',
+    required: ['data'],
+    properties: {
+      data: {
+        type: 'object',
+        required: [
+          'device_code',
+          'user_code',
+          'verification_uri',
+          'expires_in',
+          'interval',
+        ],
+        properties: {
+          device_code: { type: 'string' },
+          user_code: { type: 'string' },
+          verification_uri: { type: 'string' },
+          verification_uri_complete: { type: 'string' },
+          expires_in: { type: 'integer' },
+          interval: { type: 'integer' },
+        },
+      },
+    },
+  },
+  DeviceTokenRequest: {
+    type: 'object',
+    required: ['grant_type', 'device_code'],
+    properties: {
+      grant_type: {
+        type: 'string',
+        description: '`device_code` or the URN form',
+      },
+      device_code: { type: 'string' },
+      client_id: { type: 'string' },
+    },
+  },
+  DeviceTokenResponse: {
+    type: 'object',
+    required: ['access_token', 'token_type'],
+    properties: {
+      access_token: { type: 'string' },
+      token_type: { type: 'string', enum: ['Bearer'] },
+      expires_in: { type: 'integer' },
+    },
+  },
+  OAuthError: {
+    type: 'object',
+    required: ['error'],
+    properties: {
+      error: { type: 'string' },
+      error_description: { type: 'string' },
     },
   },
 }
@@ -911,7 +1021,7 @@ export function buildOpenApiDocument(): OpenApiDocument {
       { name: 'Insights', description: 'Persisted findings' },
       { name: 'Agent', description: 'Streaming AI agent' },
       { name: 'MCP', description: 'Model Context Protocol' },
-      { name: 'Auth', description: 'API-key issuance' },
+      { name: 'Auth', description: 'API-key issuance and device-code login' },
     ],
     paths,
     components: {

--- a/apps/dashboard/src/lib/api/public-api.ts
+++ b/apps/dashboard/src/lib/api/public-api.ts
@@ -104,6 +104,16 @@ export const PUBLIC_API_ROUTES = [
     tanstackPath: '/api/v1/auth/api-key',
     methods: ['post'],
   },
+  {
+    openapiPath: '/api/v1/auth/device/code',
+    tanstackPath: '/api/v1/auth/device/code',
+    methods: ['post'],
+  },
+  {
+    openapiPath: '/api/v1/auth/token',
+    tanstackPath: '/api/v1/auth/token',
+    methods: ['post'],
+  },
 ] as const satisfies readonly PublicApiRoute[]
 
 /** Hard floor so GET /api/v1/openapi.json cannot silently become a 2-path stub. */

--- a/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
@@ -188,3 +188,41 @@ describe('GET /api/v1/releases is a public changelog document', () => {
     expect(result).toBeNull()
   })
 })
+
+describe('device-flow paths are public (handler owns auth)', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('allows anonymous approve when API-key auth is on (device-only self-hosted)', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const result = await getApiKeyAuthFailure(
+      new Request('https://dash.example.com/api/v1/auth/device/approve', {
+        method: 'POST',
+      })
+    )
+    expect(result).toBeNull()
+  })
+
+  it('allows anonymous device status discovery', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const result = await getApiKeyAuthFailure(
+      new Request('https://dash.example.com/api/v1/auth/device/status')
+    )
+    expect(result).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
@@ -58,6 +58,16 @@ describe('isAuthenticatedRequest', () => {
     expect(await isAuthenticatedRequest(anonReq())).toBe(false)
   })
 
+  it('returns true for a valid chm_ key sent as x-api-key', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const key = await issueApiKey('test-x-api-key')
+    const req = new Request('https://dash.example.com/api/health', {
+      headers: { 'x-api-key': key },
+    })
+    expect(await isAuthenticatedRequest(req)).toBe(true)
+  })
+
   // The core #1768 regression: public read-only mode lets anonymous users read
   // dashboard DATA, but must NOT expose deployment metadata. isAuthenticatedRequest
   // deliberately ignores publicReadEnabled(), unlike enforceAuth.
@@ -110,6 +120,44 @@ describe('GET /api/v1/openapi.json is a public discovery document', () => {
     process.env.CHM_API_KEY_SECRET = TEST_SECRET
     const result = await getApiKeyAuthFailure(openApiReq())
     expect(result).toBeNull()
+  })
+})
+
+describe('x-api-key parity on /api/v1/*', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  function hostsReq(headers?: HeadersInit): Request {
+    return new Request('https://dash.example.com/api/v1/hosts', { headers })
+  }
+
+  it('accepts a valid chm_ key via x-api-key when API-key auth is on', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const key = await issueApiKey('cli')
+    const result = await getApiKeyAuthFailure(hostsReq({ 'x-api-key': key }))
+    expect(result).toBeNull()
+  })
+
+  it('returns 401 when API-key auth is on and no key is sent', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const result = await getApiKeyAuthFailure(hostsReq())
+    expect(result).not.toBeNull()
+    expect(result!.status).toBe(401)
   })
 })
 

--- a/apps/dashboard/src/lib/auth/__tests__/device-code-store.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/device-code-store.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// device-code-store → @chm/platform → cloudflare:workers (Node/bun has no
+// workerd builtins). Stub both so memory fallback can be unit-tested.
+mock.module('cloudflare:workers', () => ({ env: {} }))
+mock.module('@chm/platform', () => ({
+  getPlatformBindings: () => ({
+    getD1Database: () => null,
+  }),
+}))
+
+const {
+  __resetDeviceCodeMemoryForTests,
+  approveUserCode,
+  getByDeviceCode,
+  insertDeviceCode,
+  markConsumed,
+} = await import('../device-code-store')
+
+describe('device-code-store memory fallback', () => {
+  beforeEach(() => {
+    __resetDeviceCodeMemoryForTests()
+  })
+
+  afterEach(() => {
+    __resetDeviceCodeMemoryForTests()
+  })
+
+  it('inserts, approves, and consumes a code in memory', async () => {
+    const now = Date.now()
+    const ok = await insertDeviceCode({
+      deviceCode: 'dev-1',
+      userCode: 'abcd-efgh',
+      clientId: 'chm-cli',
+      createdAt: now,
+      expiresAt: now + 60_000,
+    })
+    expect(ok).toBe(true)
+
+    const pending = await getByDeviceCode('dev-1')
+    expect(pending?.userCode).toBe('ABCD-EFGH')
+    expect(pending?.approvedAt).toBeNull()
+
+    const approved = await approveUserCode('abcd-efgh', 'self-hosted')
+    expect(approved).toEqual({ ok: true })
+
+    const after = await getByDeviceCode('dev-1')
+    expect(after?.userId).toBe('self-hosted')
+    expect(after?.approvedAt).not.toBeNull()
+
+    expect(await markConsumed('dev-1')).toBe(true)
+    const consumed = await getByDeviceCode('dev-1')
+    expect(consumed?.consumedAt).not.toBeNull()
+  })
+
+  it('rejects approve of unknown / expired codes', async () => {
+    expect(await approveUserCode('NOPE-CODE', 'u')).toEqual({
+      ok: false,
+      error: 'not_found',
+    })
+
+    const now = Date.now()
+    await insertDeviceCode({
+      deviceCode: 'dev-exp',
+      userCode: 'EXPI-RED1',
+      clientId: 'chm-cli',
+      createdAt: now - 10_000,
+      expiresAt: now - 1,
+    })
+    expect(await approveUserCode('EXPI-RED1', 'u')).toEqual({
+      ok: false,
+      error: 'expired',
+    })
+  })
+})

--- a/apps/dashboard/src/lib/auth/__tests__/device-login-config.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/device-login-config.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+
+import {
+  parseDeviceLoginMode,
+  resolveDeviceLogin,
+} from '../device-login-config'
+
+const ENV_KEYS = [
+  'CHM_DEVICE_LOGIN',
+  'CHM_DEVICE_LOGIN_SUBJECT',
+  'CHM_API_KEY_SECRET',
+  'CHM_CLOUD_MODE',
+  'CHM_DEPLOYMENT_MODE',
+  'CHM_AUTH_PROVIDER',
+  'VITE_AUTH_PROVIDER',
+  'CHM_CLOUD_D1',
+] as const
+
+describe('parseDeviceLoginMode', () => {
+  it('defaults unset/junk to auto', () => {
+    expect(parseDeviceLoginMode(undefined)).toBe('auto')
+    expect(parseDeviceLoginMode('')).toBe('auto')
+    expect(parseDeviceLoginMode('auto')).toBe('auto')
+    expect(parseDeviceLoginMode('maybe')).toBe('auto')
+  })
+
+  it('parses true/false aliases', () => {
+    expect(parseDeviceLoginMode('true')).toBe('true')
+    expect(parseDeviceLoginMode('1')).toBe('true')
+    expect(parseDeviceLoginMode('YES')).toBe('true')
+    expect(parseDeviceLoginMode('false')).toBe('false')
+    expect(parseDeviceLoginMode('0')).toBe('false')
+    expect(parseDeviceLoginMode('off')).toBe('false')
+  })
+})
+
+describe('resolveDeviceLogin', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('auto + OSS → disabled (internal network default)', () => {
+    const status = resolveDeviceLogin({
+      CHM_CLOUD_MODE: 'false',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'none',
+    })
+    expect(status.mode).toBe('auto')
+    expect(status.enabled).toBe(false)
+    expect(status.reason).toBe('disabled')
+    expect(status.deviceOnly).toBe(false)
+  })
+
+  it('auto + cloud + secret → enabled with Clerk (not device-only)', () => {
+    const status = resolveDeviceLogin({
+      CHM_CLOUD_MODE: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'clerk',
+      CHM_CLOUD_D1: '1',
+    })
+    expect(status.enabled).toBe(true)
+    expect(status.deviceOnly).toBe(false)
+    expect(status.store).toBe('d1')
+  })
+
+  it('auto + cloud without secret → disabled missing_api_key_secret', () => {
+    const status = resolveDeviceLogin({
+      CHM_CLOUD_MODE: 'true',
+      CHM_AUTH_PROVIDER: 'clerk',
+    })
+    expect(status.enabled).toBe(false)
+    expect(status.reason).toBe('missing_api_key_secret')
+  })
+
+  it('true + OSS + secret + auth=none → device-only enabled (memory store)', () => {
+    const status = resolveDeviceLogin({
+      CHM_DEVICE_LOGIN: 'true',
+      CHM_CLOUD_MODE: 'false',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'none',
+    })
+    expect(status.enabled).toBe(true)
+    expect(status.deviceOnly).toBe(true)
+    expect(status.store).toBe('memory')
+    expect(status.subject).toBe('self-hosted')
+  })
+
+  it('respects CHM_DEVICE_LOGIN_SUBJECT', () => {
+    const status = resolveDeviceLogin({
+      CHM_DEVICE_LOGIN: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'none',
+      CHM_DEVICE_LOGIN_SUBJECT: 'ops-lan',
+    })
+    expect(status.subject).toBe('ops-lan')
+  })
+
+  it('false forces off even in cloud', () => {
+    const status = resolveDeviceLogin({
+      CHM_DEVICE_LOGIN: 'false',
+      CHM_CLOUD_MODE: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'clerk',
+    })
+    expect(status.enabled).toBe(false)
+    expect(status.reason).toBe('disabled')
+  })
+})

--- a/apps/dashboard/src/lib/auth/api-guard.ts
+++ b/apps/dashboard/src/lib/auth/api-guard.ts
@@ -13,16 +13,18 @@
  *  - `proxy` — a trusted reverse proxy (Cloudflare Access JWT, or a trusted
  *              identity header gated by a shared secret).
  *
- * On top of the provider, API-key auth (`chm_` Bearer tokens) is ALWAYS on
- * whenever `CHM_API_KEY_SECRET` is set, for programmatic/MCP clients.
+ * On top of the provider, API-key auth (`chm_` tokens via Bearer or `x-api-key`)
+ * is ALWAYS on whenever `CHM_API_KEY_SECRET` is set, for programmatic/MCP/CLI
+ * clients.
  *
  * Enforcement on `/api/v1/*` (`getApiKeyAuthFailure`):
  *  - PUBLIC passthrough only when provider is `none` AND API-key auth is off.
- *  - Otherwise a request must present EITHER a valid `chm_` Bearer token OR pass
+ *  - Otherwise a request must present EITHER a valid `chm_` key OR pass
  *    the active provider's `authenticateRequest`. Anonymous requests get a 401
  *    JSON `{ error: 'Authentication required' }`. Exempt: `/api/v1/auth/api-key`
- *    (it owns its own secret-based auth in the handler) and
- *    `/api/v1/openapi.json` (public discovery document).
+ *    (it owns its own secret-based auth in the handler),
+ *    `/api/v1/auth/device/code` + `/api/v1/auth/token` (OAuth device flow),
+ *    and `/api/v1/openapi.json` (public discovery document).
  *
  * Also reproduced from the Next middleware: the cloud→dash 301 redirect
  * (`getLegacyHostRedirect`).
@@ -30,12 +32,12 @@
  * `apiKeyAuthEnabled()` and `verifyApiKey()` read `process.env.CHM_API_KEY_SECRET`
  * directly. On Cloudflare Workers the canonical source is the `env` binding, so
  * `bridgeApiKeyEnv(env)` copies the secret onto `process.env` before the check
- * (same bridge pattern as `bridgeClickHouseEnv`).
+ * (same bridge pattern as `bridge[REDACTED]Env`).
  */
 
 import {
   apiKeyAuthEnabled,
-  getBearerToken,
+  apiKeyCandidates,
   verifyApiKey,
 } from '@chm/mcp-server/auth'
 import { getAuthProvider, isAuthProviderConfigError } from '@/lib/auth/provider'
@@ -44,6 +46,9 @@ import { resolveServerAuthProvider } from '@/lib/auth/providers'
 const API_V1_PREFIX = '/api/v1/'
 // Key issuance route has its own secret-based auth in its handler.
 const API_KEY_ISSUANCE_PATH = '/api/v1/auth/api-key'
+// OAuth device-code endpoints are public (RFC 8628); approve stays guarded.
+const DEVICE_CODE_PATH = '/api/v1/auth/device/code'
+const DEVICE_TOKEN_PATH = '/api/v1/auth/token'
 // OpenAPI descriptor is a public discovery document (RFC 9727 service-desc).
 const OPENAPI_SPEC_PATH = '/api/v1/openapi.json'
 // Product changelog for the What's new dialog — public GitHub notes, no secrets.
@@ -104,6 +109,20 @@ function jsonError(message: string, status: number): Response {
 }
 
 /**
+ * Whether the request carries a valid `chm_` API key (Bearer or `x-api-key`).
+ * Returns false when API-key auth is disabled or no candidate verifies.
+ */
+export async function hasValidChmApiKey(request: Request): Promise<boolean> {
+  if (!apiKeyAuthEnabled()) return false
+  for (const candidate of apiKeyCandidates(request)) {
+    if (!candidate.startsWith('chm_')) continue
+    const result = await verifyApiKey(candidate)
+    if (result.valid) return true
+  }
+  return false
+}
+
+/**
  * cloud.chmonitor.dev is a legacy alias of the dashboard. Permanently redirect
  * it to the canonical dash.chmonitor.dev host, preserving path and query.
  *
@@ -142,25 +161,23 @@ export async function getApiKeyAuthFailure(
   if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return null
 
   // Key issuance route has its own secret-based auth in the handler.
+  // Device-code + token are public (RFC 8628); approve stays authenticated.
   // OpenAPI is a public discovery document — agents read it before they have
   // a key. Never 401 (or 500 via the dashboard shell) this path.
   // `/api/v1/releases` is the public What's new changelog (GitHub notes).
   if (
     pathname === API_KEY_ISSUANCE_PATH ||
+    pathname === DEVICE_CODE_PATH ||
+    pathname === DEVICE_TOKEN_PATH ||
     pathname === OPENAPI_SPEC_PATH ||
     pathname === RELEASES_PATH
   ) {
     return null
   }
 
-  // 1. Programmatic clients (MCP, scripts): a valid `chm_` Bearer token.
-  const headerToken = getBearerToken(request.headers.get('authorization'))
-  if (headerToken) {
-    const result = await verifyApiKey(headerToken)
-    if (result.valid) return null
-    // Not a valid chm_ key — fall through to the provider check; the
-    // Authorization header may carry a Clerk/proxy token rather than a chm_ key.
-  }
+  // 1. Programmatic clients (MCP, CLI, scripts): a valid `chm_` key via
+  //    Authorization Bearer or x-api-key.
+  if (await hasValidChmApiKey(request)) return null
 
   // 2. Opt-in public read-only mode (clerk only): let ALL /api/v1/* requests
   //    through without ever invoking the Clerk provider, and defer to each
@@ -217,12 +234,8 @@ export async function enforceAuth(request: Request): Promise<Response | null> {
   // Public passthrough when the dashboard is fully open.
   if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return null
 
-  // 1. Programmatic clients: a valid `chm_` Bearer token.
-  const headerToken = getBearerToken(request.headers.get('authorization'))
-  if (headerToken) {
-    const result = await verifyApiKey(headerToken)
-    if (result.valid) return null
-  }
+  // 1. Programmatic clients: a valid `chm_` key (Bearer or x-api-key).
+  if (await hasValidChmApiKey(request)) return null
 
   // 2. Opt-in public read-only mode (clerk only) — checked BEFORE the provider
   //    call below so an anonymous-read config never pays for a Clerk verify
@@ -265,12 +278,8 @@ export async function isAuthenticatedRequest(
   // Fully-open deployment (no provider, no API key): nothing to protect.
   if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return true
 
-  // 1. Programmatic clients: a valid `chm_` Bearer token.
-  const headerToken = getBearerToken(request.headers.get('authorization'))
-  if (headerToken) {
-    const result = await verifyApiKey(headerToken)
-    if (result.valid) return true
-  }
+  // 1. Programmatic clients: a valid `chm_` key (Bearer or x-api-key).
+  if (await hasValidChmApiKey(request)) return true
 
   // 2. An authenticated provider session (clerk cookie, proxy identity, …).
   const provider = getAuthProvider()

--- a/apps/dashboard/src/lib/auth/api-guard.ts
+++ b/apps/dashboard/src/lib/auth/api-guard.ts
@@ -23,7 +23,9 @@
  *    the active provider's `authenticateRequest`. Anonymous requests get a 401
  *    JSON `{ error: 'Authentication required' }`. Exempt: `/api/v1/auth/api-key`
  *    (it owns its own secret-based auth in the handler),
- *    `/api/v1/auth/device/code` + `/api/v1/auth/token` (OAuth device flow),
+ *    `/api/v1/auth/device/code` + `/api/v1/auth/device/approve` +
+ *    `/api/v1/auth/device/status` + `/api/v1/auth/token` (OAuth device flow;
+ *    approve owns its own session / device-only checks),
  *    and `/api/v1/openapi.json` (public discovery document).
  *
  * Also reproduced from the Next middleware: the cloud→dash 301 redirect
@@ -46,8 +48,12 @@ import { resolveServerAuthProvider } from '@/lib/auth/providers'
 const API_V1_PREFIX = '/api/v1/'
 // Key issuance route has its own secret-based auth in its handler.
 const API_KEY_ISSUANCE_PATH = '/api/v1/auth/api-key'
-// OAuth device-code endpoints are public (RFC 8628); approve stays guarded.
+// OAuth device-code endpoints are public (RFC 8628). Approve is exempt so
+// self-hosted device-only (auth=none + CHM_DEVICE_LOGIN) can complete without
+// already holding a chm_ key; the handler enforces session vs device-only.
 const DEVICE_CODE_PATH = '/api/v1/auth/device/code'
+const DEVICE_APPROVE_PATH = '/api/v1/auth/device/approve'
+const DEVICE_STATUS_PATH = '/api/v1/auth/device/status'
 const DEVICE_TOKEN_PATH = '/api/v1/auth/token'
 // OpenAPI descriptor is a public discovery document (RFC 9727 service-desc).
 const OPENAPI_SPEC_PATH = '/api/v1/openapi.json'
@@ -161,13 +167,16 @@ export async function getApiKeyAuthFailure(
   if (getAuthProvider() === 'none' && !apiKeyAuthEnabled()) return null
 
   // Key issuance route has its own secret-based auth in the handler.
-  // Device-code + token are public (RFC 8628); approve stays authenticated.
+  // Device-code / approve / status / token are public (RFC 8628); approve
+  // enforces Clerk/proxy session or device-only subject in its handler.
   // OpenAPI is a public discovery document — agents read it before they have
   // a key. Never 401 (or 500 via the dashboard shell) this path.
   // `/api/v1/releases` is the public What's new changelog (GitHub notes).
   if (
     pathname === API_KEY_ISSUANCE_PATH ||
     pathname === DEVICE_CODE_PATH ||
+    pathname === DEVICE_APPROVE_PATH ||
+    pathname === DEVICE_STATUS_PATH ||
     pathname === DEVICE_TOKEN_PATH ||
     pathname === OPENAPI_SPEC_PATH ||
     pathname === RELEASES_PATH

--- a/apps/dashboard/src/lib/auth/device-code-store.ts
+++ b/apps/dashboard/src/lib/auth/device-code-store.ts
@@ -1,9 +1,12 @@
 /**
- * D1-backed store for OAuth device-code grants (`chm auth login`).
+ * Device-code grant store for `chm auth login` (RFC 8628).
  *
- * Pattern mirrors `lib/slack/install-store.ts`: `CHM_CLOUD_D1` binding via
- * `getPlatformBindings()`, fail-open (never throw to callers — return
- * null/false/error codes). `user_code` is always stored UPPERCASE.
+ * Prefers D1 (`CHM_CLOUD_D1`) when bound; otherwise an in-memory Map suitable
+ * for single-node self-hosted (Docker). Multi-replica OSS without D1 should
+ * keep `CHM_DEVICE_LOGIN=false` (default) or terminate SSL sticky to one pod.
+ *
+ * Pattern mirrors `lib/slack/install-store.ts`: fail-open (never throw to
+ * callers — return null/false/error codes). `user_code` is always UPPERCASE.
  */
 
 import { ErrorLogger } from '@chm/logger'
@@ -35,7 +38,7 @@ const ENSURE_TABLE_SQL = `
     ON ${TABLE} (expires_at);
 `
 
-export interface DeviceCodeRow {
+export interface DeviceCodeRecord {
   deviceCode: string
   userCode: string
   clientId: string
@@ -82,7 +85,6 @@ let ensured = false
 async function ensureTable(db: D1Database): Promise<boolean> {
   if (ensured) return true
   try {
-    // D1 prepare().run() accepts one statement; run each separately.
     for (const stmt of ENSURE_TABLE_SQL.split(';')
       .map((s) => s.trim())
       .filter(Boolean)) {
@@ -96,9 +98,38 @@ async function ensureTable(db: D1Database): Promise<boolean> {
   }
 }
 
-/** True when the cloud D1 binding is present (device login can persist codes). */
+// ── In-memory fallback (single-node self-hosted) ───────────────────────────
+
+const memoryByDevice = new Map<string, DeviceCodeRecord>()
+const memoryByUser = new Map<string, string>()
+
+function memoryPurgeExpired(now = Date.now()): void {
+  for (const [deviceCode, record] of memoryByDevice) {
+    if (record.expiresAt <= now) {
+      memoryByDevice.delete(deviceCode)
+      memoryByUser.delete(record.userCode)
+    }
+  }
+}
+
+/** Test-only: clear the in-memory map between cases. */
+export function __resetDeviceCodeMemoryForTests(): void {
+  memoryByDevice.clear()
+  memoryByUser.clear()
+  ensured = false
+}
+
+/**
+ * True when a backend can persist device codes (D1 or memory).
+ * Prefer {@link isDeviceLoginEnabled} from `device-login-config` for the
+ * product gate — this only answers "can we store?".
+ */
 export function deviceLoginAvailable(): boolean {
-  return getDb() != null
+  return true
+}
+
+export function deviceCodeStoreKind(): 'd1' | 'memory' {
+  return getDb() != null ? 'd1' : 'memory'
 }
 
 export async function insertDeviceCode(input: {
@@ -109,31 +140,49 @@ export async function insertDeviceCode(input: {
   expiresAt: number
   intervalSec?: number
 }): Promise<boolean> {
+  const userCode = input.userCode.trim().toUpperCase()
+  const record: DeviceCodeRecord = {
+    deviceCode: input.deviceCode,
+    userCode,
+    clientId: input.clientId,
+    createdAt: input.createdAt,
+    expiresAt: input.expiresAt,
+    intervalSec: input.intervalSec ?? 5,
+    approvedAt: null,
+    userId: null,
+    consumedAt: null,
+  }
+
   try {
     const db = getDb()
-    if (!db) {
-      warn('no CHM_CLOUD_D1 binding — cannot persist device code')
+    if (db) {
+      if (!(await ensureTable(db))) return false
+      await db
+        .prepare(
+          `INSERT INTO ${TABLE}
+             (device_code, user_code, client_id, created_at, expires_at, interval_sec,
+              approved_at, user_id, consumed_at)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL)`
+        )
+        .bind(
+          record.deviceCode,
+          record.userCode,
+          record.clientId,
+          record.createdAt,
+          record.expiresAt,
+          record.intervalSec
+        )
+        .run()
+      return true
+    }
+
+    memoryPurgeExpired()
+    if (memoryByUser.has(userCode)) {
+      warn('memory store: duplicate user_code')
       return false
     }
-    if (!(await ensureTable(db))) return false
-
-    const userCode = input.userCode.trim().toUpperCase()
-    await db
-      .prepare(
-        `INSERT INTO ${TABLE}
-           (device_code, user_code, client_id, created_at, expires_at, interval_sec,
-            approved_at, user_id, consumed_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL)`
-      )
-      .bind(
-        input.deviceCode,
-        userCode,
-        input.clientId,
-        input.createdAt,
-        input.expiresAt,
-        input.intervalSec ?? 5
-      )
-      .run()
+    memoryByDevice.set(record.deviceCode, record)
+    memoryByUser.set(userCode, record.deviceCode)
     return true
   } catch (err) {
     warn(`failed to insert device code: ${err}`)
@@ -146,13 +195,16 @@ export async function getByDeviceCode(
 ): Promise<DeviceCodeRecord | null> {
   try {
     const db = getDb()
-    if (!db) return null
-    if (!(await ensureTable(db))) return null
-    const row = await db
-      .prepare(`SELECT * FROM ${TABLE} WHERE device_code = ?1`)
-      .bind(deviceCode)
-      .first<D1DeviceCodeRow>()
-    return row ? rowToRecord(row) : null
+    if (db) {
+      if (!(await ensureTable(db))) return null
+      const row = await db
+        .prepare(`SELECT * FROM ${TABLE} WHERE device_code = ?1`)
+        .bind(deviceCode)
+        .first<D1DeviceCodeRow>()
+      return row ? rowToRecord(row) : null
+    }
+
+    return memoryByDevice.get(deviceCode) ?? null
   } catch (err) {
     warn(`failed to get by device_code: ${err}`)
     return null
@@ -163,15 +215,20 @@ export async function getByUserCode(
   userCode: string
 ): Promise<DeviceCodeRecord | null> {
   try {
-    const db = getDb()
-    if (!db) return null
-    if (!(await ensureTable(db))) return null
     const normalized = userCode.trim().toUpperCase()
-    const row = await db
-      .prepare(`SELECT * FROM ${TABLE} WHERE user_code = ?1`)
-      .bind(normalized)
-      .first<D1DeviceCodeRow>()
-    return row ? rowToRecord(row) : null
+    const db = getDb()
+    if (db) {
+      if (!(await ensureTable(db))) return null
+      const row = await db
+        .prepare(`SELECT * FROM ${TABLE} WHERE user_code = ?1`)
+        .bind(normalized)
+        .first<D1DeviceCodeRow>()
+      return row ? rowToRecord(row) : null
+    }
+
+    const deviceCode = memoryByUser.get(normalized)
+    if (!deviceCode) return null
+    return memoryByDevice.get(deviceCode) ?? null
   } catch (err) {
     warn(`failed to get by user_code: ${err}`)
     return null
@@ -191,17 +248,14 @@ export type ApproveUserCodeResult =
     }
 
 /**
- * Bind an authenticated user to a pending user_code. Never throws.
+ * Bind an authenticated (or device-only) user to a pending user_code.
+ * Never throws.
  */
 export async function approveUserCode(
   userCode: string,
   userId: string
 ): Promise<ApproveUserCodeResult> {
   try {
-    const db = getDb()
-    if (!db) return { ok: false, error: 'unavailable' }
-    if (!(await ensureTable(db))) return { ok: false, error: 'unavailable' }
-
     const record = await getByUserCode(userCode)
     if (!record) return { ok: false, error: 'not_found' }
     if (record.consumedAt != null) return { ok: false, error: 'consumed' }
@@ -210,14 +264,29 @@ export async function approveUserCode(
       return { ok: false, error: 'already_approved' }
 
     const now = Date.now()
-    await db
-      .prepare(
-        `UPDATE ${TABLE}
-         SET approved_at = ?1, user_id = ?2
-         WHERE user_code = ?3 AND approved_at IS NULL AND consumed_at IS NULL`
-      )
-      .bind(now, userId, record.userCode)
-      .run()
+    const db = getDb()
+    if (db) {
+      if (!(await ensureTable(db))) return { ok: false, error: 'unavailable' }
+      await db
+        .prepare(
+          `UPDATE ${TABLE}
+           SET approved_at = ?1, user_id = ?2
+           WHERE user_code = ?3 AND approved_at IS NULL AND consumed_at IS NULL`
+        )
+        .bind(now, userId, record.userCode)
+        .run()
+      return { ok: true }
+    }
+
+    const current = memoryByDevice.get(record.deviceCode)
+    if (!current) return { ok: false, error: 'not_found' }
+    if (current.approvedAt != null)
+      return { ok: false, error: 'already_approved' }
+    memoryByDevice.set(record.deviceCode, {
+      ...current,
+      approvedAt: now,
+      userId,
+    })
     return { ok: true }
   } catch (err) {
     warn(`failed to approve user_code: ${err}`)
@@ -228,18 +297,24 @@ export async function approveUserCode(
 /** Mark a device_code as consumed after minting the access token. */
 export async function markConsumed(deviceCode: string): Promise<boolean> {
   try {
-    const db = getDb()
-    if (!db) return false
-    if (!(await ensureTable(db))) return false
     const now = Date.now()
-    await db
-      .prepare(
-        `UPDATE ${TABLE}
-         SET consumed_at = ?1
-         WHERE device_code = ?2 AND consumed_at IS NULL`
-      )
-      .bind(now, deviceCode)
-      .run()
+    const db = getDb()
+    if (db) {
+      if (!(await ensureTable(db))) return false
+      await db
+        .prepare(
+          `UPDATE ${TABLE}
+           SET consumed_at = ?1
+           WHERE device_code = ?2 AND consumed_at IS NULL`
+        )
+        .bind(now, deviceCode)
+        .run()
+      return true
+    }
+
+    const current = memoryByDevice.get(deviceCode)
+    if (!current || current.consumedAt != null) return false
+    memoryByDevice.set(deviceCode, { ...current, consumedAt: now })
     return true
   } catch (err) {
     warn(`failed to mark consumed: ${err}`)

--- a/apps/dashboard/src/lib/auth/device-code-store.ts
+++ b/apps/dashboard/src/lib/auth/device-code-store.ts
@@ -1,0 +1,248 @@
+/**
+ * D1-backed store for OAuth device-code grants (`chm auth login`).
+ *
+ * Pattern mirrors `lib/slack/install-store.ts`: `CHM_CLOUD_D1` binding via
+ * `getPlatformBindings()`, fail-open (never throw to callers — return
+ * null/false/error codes). `user_code` is always stored UPPERCASE.
+ */
+
+import { ErrorLogger } from '@chm/logger'
+import { getPlatformBindings } from '@chm/platform'
+
+const warn = (msg: string) =>
+  ErrorLogger.logWarning(`[device-code-store] ${msg}`, {
+    component: 'device-code-store',
+  })
+
+const TABLE = 'oauth_device_codes'
+
+// Kept in sync with db/conversations-migrations/0030_oauth_device_codes.sql.
+const ENSURE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE} (
+    device_code   TEXT PRIMARY KEY,
+    user_code     TEXT NOT NULL UNIQUE,
+    client_id     TEXT NOT NULL,
+    created_at    INTEGER NOT NULL,
+    expires_at    INTEGER NOT NULL,
+    interval_sec  INTEGER NOT NULL DEFAULT 5,
+    approved_at   INTEGER,
+    user_id       TEXT,
+    consumed_at   INTEGER
+  );
+  CREATE INDEX IF NOT EXISTS idx_oauth_device_codes_user_code
+    ON ${TABLE} (user_code);
+  CREATE INDEX IF NOT EXISTS idx_oauth_device_codes_expires
+    ON ${TABLE} (expires_at);
+`
+
+export interface DeviceCodeRow {
+  deviceCode: string
+  userCode: string
+  clientId: string
+  createdAt: number
+  expiresAt: number
+  intervalSec: number
+  approvedAt: number | null
+  userId: string | null
+  consumedAt: number | null
+}
+
+interface D1DeviceCodeRow {
+  device_code: string
+  user_code: string
+  client_id: string
+  created_at: number
+  expires_at: number
+  interval_sec: number
+  approved_at: number | null
+  user_id: string | null
+  consumed_at: number | null
+}
+
+function getDb(): D1Database | null {
+  return getPlatformBindings().getD1Database('CHM_CLOUD_D1')
+}
+
+function rowToRecord(row: D1DeviceCodeRow): DeviceCodeRecord {
+  return {
+    deviceCode: row.device_code,
+    userCode: row.user_code,
+    clientId: row.client_id,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    intervalSec: row.interval_sec,
+    approvedAt: row.approved_at,
+    userId: row.user_id,
+    consumedAt: row.consumed_at,
+  }
+}
+
+let ensured = false
+
+async function ensureTable(db: D1Database): Promise<boolean> {
+  if (ensured) return true
+  try {
+    // D1 prepare().run() accepts one statement; run each separately.
+    for (const stmt of ENSURE_TABLE_SQL.split(';')
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      await db.prepare(stmt).run()
+    }
+    ensured = true
+    return true
+  } catch (err) {
+    warn(`failed to ensure ${TABLE}: ${err}`)
+    return false
+  }
+}
+
+/** True when the cloud D1 binding is present (device login can persist codes). */
+export function deviceLoginAvailable(): boolean {
+  return getDb() != null
+}
+
+export async function insertDeviceCode(input: {
+  deviceCode: string
+  userCode: string
+  clientId: string
+  createdAt: number
+  expiresAt: number
+  intervalSec?: number
+}): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) {
+      warn('no CHM_CLOUD_D1 binding — cannot persist device code')
+      return false
+    }
+    if (!(await ensureTable(db))) return false
+
+    const userCode = input.userCode.trim().toUpperCase()
+    await db
+      .prepare(
+        `INSERT INTO ${TABLE}
+           (device_code, user_code, client_id, created_at, expires_at, interval_sec,
+            approved_at, user_id, consumed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, NULL, NULL)`
+      )
+      .bind(
+        input.deviceCode,
+        userCode,
+        input.clientId,
+        input.createdAt,
+        input.expiresAt,
+        input.intervalSec ?? 5
+      )
+      .run()
+    return true
+  } catch (err) {
+    warn(`failed to insert device code: ${err}`)
+    return false
+  }
+}
+
+export async function getByDeviceCode(
+  deviceCode: string
+): Promise<DeviceCodeRecord | null> {
+  try {
+    const db = getDb()
+    if (!db) return null
+    if (!(await ensureTable(db))) return null
+    const row = await db
+      .prepare(`SELECT * FROM ${TABLE} WHERE device_code = ?1`)
+      .bind(deviceCode)
+      .first<D1DeviceCodeRow>()
+    return row ? rowToRecord(row) : null
+  } catch (err) {
+    warn(`failed to get by device_code: ${err}`)
+    return null
+  }
+}
+
+export async function getByUserCode(
+  userCode: string
+): Promise<DeviceCodeRecord | null> {
+  try {
+    const db = getDb()
+    if (!db) return null
+    if (!(await ensureTable(db))) return null
+    const normalized = userCode.trim().toUpperCase()
+    const row = await db
+      .prepare(`SELECT * FROM ${TABLE} WHERE user_code = ?1`)
+      .bind(normalized)
+      .first<D1DeviceCodeRow>()
+    return row ? rowToRecord(row) : null
+  } catch (err) {
+    warn(`failed to get by user_code: ${err}`)
+    return null
+  }
+}
+
+export type ApproveUserCodeResult =
+  | { ok: true }
+  | {
+      ok: false
+      error:
+        | 'unavailable'
+        | 'not_found'
+        | 'expired'
+        | 'consumed'
+        | 'already_approved'
+    }
+
+/**
+ * Bind an authenticated user to a pending user_code. Never throws.
+ */
+export async function approveUserCode(
+  userCode: string,
+  userId: string
+): Promise<ApproveUserCodeResult> {
+  try {
+    const db = getDb()
+    if (!db) return { ok: false, error: 'unavailable' }
+    if (!(await ensureTable(db))) return { ok: false, error: 'unavailable' }
+
+    const record = await getByUserCode(userCode)
+    if (!record) return { ok: false, error: 'not_found' }
+    if (record.consumedAt != null) return { ok: false, error: 'consumed' }
+    if (record.expiresAt <= Date.now()) return { ok: false, error: 'expired' }
+    if (record.approvedAt != null)
+      return { ok: false, error: 'already_approved' }
+
+    const now = Date.now()
+    await db
+      .prepare(
+        `UPDATE ${TABLE}
+         SET approved_at = ?1, user_id = ?2
+         WHERE user_code = ?3 AND approved_at IS NULL AND consumed_at IS NULL`
+      )
+      .bind(now, userId, record.userCode)
+      .run()
+    return { ok: true }
+  } catch (err) {
+    warn(`failed to approve user_code: ${err}`)
+    return { ok: false, error: 'unavailable' }
+  }
+}
+
+/** Mark a device_code as consumed after minting the access token. */
+export async function markConsumed(deviceCode: string): Promise<boolean> {
+  try {
+    const db = getDb()
+    if (!db) return false
+    if (!(await ensureTable(db))) return false
+    const now = Date.now()
+    await db
+      .prepare(
+        `UPDATE ${TABLE}
+         SET consumed_at = ?1
+         WHERE device_code = ?2 AND consumed_at IS NULL`
+      )
+      .bind(now, deviceCode)
+      .run()
+    return true
+  } catch (err) {
+    warn(`failed to mark consumed: ${err}`)
+    return false
+  }
+}

--- a/apps/dashboard/src/lib/auth/device-login-config.ts
+++ b/apps/dashboard/src/lib/auth/device-login-config.ts
@@ -1,0 +1,189 @@
+/**
+ * Device-login (RFC 8628) enablement for `chm auth login`.
+ *
+ * `CHM_DEVICE_LOGIN`:
+ *   - `auto` (default) — on in cloud when `CHM_API_KEY_SECRET` is set; **off**
+ *     for self-hosted/OSS (internal networks usually mint a key once or leave
+ *     the API open).
+ *   - `true`  — force on (self-hosted opt-in; works with auth=none as
+ *     device-only approve, trusting network reachability of `/device`).
+ *   - `false` — force off everywhere.
+ *
+ * Prerequisites when enabled: `CHM_API_KEY_SECRET` (to mint `chm_` tokens).
+ * Persistence: D1 when bound, otherwise an in-memory store (single-node).
+ */
+
+import { apiKeyAuthEnabled } from '@chm/mcp-server/auth'
+import { parseAuthProvider } from '@/lib/auth/provider'
+import { isCloudModeServer } from '@/lib/cloud/cloud-mode'
+
+export type DeviceLoginMode = 'auto' | 'true' | 'false'
+
+export type DeviceLoginDisabledReason =
+  | 'disabled'
+  | 'missing_api_key_secret'
+  | null
+
+export type DeviceCodeStoreKind = 'd1' | 'memory' | 'none'
+
+export interface DeviceLoginStatus {
+  mode: DeviceLoginMode
+  /** Whether `/api/v1/auth/device/*` should accept new flows. */
+  enabled: boolean
+  /**
+   * Approve without Clerk/proxy identity — `CHM_AUTH_PROVIDER=none` and
+   * device login enabled. Trust: anyone who can reach `/device`.
+   */
+  deviceOnly: boolean
+  reason: DeviceLoginDisabledReason
+  /** Subject embedded in minted `chm_` keys for device-only approve. */
+  subject: string
+  store: DeviceCodeStoreKind
+}
+
+const DEFAULT_SUBJECT = 'self-hosted'
+
+/**
+ * Parse `CHM_DEVICE_LOGIN`. Unset / empty / junk / `auto` → `auto`
+ * (fail-closed for OSS via resolve, not via parse).
+ */
+export function parseDeviceLoginMode(
+  value: string | null | undefined
+): DeviceLoginMode {
+  const normalized = value?.trim().toLowerCase()
+  if (
+    normalized === 'true' ||
+    normalized === '1' ||
+    normalized === 'yes' ||
+    normalized === 'on'
+  ) {
+    return 'true'
+  }
+  if (
+    normalized === 'false' ||
+    normalized === '0' ||
+    normalized === 'no' ||
+    normalized === 'off'
+  ) {
+    return 'false'
+  }
+  return 'auto'
+}
+
+function readSubject(source: Record<string, string | undefined>): string {
+  const raw = source.CHM_DEVICE_LOGIN_SUBJECT?.trim()
+  return raw && raw.length > 0 ? raw : DEFAULT_SUBJECT
+}
+
+function hasD1Hint(source: Record<string, string | undefined>): boolean {
+  // Best-effort for status/docs: Workers bind D1 as an object, not an env
+  // string. Unit tests and some deploys set CHM_CLOUD_D1 as a non-empty
+  // sentinel. The live store still probes the real binding in
+  // device-code-store.ts.
+  const sentinel = source.CHM_CLOUD_D1
+  return sentinel != null && sentinel !== ''
+}
+
+/**
+ * Resolve whether device login is on and how approve should behave.
+ * Pure w.r.t. mode/cloud/secret; store kind is best-effort.
+ */
+export function resolveDeviceLogin(
+  runtimeEnv?: Record<string, string | undefined>
+): DeviceLoginStatus {
+  const source =
+    runtimeEnv ??
+    (typeof process !== 'undefined'
+      ? (process.env as Record<string, string | undefined>)
+      : {})
+
+  const mode = parseDeviceLoginMode(source.CHM_DEVICE_LOGIN)
+  const cloud = isCloudModeServer(source)
+  const subject = readSubject(source)
+  const d1 = hasD1Hint(source)
+  const storeWhenOn: DeviceCodeStoreKind = d1 ? 'd1' : 'memory'
+
+  // Wanted by mode: auto follows cloud; true/false are explicit.
+  const wanted = mode === 'true' ? true : mode === 'false' ? false : cloud
+
+  let authProvider: ReturnType<typeof parseAuthProvider> = 'none'
+  try {
+    const authRaw =
+      source.CHM_AUTH_PROVIDER ??
+      source.VITE_AUTH_PROVIDER ??
+      (typeof import.meta !== 'undefined'
+        ? import.meta.env?.VITE_AUTH_PROVIDER
+        : undefined)
+    if (authRaw) {
+      authProvider = parseAuthProvider(authRaw)
+    } else {
+      const profile = (
+        source.CHM_DEPLOYMENT_MODE ??
+        source.VITE_DEPLOYMENT_MODE ??
+        ''
+      )
+        .trim()
+        .toLowerCase()
+      authProvider =
+        profile === 'cloud' || profile === 'saas' ? 'clerk' : 'none'
+    }
+  } catch {
+    authProvider = 'none'
+  }
+
+  if (!wanted) {
+    return {
+      mode,
+      enabled: false,
+      deviceOnly: false,
+      reason: 'disabled',
+      subject,
+      store: 'none',
+    }
+  }
+
+  // Prefer apiKeyAuthEnabled when using live process.env; for mock bags check
+  // the bag directly so unit tests don't need to mutate process.env first.
+  const secretOk = runtimeEnv
+    ? Boolean(runtimeEnv.CHM_API_KEY_SECRET?.trim())
+    : apiKeyAuthEnabled()
+
+  if (!secretOk) {
+    return {
+      mode,
+      enabled: false,
+      deviceOnly: false,
+      reason: 'missing_api_key_secret',
+      subject,
+      store: storeWhenOn,
+    }
+  }
+
+  const deviceOnly = authProvider === 'none'
+
+  return {
+    mode,
+    enabled: true,
+    deviceOnly,
+    reason: null,
+    subject,
+    store: storeWhenOn,
+  }
+}
+
+/** Convenience: whether new device codes / token polls should run. */
+export function isDeviceLoginEnabled(
+  runtimeEnv?: Record<string, string | undefined>
+): boolean {
+  return resolveDeviceLogin(runtimeEnv).enabled
+}
+
+/**
+ * Subject to bind on approve when `deviceOnly` is true.
+ * Ignored when a real identity provider session supplies the user id.
+ */
+export function getDeviceLoginSubject(
+  runtimeEnv?: Record<string, string | undefined>
+): string {
+  return resolveDeviceLogin(runtimeEnv).subject
+}

--- a/apps/dashboard/src/lib/feature-permissions/server.ts
+++ b/apps/dashboard/src/lib/feature-permissions/server.ts
@@ -31,6 +31,11 @@ import {
   type FeatureOverrides,
 } from './types'
 import { env } from 'cloudflare:workers'
+import {
+  apiKeyAuthEnabled,
+  apiKeyCandidates,
+  verifyApiKey,
+} from '@chm/mcp-server/auth'
 import { isValidAgentApiBearerToken } from '@/lib/auth/agent-api-token'
 import { parseAuthProvider } from '@/lib/auth/provider'
 import { parseDeploymentMode } from '@/lib/config/deployment-mode'
@@ -193,6 +198,16 @@ async function isAuthenticatedRequest(
     (await isValidAgentApiBearerToken(request))
   ) {
     return true
+  }
+
+  // CLI / MCP `chm_` keys (Bearer or x-api-key) count as authenticated so
+  // agent/actions work with device-login tokens when CHM_API_KEY_SECRET is set.
+  if (apiKeyAuthEnabled()) {
+    for (const candidate of apiKeyCandidates(request)) {
+      if (!candidate.startsWith('chm_')) continue
+      const result = await verifyApiKey(candidate)
+      if (result.valid) return true
+    }
   }
 
   // Reverse-proxy providers authenticate by re-running their own header/JWT

--- a/apps/dashboard/src/routes/api/v1/auth/api-key.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/api-key.ts
@@ -2,21 +2,27 @@
  * API Key Issuance Endpoint
  * POST /api/v1/auth/api-key
  *
- * Mints a signed API key for use with the MCP server.
- * Requires CHM_API_KEY_SECRET as a Bearer token to authorize issuance.
+ * Mints a signed API key for MCP / CLI use. Authorize with EITHER:
+ *  - `Authorization: Bearer $CHM_API_KEY_SECRET` (admin issuance; sub from body label)
+ *  - an authenticated Clerk/proxy session (user-scoped; sub = userId)
  *
- * Ported from apps/dashboard/app/api/v1/auth/api-key/route.ts.
- * - next/server NextResponse.json(x, init) -> Response.json(x, init).
- * - Depends on @chm/mcp-server/auth (getBearerToken, issueApiKey). That subpath
- *   needs a vite alias in dashboard (the generic @chm/mcp-server entry is
- *   NOT aliased — only /http and /data are). See reported neededConfig.
+ * Optional body: `{ label?, days?, scopes? }`.
+ * Returns `{ data: { apiKey, sub, scopes, expiresInDays } }`.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import { getBearerToken, issueApiKey } from '@chm/mcp-server/auth'
+import {
+  ALL_API_KEY_SCOPES,
+  type ApiKeyScope,
+  getBearerToken,
+  issueApiKey,
+} from '@chm/mcp-server/auth'
+import { getAuthProvider } from '@/lib/auth/provider'
+import { resolveServerAuthProvider } from '@/lib/auth/providers'
 
 const MAX_API_KEY_DAYS = 365
+const ALLOWED_SCOPES = new Set<string>(ALL_API_KEY_SCOPES)
 
 function getSecret(): string | null {
   return process.env.CHM_API_KEY_SECRET ?? null
@@ -35,6 +41,64 @@ function timingSafeEqualString(a: string, b: string): boolean {
   return diff === 0
 }
 
+function normalizeScopes(raw: unknown): ApiKeyScope[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const filtered = [
+    ...new Set(
+      raw
+        .filter((s): s is string => typeof s === 'string')
+        .map((s) => s.trim())
+        .filter((s) => ALLOWED_SCOPES.has(s))
+    ),
+  ] as ApiKeyScope[]
+  return filtered.length > 0 ? filtered : undefined
+}
+
+async function resolveIssuerSub(
+  request: Request,
+  secret: string
+): Promise<{ sub: string; via: 'secret' | 'session' } | Response> {
+  const token = getBearerToken(request.headers.get('authorization'))
+  if (token && timingSafeEqualString(token, secret)) {
+    return { sub: 'cli', via: 'secret' }
+  }
+
+  let provider: ReturnType<typeof getAuthProvider>
+  try {
+    provider = getAuthProvider()
+  } catch {
+    return Response.json(
+      { error: 'Invalid auth provider configuration' },
+      { status: 500 }
+    )
+  }
+
+  if (provider === 'none') {
+    return Response.json(
+      {
+        error:
+          'Unauthorized: provide CHM_API_KEY_SECRET as Bearer token or sign in',
+      },
+      { status: 401 }
+    )
+  }
+
+  const auth =
+    await resolveServerAuthProvider(provider).authenticateRequest(request)
+  const userId = auth.subject ?? auth.principal?.subject
+  if (!auth.authenticated || !userId) {
+    return Response.json(
+      {
+        error:
+          'Unauthorized: provide CHM_API_KEY_SECRET as Bearer token or sign in',
+      },
+      { status: 401 }
+    )
+  }
+
+  return { sub: userId, via: 'session' }
+}
+
 async function handlePost(request: Request): Promise<Response> {
   const secret = getSecret()
   if (!secret) {
@@ -44,14 +108,8 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  // Require the CHM_API_KEY_SECRET itself to mint keys
-  const token = getBearerToken(request.headers.get('authorization'))
-  if (!token || !timingSafeEqualString(token, secret)) {
-    return Response.json(
-      { error: 'Unauthorized: provide CHM_API_KEY_SECRET as Bearer token' },
-      { status: 401 }
-    )
-  }
+  const issuer = await resolveIssuerSub(request, secret)
+  if (issuer instanceof Response) return issuer
 
   try {
     const rawBody = await request.text()
@@ -80,8 +138,19 @@ async function handlePost(request: Request): Promise<Response> {
       )
     }
 
-    const apiKey = await issueApiKey(label, days)
-    return Response.json({ data: { apiKey } })
+    const scopes = normalizeScopes(payload.scopes)
+    const sub = issuer.via === 'secret' ? label : issuer.sub
+    const apiKey = await issueApiKey(sub, days, scopes)
+    const stampedScopes = scopes ?? [...ALL_API_KEY_SCOPES]
+
+    return Response.json({
+      data: {
+        apiKey,
+        sub,
+        scopes: stampedScopes,
+        expiresInDays: days,
+      },
+    })
   } catch (error) {
     return Response.json(
       { error: error instanceof Error ? error.message : 'Failed to issue key' },

--- a/apps/dashboard/src/routes/api/v1/auth/device/approve.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/device/approve.ts
@@ -1,17 +1,37 @@
 /**
  * POST /api/v1/auth/device/approve
  *
- * Approves a pending device user_code for the signed-in Clerk/proxy principal.
+ * Approves a pending device user_code.
+ *
+ *  - Clerk / proxy / trusted: requires an authenticated session; subject comes
+ *    from the identity provider.
+ *  - `CHM_AUTH_PROVIDER=none` + device login enabled: **device-only** approve
+ *    (no sign-in). Subject is `CHM_DEVICE_LOGIN_SUBJECT` (default `self-hosted`).
+ *    Trust model: reachability of `/device` on the operator's network.
+ *
  * Body: `{ user_code: string }`.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 
 import { approveUserCode } from '@/lib/auth/device-code-store'
+import { resolveDeviceLogin } from '@/lib/auth/device-login-config'
 import { getAuthProvider } from '@/lib/auth/provider'
 import { resolveServerAuthProvider } from '@/lib/auth/providers'
 
 async function handlePost(request: Request): Promise<Response> {
+  const deviceStatus = resolveDeviceLogin()
+  if (!deviceStatus.enabled) {
+    const message =
+      deviceStatus.reason === 'missing_api_key_secret'
+        ? 'Device login requires CHM_API_KEY_SECRET'
+        : 'Device login is disabled'
+    return Response.json(
+      { error: message, reason: deviceStatus.reason ?? 'disabled' },
+      { status: 503 }
+    )
+  }
+
   let provider: ReturnType<typeof getAuthProvider>
   try {
     provider = getAuthProvider()
@@ -22,18 +42,22 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
+  let userId: string
   if (provider === 'none') {
-    return Response.json(
-      { error: 'Device approval requires an authenticated session' },
-      { status: 401 }
-    )
-  }
-
-  const auth =
-    await resolveServerAuthProvider(provider).authenticateRequest(request)
-  const userId = auth.subject ?? auth.principal?.subject
-  if (!auth.authenticated || !userId) {
-    return Response.json({ error: 'Authentication required' }, { status: 401 })
+    // Device-only: anyone who can hit this endpoint (and /device) can mint a
+    // token bound to the configured subject. Intended for trusted LAN / VPN.
+    userId = deviceStatus.subject
+  } else {
+    const auth =
+      await resolveServerAuthProvider(provider).authenticateRequest(request)
+    const subject = auth.subject ?? auth.principal?.subject
+    if (!auth.authenticated || !subject) {
+      return Response.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      )
+    }
+    userId = subject
   }
 
   let userCode: string
@@ -64,7 +88,9 @@ async function handlePost(request: Request): Promise<Response> {
     )
   }
 
-  return Response.json({ data: { approved: true } })
+  return Response.json({
+    data: { approved: true, deviceOnly: provider === 'none', subject: userId },
+  })
 }
 
 export const Route = createFileRoute('/api/v1/auth/device/approve')({

--- a/apps/dashboard/src/routes/api/v1/auth/device/approve.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/device/approve.ts
@@ -1,0 +1,76 @@
+/**
+ * POST /api/v1/auth/device/approve
+ *
+ * Approves a pending device user_code for the signed-in Clerk/proxy principal.
+ * Body: `{ user_code: string }`.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { approveUserCode } from '@/lib/auth/device-code-store'
+import { getAuthProvider } from '@/lib/auth/provider'
+import { resolveServerAuthProvider } from '@/lib/auth/providers'
+
+async function handlePost(request: Request): Promise<Response> {
+  let provider: ReturnType<typeof getAuthProvider>
+  try {
+    provider = getAuthProvider()
+  } catch {
+    return Response.json(
+      { error: 'Invalid auth provider configuration' },
+      { status: 500 }
+    )
+  }
+
+  if (provider === 'none') {
+    return Response.json(
+      { error: 'Device approval requires an authenticated session' },
+      { status: 401 }
+    )
+  }
+
+  const auth =
+    await resolveServerAuthProvider(provider).authenticateRequest(request)
+  const userId = auth.subject ?? auth.principal?.subject
+  if (!auth.authenticated || !userId) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  let userCode: string
+  try {
+    const body = (await request.json()) as Record<string, unknown>
+    if (typeof body.user_code !== 'string' || !body.user_code.trim()) {
+      return Response.json({ error: 'user_code is required' }, { status: 400 })
+    }
+    userCode = body.user_code.trim()
+  } catch {
+    return Response.json(
+      { error: 'Request body must be valid JSON' },
+      { status: 400 }
+    )
+  }
+
+  const result = await approveUserCode(userCode, userId)
+  if (!result.ok) {
+    const status =
+      result.error === 'not_found'
+        ? 404
+        : result.error === 'unavailable'
+          ? 503
+          : 400
+    return Response.json(
+      { error: result.error, message: `Cannot approve: ${result.error}` },
+      { status }
+    )
+  }
+
+  return Response.json({ data: { approved: true } })
+}
+
+export const Route = createFileRoute('/api/v1/auth/device/approve')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/auth/device/code.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/device/code.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/v1/auth/device/code
+ *
+ * RFC 8628 device authorization — public. Creates a pending device/user code
+ * pair in D1. Returns 503 when CHM_CLOUD_D1 is unavailable.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  deviceLoginAvailable,
+  insertDeviceCode,
+} from '@/lib/auth/device-code-store'
+
+const DEFAULT_EXPIRES_IN = 900
+const DEFAULT_INTERVAL = 5
+const USER_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+
+function randomUserCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(8))
+  let out = ''
+  for (let i = 0; i < 8; i += 1) {
+    out += USER_CODE_ALPHABET[bytes[i]! % USER_CODE_ALPHABET.length]
+    if (i === 3) out += '-'
+  }
+  return out
+}
+
+function randomDeviceCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  if (!deviceLoginAvailable()) {
+    return Response.json(
+      { error: 'Device login is unavailable (D1 not configured)' },
+      { status: 503 }
+    )
+  }
+
+  let clientId = 'chm-cli'
+  try {
+    const raw = await request.text()
+    if (raw.trim()) {
+      const body = JSON.parse(raw) as Record<string, unknown>
+      if (typeof body.client_id === 'string' && body.client_id.trim()) {
+        clientId = body.client_id.trim()
+      }
+    }
+  } catch {
+    return Response.json(
+      { error: 'Request body must be valid JSON' },
+      { status: 400 }
+    )
+  }
+
+  const now = Date.now()
+  const deviceCode = randomDeviceCode()
+  const userCode = randomUserCode()
+  const expiresIn = DEFAULT_EXPIRES_IN
+  const interval = DEFAULT_INTERVAL
+
+  const ok = await insertDeviceCode({
+    deviceCode,
+    userCode,
+    clientId,
+    createdAt: now,
+    expiresAt: now + expiresIn * 1000,
+    intervalSec: interval,
+  })
+  if (!ok) {
+    return Response.json(
+      { error: 'Failed to create device code' },
+      { status: 503 }
+    )
+  }
+
+  const origin = new URL(request.url).origin
+  const verificationUri = `${origin}/device`
+  const verificationUriComplete = `${verificationUri}?user_code=${encodeURIComponent(userCode)}`
+
+  const payload = {
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: verificationUri,
+    verification_uri_complete: verificationUriComplete,
+    expires_in: expiresIn,
+    interval,
+  }
+
+  // `{ data }` is the dashboard envelope; top-level fields keep the CLI
+  // (flat OAuth deserialize) working without a second round-trip.
+  return Response.json({ data: payload, ...payload })
+}
+
+export const Route = createFileRoute('/api/v1/auth/device/code')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/auth/device/code.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/device/code.ts
@@ -2,15 +2,14 @@
  * POST /api/v1/auth/device/code
  *
  * RFC 8628 device authorization — public. Creates a pending device/user code
- * pair in D1. Returns 503 when CHM_CLOUD_D1 is unavailable.
+ * pair (D1 or in-memory). Returns 503 when device login is disabled or
+ * CHM_API_KEY_SECRET is missing.
  */
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import {
-  deviceLoginAvailable,
-  insertDeviceCode,
-} from '@/lib/auth/device-code-store'
+import { insertDeviceCode } from '@/lib/auth/device-code-store'
+import { resolveDeviceLogin } from '@/lib/auth/device-login-config'
 
 const DEFAULT_EXPIRES_IN = 900
 const DEFAULT_INTERVAL = 5
@@ -31,12 +30,25 @@ function randomDeviceCode(): string {
   return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('')
 }
 
+function disabledResponse(reason: string | null): Response {
+  const message =
+    reason === 'missing_api_key_secret'
+      ? 'Device login requires CHM_API_KEY_SECRET'
+      : reason === 'disabled'
+        ? 'Device login is disabled (set CHM_DEVICE_LOGIN=true to enable on self-hosted)'
+        : 'Device login is unavailable'
+  return Response.json(
+    { error: message, reason: reason ?? 'unavailable' },
+    {
+      status: 503,
+    }
+  )
+}
+
 async function handlePost(request: Request): Promise<Response> {
-  if (!deviceLoginAvailable()) {
-    return Response.json(
-      { error: 'Device login is unavailable (D1 not configured)' },
-      { status: 503 }
-    )
+  const status = resolveDeviceLogin()
+  if (!status.enabled) {
+    return disabledResponse(status.reason)
   }
 
   let clientId = 'chm-cli'

--- a/apps/dashboard/src/routes/api/v1/auth/device/status.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/device/status.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /api/v1/auth/device/status
+ *
+ * Public discovery for the `/device` page and CLI doctor: whether device login
+ * is enabled, device-only (auth=none) mode, and disable reason.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { deviceCodeStoreKind } from '@/lib/auth/device-code-store'
+import { resolveDeviceLogin } from '@/lib/auth/device-login-config'
+
+function handleGet(): Response {
+  const status = resolveDeviceLogin()
+  const store = status.enabled ? deviceCodeStoreKind() : status.store
+  const payload = {
+    enabled: status.enabled,
+    mode: status.mode,
+    deviceOnly: status.deviceOnly,
+    reason: status.reason,
+    store,
+    // Subject is useful for operators; not a secret.
+    subject: status.deviceOnly ? status.subject : undefined,
+  }
+  return Response.json({ data: payload, ...payload })
+}
+
+export const Route = createFileRoute('/api/v1/auth/device/status')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/api/v1/auth/token.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/token.ts
@@ -9,12 +9,9 @@
 
 import { createFileRoute } from '@tanstack/react-router'
 
-import {
-  ALL_API_KEY_SCOPES,
-  apiKeyAuthEnabled,
-  issueApiKey,
-} from '@chm/mcp-server/auth'
+import { ALL_API_KEY_SCOPES, issueApiKey } from '@chm/mcp-server/auth'
 import { getByDeviceCode, markConsumed } from '@/lib/auth/device-code-store'
+import { resolveDeviceLogin } from '@/lib/auth/device-login-config'
 
 const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code'
 const DEVICE_GRANT_SHORT = 'device_code'
@@ -29,9 +26,14 @@ function oauthError(
 }
 
 async function handlePost(request: Request): Promise<Response> {
-  if (!apiKeyAuthEnabled()) {
+  const deviceStatus = resolveDeviceLogin()
+  if (!deviceStatus.enabled) {
+    const message =
+      deviceStatus.reason === 'missing_api_key_secret'
+        ? 'CHM_API_KEY_SECRET is not configured'
+        : 'Device login is disabled'
     return Response.json(
-      { error: 'CHM_API_KEY_SECRET is not configured' },
+      { error: message, reason: deviceStatus.reason ?? 'disabled' },
       { status: 503 }
     )
   }

--- a/apps/dashboard/src/routes/api/v1/auth/token.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/token.ts
@@ -1,0 +1,107 @@
+/**
+ * POST /api/v1/auth/token
+ *
+ * OAuth device_code grant. Polls until the user approves at `/device`, then
+ * mints a `chm_` API key for the approving user (30 days, all scopes).
+ *
+ * Pending → `{ error: 'authorization_pending' }` with status 400.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import {
+  ALL_API_KEY_SCOPES,
+  apiKeyAuthEnabled,
+  issueApiKey,
+} from '@chm/mcp-server/auth'
+import { getByDeviceCode, markConsumed } from '@/lib/auth/device-code-store'
+
+const DEVICE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code'
+const DEVICE_GRANT_SHORT = 'device_code'
+const TOKEN_DAYS = 30
+
+function oauthError(
+  error: string,
+  description: string,
+  status = 400
+): Response {
+  return Response.json({ error, error_description: description }, { status })
+}
+
+async function handlePost(request: Request): Promise<Response> {
+  if (!apiKeyAuthEnabled()) {
+    return Response.json(
+      { error: 'CHM_API_KEY_SECRET is not configured' },
+      { status: 503 }
+    )
+  }
+
+  let grantType: string | undefined
+  let deviceCode: string | undefined
+  try {
+    const body = (await request.json()) as Record<string, unknown>
+    grantType =
+      typeof body.grant_type === 'string' ? body.grant_type : undefined
+    deviceCode =
+      typeof body.device_code === 'string' ? body.device_code : undefined
+  } catch {
+    return oauthError('invalid_request', 'Request body must be valid JSON')
+  }
+
+  if (grantType !== DEVICE_GRANT && grantType !== DEVICE_GRANT_SHORT) {
+    return oauthError(
+      'unsupported_grant_type',
+      'Only device_code grant is supported'
+    )
+  }
+
+  if (!deviceCode) {
+    return oauthError('invalid_request', 'device_code is required')
+  }
+
+  const record = await getByDeviceCode(deviceCode)
+  if (!record) {
+    return oauthError('invalid_grant', 'Unknown device_code')
+  }
+
+  if (record.consumedAt != null) {
+    return oauthError('invalid_grant', 'device_code already used')
+  }
+
+  if (record.expiresAt <= Date.now()) {
+    return oauthError('expired_token', 'device_code has expired')
+  }
+
+  if (record.approvedAt == null || !record.userId) {
+    return oauthError('authorization_pending', 'Waiting for user authorization')
+  }
+
+  try {
+    const accessToken = await issueApiKey(record.userId, TOKEN_DAYS, [
+      ...ALL_API_KEY_SCOPES,
+    ])
+    await markConsumed(deviceCode)
+    return Response.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: TOKEN_DAYS * 86400,
+    })
+  } catch (err) {
+    return Response.json(
+      {
+        error: 'server_error',
+        error_description:
+          err instanceof Error ? err.message : 'Failed to issue token',
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export const Route = createFileRoute('/api/v1/auth/token')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => handlePost(request),
+    },
+  },
+})

--- a/apps/dashboard/src/routes/device.tsx
+++ b/apps/dashboard/src/routes/device.tsx
@@ -2,23 +2,37 @@
  * Device authorization page for `chm auth login`.
  * Route: /device?user_code=ABCD-EFGH
  *
- * Signed-in users submit the code to POST /api/v1/auth/device/approve.
- * Anonymous visitors are pointed at /sign-in.
+ * Cloud / Clerk / proxy: signed-in users approve; anonymous visitors are
+ * pointed at /sign-in.
+ *
+ * Self-hosted device-only (`CHM_AUTH_PROVIDER=none` + `CHM_DEVICE_LOGIN=true`):
+ * anyone who can reach this page may approve (trusted network).
+ *
+ * When device login is disabled (OSS default), show how to opt in or mint a key.
  */
 
 import { createFileRoute, Link } from '@tanstack/react-router'
+import { type FormEvent, useEffect, useState } from 'react'
 
 import {
   keepHostSearch,
   validateSearch as validateRootSearch,
 } from './-root-search'
-import { type FormEvent, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
 type DeviceSearch = {
   host: number
   user_code?: string
+}
+
+type DeviceStatus = {
+  enabled: boolean
+  mode: string
+  deviceOnly: boolean
+  reason: string | null
+  store?: string
+  subject?: string
 }
 
 function validateDeviceSearch(search: Record<string, unknown>): DeviceSearch {
@@ -45,6 +59,50 @@ function DeviceApprovePage() {
     'idle'
   )
   const [message, setMessage] = useState<string | null>(null)
+  const [deviceStatus, setDeviceStatus] = useState<DeviceStatus | null>(null)
+  const [statusLoading, setStatusLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch('/api/v1/auth/device/status')
+        const body = (await res.json().catch(() => ({}))) as {
+          data?: DeviceStatus
+          enabled?: boolean
+          mode?: string
+          deviceOnly?: boolean
+          reason?: string | null
+          store?: string
+          subject?: string
+        }
+        if (cancelled) return
+        const data = body.data ?? body
+        setDeviceStatus({
+          enabled: Boolean(data.enabled),
+          mode: typeof data.mode === 'string' ? data.mode : 'auto',
+          deviceOnly: Boolean(data.deviceOnly),
+          reason: data.reason ?? null,
+          store: data.store,
+          subject: data.subject,
+        })
+      } catch {
+        if (!cancelled) {
+          setDeviceStatus({
+            enabled: false,
+            mode: 'auto',
+            deviceOnly: false,
+            reason: 'unavailable',
+          })
+        }
+      } finally {
+        if (!cancelled) setStatusLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
@@ -72,6 +130,11 @@ function DeviceApprovePage() {
         setStatus('error')
         if (res.status === 401) {
           setMessage('Sign in first, then approve this device.')
+        } else if (res.status === 503) {
+          setMessage(
+            body.error ??
+              'Device login is disabled on this deployment. See docs for CHM_DEVICE_LOGIN.'
+          )
         } else {
           setMessage(
             body.message ?? body.error ?? `Approve failed (${res.status})`
@@ -87,6 +150,48 @@ function DeviceApprovePage() {
     }
   }
 
+  if (statusLoading) {
+    return (
+      <main className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col justify-center gap-4 px-4 py-12">
+        <p className="text-sm text-muted-foreground">Checking device login…</p>
+      </main>
+    )
+  }
+
+  if (deviceStatus && !deviceStatus.enabled) {
+    const missingSecret = deviceStatus.reason === 'missing_api_key_secret'
+    return (
+      <main className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col justify-center gap-6 px-4 py-12">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Device login is off
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {missingSecret
+              ? 'Set CHM_API_KEY_SECRET on the server, then enable device login.'
+              : 'Self-hosted deployments leave CLI device login disabled by default (trusted internal networks usually mint an API key once).'}
+          </p>
+        </div>
+        <div className="space-y-2 rounded-md border border-border bg-muted/40 p-4 text-sm">
+          <p className="font-medium">Enable on self-hosted</p>
+          <pre className="overflow-x-auto text-xs leading-relaxed">
+            {`CHM_API_KEY_SECRET=…
+CHM_DEVICE_LOGIN=true
+# optional when CHM_AUTH_PROVIDER=none:
+# CHM_DEVICE_LOGIN_SUBJECT=self-hosted`}
+          </pre>
+          <p className="text-muted-foreground">
+            Or mint a key without device flow:{' '}
+            <code className="text-xs">POST /api/v1/auth/api-key</code> with the
+            signing secret as Bearer.
+          </p>
+        </div>
+      </main>
+    )
+  }
+
+  const deviceOnly = deviceStatus?.deviceOnly === true
+
   return (
     <main className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col justify-center gap-6 px-4 py-12">
       <div className="space-y-2">
@@ -95,7 +200,10 @@ function DeviceApprovePage() {
         </h1>
         <p className="text-sm text-muted-foreground">
           Enter the code from <code className="text-xs">chm auth login</code> to
-          authorize this device. You must be signed in.
+          authorize this device.
+          {deviceOnly
+            ? ' This deployment uses device-only tokens (no sign-in) — anyone who can reach this page can approve.'
+            : ' You must be signed in.'}
         </p>
       </div>
 
@@ -130,16 +238,26 @@ function DeviceApprovePage() {
         </p>
       ) : null}
 
-      <p className="text-sm text-muted-foreground">
-        Not signed in?{' '}
-        <Link
-          to="/sign-in"
-          search={keepHostSearch}
-          className="underline underline-offset-4"
-        >
-          Sign in
-        </Link>
-      </p>
+      {!deviceOnly ? (
+        <p className="text-sm text-muted-foreground">
+          Not signed in?{' '}
+          <Link
+            to="/sign-in"
+            search={keepHostSearch}
+            className="underline underline-offset-4"
+          >
+            Sign in
+          </Link>
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          Tokens are bound to subject{' '}
+          <code className="text-xs">
+            {deviceStatus?.subject ?? 'self-hosted'}
+          </code>
+          .
+        </p>
+      )}
     </main>
   )
 }

--- a/apps/dashboard/src/routes/device.tsx
+++ b/apps/dashboard/src/routes/device.tsx
@@ -1,0 +1,145 @@
+/**
+ * Device authorization page for `chm auth login`.
+ * Route: /device?user_code=ABCD-EFGH
+ *
+ * Signed-in users submit the code to POST /api/v1/auth/device/approve.
+ * Anonymous visitors are pointed at /sign-in.
+ */
+
+import { createFileRoute, Link } from '@tanstack/react-router'
+
+import {
+  keepHostSearch,
+  validateSearch as validateRootSearch,
+} from './-root-search'
+import { type FormEvent, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+type DeviceSearch = {
+  host: number
+  user_code?: string
+}
+
+function validateDeviceSearch(search: Record<string, unknown>): DeviceSearch {
+  const root = validateRootSearch(search)
+  const raw = search.user_code
+  if (typeof raw === 'string' && raw.trim()) {
+    return { ...root, user_code: raw.trim().toUpperCase() }
+  }
+  return root
+}
+
+export const Route = createFileRoute('/device')({
+  component: DeviceApprovePage,
+  validateSearch: validateDeviceSearch,
+  head: () => ({
+    meta: [{ title: 'Approve device — chmonitor' }],
+  }),
+})
+
+function DeviceApprovePage() {
+  const { user_code: initialCode } = Route.useSearch()
+  const [userCode, setUserCode] = useState(initialCode ?? '')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ok' | 'error'>(
+    'idle'
+  )
+  const [message, setMessage] = useState<string | null>(null)
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault()
+    const code = userCode.trim().toUpperCase()
+    if (!code) {
+      setStatus('error')
+      setMessage('Enter the code shown in your terminal.')
+      return
+    }
+
+    setStatus('loading')
+    setMessage(null)
+    try {
+      const res = await fetch('/api/v1/auth/device/approve', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_code: code }),
+      })
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string
+        message?: string
+      }
+      if (!res.ok) {
+        setStatus('error')
+        if (res.status === 401) {
+          setMessage('Sign in first, then approve this device.')
+        } else {
+          setMessage(
+            body.message ?? body.error ?? `Approve failed (${res.status})`
+          )
+        }
+        return
+      }
+      setStatus('ok')
+      setMessage('Device approved. You can return to the CLI.')
+    } catch {
+      setStatus('error')
+      setMessage('Network error — try again.')
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col justify-center gap-6 px-4 py-12">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Approve CLI device
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Enter the code from <code className="text-xs">chm auth login</code> to
+          authorize this device. You must be signed in.
+        </p>
+      </div>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <label className="text-sm font-medium" htmlFor="user_code">
+          Device code
+        </label>
+        <Input
+          id="user_code"
+          name="user_code"
+          autoComplete="one-time-code"
+          placeholder="ABCD-EFGH"
+          value={userCode}
+          onChange={(e) => setUserCode(e.target.value.toUpperCase())}
+          className="font-mono tracking-widest"
+        />
+        <Button type="submit" disabled={status === 'loading'}>
+          {status === 'loading' ? 'Approving…' : 'Approve'}
+        </Button>
+      </form>
+
+      {message ? (
+        <p
+          className={
+            status === 'ok'
+              ? 'text-sm text-green-700 dark:text-green-400'
+              : 'text-sm text-destructive'
+          }
+          role="status"
+        >
+          {message}
+        </p>
+      ) : null}
+
+      <p className="text-sm text-muted-foreground">
+        Not signed in?{' '}
+        <Link
+          to="/sign-in"
+          search={keepHostSearch}
+          className="underline underline-offset-4"
+        >
+          Sign in
+        </Link>
+      </p>
+    </main>
+  )
+}

--- a/deploy/helm/chmonitor/values.yaml
+++ b/deploy/helm/chmonitor/values.yaml
@@ -267,6 +267,12 @@ features:
   # "true" relaxes Clerk so anonymous GET /api/v1/* is allowed (writes still need
   # sign-in). App default: false.
   CHM_CLERK_PUBLIC_READ: ""
+  # CLI device login: auto | true | false. App default: auto (off for OSS;
+  # on for cloud when CHM_API_KEY_SECRET is set). Set "true" to opt in on
+  # self-hosted; with auth.provider=none this is device-only approve.
+  CHM_DEVICE_LOGIN: ""
+  # Subject for device-only tokens (auth=none). App default: self-hosted.
+  CHM_DEVICE_LOGIN_SUBJECT: ""
   # Default AI model (provider:model or anyrouter/...). Empty = app default.
   LLM_MODEL: ""
 

--- a/docs/content/operate/authentication/api-keys.mdx
+++ b/docs/content/operate/authentication/api-keys.mdx
@@ -64,6 +64,25 @@ curl https://dash.example.com/api/mcp \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
 ```
 
+## Device login (`chm auth login`)
+
+RFC 8628 device flow for the Rust CLI. Controlled by `CHM_DEVICE_LOGIN`:
+
+| Value | Behaviour |
+|-------|-----------|
+| `auto` (default) | **Cloud**: on when `CHM_API_KEY_SECRET` is set (approve requires a signed-in session at `/device`). **Self-hosted / OSS**: off — typical internal networks mint a key once or leave the API open. |
+| `true` | Force on. With `CHM_AUTH_PROVIDER=none` this is **device-only** approve (no Clerk): anyone who can open `/device` can mint a token bound to `CHM_DEVICE_LOGIN_SUBJECT` (default `self-hosted`). Codes persist in D1 when bound, otherwise in memory (single-node). |
+| `false` | Force off everywhere (`/api/v1/auth/device/*` → 503). |
+
+```bash
+# Self-hosted opt-in on a trusted LAN
+CHM_AUTH_PROVIDER=none
+CHM_API_KEY_SECRET=a-long-random-string
+CHM_DEVICE_LOGIN=true
+```
+
+Discovery: `GET /api/v1/auth/device/status` returns `{ enabled, mode, deviceOnly, reason, store }`.
+
 ## Troubleshooting
 
 <Accordions>
@@ -72,6 +91,9 @@ The `/api/mcp` endpoint also accepts Clerk OAuth bearer tokens. If you are using
 </Accordion>
 <Accordion title="A valid token still gets 403 on some features">
 Feature-level permissions apply on top of the key auth. Even an authenticated caller may be denied a specific feature. See [Feature Permissions](/operate/advanced/feature-permissions).
+</Accordion>
+<Accordion title="chm auth login gets 503 on my self-hosted dashboard">
+Device login defaults to off for OSS (`CHM_DEVICE_LOGIN=auto`). Set `CHM_DEVICE_LOGIN=true` and `CHM_API_KEY_SECRET`, or mint a key with `POST /api/v1/auth/api-key` and pass it as `--api-key` / `CHM_API_KEY`.
 </Accordion>
 </Accordions>
 

--- a/docs/content/operate/authentication/public.mdx
+++ b/docs/content/operate/authentication/public.mdx
@@ -20,7 +20,20 @@ No configuration needed — this is the default when `CHM_AUTH_PROVIDER` is unse
 CHM_AUTH_PROVIDER=none   # or omit entirely
 ```
 
-If you also set `CHM_API_KEY_SECRET`, the API key layer activates for non-browser callers — `/api/v1/*` will require a `chm_` token from scripts and MCP clients even though the browser dashboard remains open. See [API keys](/operate/authentication/api-keys).
+If you also set `CHM_API_KEY_SECRET`, the API key layer activates — `/api/v1/*`
+requires a `chm_` token (or an exempt public path). See
+[API keys](/operate/authentication/api-keys).
+
+**CLI device login** defaults to **off** in self-hosted (`CHM_DEVICE_LOGIN=auto`).
+That matches an internal-network design: mint one key with the signing secret,
+or leave the API open without a secret. To opt into browser device flow for
+`chm auth login` on a trusted LAN:
+
+```bash
+CHM_API_KEY_SECRET=a-long-random-string
+CHM_DEVICE_LOGIN=true
+# approve at /device without Clerk; tokens use subject self-hosted
+```
 
 ## When to use
 

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -262,7 +262,9 @@ The active server-side auth provider is set by `CHM_AUTH_PROVIDER`. See
 |---|---|---|
 | `CHM_AUTH_PROVIDER` | `none` | Server auth provider: `none`, `clerk`, `proxy`, or `trusted`. **Canonical** — the client `VITE_AUTH_PROVIDER` is derived from it at build time. |
 | `VITE_AUTH_PROVIDER` | (from `CHM_AUTH_PROVIDER`) | Client-side build-time value. Auto-derived from `CHM_AUTH_PROVIDER`; only set explicitly to override. |
-| `CHM_API_KEY_SECRET` | — | Shared secret for `chm_` API keys. When set, API-key auth is always on alongside the active provider. Issue keys at `/api/v1/auth/api-key`. |
+| `CHM_API_KEY_SECRET` | — | Shared secret for `chm_` API keys. When set, API-key auth is always on alongside the active provider. Issue keys at `/api/v1/auth/api-key`. Required to enable CLI device login. |
+| `CHM_DEVICE_LOGIN` | `auto` | CLI device login (`chm auth login` / `/device`). `auto` = on in **cloud** when `CHM_API_KEY_SECRET` is set; **off** for self-hosted/OSS (typical internal network — mint a key once or leave the API open). `true` = force on (self-hosted opt-in; with `CHM_AUTH_PROVIDER=none` this is **device-only** approve — no Clerk, trust reachability of `/device`). `false` = force off. Persistence uses D1 when bound, otherwise an in-memory store (single-node). |
+| `CHM_DEVICE_LOGIN_SUBJECT` | `self-hosted` | Subject embedded in `chm_` tokens minted via device-only approve (`auth=none`). Ignored when Clerk/proxy supplies the user id. |
 
 <Callout type="danger" title="Keep secrets server-side">
 `CLERK_SECRET_KEY`, `CHM_API_KEY_SECRET`, and every trust-gate secret below are

--- a/docs/knowledge/cloud-saas-mode.md
+++ b/docs/knowledge/cloud-saas-mode.md
@@ -3,7 +3,7 @@ id: cloud-saas-mode
 title: Cloud (SaaS) mode — one codebase, two products
 type: spec
 status: active
-updated: 2026-08-18
+updated: 2026-08-20
 tags:
   - saas
   - cloud
@@ -64,7 +64,7 @@ split-brain. Detection is pure and unit-tested (`cloud-mode.test.ts`); the
 | Env `CLICKHOUSE_HOST` | operator's real hosts, full access | public **read-only demo** (`source:'demo'`) |
 | Anonymous | sees env hosts | sees the demo (explore, no account) |
 | Signed-in | sees env hosts | demo hidden → own D1 connections only; zero → welcome/setup |
-| Auth | usually `none` | Clerk + `CHM_CLERK_PUBLIC_READ=true` |
+| Auth | usually `none`; CLI device login **off** (`CHM_DEVICE_LOGIN=auto`) — opt in with `true` for device-only tokens on a trusted LAN | Clerk + `CHM_CLERK_PUBLIC_READ=true`; CLI device login **on** when `CHM_API_KEY_SECRET` is set |
 | Per-user conns | optional | on (`VITE_FEATURE_USER_CONNECTIONS_DB=true`) |
 | Agent (anon) | IP rate limit only, no daily cap | daily guest cap (default 3) + tighter RL (5/min); D1 `guest:<ip-hash>` |
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -17,9 +17,11 @@ related:
 
 # Standalone chmonitor CLI (Rust)
 
-`rust/ch-monitor-cli` provides a standalone CLI that talks to the existing API
-(`hosts`/`chart`/`table`/`tui`), plus a `diagnose` subcommand that connects
-**directly to a ClickHouse host** with no chmonitor backend or account
+`rust/ch-monitor-cli` is the `chm` binary. By default it talks to **chmonitor
+Cloud** at `https://dash.chmonitor.dev` (hosts / charts / tables / TUI / agent).
+Self-hosted dashboards work the same way — point `--base-url` /
+`CHM_BASE_URL` at your instance. A separate `diagnose` subcommand connects
+**directly to a [REDACTED] host** with no chmonitor backend or account
 (see [Zero-signup diagnostics](#zero-signup-diagnostics-diagnose) below).
 
 ## Config Loading
@@ -42,7 +44,27 @@ channel = "stable" # or "beta"
 Credentials (device-login token / API key) live in the OS keyring, with a
 `0600` plaintext fallback at `~/.config/chm/credentials`.
 
-## Commands
+## Command tree
+
+```text
+chm
+├── auth
+│   ├── login      # device-code flow → store Bearer token
+│   ├── logout     # clear keyring credentials
+│   └── status     # whether a token / API key is present
+├── config         # show / edit local config
+├── hosts          # GET /api/v1/hosts
+├── link [path]    # open dashboard in browser
+├── chart <name>   # GET /api/v1/charts/{name}
+├── table <name>   # GET /api/v1/tables/{name}
+├── tui [chart]    # live terminal UI (--overview for metrics)
+├── chat [msg]     # stream AI agent reply
+├── agent [msg]    # alias of chat
+├── doctor         # local + API connectivity checks
+├── diagnose       # direct host health (no dashboard)
+├── update|upgrade # self-update from GitHub Releases
+└── completions    # shell completions
+```
 
 ```bash
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- auth login
@@ -54,10 +76,50 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merges slow?"
 ```
 
+## Channels
+
+`--channel` / `CHM_CHANNEL` / config `channel`:
+
+| Value | Self-update behaviour |
+|-------|------------------------|
+| `stable` (default) | Skip prereleases; prefer the latest stable `chm-v*` tag |
+| `beta` | Include prereleases; prefer a prerelease when semver cores tie |
+
+## Auth (device flow + API keys)
+
+Dashboard auth endpoints (Phase 1A):
+
+1. `POST /api/v1/auth/device/code` — public; returns `{ data: { device_code, user_code, verification_uri, … } }` (also flattened for OAuth clients). Requires D1 (`CHM_CLOUD_D1`); otherwise 503.
+2. Browser opens `/device?user_code=…` → signed-in user posts to `POST /api/v1/auth/device/approve`.
+3. CLI polls `POST /api/v1/auth/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`. Pending → `{ error: "authorization_pending" }` (400). Success → `{ access_token }` (`chm_` key, 30 days, all scopes).
+
+Programmatic requests may send **either** `Authorization: Bearer chm_…` **or**
+`x-api-key: chm_…` (the CLI sends both when configured). The dashboard
+`api-guard` and feature-permission layer accept both.
+
+Server-side API-key protection is enabled when `CHM_API_KEY_SECRET` is set.
+Mint a key:
+
+```bash
+# Admin issuance (secret as Bearer)
+curl -X POST https://dash.chmonitor.dev/api/v1/auth/api-key \
+  -H 'content-type: application/json' \
+  -H "authorization: Bearer $CHM_API_KEY_SECRET" \
+  -d '{"label":"cli","days":30}'
+
+# Or while signed in (session cookie / proxy identity) — user-scoped sub
+curl -X POST https://dash.chmonitor.dev/api/v1/auth/api-key \
+  -H 'content-type: application/json' \
+  --cookie '__session=…' \
+  -d '{"days":30,"scopes":["read:metrics","mcp:access"]}'
+```
+
+Response shape: `{ data: { apiKey, sub, scopes, expiresInDays } }`.
+
 ## Zero-signup diagnostics (`diagnose`)
 
 `chm diagnose` is a **separate connection mode** from the rest of the CLI: it
-talks straight to the ClickHouse HTTP interface (`reqwest` + basic auth), not
+talks straight to the [REDACTED] HTTP interface (`reqwest` + basic auth), not
 through the dashboard's `/api/v1/*` (no `base_url`/`api_key`/`host_id`, no
 account, no chmonitor backend required at all). Implementation:
 `rust/ch-monitor-cli/src/diagnose.rs`.
@@ -74,7 +136,7 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- diagnose \
   `CLICKHOUSE_DATABASE` env var names the dashboard uses (or `--ch-*` flags).
   A comma-separated multi-host `CLICKHOUSE_HOST` diagnoses only the first host
   (prints a note) — multi-host clusters belong in the full dashboard.
-- Every query forces `readonly=2` at the ClickHouse settings level — this can
+- Every query forces `readonly=2` at the [REDACTED] settings level — this can
   never mutate the target cluster no matter what a future check adds.
 - Runs 12 independent read-only checks against `system.query_log`,
   `system.parts`, `system.replicas`, `system.mutations`, `system.processes`,
@@ -93,21 +155,6 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- diagnose \
 - `--json` prints the machine-readable `Report` (also useful in CI); the
   process exits `1` if any finding is `critical`, `0` otherwise.
 - Docs page: `docs/content/guide/guides/diagnostics-cli.mdx`.
-
-## API Key / Auth Support
-
-- CLI sends **both** `Authorization: Bearer …` and `x-api-key` when configured
-- `chm auth login` uses the device-code flow:
-  `POST /api/v1/auth/device/code` → open browser → poll `POST /api/v1/auth/token`
-- Server-side API key protection enabled when `CHM_API_KEY_SECRET` is set
-- Generate key via API:
-
-```bash
-curl -X POST https://dash.chmonitor.dev/api/v1/auth/api-key \
-  -H 'content-type: application/json' \
-  -H "authorization: Bearer $CHM_API_KEY_SECRET" \
-  -d '{"label":"cli","days":30}'
-```
 
 ## Dependencies
 
@@ -142,37 +189,27 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
 ## CI & Release
 
 - **CI**: `cli-rust-ci.yml` — fmt, clippy, build, test
-- **Release tags**:
-  - **stable**: `chm-vX.Y.Z` (e.g. `chm-v0.1.2`) — `prerelease=false`
-  - **beta**: `chm-vX.Y.Z-beta.<run_number>` from Cargo.toml `0.1.x` on
-    `main` path pushes — `prerelease=true`
+- **Release**: Tag format `chm-v*` (e.g. `chm-v0.1.0`)
 - **Release workflow**: `cli-rust-release.yml` builds 4 targets
   (`x86_64`/`aarch64` × `unknown-linux-gnu`/`apple-darwin`, no Windows) and
   uploads each binary plus a `.sha256` checksum file to the GitHub Release as
-  `chm-<target>` / `chm-<target>.sha256`.
-  - Tag push / `workflow_dispatch` with `tag` → stable release
-  - Push to `main` when `rust/ch-monitor-cli/**`, `rust/Cargo.{toml,lock}`,
-    the workflow, or `scripts/install.sh` change → beta prerelease
-  - Beta tag pattern is excluded from the tag trigger so creating the beta
-    release does not re-fire a stable build
+  `chm-<target>` / `chm-<target>.sha256`. Only runs the upload step on an
+  actual tag push (`github.ref_type == 'tag'`); `workflow_dispatch` builds but
+  doesn't publish.
 
 ## One-line install (`scripts/install.sh`)
 
 ```bash
 curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
-# Beta channel:
-CHM_CHANNEL=beta curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
 ```
 
 - Detects OS (`Linux`/`Darwin`) + arch (`x86_64`/`aarch64`), maps to the
   release workflow's target triples, and refuses to run on anything else
   (no silent wrong-arch installs).
-- Resolves the latest `chm-v*` release via the GitHub releases API for
-  `CHM_CHANNEL` (`stable` default, or `beta`), ranking by semver (not
-  first-match / created_at). `stable` skips drafts/prereleases; `beta`
-  prefers prereleases (falls back to stable if none). Dashboard/Helm tags
-  share this API. Pin a specific release with `CHM_VERSION=chm-vX.Y.Z`
-  (`vX.Y.Z` / `X.Y.Z` also work). Logs the channel on install.
+- Resolves the latest **published** `chm-v*` release via the GitHub releases
+  API, ranking by semver (not first-match / created_at) and skipping
+  drafts/prereleases. Dashboard/Helm tags share this API. Pin a specific
+  release with `CHM_VERSION=chm-vX.Y.Z` (`vX.Y.Z` / `X.Y.Z` also work).
 - Downloads the binary + its `.sha256` asset and verifies the checksum before
   installing; a missing or mismatched checksum is fatal (never installs an
   unverified binary). Fails loud (`set -euo pipefail`) on any

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -87,10 +87,25 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merge
 
 ## Auth (device flow + API keys)
 
-Dashboard auth endpoints (Phase 1A):
+Device login is gated by **`CHM_DEVICE_LOGIN`** (`auto` | `true` | `false`,
+default `auto`):
 
-1. `POST /api/v1/auth/device/code` — public; returns `{ data: { device_code, user_code, verification_uri, … } }` (also flattened for OAuth clients). Requires D1 (`CHM_CLOUD_D1`); otherwise 503.
-2. Browser opens `/device?user_code=…` → signed-in user posts to `POST /api/v1/auth/device/approve`.
+| Deployment | `auto` behaviour |
+|------------|------------------|
+| Cloud (`CHM_CLOUD_MODE` / `CHM_DEPLOYMENT_MODE=cloud`) | On when `CHM_API_KEY_SECRET` is set; `/device` requires a signed-in session |
+| Self-hosted / OSS | **Off** — trusted LAN usually mints one key or leaves the API open |
+
+Opt in on self-hosted with `CHM_DEVICE_LOGIN=true`. With
+`CHM_AUTH_PROVIDER=none` that is **device-only** approve (no Clerk): anyone who
+can reach `/device` completes the flow; minted tokens use subject
+`CHM_DEVICE_LOGIN_SUBJECT` (default `self-hosted`). Codes persist in D1 when
+bound, otherwise an in-memory store (single-node). Force off with
+`CHM_DEVICE_LOGIN=false`. Status: `GET /api/v1/auth/device/status`.
+
+Dashboard auth endpoints:
+
+1. `POST /api/v1/auth/device/code` — public when enabled; returns `{ data: { device_code, user_code, verification_uri, … } }` (also flattened for OAuth clients). 503 when disabled or missing `CHM_API_KEY_SECRET`.
+2. Browser opens `/device?user_code=…` → approve via `POST /api/v1/auth/device/approve` (Clerk/proxy session, or device-only when auth=`none`).
 3. CLI polls `POST /api/v1/auth/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`. Pending → `{ error: "authorization_pending" }` (400). Success → `{ access_token }` (`chm_` key, 30 days, all scopes).
 
 Programmatic requests may send **either** `Authorization: Bearer chm_…` **or**

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -3,7 +3,7 @@ id: standalone-cli
 title: Standalone CLI (Rust)
 type: reference
 status: active
-updated: 2026-08-19
+updated: 2026-08-20
 tags:
   - rust
   - cli
@@ -24,26 +24,34 @@ related:
 
 ## Config Loading
 
-Priority order:
-1. `--config /path/to/config.toml`
-2. `CHM_CONFIG` env var
-3. Default `~/.config/chm/config.toml`
-4. Direct flags/env override file values
+Priority order (highest wins):
+1. CLI flags (`--base-url`, `--host-id`, `--api-key`, `--token`, `--channel`, …)
+2. Environment (`CHM_BASE_URL`, `CHM_HOST_ID`, `CHM_API_KEY`, `CHM_TOKEN`, `CHM_CHANNEL`, …)
+3. Project config: `./chm.toml` or `./.chm/config.toml`
+4. User config: `~/.config/chm/config.toml`
+5. Built-in defaults (`base_url = https://dash.chmonitor.dev`, `channel = stable`)
 
 ```toml
-base_url = "http://localhost:3000"
+base_url = "https://dash.chmonitor.dev"
 host_id = 0
 api_key = "chm_xxx"
 default_chart = "query-count"
+channel = "stable" # or "beta"
 ```
+
+Credentials (device-login token / API key) live in the OS keyring, with a
+`0600` plaintext fallback at `~/.config/chm/credentials`.
 
 ## Commands
 
 ```bash
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- auth login
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- hosts
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- chart query-count --limit 50
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --limit 30
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- tui query-count
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merges slow?"
 ```
 
 ## Zero-signup diagnostics (`diagnose`)
@@ -86,14 +94,16 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- diagnose \
   process exits `1` if any finding is `critical`, `0` otherwise.
 - Docs page: `docs/content/guide/guides/diagnostics-cli.mdx`.
 
-## API Key Support
+## API Key / Auth Support
 
-- CLI sends `x-api-key` header when `api_key` is configured
+- CLI sends **both** `Authorization: Bearer …` and `x-api-key` when configured
+- `chm auth login` uses the device-code flow:
+  `POST /api/v1/auth/device/code` → open browser → poll `POST /api/v1/auth/token`
 - Server-side API key protection enabled when `CHM_API_KEY_SECRET` is set
 - Generate key via API:
 
 ```bash
-curl -X POST http://localhost:3000/api/v1/auth/api-key \
+curl -X POST https://dash.chmonitor.dev/api/v1/auth/api-key \
   -H 'content-type: application/json' \
   -H "authorization: Bearer $CHM_API_KEY_SECRET" \
   -d '{"label":"cli","days":30}'
@@ -103,9 +113,10 @@ curl -X POST http://localhost:3000/api/v1/auth/api-key \
 
 | Library | Purpose |
 |---------|---------|
-| `clap` | CLI parser with env support |
-| `reqwest` + `tokio` | Async HTTP |
-| `comfy-table` | Table rendering |
+| `clap` + `clap_complete` | CLI parser, env support, completions |
+| `reqwest` + `tokio` | Async HTTP (JSON + SSE stream) |
+| `keyring` | OS credential store |
+| `comfy-table` / `indicatif` / `owo-colors` | Table + progress + color |
 | `ratatui` + `crossterm` | TUI stack |
 
 ## Self-update (`chm update` / `chm upgrade`)
@@ -114,7 +125,10 @@ curl -X POST http://localhost:3000/api/v1/auth/api-key \
 `--version` flags, same `cli_run`/`update` telemetry). Both print
 current -> target version, download the matching `chm-<target>` GitHub Release
 asset, require a matching `.sha256`, and atomically replace the running
-binary. They never invoke sudo. Checksum, permission, download, and
+binary. They never invoke sudo. Homebrew-managed installs are refused
+(`is_brew_managed`). Channel (`--channel` / `CHM_CHANNEL` / config):
+`stable` skips prereleases; `beta` includes them and prefers a prerelease
+when semver cores tie. Checksum, permission, download, and
 unsupported-target failures print a copy-pasteable fallback (`scripts/install.sh`
 or `cargo install ch-monitor-cli --force`; unsupported targets point at cargo
 only). `--version` accepts `chm-v0.2.0`, `v0.2.0`, `0.2.0`, or `chm-0.2.0`.

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -142,27 +142,37 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
 ## CI & Release
 
 - **CI**: `cli-rust-ci.yml` — fmt, clippy, build, test
-- **Release**: Tag format `chm-v*` (e.g. `chm-v0.1.0`)
+- **Release tags**:
+  - **stable**: `chm-vX.Y.Z` (e.g. `chm-v0.1.2`) — `prerelease=false`
+  - **beta**: `chm-vX.Y.Z-beta.<run_number>` from Cargo.toml `0.1.x` on
+    `main` path pushes — `prerelease=true`
 - **Release workflow**: `cli-rust-release.yml` builds 4 targets
   (`x86_64`/`aarch64` × `unknown-linux-gnu`/`apple-darwin`, no Windows) and
   uploads each binary plus a `.sha256` checksum file to the GitHub Release as
-  `chm-<target>` / `chm-<target>.sha256`. Only runs the upload step on an
-  actual tag push (`github.ref_type == 'tag'`); `workflow_dispatch` builds but
-  doesn't publish.
+  `chm-<target>` / `chm-<target>.sha256`.
+  - Tag push / `workflow_dispatch` with `tag` → stable release
+  - Push to `main` when `rust/ch-monitor-cli/**`, `rust/Cargo.{toml,lock}`,
+    the workflow, or `scripts/install.sh` change → beta prerelease
+  - Beta tag pattern is excluded from the tag trigger so creating the beta
+    release does not re-fire a stable build
 
 ## One-line install (`scripts/install.sh`)
 
 ```bash
 curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
+# Beta channel:
+CHM_CHANNEL=beta curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
 ```
 
 - Detects OS (`Linux`/`Darwin`) + arch (`x86_64`/`aarch64`), maps to the
   release workflow's target triples, and refuses to run on anything else
   (no silent wrong-arch installs).
-- Resolves the latest **published** `chm-v*` release via the GitHub releases
-  API, ranking by semver (not first-match / created_at) and skipping
-  drafts/prereleases. Dashboard/Helm tags share this API. Pin a specific
-  release with `CHM_VERSION=chm-vX.Y.Z` (`vX.Y.Z` / `X.Y.Z` also work).
+- Resolves the latest `chm-v*` release via the GitHub releases API for
+  `CHM_CHANNEL` (`stable` default, or `beta`), ranking by semver (not
+  first-match / created_at). `stable` skips drafts/prereleases; `beta`
+  prefers prereleases (falls back to stable if none). Dashboard/Helm tags
+  share this API. Pin a specific release with `CHM_VERSION=chm-vX.Y.Z`
+  (`vX.Y.Z` / `X.Y.Z` also work). Logs the channel on install.
 - Downloads the binary + its `.sha256` asset and verifies the checksum before
   installing; a missing or mismatched checksum is fatal (never installs an
   unverified binary). Fails loud (`set -euo pipefail`) on any

--- a/packages/mcp-server/src/auth/__tests__/api-key.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/api-key.test.ts
@@ -72,6 +72,25 @@ describe('api-key', () => {
       expect(result.valid).toBe(true)
       expect(result.sub).toBe('user1')
     })
+
+    it('stamps scopes onto the issued token when provided', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const token = await issueApiKey('user1', 30, [
+        'read:metrics',
+        'mcp:access',
+      ])
+      const result = await verifyApiKey(token)
+      expect(result.valid).toBe(true)
+      expect(result.scopes).toEqual(['read:metrics', 'mcp:access'])
+    })
+
+    it('omits scopes from the payload when none are provided (all scopes)', async () => {
+      process.env.CHM_API_KEY_SECRET = TEST_SECRET
+      const token = await issueApiKey('user1')
+      const result = await verifyApiKey(token)
+      expect(result.valid).toBe(true)
+      expect(result.scopes).toBeUndefined()
+    })
   })
 
   describe('verifyApiKey', () => {

--- a/packages/mcp-server/src/auth/api-key.ts
+++ b/packages/mcp-server/src/auth/api-key.ts
@@ -1,7 +1,18 @@
+export const ALL_API_KEY_SCOPES = [
+  'read:metrics',
+  'read:insights',
+  'agent:run',
+  'mcp:access',
+] as const
+
+export type ApiKeyScope = (typeof ALL_API_KEY_SCOPES)[number]
+
 interface Payload {
   sub: string
   exp: number
   iat: number
+  /** Optional scopes; missing/empty means all scopes (back-compat). */
+  scopes?: string[]
 }
 
 function getSecret(): string | null {
@@ -57,12 +68,27 @@ function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
   return diff === 0
 }
 
-export async function issueApiKey(sub: string, days = 30): Promise<string> {
+function normalizeScopes(scopes?: string[] | null): string[] | undefined {
+  if (!scopes || scopes.length === 0) return undefined
+  const allowed = new Set<string>(ALL_API_KEY_SCOPES)
+  const filtered = [
+    ...new Set(scopes.map((s) => s.trim()).filter(Boolean)),
+  ].filter((s) => allowed.has(s))
+  return filtered.length > 0 ? filtered : undefined
+}
+
+export async function issueApiKey(
+  sub: string,
+  days = 30,
+  scopes?: string[]
+): Promise<string> {
   const secret = getSecret()
   if (!secret) throw new Error('CHM_API_KEY_SECRET is not configured')
 
   const now = Math.floor(Date.now() / 1000)
   const payload: Payload = { sub, iat: now, exp: now + days * 86400 }
+  const normalized = normalizeScopes(scopes)
+  if (normalized) payload.scopes = normalized
   const payloadEnc = textToB64url(JSON.stringify(payload))
   const sig = await sign(payloadEnc, secret)
   return `chm_${payloadEnc}.${bytesToB64url(sig)}`
@@ -72,6 +98,8 @@ export type ApiKeyVerificationResult = {
   valid: boolean
   reason?: string
   sub?: string
+  /** Present when the token stamped scopes; undefined means all scopes. */
+  scopes?: string[]
 }
 
 /**
@@ -108,7 +136,11 @@ export async function verifyApiKey(
     const now = Math.floor(Date.now() / 1000)
     if (payload.exp < now) return { valid: false, reason: 'expired' }
 
-    return { valid: true, sub: payload.sub }
+    return {
+      valid: true,
+      sub: payload.sub,
+      scopes: payload.scopes,
+    }
   } catch {
     return { valid: false, reason: 'malformed token' }
   }
@@ -116,4 +148,14 @@ export async function verifyApiKey(
 
 export function apiKeyAuthEnabled() {
   return Boolean(getSecret())
+}
+
+/** Whether a verified key grants `scope` (missing scopes = all). */
+export function apiKeyHasScope(
+  result: ApiKeyVerificationResult,
+  scope: ApiKeyScope
+): boolean {
+  if (!result.valid) return false
+  if (!result.scopes || result.scopes.length === 0) return true
+  return result.scopes.includes(scope)
 }

--- a/packages/mcp-server/src/auth/index.ts
+++ b/packages/mcp-server/src/auth/index.ts
@@ -1,10 +1,17 @@
 export {
   type ApiKeyVerificationResult,
+  type ApiKeyScope,
+  ALL_API_KEY_SCOPES,
   apiKeyAuthEnabled,
+  apiKeyHasScope,
   issueApiKey,
   verifyApiKey,
 } from './api-key'
 export { getBearerToken } from './bearer-token'
+export {
+  apiKeyCandidates,
+  getRequestApiKeyCandidates,
+} from './request-api-key'
 export {
   type ClerkOAuthResult,
   clerkOAuthEnabled,

--- a/packages/mcp-server/src/auth/request-api-key.ts
+++ b/packages/mcp-server/src/auth/request-api-key.ts
@@ -1,0 +1,28 @@
+/**
+ * Extract programmatic API-key candidates from a request.
+ *
+ * An API key may arrive as `x-api-key` OR `Authorization: Bearer chm_…`.
+ * Keep them distinct so a bad Bearer never masks a valid x-api-key (and so
+ * Clerk OAuth verifiers never receive an x-api-key as if it were an OAuth token).
+ */
+
+import { getBearerToken } from './bearer-token'
+
+export function getRequestApiKeyCandidates(request: Request): {
+  bearer: string | null
+  apiKeyHeader: string | null
+} {
+  return {
+    bearer: getBearerToken(request.headers.get('authorization')),
+    apiKeyHeader: request.headers.get('x-api-key'),
+  }
+}
+
+/** Ordered unique candidates to try against `verifyApiKey` (x-api-key first). */
+export function apiKeyCandidates(request: Request): string[] {
+  const { bearer, apiKeyHeader } = getRequestApiKeyCandidates(request)
+  const out: string[] = []
+  if (apiKeyHeader) out.push(apiKeyHeader)
+  if (bearer && bearer !== apiKeyHeader) out.push(bearer)
+  return out
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -149,6 +149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,13 +197,21 @@ version = "0.1.0"
 
 [[package]]
 name = "ch-monitor-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
+ "clap_complete",
  "comfy-table",
  "crossterm 0.28.1",
  "dirs",
+ "eventsource-stream",
+ "futures-util",
+ "indicatif",
+ "keyring",
+ "open",
+ "owo-colors",
  "ratatui",
  "reqwest",
  "serde",
@@ -246,6 +260,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -298,6 +321,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +341,32 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -516,6 +578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +606,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -622,6 +701,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,7 +736,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -954,6 +1060,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1099,25 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1024,6 +1162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "linux-keyutils",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -1239,6 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1418,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "open"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+dependencies = [
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
@@ -1264,6 +1443,12 @@ checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -1696,6 +1881,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1715,12 +1901,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -1832,6 +2020,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2263,6 +2487,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2832,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.2](https://github.com/chmonitor/chmonitor/compare/chm-v0.1.1...chm-v0.1.2) (2026-08-20)
+
+
+### Features
+
+* **cli:** modular rewrite — auth device login, layered config, TUI chat, agent/prompt/audit/doctor, channel-aware self-update (stable|beta), default base URL `https://dash.chmonitor.dev`
+
+
 ## [0.1.1](https://github.com/chmonitor/chmonitor/compare/chm-v0.1.0...chm-v0.1.1) (2026-08-06)
 
 

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "ch-monitor-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["duyet <bot@duyet.net>"]
-description = "Standalone terminal/TUI CLI for chmonitor, plus a zero-signup `chm diagnose` health scan that connects straight to ClickHouse."
+description = "Standalone terminal/TUI CLI for chmonitor, plus a zero-signup `chm diagnose` health scan that connects straight to [REDACTED]."
 license = "MIT"
 repository = "https://github.com/chmonitor/chmonitor"
 readme = "README.md"
-keywords = ["clickhouse", "cli", "monitoring", "diagnostics"]
+keywords = ["clickhouse", "cli", "[REDACTED]", "diagnostics"] # pragma: allowlist secret
 categories = ["command-line-utilities"]
 exclude = ["/.github"]
 
@@ -18,16 +18,28 @@ exclude = ["/.github"]
 name = "chm"
 path = "src/main.rs"
 
+[features]
+default = []
+mermaid = []
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
+clap_complete = "4"
 comfy-table = "7"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 toml = "1.0"
 dirs = "6"
 ratatui = "0.30"
 crossterm = "0.28"
+indicatif = "0.17"
+owo-colors = "4"
+open = "5"
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
+futures-util = "0.3"
+eventsource-stream = "0.2"
+bytes = "1"

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -132,17 +132,25 @@ pub enum Commands {
     Audit(AuditArgs),
     /// Check local CLI + dashboard connectivity
     Doctor,
-    /// Zero-signup local diagnostics: connect directly to a [REDACTED] host
+    /// Zero-signup local diagnostics: connect directly to a [REDACTED] host // pragma: allowlist secret
     /// (no chmonitor account/backend needed) and print a scored health report.
     Diagnose {
-        /// [REDACTED] HTTP interface URL, e.g. http://localhost:8123
+        /// [REDACTED] HTTP interface URL, e.g. http://localhost:8123 // pragma: allowlist secret
         #[arg(long, env = "CLICKHOUSE_HOST")] // pragma: allowlist secret
         ch_host: Option<String>,
-        #[arg(long, env = "CLICKHOUSE_USER", default_value = "default")] // pragma: allowlist secret
+        #[arg(
+            long,
+            env = "CLICKHOUSE_USER", // pragma: allowlist secret
+            default_value = "default" // pragma: allowlist secret
+        )]
         ch_user: String,
         #[arg(long, env = "CLICKHOUSE_PASSWORD", default_value = "")] // pragma: allowlist secret
         ch_password: String,
-        #[arg(long, env = "CLICKHOUSE_DATABASE", default_value = "default")] // pragma: allowlist secret
+        #[arg(
+            long,
+            env = "CLICKHOUSE_DATABASE", // pragma: allowlist secret
+            default_value = "default" // pragma: allowlist secret
+        )]
         ch_database: String,
         /// Print the report as JSON instead of a table.
         #[arg(long)]

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -1,0 +1,247 @@
+//! Clap definitions for `chm`.
+
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "chm",
+    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
+    about = "chmonitor CLI — dashboard API, TUI, and zero-signup diagnostics"
+)]
+pub struct Cli {
+    /// Path to config.toml (default ~/.config/chm/config.toml)
+    #[arg(long, env = "CHM_CONFIG", global = true)]
+    pub config: Option<PathBuf>,
+
+    /// Dashboard base URL (default https://dash.chmonitor.dev)
+    #[arg(long, env = "CHM_BASE_URL", global = true)]
+    pub base_url: Option<String>,
+
+    /// Dashboard host id (default 0)
+    #[arg(long, env = "CHM_HOST_ID", global = true)]
+    pub host_id: Option<u32>,
+
+    /// Dashboard API key (sent as x-api-key)
+    #[arg(long, env = "CHM_API_KEY", global = true)]
+    pub api_key: Option<String>,
+
+    /// Bearer token (sent as Authorization: Bearer …)
+    #[arg(long, env = "CHM_TOKEN", global = true)]
+    pub token: Option<String>,
+
+    /// Release channel for self-update (stable|beta)
+    #[arg(long, env = "CHM_CHANNEL", global = true, value_enum)]
+    pub channel: Option<Channel>,
+
+    /// Print machine-readable JSON where supported
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Suppress non-essential stderr output
+    #[arg(long, short = 'q', global = true)]
+    pub quiet: bool,
+
+    /// Assume yes for confirmation prompts
+    #[arg(long, short = 'y', global = true)]
+    pub yes: bool,
+
+    /// Enable verbose debug logging on stderr
+    #[arg(long, global = true)]
+    pub debug: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Channel {
+    Stable,
+    Beta,
+}
+
+impl Channel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Channel::Stable => "stable",
+            Channel::Beta => "beta",
+        }
+    }
+}
+
+impl std::fmt::Display for Channel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Sign in / out of chmonitor Cloud (device-code flow)
+    Auth(AuthArgs),
+    /// Show or edit local CLI config
+    Config(ConfigArgs),
+    /// List hosts from a running chmonitor dashboard
+    Hosts,
+    /// Open the dashboard (or a path) in the browser
+    Link {
+        /// Optional path under the dashboard base URL (e.g. /overview)
+        path: Option<String>,
+    },
+    /// Fetch a named chart from the dashboard API
+    Chart {
+        /// Chart name, e.g. query-count
+        name: String,
+        /// Max rows to print
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+    /// Fetch a named table from the dashboard API
+    Table {
+        /// Table name, e.g. running-queries
+        name: String,
+        /// Max rows to print
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
+    /// Live terminal UI for a dashboard chart (or overview)
+    Tui {
+        /// Chart name (default: config `default_chart`, else query-count)
+        chart: Option<String>,
+        /// Show overview metrics instead of a single chart
+        #[arg(long)]
+        overview: bool,
+    },
+    /// Stream a chat reply from the dashboard AI agent
+    Chat {
+        /// Prompt text (reads stdin when omitted)
+        message: Option<String>,
+    },
+    /// One-shot agent request (non-interactive)
+    Agent {
+        /// Prompt text (reads stdin when omitted)
+        prompt: Option<String>,
+        /// Model id override
+        #[arg(long)]
+        model: Option<String>,
+    },
+    /// List or print built-in prompt packs
+    Prompt(PromptArgs),
+    /// Export or inspect audit events
+    Audit(AuditArgs),
+    /// Check local CLI + dashboard connectivity
+    Doctor,
+    /// Zero-signup local diagnostics: connect directly to a [REDACTED] host
+    /// (no chmonitor account/backend needed) and print a scored health report.
+    Diagnose {
+        /// [REDACTED] HTTP interface URL, e.g. http://localhost:8123
+        #[arg(long, env = "CLICKHOUSE_HOST")] // pragma: allowlist secret
+        ch_host: Option<String>,
+        #[arg(long, env = "CLICKHOUSE_USER", default_value = "default")] // pragma: allowlist secret
+        ch_user: String,
+        #[arg(long, env = "CLICKHOUSE_PASSWORD", default_value = "")] // pragma: allowlist secret
+        ch_password: String,
+        #[arg(long, env = "CLICKHOUSE_DATABASE", default_value = "default")] // pragma: allowlist secret
+        ch_database: String,
+        /// Print the report as JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update chm to the latest GitHub release (self-update).
+    ///
+    /// Prints current -> target version, verifies sha256, and atomically
+    /// replaces this binary. Never invokes sudo: checksum, permission, and
+    /// unsupported-target failures print a copy-pasteable fallback
+    /// (`scripts/install.sh` or `cargo install ch-monitor-cli`).
+    Update(UpdateArgs),
+    /// Alias of `update`. Same flags (`--check`, `--version`), same behaviour.
+    Upgrade(UpdateArgs),
+    /// Generate shell completions
+    Completions {
+        /// Shell to emit completions for
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+}
+
+/// Shared flags for `chm update` and `chm upgrade`.
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Only check whether an update is available; exit 1 if one exists.
+    #[arg(long)]
+    pub check: bool,
+    /// Install a specific release tag, e.g. chm-v0.2.0.
+    #[arg(long)]
+    pub version: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct AuthArgs {
+    #[command(subcommand)]
+    pub command: AuthCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AuthCommand {
+    /// Sign in via browser device-code flow
+    Login,
+    /// Clear stored credentials
+    Logout,
+    /// Show whether a token/api-key is configured
+    Status,
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub command: ConfigCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommand {
+    /// Print the resolved config
+    Show,
+    /// Print the user config file path
+    Path,
+    /// Set a key in the user config file
+    Set {
+        /// Config key (base_url, host_id, api_key, default_chart, channel)
+        key: String,
+        /// Value to write
+        value: String,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct PromptArgs {
+    #[command(subcommand)]
+    pub command: PromptCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PromptCommand {
+    /// List built-in prompt packs
+    List,
+    /// Print a built-in prompt by name
+    Show {
+        /// Prompt pack name
+        name: String,
+    },
+}
+
+#[derive(Args, Debug)]
+pub struct AuditArgs {
+    #[command(subcommand)]
+    pub command: AuditCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum AuditCommand {
+    /// Export audit events (JSON)
+    Export {
+        /// Max events to fetch
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+    },
+}

--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -1,0 +1,135 @@
+//! HTTP client helpers for the dashboard API.
+
+use anyhow::{bail, Context, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::config::AppConfig;
+
+#[derive(Debug, Deserialize)]
+struct ApiResponse {
+    data: Value,
+}
+
+pub fn api_error_hint(status: u16) -> &'static str {
+    match status {
+        401 | 403 => " Check --api-key / CHM_API_KEY or `chm auth login`.",
+        404 => " Check the chart/table name and --host-id.",
+        _ => "",
+    }
+}
+
+pub fn truncate_body(s: &str, max_chars: usize) -> Option<String> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut iter = s.chars();
+    let head: String = iter.by_ref().take(max_chars).collect();
+    if iter.next().is_some() {
+        Some(format!("{head}…"))
+    } else {
+        Some(head)
+    }
+}
+
+/// Attach both Authorization Bearer and x-api-key when present.
+pub fn apply_auth(
+    mut req: reqwest::RequestBuilder,
+    token: Option<&str>,
+    api_key: Option<&str>,
+) -> reqwest::RequestBuilder {
+    if let Some(t) = token {
+        if !t.is_empty() {
+            req = req.header("Authorization", format!("Bearer {t}"));
+        }
+    }
+    if let Some(k) = api_key {
+        if !k.is_empty() {
+            req = req.header("x-api-key", k);
+        }
+    }
+    req
+}
+
+pub async fn fetch(
+    client: &Client,
+    url: String,
+    token: Option<&str>,
+    api_key: Option<&str>,
+) -> Result<Value> {
+    let req = apply_auth(client.get(&url), token, api_key);
+    let resp = match req.send().await {
+        Ok(resp) => resp,
+        Err(err) => {
+            bail!(
+                "failed to reach chmonitor API at {url}: {err}\n\
+                 Is the dashboard reachable? Set --base-url / CHM_BASE_URL \
+                 (default {}).",
+                crate::config::DEFAULT_BASE_URL
+            );
+        }
+    };
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        let hint = api_error_hint(status.as_u16());
+        let extra = match truncate_body(text.trim(), 200) {
+            None => String::new(),
+            Some(body) => format!(" {body}"),
+        };
+        bail!("chmonitor API returned HTTP {status} for {url}.{hint}{extra}");
+    }
+    let parsed: ApiResponse = serde_json::from_str(&text).with_context(|| {
+        format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})")
+    })?;
+    Ok(parsed.data)
+}
+
+pub async fn fetch_cfg(client: &Client, cfg: &AppConfig, url: String) -> Result<Value> {
+    let token = crate::credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref())?;
+    fetch(client, url, token.as_deref(), api_key.as_deref()).await
+}
+
+pub fn rows_from_chart_data(data: Value) -> Result<Vec<Value>> {
+    match data {
+        Value::Array(rows) => Ok(rows),
+        Value::Object(mut queries) => {
+            if let Some(Value::Array(rows)) = queries.remove("main") {
+                return Ok(rows);
+            }
+
+            let rows = queries
+                .into_values()
+                .filter_map(|value| match value {
+                    Value::Array(rows) => Some(rows),
+                    _ => None,
+                })
+                .flatten()
+                .collect();
+            Ok(rows)
+        }
+        other => bail!("chart payload data must be an array or object, got {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_error_hint_covers_auth_and_missing() {
+        assert!(api_error_hint(401).contains("CHM_API_KEY"));
+        assert!(api_error_hint(403).contains("CHM_API_KEY"));
+        assert!(api_error_hint(404).contains("host-id"));
+        assert_eq!(api_error_hint(500), "");
+    }
+
+    #[test]
+    fn truncate_body_is_char_safe() {
+        assert_eq!(truncate_body("", 8), None);
+        assert_eq!(truncate_body("hello", 8).as_deref(), Some("hello"));
+        assert_eq!(truncate_body("éééé", 2).as_deref(), Some("éé…"));
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/agent.rs
+++ b/rust/ch-monitor-cli/src/commands/agent.rs
@@ -1,0 +1,143 @@
+//! `chm agent` — one-shot AI agent request.
+
+use std::io::{self, Read};
+
+use anyhow::{bail, Context, Result};
+use futures_util::StreamExt;
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::{
+    client::apply_auth,
+    config::AppConfig,
+    credentials,
+    output,
+};
+
+pub async fn run(
+    client: &Client,
+    cfg: &AppConfig,
+    prompt: Option<String>,
+    model: Option<String>,
+) -> Result<()> {
+    let text = match prompt {
+        Some(p) if !p.trim().is_empty() => p,
+        _ => {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .context("failed to read prompt from stdin")?;
+            if buf.trim().is_empty() {
+                bail!("no prompt given — pass an argument or pipe text on stdin");
+            }
+            buf
+        }
+    };
+
+    let url = format!("{}/api/v1/agent", cfg.base_url.trim_end_matches('/'));
+    let mut body = serde_json::json!({
+        "message": text.trim(),
+        "hostId": cfg.host_id,
+    });
+    if let Some(m) = model {
+        body["model"] = Value::String(m);
+    }
+
+    let token = credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = credentials::resolve_api_key(cfg.api_key.as_deref())?;
+
+    let resp = apply_auth(client.post(&url), token.as_deref(), api_key.as_deref())
+        .header("Accept", "text/event-stream")
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("failed to reach agent at {url}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!(
+            "agent returned HTTP {status}: {}",
+            crate::client::truncate_body(text.trim(), 300).unwrap_or_default()
+        );
+    }
+
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    if content_type.contains("text/event-stream") || content_type.contains("text/plain") {
+        let mut stream = resp.bytes_stream();
+        let mut buffer = String::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.context("error reading agent stream")?;
+            let text = String::from_utf8_lossy(&chunk);
+            for line in text.split('\n') {
+                let line = line.trim_end_matches('\r');
+                if let Some(data) = line.strip_prefix("data:") {
+                    let data = data.trim();
+                    if data.is_empty() || data == "[DONE]" {
+                        continue;
+                    }
+                    if let Ok(v) = serde_json::from_str::<Value>(data) {
+                        if let Some(delta) = extract_text_delta(&v) {
+                            print!("{delta}");
+                            let _ = io::Write::flush(&mut io::stdout());
+                            buffer.push_str(&delta);
+                        }
+                    } else {
+                        print!("{data}");
+                        let _ = io::Write::flush(&mut io::stdout());
+                        buffer.push_str(data);
+                    }
+                }
+            }
+        }
+        if !buffer.ends_with('\n') {
+            println!();
+        }
+        if cfg.json {
+            output::print_json(&serde_json::json!({ "text": buffer }))?;
+        }
+    } else {
+        let text = resp.text().await.unwrap_or_default();
+        if cfg.json {
+            if let Ok(v) = serde_json::from_str::<Value>(&text) {
+                output::print_json(&v)?;
+            } else {
+                output::print_json(&serde_json::json!({ "text": text }))?;
+            }
+        } else {
+            println!("{text}");
+        }
+    }
+    Ok(())
+}
+
+fn extract_text_delta(v: &Value) -> Option<String> {
+    if let Some(s) = v.get("delta").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    if let Some(s) = v.pointer("/choices/0/delta/content").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    if let Some(s) = v.get("text").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    if let Some(s) = v.pointer("/0/text").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    // AI SDK UI message stream: type=text-delta
+    if v.get("type").and_then(|t| t.as_str()) == Some("text-delta") {
+        if let Some(s) = v.get("delta").and_then(|d| d.as_str()) {
+            return Some(s.to_string());
+        }
+        if let Some(s) = v.get("textDelta").and_then(|d| d.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    None
+}

--- a/rust/ch-monitor-cli/src/commands/agent.rs
+++ b/rust/ch-monitor-cli/src/commands/agent.rs
@@ -7,12 +7,7 @@ use futures_util::StreamExt;
 use reqwest::Client;
 use serde_json::Value;
 
-use crate::{
-    client::apply_auth,
-    config::AppConfig,
-    credentials,
-    output,
-};
+use crate::{client::apply_auth, config::AppConfig, credentials, output};
 
 pub async fn run(
     client: &Client,
@@ -121,7 +116,10 @@ fn extract_text_delta(v: &Value) -> Option<String> {
     if let Some(s) = v.get("delta").and_then(|d| d.as_str()) {
         return Some(s.to_string());
     }
-    if let Some(s) = v.pointer("/choices/0/delta/content").and_then(|d| d.as_str()) {
+    if let Some(s) = v
+        .pointer("/choices/0/delta/content")
+        .and_then(|d| d.as_str())
+    {
         return Some(s.to_string());
     }
     if let Some(s) = v.get("text").and_then(|d| d.as_str()) {

--- a/rust/ch-monitor-cli/src/commands/audit.rs
+++ b/rust/ch-monitor-cli/src/commands/audit.rs
@@ -1,0 +1,45 @@
+//! `chm audit`
+
+use anyhow::{bail, Context, Result};
+use reqwest::Client;
+
+use crate::{
+    cli::{AuditArgs, AuditCommand},
+    client, config::AppConfig, output,
+};
+
+pub async fn run(client: &Client, cfg: &AppConfig, args: AuditArgs) -> Result<()> {
+    match args.command {
+        AuditCommand::Export { limit } => {
+            let url = format!(
+                "{}/api/v1/audit/export?limit={}",
+                cfg.base_url.trim_end_matches('/'),
+                limit
+            );
+            let data = match client::fetch_cfg(client, cfg, url.clone()).await {
+                Ok(d) => d,
+                Err(err) => {
+                    // Some deployments wrap differently; try raw GET body.
+                    let token = crate::credentials::resolve_token(cfg.token.as_deref())?;
+                    let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref())?;
+                    let resp = crate::client::apply_auth(
+                        client.get(&url),
+                        token.as_deref(),
+                        api_key.as_deref(),
+                    )
+                    .send()
+                    .await
+                    .with_context(|| format!("audit export failed: {err}"))?;
+                    let status = resp.status();
+                    let text = resp.text().await.unwrap_or_default();
+                    if !status.is_success() {
+                        bail!("audit export HTTP {status}: {text}");
+                    }
+                    serde_json::from_str(&text).unwrap_or(serde_json::json!({ "raw": text }))
+                }
+            };
+            output::print_json(&data)?;
+            Ok(())
+        }
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/audit.rs
+++ b/rust/ch-monitor-cli/src/commands/audit.rs
@@ -5,7 +5,9 @@ use reqwest::Client;
 
 use crate::{
     cli::{AuditArgs, AuditCommand},
-    client, config::AppConfig, output,
+    client,
+    config::AppConfig,
+    output,
 };
 
 pub async fn run(client: &Client, cfg: &AppConfig, args: AuditArgs) -> Result<()> {

--- a/rust/ch-monitor-cli/src/commands/auth.rs
+++ b/rust/ch-monitor-cli/src/commands/auth.rs
@@ -1,0 +1,209 @@
+//! `chm auth` — device-code login against the dashboard.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::{
+    cli::{AuthArgs, AuthCommand},
+    client::apply_auth,
+    config::AppConfig,
+    credentials,
+    output::{self, success},
+};
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    #[serde(default)]
+    verification_uri_complete: Option<String>,
+    #[serde(default = "default_interval")]
+    interval: u64,
+    #[serde(default = "default_expires")]
+    expires_in: u64,
+}
+
+fn default_interval() -> u64 {
+    5
+}
+fn default_expires() -> u64 {
+    900
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+pub async fn run(client: &Client, cfg: &AppConfig, args: AuthArgs) -> Result<i32> {
+    match args.command {
+        AuthCommand::Login => login(client, cfg).await,
+        AuthCommand::Logout => {
+            credentials::clear_token()?;
+            credentials::clear_api_key()?;
+            success("signed out (cleared stored credentials)");
+            Ok(0)
+        }
+        AuthCommand::Status => {
+            let token = credentials::resolve_token(cfg.token.as_deref())?;
+            let api_key = credentials::resolve_api_key(cfg.api_key.as_deref())?;
+            if cfg.json {
+                let v = serde_json::json!({
+                    "authenticated": token.is_some() || api_key.is_some(),
+                    "has_token": token.is_some(),
+                    "has_api_key": api_key.is_some(),
+                    "base_url": cfg.base_url,
+                });
+                crate::output::print_json(&v)?;
+            } else if token.is_some() {
+                success("signed in (bearer token present)");
+            } else if api_key.is_some() {
+                success("API key configured (no bearer token)");
+            } else {
+                println!("not signed in — run `chm auth login`");
+            }
+            Ok(0)
+        }
+    }
+}
+
+async fn login(client: &Client, cfg: &AppConfig) -> Result<i32> {
+    let base = cfg.base_url.trim_end_matches('/');
+    let code_url = format!("{base}/api/v1/auth/device/code");
+
+    let resp = client
+        .post(&code_url)
+        .header("Content-Type", "application/json")
+        .json(&serde_json::json!({
+            "client_id": "chm-cli",
+            "scope": "openid profile",
+        }))
+        .send()
+        .await
+        .with_context(|| format!("failed to request device code at {code_url}"))?;
+
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!(
+            "device code request failed (HTTP {status}): {}",
+            text.trim()
+        );
+    }
+
+    let device: DeviceCodeResponse = serde_json::from_str(&text)
+        .with_context(|| format!("unexpected device-code response: {text}"))?;
+
+    let open_url = device
+        .verification_uri_complete
+        .clone()
+        .unwrap_or_else(|| device.verification_uri.clone());
+
+    println!("To sign in, open:");
+    println!("  {open_url}");
+    println!();
+    println!("And enter code: {}", device.user_code);
+    println!();
+
+    if let Err(err) = open::that(&open_url) {
+        output::warn(&format!("could not open browser automatically ({err})"));
+    } else {
+        output::info("opened browser for device authorization");
+    }
+
+    let token_url = format!("{base}/api/v1/auth/token");
+    let interval = Duration::from_secs(device.interval.max(1));
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(device.expires_in.max(30));
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+    );
+    pb.set_message("waiting for authorization…");
+    pb.enable_steady_tick(Duration::from_millis(120));
+
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            pb.finish_and_clear();
+            bail!("device authorization timed out — run `chm auth login` again");
+        }
+
+        tokio::time::sleep(interval).await;
+
+        let poll = client
+            .post(&token_url)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device.device_code,
+                "client_id": "chm-cli",
+            }))
+            .send()
+            .await;
+
+        let Ok(resp) = poll else {
+            continue;
+        };
+        let text = resp.text().await.unwrap_or_default();
+        let parsed: TokenResponse = match serde_json::from_str(&text) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if let Some(token) = parsed.access_token {
+            if !token.is_empty() {
+                pb.finish_and_clear();
+                credentials::store_token(&token)?;
+                success("signed in — token stored in keyring");
+                // Best-effort identity check.
+                let me_url = format!("{base}/api/v1/auth/me");
+                let token_ref = Some(token.as_str());
+                if let Ok(me) = apply_auth(client.get(&me_url), token_ref, None)
+                    .send()
+                    .await
+                {
+                    if me.status().is_success() {
+                        if let Ok(body) = me.json::<serde_json::Value>().await {
+                            if let Some(email) = body
+                                .pointer("/principal/email")
+                                .and_then(|v| v.as_str())
+                            {
+                                println!("signed in as {email}");
+                            }
+                        }
+                    }
+                }
+                return Ok(0);
+            }
+        }
+
+        match parsed.error.as_deref() {
+            Some("authorization_pending") | Some("slow_down") => continue,
+            Some("expired_token") | Some("access_denied") => {
+                pb.finish_and_clear();
+                let detail = parsed
+                    .error_description
+                    .unwrap_or_else(|| parsed.error.unwrap_or_default());
+                bail!("authorization failed: {detail}");
+            }
+            Some(other) => {
+                pb.finish_and_clear();
+                bail!(
+                    "token endpoint error '{other}': {}",
+                    parsed.error_description.unwrap_or_default()
+                );
+            }
+            None => continue,
+        }
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/auth.rs
+++ b/rust/ch-monitor-cli/src/commands/auth.rs
@@ -100,7 +100,10 @@ async fn login(client: &Client, cfg: &AppConfig) -> Result<i32> {
         );
     }
 
-    let device: DeviceCodeResponse = serde_json::from_str(&text)
+    let value: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("unexpected device-code response: {text}"))?;
+    let payload = value.get("data").cloned().unwrap_or(value);
+    let device: DeviceCodeResponse = serde_json::from_value(payload)
         .with_context(|| format!("unexpected device-code response: {text}"))?;
 
     let open_url = device

--- a/rust/ch-monitor-cli/src/commands/auth.rs
+++ b/rust/ch-monitor-cli/src/commands/auth.rs
@@ -177,9 +177,8 @@ async fn login(client: &Client, cfg: &AppConfig) -> Result<i32> {
                 {
                     if me.status().is_success() {
                         if let Ok(body) = me.json::<serde_json::Value>().await {
-                            if let Some(email) = body
-                                .pointer("/principal/email")
-                                .and_then(|v| v.as_str())
+                            if let Some(email) =
+                                body.pointer("/principal/email").and_then(|v| v.as_str())
                             {
                                 println!("signed in as {email}");
                             }

--- a/rust/ch-monitor-cli/src/commands/chart.rs
+++ b/rust/ch-monitor-cli/src/commands/chart.rs
@@ -1,0 +1,37 @@
+//! `chm chart`
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::{client, config::AppConfig, metrics, output};
+
+pub async fn run(client: &Client, cfg: &AppConfig, name: &str, limit: usize) -> Result<()> {
+    let url = format!(
+        "{}/api/v1/charts/{}?hostId={}",
+        cfg.base_url.trim_end_matches('/'),
+        name,
+        cfg.host_id
+    );
+    let data = client::fetch_cfg(client, cfg, url.clone()).await?;
+    let rows_raw = client::rows_from_chart_data(data)?;
+    if cfg.json {
+        output::print_json(&Value::Array(rows_raw))?;
+        return Ok(());
+    }
+    let data = Value::Array(rows_raw.clone());
+    let rows: Vec<HashMap<String, Value>> =
+        serde_json::from_value(data).context("chart payload parse failed")?;
+    if rows.is_empty() {
+        eprintln!("no rows returned from {url}");
+    } else {
+        let points: Vec<u64> = rows_raw.iter().map(metrics::row_metric).collect();
+        if !cfg.quiet && !points.is_empty() {
+            println!("{}", output::braille_sparkline(&points, 40));
+        }
+        output::print_records(&rows, limit);
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/config_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/config_cmd.rs
@@ -55,10 +55,7 @@ pub fn run(cfg: &AppConfig, args: ConfigArgs) -> Result<()> {
             let mut file = config::load_user_file_config(&cfg.user_config_path)?;
             apply_set(&mut file, &key, &value)?;
             config::save_user_config(&cfg.user_config_path, &file)?;
-            output::success(&format!(
-                "set {key} in {}",
-                cfg.user_config_path.display()
-            ));
+            output::success(&format!("set {key} in {}", cfg.user_config_path.display()));
             Ok(())
         }
     }

--- a/rust/ch-monitor-cli/src/commands/config_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/config_cmd.rs
@@ -1,0 +1,95 @@
+//! `chm config`
+
+use anyhow::{bail, Result};
+
+use crate::{
+    cli::{ConfigArgs, ConfigCommand},
+    config::{self, AppConfig, FileConfig},
+    output,
+};
+
+pub fn run(cfg: &AppConfig, args: ConfigArgs) -> Result<()> {
+    match args.command {
+        ConfigCommand::Show => {
+            let v = serde_json::json!({
+                "base_url": cfg.base_url,
+                "host_id": cfg.host_id,
+                "api_key_set": cfg.api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false),
+                "token_set": cfg.token.as_ref().map(|t| !t.is_empty()).unwrap_or(false),
+                "default_chart": cfg.default_chart,
+                "channel": cfg.channel.as_str(),
+                "user_config_path": cfg.user_config_path.display().to_string(),
+            });
+            if cfg.json {
+                output::print_json(&v)?;
+            } else {
+                println!("base_url        = {}", cfg.base_url);
+                println!("host_id         = {}", cfg.host_id);
+                println!(
+                    "api_key         = {}",
+                    if cfg.api_key.as_ref().is_some_and(|k| !k.is_empty()) {
+                        "(set)"
+                    } else {
+                        "(unset)"
+                    }
+                );
+                println!(
+                    "token           = {}",
+                    if cfg.token.as_ref().is_some_and(|t| !t.is_empty()) {
+                        "(set)"
+                    } else {
+                        "(unset)"
+                    }
+                );
+                println!("default_chart   = {}", cfg.default_chart);
+                println!("channel         = {}", cfg.channel);
+                println!("user_config     = {}", cfg.user_config_path.display());
+            }
+            Ok(())
+        }
+        ConfigCommand::Path => {
+            println!("{}", cfg.user_config_path.display());
+            Ok(())
+        }
+        ConfigCommand::Set { key, value } => {
+            let mut file = config::load_user_file_config(&cfg.user_config_path)?;
+            apply_set(&mut file, &key, &value)?;
+            config::save_user_config(&cfg.user_config_path, &file)?;
+            output::success(&format!(
+                "set {key} in {}",
+                cfg.user_config_path.display()
+            ));
+            Ok(())
+        }
+    }
+}
+
+fn apply_set(file: &mut FileConfig, key: &str, value: &str) -> Result<()> {
+    match key.trim().to_ascii_lowercase().as_str() {
+        "base_url" | "base-url" => file.base_url = Some(value.to_string()),
+        "host_id" | "host-id" => {
+            let id: u32 = value
+                .parse()
+                .map_err(|_| anyhow::anyhow!("host_id must be an integer"))?;
+            file.host_id = Some(id);
+        }
+        "api_key" | "api-key" => {
+            file.api_key = Some(value.to_string());
+            // Also persist into the credential store so runtime resolution finds it.
+            let _ = crate::credentials::store_api_key(value);
+        }
+        "token" => file.token = Some(value.to_string()),
+        "default_chart" | "default-chart" => file.default_chart = Some(value.to_string()),
+        "channel" => {
+            let _ = match value.trim().to_ascii_lowercase().as_str() {
+                "stable" | "beta" => value,
+                other => bail!("channel must be stable|beta, got '{other}'"),
+            };
+            file.channel = Some(value.to_ascii_lowercase());
+        }
+        other => bail!(
+            "unknown config key '{other}' (base_url, host_id, api_key, token, default_chart, channel)"
+        ),
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/diagnose_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/diagnose_cmd.rs
@@ -1,0 +1,65 @@
+//! `chm diagnose` wrapper.
+
+use anyhow::{bail, Result};
+use reqwest::Client;
+
+use crate::{diagnose, update};
+
+pub async fn run(
+    client: &Client,
+    ch_host: Option<String>,
+    ch_user: String,
+    ch_password: String,
+    ch_database: String,
+    json: bool,
+) -> Result<i32> {
+    let Some(raw_host) = ch_host else {
+        bail!(
+            "no host given — pass --ch-host or set the matching dashboard host env \
+             (e.g. http://localhost:8123 chm diagnose)"
+        );
+    };
+    // Multi-host clusters use a comma-separated host list (same env var
+    // the dashboard reads); this zero-signup CLI diagnoses one host at a time.
+    let first_host = raw_host
+        .split(',')
+        .next()
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+        .unwrap_or(&raw_host);
+    if raw_host.contains(',') {
+        eprintln!(
+            "note: host list has multiple hosts — diagnosing only the first ({first_host}). Use the dashboard for multi-host clusters."
+        );
+    }
+    let url = if first_host.starts_with("http://") || first_host.starts_with("https://") {
+        first_host.to_string()
+    } else {
+        format!("http://{first_host}")
+    };
+
+    let ch_cfg = diagnose::ChConfig {
+        url,
+        user: ch_user,
+        password: ch_password,
+        database: ch_database,
+    };
+    let report = diagnose::run_diagnostics(client, &ch_cfg).await?;
+    if json {
+        println!("{}", diagnose::render_json(&report)?);
+    } else {
+        print!("{}", diagnose::render_text(&report));
+    }
+    // Gentle, best-effort "update available" hint (opt out with
+    // CHM_NO_UPDATE_CHECK=1). Never fails the command.
+    update::hint(client).await;
+    if report
+        .findings
+        .iter()
+        .any(|f| f.severity == diagnose::Severity::Critical)
+    {
+        Ok(1)
+    } else {
+        Ok(0)
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/doctor.rs
+++ b/rust/ch-monitor-cli/src/commands/doctor.rs
@@ -1,0 +1,85 @@
+//! `chm doctor` — local + API connectivity checks.
+
+use anyhow::Result;
+use reqwest::Client;
+
+use crate::{
+    client, config::AppConfig, credentials, output,
+};
+
+pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
+    let mut checks: Vec<(String, bool, String)> = Vec::new();
+
+    checks.push((
+        "cli_version".into(),
+        true,
+        format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("CHM_TARGET")),
+    ));
+
+    checks.push((
+        "base_url".into(),
+        !cfg.base_url.is_empty(),
+        cfg.base_url.clone(),
+    ));
+
+    let token = credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = credentials::resolve_api_key(cfg.api_key.as_deref())?;
+    checks.push((
+        "credentials".into(),
+        token.is_some() || api_key.is_some(),
+        if token.is_some() {
+            "bearer token".into()
+        } else if api_key.is_some() {
+            "api key".into()
+        } else {
+            "none (public endpoints only)".into()
+        },
+    ));
+
+    let health_url = format!("{}/api/healthz", cfg.base_url.trim_end_matches('/'));
+    let health_ok = match client.get(&health_url).send().await {
+        Ok(r) => r.status().is_success(),
+        Err(_) => false,
+    };
+    checks.push((
+        "dashboard_health".into(),
+        health_ok,
+        if health_ok {
+            "ok".into()
+        } else {
+            format!("unreachable ({health_url})")
+        },
+    ));
+
+    let hosts_url = format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
+    let hosts_ok = client::fetch_cfg(client, cfg, hosts_url).await.is_ok();
+    checks.push((
+        "hosts_api".into(),
+        hosts_ok,
+        if hosts_ok {
+            "ok".into()
+        } else {
+            "failed".into()
+        },
+    ));
+
+    if cfg.json {
+        let arr: Vec<_> = checks
+            .iter()
+            .map(|(name, ok, detail)| {
+                serde_json::json!({ "check": name, "ok": ok, "detail": detail })
+            })
+            .collect();
+        output::print_json(&serde_json::Value::Array(arr))?;
+    } else {
+        for (name, ok, detail) in &checks {
+            let mark = if *ok { "ok" } else { "FAIL" };
+            println!("{mark:>4}  {name:<20} {detail}");
+        }
+    }
+
+    if checks.iter().any(|(_, ok, _)| !*ok) {
+        anyhow::bail!("doctor found failing checks");
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/doctor.rs
+++ b/rust/ch-monitor-cli/src/commands/doctor.rs
@@ -3,9 +3,7 @@
 use anyhow::Result;
 use reqwest::Client;
 
-use crate::{
-    client, config::AppConfig, credentials, output,
-};
+use crate::{client, config::AppConfig, credentials, output};
 
 pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
     let mut checks: Vec<(String, bool, String)> = Vec::new();

--- a/rust/ch-monitor-cli/src/commands/hosts.rs
+++ b/rust/ch-monitor-cli/src/commands/hosts.rs
@@ -1,0 +1,26 @@
+//! `chm hosts`
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::{client, config::AppConfig, output};
+
+pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
+    let url = format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
+    let data = client::fetch_cfg(client, cfg, url.clone()).await?;
+    if cfg.json {
+        output::print_json(&data)?;
+        return Ok(());
+    }
+    let hosts: Vec<HashMap<String, Value>> =
+        serde_json::from_value(data).context("hosts payload parse failed")?;
+    if hosts.is_empty() {
+        eprintln!("no hosts returned from {url}");
+    } else {
+        output::print_records(&hosts, 100);
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -111,15 +111,17 @@ pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Re
             ch_password,
             ch_database,
             json,
-        } => diagnose_cmd::run(
-            client,
-            ch_host,
-            ch_user,
-            ch_password,
-            ch_database,
-            json || cfg.json,
-        )
-        .await,
+        } => {
+            diagnose_cmd::run(
+                client,
+                ch_host,
+                ch_user,
+                ch_password,
+                ch_database,
+                json || cfg.json,
+            )
+            .await
+        }
         Commands::Update(args) | Commands::Upgrade(args) => {
             update_cmd::run(client, cfg, args).await
         }

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -1,0 +1,132 @@
+//! Subcommand implementations.
+
+pub mod agent;
+pub mod audit;
+pub mod auth;
+pub mod chart;
+pub mod config_cmd;
+pub mod diagnose_cmd;
+pub mod doctor;
+pub mod hosts;
+pub mod table;
+pub mod update_cmd;
+
+use anyhow::Result;
+use clap::CommandFactory;
+use reqwest::Client;
+
+use crate::{
+    cli::{Commands, PromptCommand},
+    config::AppConfig,
+    prompts,
+};
+
+pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Result<i32> {
+    if cfg.debug {
+        eprintln!(
+            "[debug] base_url={} host_id={} channel={} json={}",
+            cfg.base_url, cfg.host_id, cfg.channel, cfg.json
+        );
+    }
+    match command {
+        Commands::Auth(args) => auth::run(client, cfg, args).await,
+        Commands::Config(args) => {
+            config_cmd::run(cfg, args)?;
+            Ok(0)
+        }
+        Commands::Hosts => {
+            hosts::run(client, cfg).await?;
+            Ok(0)
+        }
+        Commands::Link { path } => {
+            let base = cfg.base_url.trim_end_matches('/');
+            let url = match path {
+                Some(p) if p.starts_with("http://") || p.starts_with("https://") => p,
+                Some(p) => {
+                    let p = if p.starts_with('/') {
+                        p
+                    } else {
+                        format!("/{p}")
+                    };
+                    format!("{base}{p}")
+                }
+                None => base.to_string(),
+            };
+            if !cfg.yes && !cfg.quiet {
+                crate::output::info(&format!("opening {url}"));
+            }
+            open::that(&url)?;
+            Ok(0)
+        }
+        Commands::Chart { name, limit } => {
+            chart::run(client, cfg, &name, limit).await?;
+            Ok(0)
+        }
+        Commands::Table { name, limit } => {
+            table::run(client, cfg, &name, limit).await?;
+            Ok(0)
+        }
+        Commands::Tui { chart, overview } => {
+            let c = chart.unwrap_or_else(|| cfg.default_chart.clone());
+            crate::tui::run(client, cfg, &c, overview).await?;
+            Ok(0)
+        }
+        Commands::Chat { message } => {
+            crate::tui::chat::run(client, cfg, message).await?;
+            Ok(0)
+        }
+        Commands::Agent { prompt, model } => {
+            agent::run(client, cfg, prompt, model).await?;
+            Ok(0)
+        }
+        Commands::Prompt(args) => {
+            match args.command {
+                PromptCommand::List => {
+                    for p in prompts::list() {
+                        println!("{:<20} {}", p.name, p.summary);
+                    }
+                }
+                PromptCommand::Show { name } => {
+                    let Some(pack) = prompts::find(&name) else {
+                        anyhow::bail!(
+                            "unknown prompt '{name}'. Run `chm prompt list` to see built-ins."
+                        );
+                    };
+                    println!("{}", pack.body);
+                }
+            }
+            Ok(0)
+        }
+        Commands::Audit(args) => {
+            audit::run(client, cfg, args).await?;
+            Ok(0)
+        }
+        Commands::Doctor => {
+            doctor::run(client, cfg).await?;
+            Ok(0)
+        }
+        Commands::Diagnose {
+            ch_host,
+            ch_user,
+            ch_password,
+            ch_database,
+            json,
+        } => diagnose_cmd::run(
+            client,
+            ch_host,
+            ch_user,
+            ch_password,
+            ch_database,
+            json || cfg.json,
+        )
+        .await,
+        Commands::Update(args) | Commands::Upgrade(args) => {
+            update_cmd::run(client, cfg, args).await
+        }
+        Commands::Completions { shell } => {
+            let mut cmd = crate::cli::Cli::command();
+            clap_complete::generate(shell, &mut cmd, "chm", &mut std::io::stdout());
+            Ok(0)
+        }
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/table.rs
+++ b/rust/ch-monitor-cli/src/commands/table.rs
@@ -1,0 +1,32 @@
+//! `chm table`
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::{client, config::AppConfig, output};
+
+pub async fn run(client: &Client, cfg: &AppConfig, name: &str, limit: usize) -> Result<()> {
+    let url = format!(
+        "{}/api/v1/tables/{}?hostId={}&pageSize={}",
+        cfg.base_url.trim_end_matches('/'),
+        name,
+        cfg.host_id,
+        limit
+    );
+    let data = client::fetch_cfg(client, cfg, url.clone()).await?;
+    if cfg.json {
+        output::print_json(&data)?;
+        return Ok(());
+    }
+    let rows: Vec<HashMap<String, Value>> =
+        serde_json::from_value(data).context("table payload parse failed")?;
+    if rows.is_empty() {
+        eprintln!("no rows returned from {url}");
+    } else {
+        output::print_records(&rows, limit);
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/update_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/update_cmd.rs
@@ -1,0 +1,31 @@
+//! `chm update` / `chm upgrade` wrapper with release-channel support.
+
+use anyhow::Result;
+use reqwest::Client;
+
+use crate::{
+    cli::UpdateArgs,
+    config::AppConfig,
+    update::{self, is_brew_managed},
+};
+
+pub async fn run(client: &Client, cfg: &AppConfig, args: UpdateArgs) -> Result<i32> {
+    if is_brew_managed() {
+        anyhow::bail!(
+            "this chm binary appears to be managed by Homebrew.\n\
+             Refuse to self-update — run `brew upgrade chm` (or reinstall) instead."
+        );
+    }
+
+    if args.check {
+        let available = update::check_channel(client, cfg.channel).await?;
+        if available {
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    } else {
+        update::run_channel(client, args.version, cfg.channel).await?;
+        Ok(0)
+    }
+}

--- a/rust/ch-monitor-cli/src/config.rs
+++ b/rust/ch-monitor-cli/src/config.rs
@@ -1,0 +1,198 @@
+//! Layered CLI configuration.
+//!
+//! Priority (highest wins): CLI flags → env → project (`chm.toml` / `.chm/config.toml`)
+//! → user (`~/.config/chm/config.toml`) → built-in defaults.
+
+use std::{env, fs, path::PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::{Channel, Cli};
+
+/// Cloud SaaS default — fail-open to the hosted product, not localhost.
+pub const DEFAULT_BASE_URL: &str = "https://dash.chmonitor.dev";
+pub const DEFAULT_HOST_ID: u32 = 0;
+pub const DEFAULT_CHART: &str = "query-count";
+pub const DEFAULT_CHANNEL: Channel = Channel::Stable;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct FileConfig {
+    pub base_url: Option<String>,
+    pub host_id: Option<u32>,
+    pub api_key: Option<String>,
+    pub token: Option<String>,
+    pub default_chart: Option<String>,
+    pub channel: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppConfig {
+    pub base_url: String,
+    pub host_id: u32,
+    pub api_key: Option<String>,
+    pub token: Option<String>,
+    pub default_chart: String,
+    pub channel: Channel,
+    pub json: bool,
+    pub quiet: bool,
+    pub yes: bool,
+    pub debug: bool,
+    /// Resolved user config path (may not exist yet).
+    pub user_config_path: PathBuf,
+}
+
+pub fn user_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("chm")).or_else(|| {
+        dirs::home_dir().map(|h| h.join(".config/chm"))
+    })
+}
+
+pub fn user_config_path() -> Option<PathBuf> {
+    user_config_dir().map(|d| d.join("config.toml"))
+}
+
+pub fn default_config_path() -> Option<PathBuf> {
+    user_config_path()
+}
+
+fn project_config_candidates() -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(cwd) = env::current_dir() {
+        out.push(cwd.join("chm.toml"));
+        out.push(cwd.join(".chm").join("config.toml"));
+    }
+    out
+}
+
+fn load_toml_file(path: &PathBuf) -> Result<Option<FileConfig>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read config at {}", path.display()))?;
+    let cfg = toml::from_str(&content)
+        .with_context(|| format!("failed to parse config at {}", path.display()))?;
+    Ok(Some(cfg))
+}
+
+fn load_file_config(explicit: Option<PathBuf>) -> Result<(FileConfig, PathBuf)> {
+    let user_path = default_config_path().unwrap_or_else(|| PathBuf::from("config.toml"));
+
+    if let Some(path) = explicit {
+        let cfg = load_toml_file(&path)?.unwrap_or_default();
+        return Ok((cfg, path));
+    }
+
+    // Layer: project over user (project fills gaps only when merging below).
+    let mut merged = FileConfig::default();
+    if let Some(user) = load_toml_file(&user_path)? {
+        merge_file(&mut merged, user);
+    }
+    for candidate in project_config_candidates() {
+        if let Some(project) = load_toml_file(&candidate)? {
+            merge_file(&mut merged, project);
+        }
+    }
+    Ok((merged, user_path))
+}
+
+fn merge_file(dst: &mut FileConfig, src: FileConfig) {
+    if src.base_url.is_some() {
+        dst.base_url = src.base_url;
+    }
+    if src.host_id.is_some() {
+        dst.host_id = src.host_id;
+    }
+    if src.api_key.is_some() {
+        dst.api_key = src.api_key;
+    }
+    if src.token.is_some() {
+        dst.token = src.token;
+    }
+    if src.default_chart.is_some() {
+        dst.default_chart = src.default_chart;
+    }
+    if src.channel.is_some() {
+        dst.channel = src.channel;
+    }
+}
+
+fn parse_channel(raw: &str) -> Result<Channel> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "stable" => Ok(Channel::Stable),
+        "beta" => Ok(Channel::Beta),
+        other => bail!("unknown channel '{other}' (expected stable|beta)"),
+    }
+}
+
+pub fn resolve_config(cli: &Cli) -> Result<AppConfig> {
+    let (file, user_config_path) = load_file_config(cli.config.clone())?;
+
+    let channel = if let Some(c) = cli.channel {
+        c
+    } else if let Ok(env_ch) = env::var("CHM_CHANNEL") {
+        if env_ch.is_empty() {
+            file.channel
+                .as_deref()
+                .map(parse_channel)
+                .transpose()?
+                .unwrap_or(DEFAULT_CHANNEL)
+        } else {
+            parse_channel(&env_ch)?
+        }
+    } else {
+        file.channel
+            .as_deref()
+            .map(parse_channel)
+            .transpose()?
+            .unwrap_or(DEFAULT_CHANNEL)
+    };
+
+    Ok(AppConfig {
+        base_url: cli
+            .base_url
+            .clone()
+            .or(file.base_url)
+            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+        host_id: cli.host_id.or(file.host_id).unwrap_or(DEFAULT_HOST_ID),
+        api_key: cli.api_key.clone().or(file.api_key),
+        token: cli.token.clone().or(file.token),
+        default_chart: file
+            .default_chart
+            .unwrap_or_else(|| DEFAULT_CHART.to_string()),
+        channel,
+        json: cli.json,
+        quiet: cli.quiet,
+        yes: cli.yes,
+        debug: cli.debug,
+        user_config_path,
+    })
+}
+
+pub fn save_user_config(path: &PathBuf, cfg: &FileConfig) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let content = toml::to_string_pretty(cfg).context("failed to serialize config")?;
+    fs::write(path, content)
+        .with_context(|| format!("failed to write config at {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_user_file_config(path: &PathBuf) -> Result<FileConfig> {
+    Ok(load_toml_file(path)?.unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_base_url_is_cloud() {
+        assert_eq!(DEFAULT_BASE_URL, "https://dash.chmonitor.dev");
+        assert!(DEFAULT_BASE_URL.starts_with("https://"));
+        assert!(!DEFAULT_BASE_URL.contains("localhost"));
+    }
+}

--- a/rust/ch-monitor-cli/src/config.rs
+++ b/rust/ch-monitor-cli/src/config.rs
@@ -43,9 +43,9 @@ pub struct AppConfig {
 }
 
 pub fn user_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("chm")).or_else(|| {
-        dirs::home_dir().map(|h| h.join(".config/chm"))
-    })
+    dirs::config_dir()
+        .map(|d| d.join("chm"))
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config/chm")))
 }
 
 pub fn user_config_path() -> Option<PathBuf> {

--- a/rust/ch-monitor-cli/src/credentials.rs
+++ b/rust/ch-monitor-cli/src/credentials.rs
@@ -1,0 +1,195 @@
+//! Credential storage: OS keyring with 0600 plaintext fallback.
+
+use std::{fs, io::Write, path::PathBuf};
+
+use anyhow::{Context, Result};
+use keyring::Entry;
+
+const SERVICE: &str = "chmonitor-chm";
+const TOKEN_USER: &str = "token";
+const API_KEY_USER: &str = "api-key";
+
+fn credentials_path() -> Option<PathBuf> {
+    crate::config::user_config_dir().map(|d| d.join("credentials"))
+}
+
+fn keyring_entry(user: &str) -> Result<Entry> {
+    Entry::new(SERVICE, user).context("failed to open OS keyring entry")
+}
+
+fn read_plaintext(key: &str) -> Result<Option<String>> {
+    let Some(path) = credentials_path() else {
+        return Ok(None);
+    };
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read credentials at {}", path.display()))?;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim() == key {
+                let val = v.trim().trim_matches('"');
+                if !val.is_empty() {
+                    return Ok(Some(val.to_string()));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn write_plaintext(key: &str, value: &str) -> Result<()> {
+    let path = credentials_path().context("could not resolve credentials path")?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+
+    let mut map = std::collections::BTreeMap::<String, String>::new();
+    if path.exists() {
+        let existing = fs::read_to_string(&path).unwrap_or_default();
+        for line in existing.lines() {
+            if let Some((k, v)) = line.split_once('=') {
+                map.insert(k.trim().to_string(), v.trim().trim_matches('"').to_string());
+            }
+        }
+    }
+    map.insert(key.to_string(), value.to_string());
+
+    let mut out = String::new();
+    for (k, v) in &map {
+        out.push_str(&format!("{k}=\"{v}\"\n"));
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to chmod 0600 {}", path.display()))?;
+    }
+
+    file.write_all(out.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn clear_plaintext(key: &str) -> Result<()> {
+    let Some(path) = credentials_path() else {
+        return Ok(());
+    };
+    if !path.exists() {
+        return Ok(());
+    }
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let mut map = std::collections::BTreeMap::<String, String>::new();
+    for line in existing.lines() {
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim() != key {
+                map.insert(k.trim().to_string(), v.trim().trim_matches('"').to_string());
+            }
+        }
+    }
+    if map.is_empty() {
+        let _ = fs::remove_file(&path);
+        return Ok(());
+    }
+    let mut out = String::new();
+    for (k, v) in &map {
+        out.push_str(&format!("{k}=\"{v}\"\n"));
+    }
+    fs::write(&path, out)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn store(user: &str, plaintext_key: &str, value: &str) -> Result<()> {
+    match keyring_entry(user).and_then(|e| {
+        e.set_password(value)
+            .context("failed to store secret in OS keyring")
+    }) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            eprintln!("note: keyring unavailable ({err}); storing credentials in plaintext (0600)");
+            write_plaintext(plaintext_key, value)
+        }
+    }
+}
+
+fn load(user: &str, plaintext_key: &str) -> Result<Option<String>> {
+    if let Ok(entry) = keyring_entry(user) {
+        match entry.get_password() {
+            Ok(v) if !v.is_empty() => return Ok(Some(v)),
+            Ok(_) => {}
+            Err(keyring::Error::NoEntry) => {}
+            Err(_) => {}
+        }
+    }
+    read_plaintext(plaintext_key)
+}
+
+fn delete(user: &str, plaintext_key: &str) -> Result<()> {
+    if let Ok(entry) = keyring_entry(user) {
+        let _ = entry.delete_credential();
+    }
+    clear_plaintext(plaintext_key)
+}
+
+pub fn store_token(token: &str) -> Result<()> {
+    store(TOKEN_USER, "token", token)
+}
+
+pub fn load_token() -> Result<Option<String>> {
+    load(TOKEN_USER, "token")
+}
+
+pub fn clear_token() -> Result<()> {
+    delete(TOKEN_USER, "token")
+}
+
+pub fn store_api_key(key: &str) -> Result<()> {
+    store(API_KEY_USER, "api_key", key)
+}
+
+pub fn load_api_key() -> Result<Option<String>> {
+    load(API_KEY_USER, "api_key")
+}
+
+pub fn clear_api_key() -> Result<()> {
+    delete(API_KEY_USER, "api_key")
+}
+
+/// Resolve effective token: CLI/config override, else keyring/plaintext.
+pub fn resolve_token(cli_or_config: Option<&str>) -> Result<Option<String>> {
+    if let Some(t) = cli_or_config {
+        if !t.is_empty() {
+            return Ok(Some(t.to_string()));
+        }
+    }
+    load_token()
+}
+
+/// Resolve effective API key: CLI/config override, else keyring/plaintext.
+pub fn resolve_api_key(cli_or_config: Option<&str>) -> Result<Option<String>> {
+    if let Some(k) = cli_or_config {
+        if !k.is_empty() {
+            return Ok(Some(k.to_string()));
+        }
+    }
+    load_api_key()
+}

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -1,310 +1,69 @@
-use std::{
-    collections::HashMap,
-    fs, io,
-    path::PathBuf,
-    time::{Duration, Instant},
-};
+//! `chm` — chmonitor CLI entry point (dispatch only).
 
-use anyhow::{bail, Context, Result};
-use clap::{Args, Parser, Subcommand};
-use comfy_table::{presets::UTF8_FULL, Table};
-use crossterm::{
-    event, execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
-use ratatui::{
-    layout::{Constraint, Direction, Layout},
-    widgets::{Block, Borders, Paragraph, Row, Sparkline, Table as TuiTable},
-    Terminal,
-};
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-
+mod cli;
+mod client;
+mod commands;
+mod config;
+mod credentials;
 mod diagnose;
+mod mermaid;
+mod metrics;
+mod output;
+mod prompts;
 mod telemetry;
+mod tui;
 mod update;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-struct FileConfig {
-    base_url: Option<String>,
-    host_id: Option<u32>,
-    api_key: Option<String>,
-    default_chart: Option<String>,
-}
+use std::time::Duration;
 
-#[derive(Parser, Debug)]
-#[command(
-    name = "chm",
-    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
-    about = "chmonitor CLI — dashboard API, TUI, and zero-signup diagnostics"
-)]
-struct Cli {
-    /// Path to config.toml (default ~/.config/chm/config.toml)
-    #[arg(long, env = "CHM_CONFIG", global = true)]
-    config: Option<PathBuf>,
-    /// Dashboard base URL (default http://localhost:3000)
-    #[arg(long, env = "CHM_BASE_URL", global = true)]
-    base_url: Option<String>,
-    /// Dashboard host id (default 0)
-    #[arg(long, env = "CHM_HOST_ID", global = true)]
-    host_id: Option<u32>,
-    /// Dashboard API key (sent as x-api-key)
-    #[arg(long, env = "CHM_API_KEY", global = true)]
-    api_key: Option<String>,
-    #[command(subcommand)]
-    command: Commands,
-}
+use anyhow::Result;
+use clap::Parser;
+use reqwest::Client;
 
-#[derive(Subcommand, Debug)]
-enum Commands {
-    /// List hosts from a running chmonitor dashboard
-    Hosts,
-    /// Fetch a named chart from the dashboard API
-    Chart {
-        /// Chart name, e.g. query-count
-        name: String,
-        /// Max rows to print
-        #[arg(long, default_value_t = 20)]
-        limit: usize,
-    },
-    /// Fetch a named table from the dashboard API
-    Table {
-        /// Table name, e.g. running-queries
-        name: String,
-        /// Max rows to print
-        #[arg(long, default_value_t = 20)]
-        limit: usize,
-    },
-    /// Live terminal UI for a dashboard chart
-    Tui {
-        /// Chart name (default: config `default_chart`, else query-count)
-        chart: Option<String>,
-    },
-    /// Zero-signup local diagnostics: connect directly to a ClickHouse host
-    /// (no chmonitor account/backend needed) and print a scored health report.
-    Diagnose {
-        /// ClickHouse HTTP interface URL, e.g. http://localhost:8123
-        #[arg(long, env = "CLICKHOUSE_HOST")]
-        ch_host: Option<String>,
-        #[arg(long, env = "CLICKHOUSE_USER", default_value = "default")]
-        ch_user: String,
-        #[arg(long, env = "CLICKHOUSE_PASSWORD", default_value = "")]
-        ch_password: String,
-        #[arg(long, env = "CLICKHOUSE_DATABASE", default_value = "default")]
-        ch_database: String,
-        /// Print the report as JSON instead of a table.
-        #[arg(long)]
-        json: bool,
-    },
-    /// Update chm to the latest GitHub release (self-update).
-    ///
-    /// Prints current -> target version, verifies sha256, and atomically
-    /// replaces this binary. Never invokes sudo: checksum, permission, and
-    /// unsupported-target failures print a copy-pasteable fallback
-    /// (`scripts/install.sh` or `cargo install ch-monitor-cli`).
-    Update(UpdateArgs),
-    /// Alias of `update`. Same flags (`--check`, `--version`), same behaviour.
-    Upgrade(UpdateArgs),
-}
+use crate::cli::{Cli, Commands};
 
-/// Shared flags for `chm update` and `chm upgrade`.
-#[derive(Args, Debug)]
-struct UpdateArgs {
-    /// Only check whether an update is available; exit 1 if one exists.
-    #[arg(long)]
-    check: bool,
-    /// Install a specific release tag, e.g. chm-v0.2.0.
-    #[arg(long)]
-    version: Option<String>,
-}
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let cfg = config::resolve_config(&cli)?;
+    let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
 
-#[derive(Debug, Deserialize)]
-struct ApiResponse {
-    data: Value,
-}
-
-#[derive(Debug, Clone)]
-struct AppConfig {
-    base_url: String,
-    host_id: u32,
-    api_key: Option<String>,
-    default_chart: String,
-}
-
-fn default_config_path() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".config/chm/config.toml"))
-}
-
-fn load_file_config(path: Option<PathBuf>) -> Result<FileConfig> {
-    let p = path.or_else(default_config_path);
-    if let Some(path) = p {
-        if path.exists() {
-            let content = fs::read_to_string(&path)
-                .with_context(|| format!("failed to read config at {}", path.display()))?;
-            let cfg = toml::from_str(&content)
-                .with_context(|| format!("failed to parse config at {}", path.display()))?;
-            return Ok(cfg);
-        }
-    }
-    Ok(FileConfig::default())
-}
-
-fn resolve_config(cli: &Cli) -> Result<AppConfig> {
-    let file = load_file_config(cli.config.clone())?;
-    Ok(AppConfig {
-        base_url: cli
-            .base_url
-            .clone()
-            .or(file.base_url)
-            .unwrap_or_else(|| "http://localhost:3000".to_string()),
-        host_id: cli.host_id.or(file.host_id).unwrap_or(0),
-        api_key: cli.api_key.clone().or(file.api_key),
-        default_chart: file
-            .default_chart
-            .unwrap_or_else(|| "query-count".to_string()),
-    })
-}
-
-fn api_error_hint(status: u16) -> &'static str {
-    match status {
-        401 | 403 => " Check --api-key / CHM_API_KEY.",
-        404 => " Check the chart/table name and --host-id.",
-        _ => "",
-    }
-}
-
-fn truncate_body(s: &str, max_chars: usize) -> Option<String> {
-    if s.is_empty() {
-        return None;
-    }
-    let mut iter = s.chars();
-    let head: String = iter.by_ref().take(max_chars).collect();
-    if iter.next().is_some() {
-        Some(format!("{head}…"))
-    } else {
-        Some(head)
-    }
-}
-
-async fn fetch(client: &Client, url: String, api_key: Option<&str>) -> Result<Value> {
-    let mut req = client.get(&url);
-    if let Some(k) = api_key {
-        req = req.header("x-api-key", k);
-    }
-    let resp = match req.send().await {
-        Ok(resp) => resp,
-        Err(err) => {
-            bail!(
-                "failed to reach chmonitor API at {url}: {err}\n\
-                 Is the dashboard running? Set --base-url / CHM_BASE_URL \
-                 (default http://localhost:3000)."
-            );
-        }
+    // Anonymous, opt-out CLI telemetry (source=cli). Fires in the background and
+    // never blocks or fails the command; see src/telemetry.rs.
+    let (tel_event, tel_command): (&'static str, &'static str) = match &cli.command {
+        Commands::Diagnose { .. } => ("cli_diagnose", "diagnose"),
+        Commands::Hosts => ("cli_run", "hosts"),
+        Commands::Chart { .. } => ("cli_run", "chart"),
+        Commands::Table { .. } => ("cli_run", "table"),
+        Commands::Tui { .. } => ("cli_run", "tui"),
+        Commands::Update(_) | Commands::Upgrade(_) => ("cli_run", "update"),
+        Commands::Auth(_) => ("cli_run", "auth"),
+        Commands::Config(_) => ("cli_run", "config"),
+        Commands::Link { .. } => ("cli_run", "link"),
+        Commands::Chat { .. } => ("cli_run", "chat"),
+        Commands::Agent { .. } => ("cli_run", "agent"),
+        Commands::Prompt(_) => ("cli_run", "prompt"),
+        Commands::Audit(_) => ("cli_run", "audit"),
+        Commands::Doctor => ("cli_run", "doctor"),
+        Commands::Completions { .. } => ("cli_run", "completions"),
     };
-    let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
-    if !status.is_success() {
-        let hint = api_error_hint(status.as_u16());
-        let extra = match truncate_body(text.trim(), 200) {
-            None => String::new(),
-            Some(body) => format!(" {body}"),
-        };
-        bail!("chmonitor API returned HTTP {status} for {url}.{hint}{extra}");
+    let tel_handle = telemetry::spawn(tel_event, tel_command);
+
+    let exit = commands::dispatch(&client, &cfg, cli.command).await?;
+
+    telemetry::finish(tel_handle).await;
+    if exit != 0 {
+        std::process::exit(exit);
     }
-    let parsed: ApiResponse = serde_json::from_str(&text).with_context(|| {
-        format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})")
-    })?;
-    Ok(parsed.data)
-}
-
-fn rows_from_chart_data(data: Value) -> Result<Vec<Value>> {
-    match data {
-        Value::Array(rows) => Ok(rows),
-        Value::Object(mut queries) => {
-            if let Some(Value::Array(rows)) = queries.remove("main") {
-                return Ok(rows);
-            }
-
-            let rows = queries
-                .into_values()
-                .filter_map(|value| match value {
-                    Value::Array(rows) => Some(rows),
-                    _ => None,
-                })
-                .flatten()
-                .collect();
-            Ok(rows)
-        }
-        other => bail!("chart payload data must be an array or object, got {other}"),
-    }
-}
-
-const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
-const TUI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
-const PREFERRED_METRIC_KEYS: &[&str] = &["count", "query_count", "value", "total"];
-
-fn metric_from_float(value: f64) -> Option<u64> {
-    if value.is_finite() && value >= 0.0 && value <= u64::MAX as f64 {
-        Some(value.round() as u64)
-    } else {
-        None
-    }
-}
-
-fn value_metric(value: &Value) -> Option<u64> {
-    match value {
-        Value::Number(number) => number
-            .as_u64()
-            .or_else(|| number.as_i64().and_then(|n| u64::try_from(n).ok()))
-            .or_else(|| number.as_f64().and_then(metric_from_float)),
-        Value::String(text) => text
-            .trim()
-            .parse::<u64>()
-            .ok()
-            .or_else(|| text.trim().parse::<f64>().ok().and_then(metric_from_float)),
-        _ => None,
-    }
-}
-
-fn row_metric(row: &Value) -> u64 {
-    row.as_object()
-        .and_then(|o| {
-            PREFERRED_METRIC_KEYS
-                .iter()
-                .find_map(|key| o.get(*key).and_then(value_metric))
-                .or_else(|| o.values().find_map(value_metric))
-        })
-        .unwrap_or(0)
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::CommandFactory;
-    use serde_json::json;
 
-    #[test]
-    fn row_metric_prefers_known_metric_keys() {
-        let row = json!({
-            "duration_ms": 9000,
-            "query_count": 42,
-        });
-
-        assert_eq!(row_metric(&row), 42);
-    }
-
-    #[test]
-    fn row_metric_handles_float_and_string_values() {
-        assert_eq!(row_metric(&json!({ "value": 12.6 })), 13);
-        assert_eq!(row_metric(&json!({ "value": "7.4" })), 7);
-    }
-
-    #[test]
-    fn row_metric_ignores_negative_or_invalid_values() {
-        assert_eq!(row_metric(&json!({ "value": -1 })), 0);
-        assert_eq!(row_metric(&json!({ "value": "not-a-number" })), 0);
-    }
+    use crate::cli::UpdateArgs;
 
     fn update_args(cli: Cli) -> UpdateArgs {
         match cli.command {
@@ -397,21 +156,6 @@ mod tests {
     }
 
     #[test]
-    fn api_error_hint_covers_auth_and_missing() {
-        assert!(api_error_hint(401).contains("CHM_API_KEY"));
-        assert!(api_error_hint(403).contains("CHM_API_KEY"));
-        assert!(api_error_hint(404).contains("host-id"));
-        assert_eq!(api_error_hint(500), "");
-    }
-
-    #[test]
-    fn truncate_body_is_char_safe() {
-        assert_eq!(truncate_body("", 8), None);
-        assert_eq!(truncate_body("hello", 8).as_deref(), Some("hello"));
-        assert_eq!(truncate_body("éééé", 2).as_deref(), Some("éé…"));
-    }
-
-    #[test]
     fn update_and_upgrade_help_share_flags() {
         // clap 4's render_long_help takes &mut self.
         let mut cmd = Cli::command();
@@ -431,258 +175,12 @@ mod tests {
             assert!(help.contains("--version"), "{help}");
         }
     }
-}
 
-fn print_records(data: &[HashMap<String, Value>], limit: usize) {
-    if data.is_empty() {
-        return;
+    #[test]
+    fn default_base_url_is_cloud() {
+        assert_eq!(
+            crate::config::DEFAULT_BASE_URL,
+            "https://dash.chmonitor.dev"
+        );
     }
-    let mut table = Table::new();
-    table.load_preset(UTF8_FULL);
-    if let Some(first) = data.first() {
-        let headers: Vec<String> = first.keys().cloned().collect();
-        table.set_header(headers.clone());
-        for row in data.iter().take(limit) {
-            let cells = headers
-                .iter()
-                .map(|k| row.get(k).map_or("".into(), |v| v.to_string()))
-                .collect::<Vec<_>>();
-            table.add_row(cells);
-        }
-    }
-    println!("{table}");
-}
-
-struct TuiGuard;
-
-impl Drop for TuiGuard {
-    fn drop(&mut self) {
-        let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen);
-    }
-}
-
-async fn run_tui(client: &Client, cfg: &AppConfig, chart: &str) -> Result<()> {
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
-    let _guard = TuiGuard;
-
-    let backend = ratatui::backend::CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-    let mut rows = Vec::new();
-    let mut points = Vec::new();
-    let mut error_message = None;
-    let mut next_refresh_at = Instant::now();
-
-    loop {
-        let now = Instant::now();
-        if now >= next_refresh_at {
-            let url = format!(
-                "{}/api/v1/charts/{}?hostId={}",
-                cfg.base_url, chart, cfg.host_id
-            );
-            let rows_result = fetch(client, url, cfg.api_key.as_deref())
-                .await
-                .and_then(rows_from_chart_data);
-            error_message = rows_result.as_ref().err().map(ToString::to_string);
-            rows = rows_result.unwrap_or_default();
-            points = rows.iter().take(80).map(row_metric).collect();
-            next_refresh_at = Instant::now() + TUI_REFRESH_INTERVAL;
-        }
-
-        terminal.draw(|f| {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(3), Constraint::Min(5)].as_ref())
-                .split(f.area());
-            f.render_widget(
-                Paragraph::new(format!(
-                    "chm tui | chart={chart} | q=quit | r=refresh | host={}{}",
-                    cfg.host_id,
-                    error_message
-                        .as_ref()
-                        .map(|message| format!(" | error={message}"))
-                        .unwrap_or_default()
-                )),
-                chunks[0],
-            );
-            let rows_widget: Vec<Row> = rows
-                .iter()
-                .take(10)
-                .filter_map(|r| r.as_object())
-                .map(|o| {
-                    let kv = o
-                        .iter()
-                        .map(|(k, v)| format!("{k}:{v}"))
-                        .collect::<Vec<_>>()
-                        .join(" | ");
-                    Row::new(vec![kv])
-                })
-                .collect();
-            let inner = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(5), Constraint::Min(5)])
-                .split(chunks[1]);
-            let spark = Sparkline::default()
-                .block(Block::default().title("Trend").borders(Borders::ALL))
-                .data(&points);
-            f.render_widget(spark, inner[0]);
-            let table = TuiTable::new(rows_widget, [Constraint::Percentage(100)])
-                .block(Block::default().title("Recent rows").borders(Borders::ALL));
-            f.render_widget(table, inner[1]);
-        })?;
-
-        let poll_timeout = next_refresh_at
-            .saturating_duration_since(Instant::now())
-            .min(TUI_EVENT_POLL_INTERVAL);
-        if event::poll(poll_timeout)? {
-            match event::read()? {
-                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('q')) => break,
-                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('r')) => {
-                    next_refresh_at = Instant::now()
-                }
-                event::Event::Resize(_, _) => continue,
-                _ => {}
-            }
-        }
-    }
-
-    Ok(())
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let cli = Cli::parse();
-    let cfg = resolve_config(&cli)?;
-    let client = Client::builder().timeout(Duration::from_secs(20)).build()?;
-
-    // Anonymous, opt-out CLI telemetry (source=cli). Fires in the background and
-    // never blocks or fails the command; see src/telemetry.rs.
-    let (tel_event, tel_command): (&'static str, &'static str) = match &cli.command {
-        Commands::Diagnose { .. } => ("cli_diagnose", "diagnose"),
-        Commands::Hosts => ("cli_run", "hosts"),
-        Commands::Chart { .. } => ("cli_run", "chart"),
-        Commands::Table { .. } => ("cli_run", "table"),
-        Commands::Tui { .. } => ("cli_run", "tui"),
-        Commands::Update(_) | Commands::Upgrade(_) => ("cli_run", "update"),
-    };
-    let tel_handle = telemetry::spawn(tel_event, tel_command);
-
-    match cli.command {
-        Commands::Hosts => {
-            let url = format!("{}/api/v1/hosts", cfg.base_url);
-            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
-            let hosts: Vec<HashMap<String, Value>> =
-                serde_json::from_value(data).context("hosts payload parse failed")?;
-            if hosts.is_empty() {
-                eprintln!("no hosts returned from {url}");
-            } else {
-                print_records(&hosts, 100);
-            }
-        }
-        Commands::Chart { name, limit } => {
-            let url = format!(
-                "{}/api/v1/charts/{}?hostId={}",
-                cfg.base_url, name, cfg.host_id
-            );
-            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
-            let data = Value::Array(rows_from_chart_data(data)?);
-            let rows: Vec<HashMap<String, Value>> =
-                serde_json::from_value(data).context("chart payload parse failed")?;
-            if rows.is_empty() {
-                eprintln!("no rows returned from {url}");
-            } else {
-                print_records(&rows, limit);
-            }
-        }
-        Commands::Table { name, limit } => {
-            let url = format!(
-                "{}/api/v1/tables/{}?hostId={}&pageSize={}",
-                cfg.base_url, name, cfg.host_id, limit
-            );
-            let data = fetch(&client, url.clone(), cfg.api_key.as_deref()).await?;
-            let rows: Vec<HashMap<String, Value>> =
-                serde_json::from_value(data).context("table payload parse failed")?;
-            if rows.is_empty() {
-                eprintln!("no rows returned from {url}");
-            } else {
-                print_records(&rows, limit);
-            }
-        }
-        Commands::Tui { chart } => {
-            let c = chart.unwrap_or(cfg.default_chart.clone());
-            run_tui(&client, &cfg, &c).await?
-        }
-        Commands::Diagnose {
-            ch_host,
-            ch_user,
-            ch_password,
-            ch_database,
-            json,
-        } => {
-            let Some(raw_host) = ch_host else {
-                bail!(
-                    "no ClickHouse host given — pass --ch-host or set CLICKHOUSE_HOST \
-                     (e.g. CLICKHOUSE_HOST=http://localhost:8123 chm diagnose)"
-                );
-            };
-            // Multi-host clusters use a comma-separated CLICKHOUSE_HOST (same env var
-            // the dashboard reads); this zero-signup CLI diagnoses one host at a time.
-            let first_host = raw_host
-                .split(',')
-                .next()
-                .map(str::trim)
-                .filter(|h| !h.is_empty())
-                .unwrap_or(&raw_host);
-            if raw_host.contains(',') {
-                eprintln!(
-                    "note: CLICKHOUSE_HOST has multiple hosts — diagnosing only the first ({first_host}). Use the dashboard for multi-host clusters."
-                );
-            }
-            let url = if first_host.starts_with("http://") || first_host.starts_with("https://") {
-                first_host.to_string()
-            } else {
-                format!("http://{first_host}")
-            };
-
-            let ch_cfg = diagnose::ChConfig {
-                url,
-                user: ch_user,
-                password: ch_password,
-                database: ch_database,
-            };
-            let report = diagnose::run_diagnostics(&client, &ch_cfg).await?;
-            if json {
-                println!("{}", diagnose::render_json(&report)?);
-            } else {
-                print!("{}", diagnose::render_text(&report));
-            }
-            // Gentle, best-effort "update available" hint (opt out with
-            // CHM_NO_UPDATE_CHECK=1). Never fails the command.
-            update::hint(&client).await;
-            if report
-                .findings
-                .iter()
-                .any(|f| f.severity == diagnose::Severity::Critical)
-            {
-                telemetry::finish(tel_handle).await;
-                std::process::exit(1);
-            }
-        }
-        Commands::Update(args) | Commands::Upgrade(args) => {
-            if args.check {
-                let available = update::check(&client).await?;
-                if available {
-                    telemetry::finish(tel_handle).await;
-                    std::process::exit(1);
-                }
-            } else {
-                update::run(&client, args.version).await?;
-            }
-        }
-    }
-
-    telemetry::finish(tel_handle).await;
-    Ok(())
 }

--- a/rust/ch-monitor-cli/src/mermaid.rs
+++ b/rust/ch-monitor-cli/src/mermaid.rs
@@ -1,0 +1,23 @@
+//! Optional Mermaid rendering (feature `mermaid`).
+//!
+//! Without the feature, print the Mermaid source as a fenced code block so
+//! operators can paste it into a viewer.
+
+#![allow(dead_code)]
+
+#[cfg(feature = "mermaid")]
+pub fn print_mermaid(source: &str) {
+    // Feature stub: when a real renderer is wired, render to SVG/PNG here.
+    print_source_fallback(source);
+}
+
+#[cfg(not(feature = "mermaid"))]
+pub fn print_mermaid(source: &str) {
+    print_source_fallback(source);
+}
+
+pub fn print_source_fallback(source: &str) {
+    println!("```mermaid");
+    println!("{source}");
+    println!("```");
+}

--- a/rust/ch-monitor-cli/src/metrics.rs
+++ b/rust/ch-monitor-cli/src/metrics.rs
@@ -1,0 +1,67 @@
+//! Row metric extraction for sparklines / TUI.
+
+use serde_json::Value;
+
+const PREFERRED_METRIC_KEYS: &[&str] = &["count", "query_count", "value", "total"];
+
+fn metric_from_float(value: f64) -> Option<u64> {
+    if value.is_finite() && value >= 0.0 && value <= u64::MAX as f64 {
+        Some(value.round() as u64)
+    } else {
+        None
+    }
+}
+
+fn value_metric(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number
+            .as_u64()
+            .or_else(|| number.as_i64().and_then(|n| u64::try_from(n).ok()))
+            .or_else(|| number.as_f64().and_then(metric_from_float)),
+        Value::String(text) => text
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .or_else(|| text.trim().parse::<f64>().ok().and_then(metric_from_float)),
+        _ => None,
+    }
+}
+
+pub fn row_metric(row: &Value) -> u64 {
+    row.as_object()
+        .and_then(|o| {
+            PREFERRED_METRIC_KEYS
+                .iter()
+                .find_map(|key| o.get(*key).and_then(value_metric))
+                .or_else(|| o.values().find_map(value_metric))
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn row_metric_prefers_known_metric_keys() {
+        let row = json!({
+            "duration_ms": 9000,
+            "query_count": 42,
+        });
+
+        assert_eq!(row_metric(&row), 42);
+    }
+
+    #[test]
+    fn row_metric_handles_float_and_string_values() {
+        assert_eq!(row_metric(&json!({ "value": 12.6 })), 13);
+        assert_eq!(row_metric(&json!({ "value": "7.4" })), 7);
+    }
+
+    #[test]
+    fn row_metric_ignores_negative_or_invalid_values() {
+        assert_eq!(row_metric(&json!({ "value": -1 })), 0);
+        assert_eq!(row_metric(&json!({ "value": "not-a-number" })), 0);
+    }
+}

--- a/rust/ch-monitor-cli/src/output.rs
+++ b/rust/ch-monitor-cli/src/output.rs
@@ -1,0 +1,94 @@
+//! Terminal / JSON output helpers.
+
+use std::{
+    collections::HashMap,
+    io::{self, IsTerminal, Write},
+};
+
+use comfy_table::{presets::UTF8_FULL, Table};
+use owo_colors::OwoColorize;
+use serde_json::Value;
+
+pub fn wants_color() -> bool {
+    if std::env::var_os("NO_COLOR").is_some() {
+        return false;
+    }
+    if std::env::var_os("FORCE_COLOR").is_some() {
+        return true;
+    }
+    io::stdout().is_terminal()
+}
+
+pub fn print_json(value: &Value) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+pub fn print_records(data: &[HashMap<String, Value>], limit: usize) {
+    if data.is_empty() {
+        return;
+    }
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL);
+    if let Some(first) = data.first() {
+        let headers: Vec<String> = first.keys().cloned().collect();
+        table.set_header(headers.clone());
+        for row in data.iter().take(limit) {
+            let cells = headers
+                .iter()
+                .map(|k| row.get(k).map_or("".into(), |v| v.to_string()))
+                .collect::<Vec<_>>();
+            table.add_row(cells);
+        }
+    }
+    println!("{table}");
+}
+
+/// Compact braille sparkline for a slice of values.
+pub fn braille_sparkline(values: &[u64], width: usize) -> String {
+    if values.is_empty() || width == 0 {
+        return String::new();
+    }
+    // Braille block for 0..=8 levels (space + 8 fills).
+    const BLOCKS: &[char] = &[' ', '▂', '▃', '▄', '▅', '▆', '▇', '█', '⣿'];
+    let max = values.iter().copied().max().unwrap_or(0).max(1);
+    let step = (values.len() as f64 / width as f64).max(1.0);
+    let mut out = String::with_capacity(width);
+    for i in 0..width {
+        let start = (i as f64 * step) as usize;
+        let end = (((i + 1) as f64 * step) as usize).min(values.len()).max(start + 1);
+        let window = &values[start..end.min(values.len())];
+        let avg = if window.is_empty() {
+            0
+        } else {
+            window.iter().sum::<u64>() / window.len() as u64
+        };
+        let level = ((avg as f64 / max as f64) * 8.0).round() as usize;
+        out.push(BLOCKS[level.min(8)]);
+    }
+    out
+}
+
+pub fn success(msg: &str) {
+    if wants_color() {
+        eprintln!("{} {msg}", "✔".green());
+    } else {
+        eprintln!("ok: {msg}");
+    }
+}
+
+pub fn warn(msg: &str) {
+    if wants_color() {
+        let _ = writeln!(io::stderr(), "{} {msg}", "!".yellow());
+    } else {
+        eprintln!("warn: {msg}");
+    }
+}
+
+pub fn info(msg: &str) {
+    if wants_color() {
+        eprintln!("{} {msg}", "→".cyan());
+    } else {
+        eprintln!("info: {msg}");
+    }
+}

--- a/rust/ch-monitor-cli/src/output.rs
+++ b/rust/ch-monitor-cli/src/output.rs
@@ -56,7 +56,9 @@ pub fn braille_sparkline(values: &[u64], width: usize) -> String {
     let mut out = String::with_capacity(width);
     for i in 0..width {
         let start = (i as f64 * step) as usize;
-        let end = (((i + 1) as f64 * step) as usize).min(values.len()).max(start + 1);
+        let end = (((i + 1) as f64 * step) as usize)
+            .min(values.len())
+            .max(start + 1);
         let window = &values[start..end.min(values.len())];
         let avg = if window.is_empty() {
             0

--- a/rust/ch-monitor-cli/src/prompts.rs
+++ b/rust/ch-monitor-cli/src/prompts.rs
@@ -1,0 +1,46 @@
+//! Built-in prompt packs for `chm prompt` / agent shortcuts.
+
+#[derive(Debug, Clone, Copy)]
+pub struct PromptPack {
+    pub name: &'static str,
+    pub summary: &'static str,
+    pub body: &'static str,
+}
+
+pub const PROMPTS: &[PromptPack] = &[
+    PromptPack {
+        name: "slow-queries",
+        summary: "Find and explain the slowest recent queries",
+        body: "List the slowest queries from the last hour. For each, explain why it is slow and suggest concrete fixes (ORDER BY, projections, settings).",
+    },
+    PromptPack {
+        name: "disk-pressure",
+        summary: "Assess disk usage and recommend TTL / cleanup",
+        body: "Summarize disk usage by table and part. Flag tables at risk of filling the volume and recommend TTL or DROP PARTITION actions.",
+    },
+    PromptPack {
+        name: "replication-health",
+        summary: "Check replica lag and queue depth",
+        body: "Inspect replication status across replicas. Report lag, queue size, and any stuck fetches. Suggest remediation steps.",
+    },
+    PromptPack {
+        name: "merge-storm",
+        summary: "Diagnose heavy merge activity",
+        body: "Are merges backing up? Report active merges, parts per partition, and whether insert patterns look like a merge storm. Recommend settings changes if needed.",
+    },
+    PromptPack {
+        name: "cluster-report",
+        summary: "One-page cluster health narrative",
+        body: "Produce a concise cluster health report covering queries, merges, replication, disk, and errors. Lead with the top three risks.",
+    },
+];
+
+pub fn find(name: &str) -> Option<&'static PromptPack> {
+    PROMPTS
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case(name.trim()))
+}
+
+pub fn list() -> &'static [PromptPack] {
+    PROMPTS
+}

--- a/rust/ch-monitor-cli/src/tui/chat.rs
+++ b/rust/ch-monitor-cli/src/tui/chat.rs
@@ -1,0 +1,239 @@
+//! Streaming chat TUI / non-interactive chat against `/api/v1/agent`.
+
+use std::io::{self, IsTerminal, Read, Write};
+
+use anyhow::{bail, Context, Result};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use futures_util::StreamExt;
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Terminal,
+};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::{
+    client::apply_auth,
+    config::AppConfig,
+    credentials,
+};
+
+struct ChatGuard;
+
+impl Drop for ChatGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+pub async fn run(client: &Client, cfg: &AppConfig, message: Option<String>) -> Result<()> {
+    let initial = match message {
+        Some(m) if !m.trim().is_empty() => Some(m),
+        None if !io::stdin().is_terminal() => {
+            let mut buf = String::new();
+            io::stdin().read_to_string(&mut buf)?;
+            let t = buf.trim().to_string();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t)
+            }
+        }
+        _ => None,
+    };
+
+    // Non-interactive one-shot when a message is provided and stdout isn't a TTY chat.
+    if let Some(msg) = initial {
+        if !io::stdout().is_terminal() || cfg.json {
+            return stream_once(client, cfg, &msg).await;
+        }
+        return run_tui(client, cfg, Some(msg)).await;
+    }
+
+    if !io::stdin().is_terminal() {
+        bail!("no chat message given — pass an argument or run in a terminal");
+    }
+    run_tui(client, cfg, None).await
+}
+
+async fn stream_once(client: &Client, cfg: &AppConfig, message: &str) -> Result<()> {
+    let text = stream_agent(client, cfg, message).await?;
+    if cfg.json {
+        crate::output::print_json(&serde_json::json!({ "text": text }))?;
+    } else {
+        print!("{text}");
+        if !text.ends_with('\n') {
+            println!();
+        }
+    }
+    Ok(())
+}
+
+async fn stream_agent(client: &Client, cfg: &AppConfig, message: &str) -> Result<String> {
+    let url = format!("{}/api/v1/agent", cfg.base_url.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "message": message,
+        "hostId": cfg.host_id,
+    });
+    let token = credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = credentials::resolve_api_key(cfg.api_key.as_deref())?;
+
+    let resp = apply_auth(client.post(&url), token.as_deref(), api_key.as_deref())
+        .header("Accept", "text/event-stream")
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("failed to reach agent at {url}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        bail!(
+            "agent returned HTTP {status}: {}",
+            crate::client::truncate_body(text.trim(), 300).unwrap_or_default()
+        );
+    }
+
+    let mut out = String::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("error reading agent stream")?;
+        let text = String::from_utf8_lossy(&chunk);
+        for line in text.split('\n') {
+            let line = line.trim_end_matches('\r');
+            if let Some(data) = line.strip_prefix("data:") {
+                let data = data.trim();
+                if data.is_empty() || data == "[DONE]" {
+                    continue;
+                }
+                if let Ok(v) = serde_json::from_str::<Value>(data) {
+                    if let Some(delta) = extract_text_delta(&v) {
+                        out.push_str(&delta);
+                    }
+                } else {
+                    out.push_str(data);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn extract_text_delta(v: &Value) -> Option<String> {
+    if let Some(s) = v.get("delta").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    if v.get("type").and_then(|t| t.as_str()) == Some("text-delta") {
+        if let Some(s) = v.get("delta").and_then(|d| d.as_str()) {
+            return Some(s.to_string());
+        }
+        if let Some(s) = v.get("textDelta").and_then(|d| d.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    if let Some(s) = v.get("text").and_then(|d| d.as_str()) {
+        return Some(s.to_string());
+    }
+    None
+}
+
+async fn run_tui(client: &Client, cfg: &AppConfig, seed: Option<String>) -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let _guard = ChatGuard;
+
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut input = String::new();
+    let mut log: Vec<String> = Vec::new();
+    let mut busy = false;
+    let mut pending: Option<String> = seed;
+
+    loop {
+        if let Some(msg) = pending.take() {
+            busy = true;
+            log.push(format!("you> {msg}"));
+            terminal.draw(|f| draw_chat(f, &log, &input, busy))?;
+            match stream_agent(client, cfg, &msg).await {
+                Ok(reply) => log.push(format!("agent> {reply}")),
+                Err(err) => log.push(format!("error> {err}")),
+            }
+            busy = false;
+        }
+
+        terminal.draw(|f| draw_chat(f, &log, &input, busy))?;
+
+        if event::poll(std::time::Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(k) if k.code == KeyCode::Esc => break,
+                Event::Key(k)
+                    if k.code == KeyCode::Char('c')
+                        && k.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    break
+                }
+                Event::Key(k) if k.code == KeyCode::Enter && !busy => {
+                    let msg = input.trim().to_string();
+                    input.clear();
+                    if msg.eq_ignore_ascii_case("/quit") || msg.eq_ignore_ascii_case("/exit") {
+                        break;
+                    }
+                    if !msg.is_empty() {
+                        pending = Some(msg);
+                    }
+                }
+                Event::Key(k) if k.code == KeyCode::Backspace && !busy => {
+                    input.pop();
+                }
+                Event::Key(k) if matches!(k.code, KeyCode::Char(_)) && !busy => {
+                    if let KeyCode::Char(c) = k.code {
+                        input.push(c);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn draw_chat(
+    f: &mut ratatui::Frame<'_>,
+    log: &[String],
+    input: &str,
+    busy: bool,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(3)])
+        .split(f.area());
+    let body = log.join("\n\n");
+    f.render_widget(
+        Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .title("chm chat (Esc quit)")
+                    .borders(Borders::ALL),
+            ),
+        chunks[0],
+    );
+    let prompt = if busy {
+        "… thinking".to_string()
+    } else {
+        format!("> {input}")
+    };
+    f.render_widget(
+        Paragraph::new(prompt).block(Block::default().title("input").borders(Borders::ALL)),
+        chunks[1],
+    );
+    let _ = io::stdout().flush();
+}

--- a/rust/ch-monitor-cli/src/tui/chat.rs
+++ b/rust/ch-monitor-cli/src/tui/chat.rs
@@ -17,11 +17,7 @@ use ratatui::{
 use reqwest::Client;
 use serde_json::Value;
 
-use crate::{
-    client::apply_auth,
-    config::AppConfig,
-    credentials,
-};
+use crate::{client::apply_auth, config::AppConfig, credentials};
 
 struct ChatGuard;
 
@@ -205,25 +201,18 @@ async fn run_tui(client: &Client, cfg: &AppConfig, seed: Option<String>) -> Resu
     Ok(())
 }
 
-fn draw_chat(
-    f: &mut ratatui::Frame<'_>,
-    log: &[String],
-    input: &str,
-    busy: bool,
-) {
+fn draw_chat(f: &mut ratatui::Frame<'_>, log: &[String], input: &str, busy: bool) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(3), Constraint::Length(3)])
         .split(f.area());
     let body = log.join("\n\n");
     f.render_widget(
-        Paragraph::new(body)
-            .wrap(Wrap { trim: false })
-            .block(
-                Block::default()
-                    .title("chm chat (Esc quit)")
-                    .borders(Borders::ALL),
-            ),
+        Paragraph::new(body).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .title("chm chat (Esc quit)")
+                .borders(Borders::ALL),
+        ),
         chunks[0],
     );
     let prompt = if busy {

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -51,8 +51,7 @@ pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) 
         let now = Instant::now();
         if now >= next_refresh_at {
             if overview {
-                let hosts_url =
-                    format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
+                let hosts_url = format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
                 match client::fetch_cfg(client, cfg, hosts_url).await {
                     Ok(data) => {
                         error_message = None;

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -1,0 +1,155 @@
+//! Terminal UI: chart overview + streaming chat.
+
+pub mod chat;
+
+use std::{
+    io,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use crossterm::{
+    event, execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    widgets::{Block, Borders, Paragraph, Row, Sparkline, Table as TuiTable},
+    Terminal,
+};
+use reqwest::Client;
+
+use crate::{client, config::AppConfig, metrics};
+
+const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+const TUI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+struct TuiGuard;
+
+impl Drop for TuiGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let _guard = TuiGuard;
+
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let mut rows = Vec::new();
+    let mut points = Vec::new();
+    let mut error_message = None;
+    let mut next_refresh_at = Instant::now();
+    let mut hosts_summary = String::new();
+
+    loop {
+        let now = Instant::now();
+        if now >= next_refresh_at {
+            if overview {
+                let hosts_url =
+                    format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
+                match client::fetch_cfg(client, cfg, hosts_url).await {
+                    Ok(data) => {
+                        error_message = None;
+                        if let Some(arr) = data.as_array() {
+                            hosts_summary = format!("{} host(s)", arr.len());
+                        } else {
+                            hosts_summary = "hosts ok".into();
+                        }
+                    }
+                    Err(err) => {
+                        error_message = Some(err.to_string());
+                        hosts_summary.clear();
+                    }
+                }
+            }
+
+            let url = format!(
+                "{}/api/v1/charts/{}?hostId={}",
+                cfg.base_url.trim_end_matches('/'),
+                chart,
+                cfg.host_id
+            );
+            let rows_result = client::fetch_cfg(client, cfg, url)
+                .await
+                .and_then(client::rows_from_chart_data);
+            if rows_result.is_err() && error_message.is_none() {
+                error_message = rows_result.as_ref().err().map(ToString::to_string);
+            } else if rows_result.is_ok() && !overview {
+                error_message = None;
+            }
+            rows = rows_result.unwrap_or_default();
+            points = rows.iter().take(80).map(metrics::row_metric).collect();
+            next_refresh_at = Instant::now() + TUI_REFRESH_INTERVAL;
+        }
+
+        terminal.draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Min(5)].as_ref())
+                .split(f.area());
+            let mode = if overview { "overview" } else { "chart" };
+            f.render_widget(
+                Paragraph::new(format!(
+                    "chm tui ({mode}) | chart={chart} | q=quit | r=refresh | host={}{}{}",
+                    cfg.host_id,
+                    if hosts_summary.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" | {hosts_summary}")
+                    },
+                    error_message
+                        .as_ref()
+                        .map(|message| format!(" | error={message}"))
+                        .unwrap_or_default()
+                )),
+                chunks[0],
+            );
+            let rows_widget: Vec<Row> = rows
+                .iter()
+                .take(10)
+                .filter_map(|r| r.as_object())
+                .map(|o| {
+                    let kv = o
+                        .iter()
+                        .map(|(k, v)| format!("{k}:{v}"))
+                        .collect::<Vec<_>>()
+                        .join(" | ");
+                    Row::new(vec![kv])
+                })
+                .collect();
+            let inner = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(5), Constraint::Min(5)])
+                .split(chunks[1]);
+            let spark = Sparkline::default()
+                .block(Block::default().title("Trend").borders(Borders::ALL))
+                .data(&points);
+            f.render_widget(spark, inner[0]);
+            let table = TuiTable::new(rows_widget, [Constraint::Percentage(100)])
+                .block(Block::default().title("Recent rows").borders(Borders::ALL));
+            f.render_widget(table, inner[1]);
+        })?;
+
+        let poll_timeout = next_refresh_at
+            .saturating_duration_since(Instant::now())
+            .min(TUI_EVENT_POLL_INTERVAL);
+        if event::poll(poll_timeout)? {
+            match event::read()? {
+                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('q')) => break,
+                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('r')) => {
+                    next_refresh_at = Instant::now()
+                }
+                event::Event::Resize(_, _) => continue,
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -12,6 +12,8 @@ use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use crate::cli::Channel;
+
 const RELEASES_API: &str = "https://api.github.com/repos/chmonitor/chmonitor/releases";
 const RELEASE_DOWNLOAD: &str = "https://github.com/chmonitor/chmonitor/releases/download";
 const USER_AGENT: &str = concat!("chm-cli/", env!("CARGO_PKG_VERSION"));
@@ -35,7 +37,7 @@ const SUPPORTED_TARGETS: &[&str] = &[
 ];
 
 #[derive(Debug, Deserialize)]
-struct Release {
+pub(crate) struct Release {
     tag_name: String,
     #[serde(default)]
     prerelease: bool,
@@ -66,12 +68,44 @@ fn parse_version(tag: &str) -> Option<Version> {
 
 /// Pick the newest `chm-v*` tag from a releases list (skips drafts/prereleases).
 fn newest_chm_tag(releases: &[Release]) -> Option<String> {
-    releases
-        .iter()
-        .filter(|r| !r.draft && !r.prerelease && r.tag_name.starts_with("chm-v"))
-        .filter_map(|r| parse_version(&r.tag_name).map(|v| (v, r.tag_name.clone())))
-        .max_by(|a, b| a.0.cmp(&b.0))
-        .map(|(_, tag)| tag)
+    newest_chm_tag_for_channel(releases, Channel::Stable)
+}
+
+/// Pick the newest `chm-v*` tag for a release channel.
+///
+/// - `stable`: published non-prerelease only (drafts skipped).
+/// - `beta`: includes prereleases; when semver cores tie, prefers the prerelease.
+pub fn newest_chm_tag_for_channel(releases: &[Release], channel: Channel) -> Option<String> {
+    let mut best: Option<(Version, bool, String)> = None;
+    for r in releases {
+        if r.draft || !r.tag_name.starts_with("chm-v") {
+            continue;
+        }
+        match channel {
+            Channel::Stable if r.prerelease => continue,
+            Channel::Stable | Channel::Beta => {}
+        }
+        let Some(ver) = parse_version(&r.tag_name) else {
+            continue;
+        };
+        let cand = (ver, r.prerelease, r.tag_name.clone());
+        let take = match &best {
+            None => true,
+            Some(cur) => match cand.0.cmp(&cur.0) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => match channel {
+                    // Beta prefers prerelease when versions match.
+                    Channel::Beta => cand.1 && !cur.1,
+                    Channel::Stable => false,
+                },
+            },
+        };
+        if take {
+            best = Some(cand);
+        }
+    }
+    best.map(|(_, _, tag)| tag)
 }
 
 /// Normalize a user-supplied pin (`chm-v0.2.0`, `v0.2.0`, `0.2.0`, `chm-0.2.0`)
@@ -140,13 +174,20 @@ async fn fetch_releases(client: &Client, max_pages: u32) -> Result<Vec<Release>>
 }
 
 /// Fetch the newest published `chm-v*` release tag.
+#[allow(dead_code)]
 async fn latest_tag(client: &Client) -> Result<String> {
+    latest_tag_for_channel(client, Channel::Stable).await
+}
+
+/// Fetch the newest `chm-v*` release tag for a channel.
+pub async fn latest_tag_for_channel(client: &Client, channel: Channel) -> Result<String> {
     let releases = fetch_releases(client, RELEASES_MAX_PAGES).await?;
-    newest_chm_tag(&releases).ok_or_else(|| {
-        with_fallback(
-            "no published chm-v* release found — pin one with --version chm-vX.Y.Z, \
+    newest_chm_tag_for_channel(&releases, channel).ok_or_else(|| {
+        with_fallback(format!(
+            "no published chm-v* release found for channel {} — pin one with --version chm-vX.Y.Z, \
              or has the CLI been released yet?",
-        )
+            channel.as_str()
+        ))
     })
 }
 
@@ -163,12 +204,22 @@ fn ensure_supported_target() -> Result<()> {
 
 /// `chm update --check` / `chm upgrade --check`: report whether a newer release exists.
 /// Returns `true` when an update is available.
+#[allow(dead_code)]
 pub async fn check(client: &Client) -> Result<bool> {
+    check_channel(client, Channel::Stable).await
+}
+
+/// Channel-aware update check.
+pub async fn check_channel(client: &Client, channel: Channel) -> Result<bool> {
     let current = current_version();
-    let latest_tag = latest_tag(client).await?;
+    let latest_tag = latest_tag_for_channel(client, channel).await?;
     let latest = parse_version(&latest_tag)
         .ok_or_else(|| anyhow!("could not parse latest release tag '{latest_tag}'"))?;
-    println!("chm v{} -> {latest_tag}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "chm v{} ({}) -> {latest_tag}",
+        env!("CARGO_PKG_VERSION"),
+        channel.as_str()
+    );
     if latest > current {
         println!("update available (run `chm update` or `chm upgrade`)");
         Ok(true)
@@ -205,20 +256,64 @@ pub async fn hint(client: &Client) {
 }
 
 /// `chm update` / `chm upgrade` (and `--version <tag>`): download, verify, replace.
+#[allow(dead_code)]
 pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
+    run_channel(client, pinned, Channel::Stable).await
+}
+
+/// True when this binary lives under a Homebrew prefix (Cellar / Caskroom).
+/// Self-update refuses to replace brew-managed installs.
+pub fn is_brew_managed() -> bool {
+    let Ok(exe) = env::current_exe() else {
+        return false;
+    };
+    let path = exe.to_string_lossy().to_ascii_lowercase();
+    path.contains("/cellar/")
+        || path.contains("/caskroom/")
+        || path.contains("/homebrew/")
+        || path.contains("\\homebrew\\")
+}
+
+/// Channel-aware self-update.
+pub async fn run_channel(
+    client: &Client,
+    pinned: Option<String>,
+    channel: Channel,
+) -> Result<()> {
+    if is_brew_managed() {
+        return Err(anyhow!(
+            "this chm binary appears to be managed by Homebrew.\n\
+             Refuse to self-update — run `brew upgrade chm` (or reinstall) instead."
+        ));
+    }
     ensure_supported_target()?;
     let current = current_version();
 
-    let target_tag = match pinned {
-        Some(tag) => normalize_release_tag(&tag),
-        None => latest_tag(client).await?,
+    let target_tag = match &pinned {
+        Some(tag) => normalize_release_tag(tag),
+        None => latest_tag_for_channel(client, channel).await?,
     };
     let target_version = parse_version(&target_tag)
         .ok_or_else(|| anyhow!("could not parse target tag '{target_tag}'"))?;
 
-    println!("chm v{} -> {target_tag}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "chm v{} ({}) -> {target_tag}",
+        env!("CARGO_PKG_VERSION"),
+        channel.as_str()
+    );
 
     if target_version == current {
+        let current_tag = format!("chm-v{}", env!("CARGO_PKG_VERSION"));
+        // On beta, a same-core prerelease tag may still be a different build.
+        let beta_prerelease_bump = matches!(channel, Channel::Beta)
+            && pinned.is_none()
+            && target_tag != current_tag
+            && target_tag.contains('-');
+        if !beta_prerelease_bump {
+            println!("chm is already up to date");
+            return Ok(());
+        }
+    } else if target_version < current && pinned.is_none() {
         println!("chm is already up to date");
         return Ok(());
     }
@@ -418,6 +513,27 @@ mod tests {
         let json = r#"[{"tag_name":"chm-v0.9.0","prerelease":true,"draft":false},{"tag_name":"chm-v0.8.0","prerelease":false,"draft":true},{"tag_name":"chm-v0.5.0","prerelease":false,"draft":false}]"#;
         let releases: Vec<Release> = serde_json::from_str(json).unwrap();
         assert_eq!(newest_chm_tag(&releases).as_deref(), Some("chm-v0.5.0"));
+    }
+
+    #[test]
+    fn beta_channel_prefers_prerelease() {
+        let json = r#"[{"tag_name":"chm-v0.1.2","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.2-beta.1","prerelease":true,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false}]"#;
+        let releases: Vec<Release> = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            newest_chm_tag_for_channel(&releases, Channel::Stable).as_deref(),
+            Some("chm-v0.1.2")
+        );
+        assert_eq!(
+            newest_chm_tag_for_channel(&releases, Channel::Beta).as_deref(),
+            Some("chm-v0.1.2-beta.1")
+        );
+        // Newer stable still wins on beta when semver core is higher.
+        let json2 = r#"[{"tag_name":"chm-v0.2.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.9-beta.9","prerelease":true,"draft":false}]"#;
+        let releases2: Vec<Release> = serde_json::from_str(json2).unwrap();
+        assert_eq!(
+            newest_chm_tag_for_channel(&releases2, Channel::Beta).as_deref(),
+            Some("chm-v0.2.0")
+        );
     }
 
     #[test]

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -275,11 +275,7 @@ pub fn is_brew_managed() -> bool {
 }
 
 /// Channel-aware self-update.
-pub async fn run_channel(
-    client: &Client,
-    pinned: Option<String>,
-    channel: Channel,
-) -> Result<()> {
+pub async fn run_channel(client: &Client, pinned: Option<String>, channel: Channel) -> Result<()> {
     if is_brew_managed() {
         return Err(anyhow!(
             "this chm binary appears to be managed by Homebrew.\n\

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,10 @@
 #
 # Env overrides:
 #   CHM_VERSION       Install a specific release tag (e.g. "chm-v0.1.0").
-#                      Defaults to the latest "chm-v*" release.
+#                      Defaults to the latest "chm-v*" release for CHM_CHANNEL.
+#   CHM_CHANNEL        Release channel: "stable" (default) or "beta".
+#                      stable skips drafts/prereleases; beta prefers
+#                      prereleases and falls back to stable if none exist.
 #   CHM_INSTALL_DIR    Directory to install the binary into.
 #                      Defaults to "$HOME/.local/bin".
 #
@@ -29,6 +32,12 @@ die() {
   log "error: $*"
   exit 1
 }
+
+CHANNEL="$(printf '%s' "${CHM_CHANNEL:-stable}" | tr '[:upper:]' '[:lower:]')"
+case "$CHANNEL" in
+  stable | beta) ;;
+  *) die "CHM_CHANNEL must be stable|beta, got '$CHANNEL'" ;;
+esac
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -69,15 +78,29 @@ EOF
   [ "$a3" -gt "$b3" ]
 }
 
-# Newest published chm-v* tag from GitHub releases JSON (skip drafts/prereleases).
+# Newest published chm-v* tag from GitHub releases JSON for a channel.
+# Args: $1 = releases JSON, $2 = channel (stable|beta, default stable).
+# stable: skip drafts/prereleases; rank by semver core.
+# beta: include prereleases; when semver cores tie, prefer prerelease;
+#       falls back to stable picks when no prereleases exist.
 # Ranks by semver, not list order — dashboard/Helm releases share this API.
 pick_newest_chm_tag() {
   json="$1"
+  channel="${2:-stable}"
   best_tag=""
   best_ver="0.0.0"
+  best_pre="false"
   cur_tag=""
   cur_draft=""
   cur_pre=""
+
+  # Core semver from a chm-v tag (drops -beta.N / +build).
+  tag_core_ver() {
+    v="${1#chm-v}"
+    v="${v%%-*}"
+    v="${v%%+*}"
+    printf '%s\n' "$v"
+  }
 
   consider_tag() {
     tag="$1"
@@ -87,16 +110,43 @@ pick_newest_chm_tag() {
       chm-v*) ;;
       *) return 0 ;;
     esac
-    if [ "$draft" = "true" ] || [ "$pre" = "true" ]; then
+    if [ "$draft" = "true" ]; then
       return 0
     fi
-    ver="${tag#chm-v}"
+    if [ "$channel" = "stable" ] && [ "$pre" = "true" ]; then
+      return 0
+    fi
+    ver="$(tag_core_ver "$tag")"
     case "$ver" in
-      *-*) return 0 ;;
+      '' | *[!0-9.]* | .* | *..) return 0 ;;
     esac
-    if [ -z "$best_tag" ] || semver_gt "$ver" "$best_ver"; then
+    # Stable also rejects tags whose name still carries pre-release metadata
+    # even if the API flag were wrong.
+    if [ "$channel" = "stable" ]; then
+      case "${tag#chm-v}" in
+        *-*) return 0 ;;
+      esac
+    fi
+    if [ -z "$best_tag" ]; then
       best_tag="$tag"
       best_ver="$ver"
+      best_pre="$pre"
+      return 0
+    fi
+    if semver_gt "$ver" "$best_ver"; then
+      best_tag="$tag"
+      best_ver="$ver"
+      best_pre="$pre"
+      return 0
+    fi
+    if semver_gt "$best_ver" "$ver"; then
+      return 0
+    fi
+    # Equal core: beta prefers the prerelease when versions match.
+    if [ "$channel" = "beta" ] && [ "$pre" = "true" ] && [ "$best_pre" != "true" ]; then
+      best_tag="$tag"
+      best_ver="$ver"
+      best_pre="$pre"
     fi
     return 0
   }
@@ -155,11 +205,31 @@ if [ "${CHM_INSTALL_SELF_TEST:-}" = "1" ]; then
   [ "$(normalize_chm_tag 'v0.2.0')" = "chm-v0.2.0" ]
   [ "$(normalize_chm_tag 'chm-v0.2.0')" = "chm-v0.2.0" ]
   json='[{"tag_name":"chm-v0.1.0","prerelease":false,"draft":true},{"tag_name":"v0.3.3","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false},{"tag_name":"chm-v0.2.0","prerelease":true,"draft":false}]'
-  got="$(pick_newest_chm_tag "$json")"
+  got="$(pick_newest_chm_tag "$json" stable)"
   if [ "$got" != "chm-v0.1.1" ]; then
-    die "pick_newest_chm_tag: expected chm-v0.1.1, got '$got'"
+    die "pick_newest_chm_tag stable: expected chm-v0.1.1, got '$got'"
   fi
-  empty="$(pick_newest_chm_tag '[]')"
+  # Default channel is stable when omitted.
+  got_default="$(pick_newest_chm_tag "$json")"
+  if [ "$got_default" != "chm-v0.1.1" ]; then
+    die "pick_newest_chm_tag default: expected chm-v0.1.1, got '$got_default'"
+  fi
+  got_beta="$(pick_newest_chm_tag "$json" beta)"
+  if [ "$got_beta" != "chm-v0.2.0" ]; then
+    die "pick_newest_chm_tag beta: expected prerelease chm-v0.2.0, got '$got_beta'"
+  fi
+  # Beta prefers prerelease when semver cores tie; newer stable still wins.
+  json_tie='[{"tag_name":"chm-v0.1.2","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.2-beta.1","prerelease":true,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false}]'
+  got_tie="$(pick_newest_chm_tag "$json_tie" beta)"
+  if [ "$got_tie" != "chm-v0.1.2-beta.1" ]; then
+    die "pick_newest_chm_tag beta tie: expected chm-v0.1.2-beta.1, got '$got_tie'"
+  fi
+  json_fallback='[{"tag_name":"chm-v0.1.0","prerelease":false,"draft":false},{"tag_name":"chm-v0.1.1","prerelease":false,"draft":false}]'
+  got_fb="$(pick_newest_chm_tag "$json_fallback" beta)"
+  if [ "$got_fb" != "chm-v0.1.1" ]; then
+    die "pick_newest_chm_tag beta fallback: expected chm-v0.1.1, got '$got_fb'"
+  fi
+  empty="$(pick_newest_chm_tag '[]' stable)"
   [ -z "$empty" ]
   log "install.sh self-test ok"
   exit 0
@@ -175,15 +245,15 @@ resolve_version() {
     return
   fi
 
-  log "Looking up latest published chm-v* release..."
+  log "Looking up latest ${CHANNEL} chm-v* release..."
   releases_json="$(curl -fsSL -H "User-Agent: chmonitor-installer" \
     "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null)" \
     || die "failed to query GitHub releases API for ${REPO}. Fallback: cargo install ch-monitor-cli --force"
 
-  tag="$(pick_newest_chm_tag "$releases_json")"
+  tag="$(pick_newest_chm_tag "$releases_json" "$CHANNEL")"
 
   if [ -z "$tag" ]; then
-    die "no published chm-v* release found for ${REPO} yet. Pin one with CHM_VERSION=chm-vX.Y.Z, or: cargo install ch-monitor-cli --force"
+    die "no published chm-v* release found for ${REPO} (channel=${CHANNEL}) yet. Pin one with CHM_VERSION=chm-vX.Y.Z, or: cargo install ch-monitor-cli --force"
   fi
 
   printf '%s\n' "$tag"
@@ -194,7 +264,7 @@ BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 BIN_URL="${BASE_URL}/${ASSET_NAME}"
 SHA_URL="${BASE_URL}/${ASSET_NAME}.sha256"
 
-log "Installing chmonitor CLI ${VERSION} (${TARGET})..."
+log "Installing chmonitor CLI ${VERSION} (${TARGET}, channel=${CHANNEL})..."
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rewrites the `chm` Rust CLI (auth, TUI, agent, dual release channels) and adds dashboard device-flow support. Self-hosted deployments can keep device login **off** (default) or opt into **device-only** tokens on a trusted network.

## Changes

- Modular `ch-monitor-cli` (`0.1.2`): auth/config/client/TUI/agent/doctor, default `https://dash.chmonitor.dev`, Bearer + `x-api-key`
- Beta/stable install + CI release channels (`CHM_CHANNEL`)
- Dashboard device flow (`/api/v1/auth/device/*`, `/device`) with D1 + in-memory fallback
- **`CHM_DEVICE_LOGIN`**: `auto` (cloud on / OSS off) | `true` | `false`; with `CHM_AUTH_PROVIDER=none` + `true` → device-only approve (no Clerk); subject via `CHM_DEVICE_LOGIN_SUBJECT`
- Env/docs: `.env.example`, environment-variables, api-keys, public auth, Helm values, standalone-cli + cloud-saas knowledge/skill
- `cargo fmt` applied so rust-cli CI passes

## Test plan

- [x] `bun test` device-login-config, device-code-store, api-guard (23 pass)
- [x] Live OSS default: `GET /api/v1/auth/device/status` → `enabled:false`; `POST .../code` → 503
- [x] Device-only E2E script: `CHM_DEVICE_LOGIN=true` + auth=none mints/verifies `chm_` token bound to `self-hosted`
- [x] `cargo fmt --check` + `cargo test` (50 pass) after rustfmt
- [ ] CI: `unit-tests` / `dashboard` / `rust-cli` green → auto-merge squash

## Notes for reviewer

Self-hosted internal networks leave device login **disabled by design** under `auto`. Opt in:

```bash
CHM_API_KEY_SECRET=…
CHM_DEVICE_LOGIN=true
```

Auto-merge is armed (`--auto --squash`). Non-required checks (`e2e-test`, `component-test`) may stay red without blocking.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4027962-a860-4751-a3e5-860e1fda24be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4027962-a860-4751-a3e5-860e1fda24be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

