### PR TITLE
feat(cli): auth auto-detect, TUI panes, and chm/chmonitor alias

### DIFF
--- a/.github/workflows/cli-rust-release.yml
+++ b/.github/workflows/cli-rust-release.yml
@@ -24,35 +24,31 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: cli-rust-release-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            bin: chm
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            bin: chm
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            bin: chm
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            bin: chm
-    runs-on: ${{ matrix.os }}
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      channel: ${{ steps.meta.outputs.channel }}
+      should_publish: ${{ steps.meta.outputs.should_publish }}
+      make_latest: ${{ steps.meta.outputs.make_latest }}
+      checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
     steps:
       - uses: actions/checkout@v7
         with:
-          # On tag push this is the tag itself; on dispatch, check out the
-          # requested tag so the built binary matches the release version.
-          # On main push this is refs/heads/main (beta prerelease build).
           ref: ${{ inputs.tag || github.ref }}
       - name: Release meta
         id: meta
         run: |
           set -euo pipefail
+          checkout_ref="${{ inputs.tag || github.ref }}"
+          echo "checkout_ref=${checkout_ref}" >> "$GITHUB_OUTPUT"
+
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
             version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' rust/ch-monitor-cli/Cargo.toml | head -n1)"
             if [ -z "$version" ]; then
@@ -69,12 +65,45 @@ jobs:
             echo "tag=chm-v${version}-beta.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "channel=beta" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
           else
             tag="${{ inputs.tag || github.ref_name }}"
+            if [ -z "$tag" ]; then
+              echo "stable release requires inputs.tag or a chm-v* tag push" >&2
+              exit 1
+            fi
             echo "tag=${tag}" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "channel=stable" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+            # Publish on tag push, workflow_dispatch with tag, or (above) main beta.
+            if [ "${{ github.ref_type }}" = "tag" ] || [ -n "${{ inputs.tag }}" ]; then
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
+
+  build:
+    needs: meta
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.meta.outputs.checkout_ref }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -83,6 +112,7 @@ jobs:
           # ch-monitor-cli is a member of the rust/ Cargo workspace, so it
           # builds into the shared rust/target dir.
           workspaces: rust -> target
+          key: ${{ matrix.target }}
       - name: Install Linux ARM64 linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -95,19 +125,113 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
       - name: Package
         run: |
+          set -euo pipefail
           mkdir -p dist
           # The crate's [[bin]] is named `chm` (so `cargo install` matches the docs).
-          cp rust/target/${{ matrix.target }}/release/chm dist/${{ matrix.bin }}-${{ matrix.target }}
+          cp "rust/target/${{ matrix.target }}/release/chm" "dist/chm-${{ matrix.target }}"
           cd dist
-          shasum -a 256 ${{ matrix.bin }}-${{ matrix.target }} > ${{ matrix.bin }}-${{ matrix.target }}.sha256
-      - uses: softprops/action-gh-release@v3
-        if: >-
-          github.ref_type == 'tag' ||
-          inputs.tag != '' ||
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          shasum -a 256 "chm-${{ matrix.target }}" > "chm-${{ matrix.target }}.sha256"
+          ls -la
+      - uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.tag }}
-          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
+          name: chm-${{ matrix.target }}
+          path: |
+            dist/chm-${{ matrix.target }}
+            dist/chm-${{ matrix.target }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: [meta, build]
+    if: needs.meta.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: chm-*
+          merge-multiple: true
+      - name: Assert expected assets before upload
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          expected=(
+            chm-x86_64-unknown-linux-gnu
+            chm-x86_64-unknown-linux-gnu.sha256
+            chm-aarch64-unknown-linux-gnu
+            chm-aarch64-unknown-linux-gnu.sha256
+            chm-x86_64-apple-darwin
+            chm-x86_64-apple-darwin.sha256
+            chm-aarch64-apple-darwin
+            chm-aarch64-apple-darwin.sha256
+          )
+          echo "Artifacts present:"
+          ls -la
+          missing=0
+          for f in "${expected[@]}"; do
+            if [ ! -f "$f" ]; then
+              echo "MISSING: $f" >&2
+              missing=1
+            else
+              echo "ok: $f ($(wc -c < "$f") bytes)"
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "expected 8 release assets (4 binaries + 4 sha256); aborting publish" >&2
+            exit 1
+          fi
+          count="$(find . -maxdepth 1 -type f | wc -l | tr -d ' ')"
+          if [ "$count" -ne 8 ]; then
+            echo "expected exactly 8 files in dist/, found $count" >&2
+            exit 1
+          fi
+      - name: Create / update GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.meta.outputs.tag }}
+          name: ${{ needs.meta.outputs.tag }}
+          prerelease: ${{ needs.meta.outputs.prerelease == 'true' }}
+          make_latest: ${{ needs.meta.outputs.make_latest }}
           files: dist/*
           generate_release_notes: true
+          fail_on_unmatched_files: true
+      - name: Verify release assets after upload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          expected=(
+            chm-x86_64-unknown-linux-gnu
+            chm-x86_64-unknown-linux-gnu.sha256
+            chm-aarch64-unknown-linux-gnu
+            chm-aarch64-unknown-linux-gnu.sha256
+            chm-x86_64-apple-darwin
+            chm-x86_64-apple-darwin.sha256
+            chm-aarch64-apple-darwin
+            chm-aarch64-apple-darwin.sha256
+          )
+          # softprops may need a moment for the Assets API to settle.
+          assets=""
+          for attempt in 1 2 3 4 5; do
+            assets="$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" --jq '[.assets[].name] | join("\n")')"
+            missing=0
+            for f in "${expected[@]}"; do
+              if ! printf '%s\n' "$assets" | grep -Fxq "$f"; then
+                missing=1
+                break
+              fi
+            done
+            if [ "$missing" -eq 0 ]; then
+              echo "All 8 assets present on release ${TAG}:"
+              printf '%s\n' "$assets"
+              exit 0
+            fi
+            echo "attempt ${attempt}: assets incomplete, retrying in 5s…" >&2
+            sleep 5
+          done
+          echo "Release ${TAG} is missing expected assets after upload." >&2
+          echo "Found:" >&2
+          printf '%s\n' "$assets" >&2
+          exit 1

--- a/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/api-guard.test.ts
@@ -226,3 +226,39 @@ describe('device-flow paths are public (handler owns auth)', () => {
     expect(result).toBeNull()
   })
 })
+
+describe('GET /api/v1/auth/cli is public CLI discovery', () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  function cliAuthReq(): Request {
+    return new Request('https://dash.example.com/api/v1/auth/cli')
+  }
+
+  it('passes anonymous callers when API-key auth is on', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'none'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const result = await getApiKeyAuthFailure(cliAuthReq())
+    expect(result).toBeNull()
+  })
+
+  it('passes anonymous callers when clerk requires a session', async () => {
+    process.env.CHM_AUTH_PROVIDER = 'clerk'
+    process.env.CHM_API_KEY_SECRET = TEST_SECRET
+    const result = await getApiKeyAuthFailure(cliAuthReq())
+    expect(result).toBeNull()
+  })
+})

--- a/apps/dashboard/src/lib/auth/__tests__/cli-auth-discovery.test.ts
+++ b/apps/dashboard/src/lib/auth/__tests__/cli-auth-discovery.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+
+import { resolveCliAuthDiscovery } from '../cli-auth-discovery'
+
+describe('resolveCliAuthDiscovery', () => {
+  it('method=none when auth=none and no API key secret (open API)', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_AUTH_PROVIDER: 'none',
+      CHM_CLOUD_MODE: 'false',
+    })
+    expect(d.method).toBe('none')
+    expect(d.api).toBe('open')
+    expect(d.authProvider).toBe('none')
+    expect(d.deviceLogin.enabled).toBe(false)
+    expect(d.hint).toMatch(/open/i)
+  })
+
+  it('method=device when device login is enabled (cloud + secret)', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_CLOUD_MODE: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'clerk',
+      CHM_CLOUD_D1: '1',
+    })
+    expect(d.method).toBe('device')
+    expect(d.api).toBe('key_required')
+    expect(d.authProvider).toBe('clerk')
+    expect(d.deviceLogin.enabled).toBe(true)
+    expect(d.deviceLogin.deviceOnly).toBe(false)
+    expect(d.hint).toMatch(/device/i)
+  })
+
+  it('method=device for self-hosted opt-in (device-only)', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_DEVICE_LOGIN: 'true',
+      CHM_CLOUD_MODE: 'false',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'none',
+    })
+    expect(d.method).toBe('device')
+    expect(d.api).toBe('key_required')
+    expect(d.deviceLogin.enabled).toBe(true)
+    expect(d.deviceLogin.deviceOnly).toBe(true)
+    expect(d.hint).toMatch(/device-only/i)
+  })
+
+  it('method=api_key when secret set but device login off (OSS default)', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_AUTH_PROVIDER: 'none',
+      CHM_CLOUD_MODE: 'false',
+      CHM_API_KEY_SECRET: 'secret',
+    })
+    expect(d.method).toBe('api_key')
+    expect(d.api).toBe('key_required')
+    expect(d.deviceLogin.enabled).toBe(false)
+    expect(d.hint).toMatch(/API key/i)
+  })
+
+  it('prefers device over api_key when both would apply', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_DEVICE_LOGIN: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+      CHM_AUTH_PROVIDER: 'none',
+      CHM_CLOUD_MODE: 'false',
+    })
+    expect(d.method).toBe('device')
+  })
+
+  it('cloud deployment mode without explicit provider → clerk + device when secret', () => {
+    const d = resolveCliAuthDiscovery({
+      CHM_DEPLOYMENT_MODE: 'cloud',
+      CHM_CLOUD_MODE: 'true',
+      CHM_API_KEY_SECRET: 'secret',
+    })
+    expect(d.authProvider).toBe('clerk')
+    expect(d.method).toBe('device')
+  })
+})

--- a/apps/dashboard/src/lib/auth/api-guard.ts
+++ b/apps/dashboard/src/lib/auth/api-guard.ts
@@ -26,6 +26,7 @@
  *    `/api/v1/auth/device/code` + `/api/v1/auth/device/approve` +
  *    `/api/v1/auth/device/status` + `/api/v1/auth/token` (OAuth device flow;
  *    approve owns its own session / device-only checks),
+ *    `/api/v1/auth/cli` (CLI auth-method discovery — no secrets),
  *    and `/api/v1/openapi.json` (public discovery document).
  *
  * Also reproduced from the Next middleware: the cloud→dash 301 redirect
@@ -55,6 +56,8 @@ const DEVICE_CODE_PATH = '/api/v1/auth/device/code'
 const DEVICE_APPROVE_PATH = '/api/v1/auth/device/approve'
 const DEVICE_STATUS_PATH = '/api/v1/auth/device/status'
 const DEVICE_TOKEN_PATH = '/api/v1/auth/token'
+// CLI probes this before login — must stay public when API-key auth is on.
+const CLI_AUTH_DISCOVERY_PATH = '/api/v1/auth/cli'
 // OpenAPI descriptor is a public discovery document (RFC 9727 service-desc).
 const OPENAPI_SPEC_PATH = '/api/v1/openapi.json'
 // Product changelog for the What's new dialog — public GitHub notes, no secrets.
@@ -178,6 +181,7 @@ export async function getApiKeyAuthFailure(
     pathname === DEVICE_APPROVE_PATH ||
     pathname === DEVICE_STATUS_PATH ||
     pathname === DEVICE_TOKEN_PATH ||
+    pathname === CLI_AUTH_DISCOVERY_PATH ||
     pathname === OPENAPI_SPEC_PATH ||
     pathname === RELEASES_PATH
   ) {

--- a/apps/dashboard/src/lib/auth/cli-auth-discovery.ts
+++ b/apps/dashboard/src/lib/auth/cli-auth-discovery.ts
@@ -1,0 +1,118 @@
+/**
+ * CLI auth auto-detection for `chm auth login`.
+ *
+ * Public discovery at `GET /api/v1/auth/cli` — the CLI probes this once and
+ * branches without any `auth_mode` in chm.toml:
+ *
+ *   - `none`    — auth=none and no `CHM_API_KEY_SECRET` (API is open)
+ *   - `device`  — device login enabled (`resolveDeviceLogin().enabled`)
+ *   - `api_key` — API key required, device login off (typical self-hosted
+ *                 without meta DB / without `CHM_DEVICE_LOGIN=true`)
+ */
+
+import { apiKeyAuthEnabled } from '@chm/mcp-server/auth'
+import {
+  type DeviceLoginStatus,
+  resolveDeviceLogin,
+} from '@/lib/auth/device-login-config'
+import { type AuthProvider, parseAuthProvider } from '@/lib/auth/provider'
+
+export type CliAuthMethod = 'none' | 'device' | 'api_key'
+export type CliApiAccess = 'open' | 'key_required'
+
+export interface CliAuthDiscovery {
+  /** Whether anonymous `/api/v1/*` calls need a `chm_` key. */
+  api: CliApiAccess
+  authProvider: AuthProvider
+  deviceLogin: DeviceLoginStatus
+  /** Recommended login path for `chm auth login`. */
+  method: CliAuthMethod
+  /** One-line operator / CLI hint. */
+  hint: string
+}
+
+function resolveAuthProvider(
+  source: Record<string, string | undefined>
+): AuthProvider {
+  try {
+    const authRaw =
+      source.CHM_AUTH_PROVIDER ??
+      source.VITE_AUTH_PROVIDER ??
+      (typeof import.meta !== 'undefined'
+        ? import.meta.env?.VITE_AUTH_PROVIDER
+        : undefined)
+    if (authRaw) {
+      return parseAuthProvider(authRaw)
+    }
+    const profile = (
+      source.CHM_DEPLOYMENT_MODE ??
+      source.VITE_DEPLOYMENT_MODE ??
+      ''
+    )
+      .trim()
+      .toLowerCase()
+    return profile === 'cloud' || profile === 'saas' ? 'clerk' : 'none'
+  } catch {
+    return 'none'
+  }
+}
+
+function hintFor(
+  method: CliAuthMethod,
+  deviceLogin: DeviceLoginStatus
+): string {
+  switch (method) {
+    case 'none':
+      return 'Dashboard API is open (auth=none, no API key). No login needed.'
+    case 'device':
+      return deviceLogin.deviceOnly
+        ? 'Device login enabled (device-only). Open /device to approve.'
+        : 'Device login enabled. Sign in via browser device flow.'
+    case 'api_key':
+      return 'API key required. Pass --api-key / CHM_API_KEY, or mint one with POST /api/v1/auth/api-key.'
+    default: {
+      const _exhaustive: never = method
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Resolve how the CLI should authenticate against this dashboard.
+ * Pure w.r.t. env bag (same pattern as `resolveDeviceLogin`).
+ */
+export function resolveCliAuthDiscovery(
+  runtimeEnv?: Record<string, string | undefined>
+): CliAuthDiscovery {
+  const source =
+    runtimeEnv ??
+    (typeof process !== 'undefined'
+      ? (process.env as Record<string, string | undefined>)
+      : {})
+
+  const deviceLogin = resolveDeviceLogin(runtimeEnv)
+  const authProvider = resolveAuthProvider(source)
+
+  // Prefer apiKeyAuthEnabled when using live process.env; for mock bags check
+  // the bag directly so unit tests don't need to mutate process.env first.
+  const keyRequired = runtimeEnv
+    ? Boolean(runtimeEnv.CHM_API_KEY_SECRET?.trim())
+    : apiKeyAuthEnabled()
+
+  let method: CliAuthMethod
+  if (deviceLogin.enabled) {
+    method = 'device'
+  } else if (keyRequired) {
+    method = 'api_key'
+  } else {
+    method = 'none'
+  }
+
+  return {
+    api: keyRequired ? 'key_required' : 'open',
+    authProvider,
+    deviceLogin,
+    method,
+    hint: hintFor(method, deviceLogin),
+  }
+}

--- a/apps/dashboard/src/routes/api/v1/auth/cli.ts
+++ b/apps/dashboard/src/routes/api/v1/auth/cli.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /api/v1/auth/cli
+ *
+ * Public discovery for `chm auth login`: which auth method the CLI should use
+ * (`none` | `device` | `api_key`). No secrets — enablement + hints only.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { resolveCliAuthDiscovery } from '@/lib/auth/cli-auth-discovery'
+import { deviceCodeStoreKind } from '@/lib/auth/device-code-store'
+
+function handleGet(): Response {
+  const discovery = resolveCliAuthDiscovery()
+  const store = discovery.deviceLogin.enabled
+    ? deviceCodeStoreKind()
+    : discovery.deviceLogin.store
+
+  const deviceLogin = {
+    enabled: discovery.deviceLogin.enabled,
+    mode: discovery.deviceLogin.mode,
+    deviceOnly: discovery.deviceLogin.deviceOnly,
+    reason: discovery.deviceLogin.reason,
+    store,
+    subject: discovery.deviceLogin.deviceOnly
+      ? discovery.deviceLogin.subject
+      : undefined,
+  }
+
+  const payload = {
+    api: discovery.api,
+    authProvider: discovery.authProvider,
+    deviceLogin,
+    method: discovery.method,
+    hint: discovery.hint,
+  }
+
+  return Response.json({ data: payload, ...payload })
+}
+
+export const Route = createFileRoute('/api/v1/auth/cli')({
+  server: {
+    handlers: {
+      GET: async () => handleGet(),
+    },
+  },
+})

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -22,14 +22,17 @@ curl -sSf https://chmonitor.dev/install.sh | bash
 ```
 
 Already have a Rust toolchain? `cargo install` works too and builds the same
-binary from [crates.io](https://crates.io/crates/ch-monitor-cli):
+binaries (`chm` and `chmonitor`) from
+[crates.io](https://crates.io/crates/ch-monitor-cli):
 
 ```bash
 cargo install ch-monitor-cli
+# both `chm` and `chmonitor` land in ~/.cargo/bin
 ```
 
 ```bash
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
+# same as: chmonitor diagnose
 ```
 
 <Callout type="info" title="No release yet? Build from source">

--- a/docs/content/operate/authentication/api-keys.mdx
+++ b/docs/content/operate/authentication/api-keys.mdx
@@ -66,7 +66,16 @@ curl https://dash.example.com/api/mcp \
 
 ## Device login (`chm auth login`)
 
-RFC 8628 device flow for the Rust CLI. Controlled by `CHM_DEVICE_LOGIN`:
+`chm auth login` **auto-detects** the dashboard auth mode via
+`GET /api/v1/auth/cli` (public; no `auth_mode` in `chm.toml`):
+
+| Discovery `method` | Meaning | CLI action |
+|--------------------|---------|------------|
+| `none` | Open API (`auth=none`, no `CHM_API_KEY_SECRET`) | No credentials needed |
+| `device` | Device login enabled | RFC 8628 browser flow |
+| `api_key` | Key required, device off | Prompt / `--api-key` / `CHM_API_KEY` |
+
+Device login itself is controlled by `CHM_DEVICE_LOGIN`:
 
 | Value | Behaviour |
 |-------|-----------|
@@ -81,7 +90,8 @@ CHM_API_KEY_SECRET=a-long-random-string
 CHM_DEVICE_LOGIN=true
 ```
 
-Discovery: `GET /api/v1/auth/device/status` returns `{ enabled, mode, deviceOnly, reason, store }`.
+Discovery: `GET /api/v1/auth/cli` returns `{ method, api, authProvider, deviceLogin, hint }`.
+Legacy: `GET /api/v1/auth/device/status` returns `{ enabled, mode, deviceOnly, reason, store }`.
 
 ## Troubleshooting
 
@@ -93,7 +103,7 @@ The `/api/mcp` endpoint also accepts Clerk OAuth bearer tokens. If you are using
 Feature-level permissions apply on top of the key auth. Even an authenticated caller may be denied a specific feature. See [Feature Permissions](/operate/advanced/feature-permissions).
 </Accordion>
 <Accordion title="chm auth login gets 503 on my self-hosted dashboard">
-Device login defaults to off for OSS (`CHM_DEVICE_LOGIN=auto`). Set `CHM_DEVICE_LOGIN=true` and `CHM_API_KEY_SECRET`, or mint a key with `POST /api/v1/auth/api-key` and pass it as `--api-key` / `CHM_API_KEY`.
+`chm auth login` auto-detects via `/api/v1/auth/cli`. Device login defaults to off for OSS (`CHM_DEVICE_LOGIN=auto`), so discovery usually returns `method=api_key`. Set `CHM_DEVICE_LOGIN=true` and `CHM_API_KEY_SECRET` for the browser flow, or mint a key with `POST /api/v1/auth/api-key` and pass `--api-key` / `CHM_API_KEY`.
 </Accordion>
 </Accordions>
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -49,16 +49,17 @@ Credentials (device-login token / API key) live in the OS keyring, with a
 ```text
 chm
 ├── auth
-│   ├── login      # device-code flow → store Bearer token
+│   ├── login [--api-key]  # auto-detect none|device|api_key
 │   ├── logout     # clear keyring credentials
-│   └── status     # whether a token / API key is present
+│   ├── status     # whether a token / API key is present
+│   └── token      # print stored bearer token (CI)
 ├── config         # show / edit local config
 ├── hosts          # GET /api/v1/hosts
 ├── link [path]    # open dashboard in browser
-├── chart <name>   # GET /api/v1/charts/{name}
-├── table <name>   # GET /api/v1/tables/{name}
-├── tui [chart]    # live terminal UI (--overview for metrics)
-├── chat [msg]     # stream AI agent reply
+├── chart <name>   # GET /api/v1/charts/{name} (+ braille sparkline + min/max/avg)
+├── table <name>   # GET /api/v1/tables/{name} (--explain for columns / SQL)
+├── tui [chart]    # multi-pane TUI: 1=overview 2=chart 3=table (alt-screen)
+├── chat [msg]     # stream AI agent reply (alt-screen when interactive)
 ├── agent [msg]    # alias of chat
 ├── doctor         # local + API connectivity checks
 ├── diagnose       # direct host health (no dashboard)
@@ -71,10 +72,30 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- auth login
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- hosts
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- chart query-count --limit 50
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --limit 30
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --explain
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- tui query-count
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merges slow?"
 ```
+
+## TUI (`chm tui`)
+
+Multi-pane live UI (ratatui + crossterm). **Only** `chm tui` and interactive
+`chm chat` enter the terminal alternate screen; other commands stay on the
+normal screen.
+
+| Key | Action |
+|-----|--------|
+| `1` | Overview — hosts summary + default chart sparkline |
+| `2` | Chart — current chart sparkline + recent rows |
+| `3` | Table — `/api/v1/tables/{name}` (default `running-queries`, `--table` / `--page-size`) |
+| `h` / `l` or `[` / `]` | Decrement / increment session `host_id` (clamped ≥ 0) |
+| `j` / `k` or ↑ / ↓ | Scroll table pane |
+| `r` | Refresh now |
+| `q` | Quit |
+
+Header shows mode, host, channel, chart, and table name. Start in overview with
+`--overview`.
 
 ## Channels
 
@@ -85,9 +106,23 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merge
 | `stable` (default) | Skip prereleases; prefer the latest stable `chm-v*` tag |
 | `beta` | Include prereleases; prefer a prerelease when semver cores tie |
 
-## Auth (device flow + API keys)
+## Auth (auto-detect: none / device / API key)
 
-Device login is gated by **`CHM_DEVICE_LOGIN`** (`auto` | `true` | `false`,
+`chm auth login` probes **`GET /api/v1/auth/cli`** (public) and branches on
+`method` — there is **no** `auth_mode` in `chm.toml`:
+
+| `method` | When | CLI behaviour |
+|----------|------|----------------|
+| `none` | `CHM_AUTH_PROVIDER=none` and no `CHM_API_KEY_SECRET` | Prints that the API is open; no credentials stored |
+| `device` | Device login enabled (`resolveDeviceLogin`) | Existing RFC 8628 browser flow → store Bearer token |
+| `api_key` | Secret set, device off (typical OSS without meta DB) | Prompt for a `chm_` key, or `--api-key` / `CHM_API_KEY` |
+
+Older dashboards without `/auth/cli` fall back to `GET /api/v1/auth/device/status`
+plus an anonymous `GET /api/v1/hosts` probe. `chm doctor` shows `auth_method`
+from the same discovery; credentials are OK when `method=none`.
+`chm auth token` prints the stored bearer token to stdout (CI).
+
+Device login is still gated by **`CHM_DEVICE_LOGIN`** (`auto` | `true` | `false`,
 default `auto`):
 
 | Deployment | `auto` behaviour |
@@ -100,13 +135,15 @@ Opt in on self-hosted with `CHM_DEVICE_LOGIN=true`. With
 can reach `/device` completes the flow; minted tokens use subject
 `CHM_DEVICE_LOGIN_SUBJECT` (default `self-hosted`). Codes persist in D1 when
 bound, otherwise an in-memory store (single-node). Force off with
-`CHM_DEVICE_LOGIN=false`. Status: `GET /api/v1/auth/device/status`.
+`CHM_DEVICE_LOGIN=false`.
 
 Dashboard auth endpoints:
 
-1. `POST /api/v1/auth/device/code` — public when enabled; returns `{ data: { device_code, user_code, verification_uri, … } }` (also flattened for OAuth clients). 503 when disabled or missing `CHM_API_KEY_SECRET`.
-2. Browser opens `/device?user_code=…` → approve via `POST /api/v1/auth/device/approve` (Clerk/proxy session, or device-only when auth=`none`).
-3. CLI polls `POST /api/v1/auth/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`. Pending → `{ error: "authorization_pending" }` (400). Success → `{ access_token }` (`chm_` key, 30 days, all scopes).
+1. `GET /api/v1/auth/cli` — public discovery: `{ method, api, authProvider, deviceLogin, hint }`.
+2. `GET /api/v1/auth/device/status` — device enablement only (legacy / UI).
+3. `POST /api/v1/auth/device/code` — public when enabled; returns `{ data: { device_code, user_code, verification_uri, … } }` (also flattened for OAuth clients). 503 when disabled or missing `CHM_API_KEY_SECRET`.
+4. Browser opens `/device?user_code=…` → approve via `POST /api/v1/auth/device/approve` (Clerk/proxy session, or device-only when auth=`none`).
+5. CLI polls `POST /api/v1/auth/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`. Pending → `{ error: "authorization_pending" }` (400). Success → `{ access_token }` (`chm_` key, 30 days, all scopes).
 
 Programmatic requests may send **either** `Authorization: Bearer chm_…` **or**
 `x-api-key: chm_…` (the CLI sends both when configured). The dashboard

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -17,7 +17,12 @@ related:
 
 # Standalone chmonitor CLI (Rust)
 
-`rust/ch-monitor-cli` is the `chm` binary. By default it talks to **chmonitor
+`rust/ch-monitor-cli` ships two command names for the same binary: **`chm`**
+(short, preferred) and **`chmonitor`** (full alias). Release assets stay
+`chm-<target>`; `scripts/install.sh` installs `chm` and symlinks `chmonitor`.
+`cargo install ch-monitor-cli` installs both binaries.
+
+By default it talks to **chmonitor
 Cloud** at `https://dash.chmonitor.dev` (hosts / charts / tables / TUI / agent).
 Self-hosted dashboards work the same way — point `--base-url` /
 `CHM_BASE_URL` at your instance. A separate `diagnose` subcommand connects

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -246,27 +246,52 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
 ## CI & Release
 
 - **CI**: `cli-rust-ci.yml` — fmt, clippy, build, test
-- **Release**: Tag format `chm-v*` (e.g. `chm-v0.1.0`)
-- **Release workflow**: `cli-rust-release.yml` builds 4 targets
-  (`x86_64`/`aarch64` × `unknown-linux-gnu`/`apple-darwin`, no Windows) and
-  uploads each binary plus a `.sha256` checksum file to the GitHub Release as
-  `chm-<target>` / `chm-<target>.sha256`. Only runs the upload step on an
-  actual tag push (`github.ref_type == 'tag'`); `workflow_dispatch` builds but
-  doesn't publish.
+- **Platforms**: Linux + macOS × `x86_64` + `aarch64` only (no Windows yet).
+  Asset names: `chm-<target>` and `chm-<target>.sha256` for each of
+  `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
+  `x86_64-apple-darwin`, `aarch64-apple-darwin` (8 files per release).
+- **Release workflow** (`cli-rust-release.yml`): split into `meta` → `build`
+  (matrix, upload-artifact per target) → `publish` (download all artifacts,
+  softprops **once**, assert all 8 assets before and after upload).
+  Concurrency group `cli-rust-release-${{ inputs.tag || github.ref }}`
+  (`cancel-in-progress: false`).
+
+### Beta (prerelease from `main`)
+
+Every push to `main` that touches CLI paths
+(`rust/ch-monitor-cli/**`, `rust/Cargo.lock`, `rust/Cargo.toml`,
+`.github/workflows/cli-rust-release.yml`, `scripts/install.sh`) publishes a
+**prerelease** tag `chm-vX.Y.Z-beta.N` where `X.Y.Z` is
+`rust/ch-monitor-cli/Cargo.toml`’s version and `N` is `github.run_number`.
+`make_latest=false`. Versions outside `0.1.x` are refused.
+
+### Stable (release-please + dispatch)
+
+1. release-please opens `chore(main): release cli chm-vX.Y.Z` when CLI commits
+   warrant a stable bump.
+2. Merging that PR tags `chm-vX.Y.Z` and dispatches `cli-rust-release.yml`
+   with `tag=` (GITHUB_TOKEN-created tags do not fire `on: push: tags`).
+3. Direct `workflow_dispatch` with a tag, or a human-pushed stable
+   `chm-vX.Y.Z` tag, also publish. `prerelease=false`, `make_latest=true`.
 
 ## One-line install (`scripts/install.sh`)
 
 ```bash
+# Stable (default)
 curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
+
+# Beta channel
+CHM_CHANNEL=beta curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
 ```
 
 - Detects OS (`Linux`/`Darwin`) + arch (`x86_64`/`aarch64`), maps to the
   release workflow's target triples, and refuses to run on anything else
   (no silent wrong-arch installs).
-- Resolves the latest **published** `chm-v*` release via the GitHub releases
-  API, ranking by semver (not first-match / created_at) and skipping
-  drafts/prereleases. Dashboard/Helm tags share this API. Pin a specific
-  release with `CHM_VERSION=chm-vX.Y.Z` (`vX.Y.Z` / `X.Y.Z` also work).
+- Resolves the latest **published** `chm-v*` release via the GitHub Releases
+  API for `CHM_CHANNEL` (`stable` | `beta`). Stable skips drafts/prereleases;
+  beta prefers prereleases (falls back to stable if none). Ranking is by
+  semver, not first-match / created_at. Pin with
+  `CHM_VERSION=chm-vX.Y.Z` (`vX.Y.Z` / `X.Y.Z` also work).
 - Downloads the binary + its `.sha256` asset and verifies the checksum before
   installing; a missing or mismatched checksum is fatal (never installs an
   unverified binary). Fails loud (`set -euo pipefail`) on any
@@ -275,6 +300,9 @@ curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/ins
   `CHM_INSTALL_DIR`); never invokes `sudo` — if the target dir isn't
   writable it errors with `CHM_INSTALL_DIR` / `cargo install` fallback
   instead of escalating itself.
+- Also installs a `chmonitor` symlink/alias pointing at `chm`.
+- Self-update: `chm update` / `chm upgrade` (`--channel stable|beta`, or
+  `CHM_CHANNEL` / config `channel`) pull from the same GitHub Releases.
 - `rust/ch-monitor-cli/Cargo.toml` carries `authors`/`repository`/`readme`/
   `keywords`/`categories`. `cargo-publish.yml` publishes the crate so
   `cargo install ch-monitor-cli` works as a self-update fallback. Homebrew

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 * **cli:** modular rewrite — auth device login, layered config, TUI chat, agent/prompt/audit/doctor, channel-aware self-update (stable|beta), default base URL `https://dash.chmonitor.dev`
+* **cli:** ship `chmonitor` as an alias of `chm` (second cargo bin + install.sh symlink)
 
 
 ## [0.1.1](https://github.com/chmonitor/chmonitor/compare/chm-v0.1.0...chm-v0.1.1) (2026-08-06)

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -18,6 +18,10 @@ exclude = ["/.github"]
 name = "chm"
 path = "src/main.rs"
 
+[[bin]]
+name = "chmonitor"
+path = "src/main.rs"
+
 [features]
 default = []
 mermaid = []

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -1,12 +1,16 @@
-# ch-monitor-cli
+# chm / chmonitor
 
-Standalone terminal/TUI CLI (`chm`) for [chmonitor](https://github.com/chmonitor/chmonitor).
+Standalone terminal/TUI CLI for [chmonitor](https://github.com/chmonitor/chmonitor).
+
+**Command names:** `chm` (short, preferred) and `chmonitor` (full alias). Same binary;
+`cargo install ch-monitor-cli` installs both; `scripts/install.sh` installs `chm`
+and symlinks `chmonitor` → `chm`.
 
 Two ways to use it:
 
 - `chm hosts` / `chm chart` / `chm table` / `chm tui` — talk to a running chmonitor dashboard's API.
-- `chm diagnose` — **zero-signup** health scan that connects straight to a ClickHouse
-  host's HTTP interface (no chmonitor account or backend needed) and prints a
+- `chm diagnose` — **zero-signup** health scan that connects straight to a cluster
+  HTTP interface (no chmonitor account or backend needed) and prints a
   scored, read-only report.
 
 ## Install
@@ -18,9 +22,12 @@ curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/ins
 Downloads and verifies the right prebuilt binary for your OS/arch from
 [GitHub Releases](https://github.com/chmonitor/chmonitor/releases) (tag format `chm-v*`).
 
-Or build from source:
+Or from crates.io / source:
 
 ```bash
+cargo install ch-monitor-cli --force
+# installs both `chm` and `chmonitor` into ~/.cargo/bin
+
 cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 ```
 
@@ -28,6 +35,7 @@ cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 
 ```bash
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm diagnose
+# same as: chmonitor diagnose
 ```
 
 ## Update
@@ -58,7 +66,7 @@ for the full CLI reference.
 
 The CLI sends a best-effort, anonymous usage ping (a random install id, CLI
 version, command name, and OS/arch) to `telemetry.chmonitor.dev` — a separate
-stream from the dashboard's telemetry, with **no** ClickHouse host, query text,
+stream from the dashboard's telemetry, with **no** cluster host, query text,
 arguments, paths, or IPs. It runs on a background thread with a sub-second
 timeout and never blocks or fails a command.
 

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -16,11 +16,16 @@ Two ways to use it:
 ## Install
 
 ```bash
+# Stable (default)
 curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash
+
+# Beta channel
+CHM_CHANNEL=beta bash <(curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh)
 ```
 
 Downloads and verifies the right prebuilt binary for your OS/arch from
-[GitHub Releases](https://github.com/chmonitor/chmonitor/releases) (tag format `chm-v*`).
+[GitHub Releases](https://github.com/chmonitor/chmonitor/releases) (tag format
+`chm-v*`). Stable skips prereleases; `CHM_CHANNEL=beta` prefers them.
 
 Or from crates.io / source:
 
@@ -48,9 +53,10 @@ print a copy-pasteable fallback (`scripts/install.sh` or
 `cargo install ch-monitor-cli --force`).
 
 ```bash
-chm upgrade                      # alias of update — install the latest chm-v* release
+chm upgrade                      # alias of update — latest stable chm-v* release
 chm update                       # same behaviour
 chm update --check               # only report if a newer release exists (exit 1 if so)
+chm update --channel beta        # prefer prereleases (or CHM_CHANNEL=beta)
 chm upgrade --version chm-v0.2.0 # pin a specific release (`0.2.0` / `v0.2.0` also work)
 ```
 

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for Channel {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Sign in / out of chmonitor Cloud (device-code flow)
+    /// Sign in / out — auto-detects open API, device login, or API key
     Auth(AuthArgs),
     /// Show or edit local CLI config
     Config(ConfigArgs),
@@ -192,12 +192,21 @@ pub struct AuthArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum AuthCommand {
-    /// Sign in via browser device-code flow
-    Login,
+    /// Sign in (auto-detects none / device / api_key)
+    Login(AuthLoginArgs),
     /// Clear stored credentials
     Logout,
     /// Show whether a token/api-key is configured
     Status,
+    /// Print the stored bearer token to stdout (for CI)
+    Token,
+}
+
+#[derive(Args, Debug)]
+pub struct AuthLoginArgs {
+    /// API key to store when the dashboard requires key auth (skips prompt)
+    #[arg(long, env = "CHM_API_KEY")]
+    pub api_key: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -1,4 +1,4 @@
-//! Clap definitions for `chm`.
+//! Clap definitions for `chm` / `chmonitor`.
 
 use std::path::PathBuf;
 
@@ -8,7 +8,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[command(
     name = "chm",
     version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
-    about = "chmonitor CLI — dashboard API, TUI, and zero-signup diagnostics"
+    about = "chmonitor CLI (`chm` / `chmonitor`) — dashboard API, TUI, and zero-signup diagnostics"
 )]
 pub struct Cli {
     /// Path to config.toml (default ~/.config/chm/config.toml)

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -104,14 +104,23 @@ pub enum Commands {
         /// Max rows to print
         #[arg(long, default_value_t = 20)]
         limit: usize,
+        /// Print column names / query-config metadata (SQL hint when available)
+        #[arg(long)]
+        explain: bool,
     },
-    /// Live terminal UI for a dashboard chart (or overview)
+    /// Live multi-pane terminal UI (overview / chart / table). Enters alt-screen.
     Tui {
         /// Chart name (default: config `default_chart`, else query-count)
         chart: Option<String>,
-        /// Show overview metrics instead of a single chart
+        /// Start in overview mode (hosts summary + default chart sparkline)
         #[arg(long)]
         overview: bool,
+        /// Table name for pane 3 (default: running-queries)
+        #[arg(long, default_value = "running-queries")]
+        table: String,
+        /// Page size when fetching the TUI table pane
+        #[arg(long, default_value_t = 15)]
+        page_size: usize,
     },
     /// Stream a chat reply from the dashboard AI agent
     Chat {

--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -14,7 +14,9 @@ struct ApiResponse {
 
 pub fn api_error_hint(status: u16) -> &'static str {
     match status {
-        401 | 403 => " Check --api-key / CHM_API_KEY or `chm auth login`.",
+        401 | 403 => {
+            " Check --api-key / CHM_API_KEY, or run `chm auth login` (auto-detects device vs API key)."
+        }
         404 => " Check the chart/table name and --host-id.",
         _ => "",
     }

--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -12,6 +12,36 @@ struct ApiResponse {
     data: Value,
 }
 
+/// Full `{ success, data, metadata|meta }` envelope from the dashboard API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiEnvelope {
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub success: Option<bool>,
+    pub data: Value,
+    #[serde(default)]
+    pub metadata: Option<Value>,
+    /// Some older/alternate responses nest metadata under `meta`.
+    #[serde(default)]
+    pub meta: Option<Value>,
+}
+
+impl ApiEnvelope {
+    /// Prefer `metadata`, fall back to `meta`.
+    pub fn meta_object(&self) -> Option<&Value> {
+        self.metadata.as_ref().or(self.meta.as_ref())
+    }
+
+    /// SQL / query hint from the response envelope when present.
+    pub fn query_hint(&self) -> Option<&str> {
+        let meta = self.meta_object()?;
+        meta.get("sql")
+            .or_else(|| meta.get("query"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+    }
+}
+
 pub fn api_error_hint(status: u16) -> &'static str {
     match status {
         401 | 403 => {
@@ -54,13 +84,13 @@ pub fn apply_auth(
     req
 }
 
-pub async fn fetch(
+async fn send_get(
     client: &Client,
-    url: String,
+    url: &str,
     token: Option<&str>,
     api_key: Option<&str>,
-) -> Result<Value> {
-    let req = apply_auth(client.get(&url), token, api_key);
+) -> Result<(u16, String)> {
+    let req = apply_auth(client.get(url), token, api_key);
     let resp = match req.send().await {
         Ok(resp) => resp,
         Err(err) => {
@@ -72,26 +102,64 @@ pub async fn fetch(
             );
         }
     };
-    let status = resp.status();
+    let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();
-    if !status.is_success() {
-        let hint = api_error_hint(status.as_u16());
+    Ok((status, text))
+}
+
+fn ensure_success(url: &str, status: u16, text: &str) -> Result<()> {
+    if !(200..300).contains(&status) {
+        let hint = api_error_hint(status);
         let extra = match truncate_body(text.trim(), 200) {
             None => String::new(),
             Some(body) => format!(" {body}"),
         };
         bail!("chmonitor API returned HTTP {status} for {url}.{hint}{extra}");
     }
+    Ok(())
+}
+
+pub async fn fetch(
+    client: &Client,
+    url: String,
+    token: Option<&str>,
+    api_key: Option<&str>,
+) -> Result<Value> {
+    let (status, text) = send_get(client, &url, token, api_key).await?;
+    ensure_success(&url, status, &text)?;
     let parsed: ApiResponse = serde_json::from_str(&text).with_context(|| {
         format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})")
     })?;
     Ok(parsed.data)
 }
 
+/// Fetch the full API envelope (`data` + optional `metadata`/`meta`).
+pub async fn fetch_envelope(
+    client: &Client,
+    url: String,
+    token: Option<&str>,
+    api_key: Option<&str>,
+) -> Result<ApiEnvelope> {
+    let (status, text) = send_get(client, &url, token, api_key).await?;
+    ensure_success(&url, status, &text)?;
+    serde_json::from_str(&text)
+        .with_context(|| format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})"))
+}
+
 pub async fn fetch_cfg(client: &Client, cfg: &AppConfig, url: String) -> Result<Value> {
     let token = crate::credentials::resolve_token(cfg.token.as_deref())?;
     let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref())?;
     fetch(client, url, token.as_deref(), api_key.as_deref()).await
+}
+
+pub async fn fetch_envelope_cfg(
+    client: &Client,
+    cfg: &AppConfig,
+    url: String,
+) -> Result<ApiEnvelope> {
+    let token = crate::credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref())?;
+    fetch_envelope(client, url, token.as_deref(), api_key.as_deref()).await
 }
 
 pub fn rows_from_chart_data(data: Value) -> Result<Vec<Value>> {
@@ -133,5 +201,20 @@ mod tests {
         assert_eq!(truncate_body("", 8), None);
         assert_eq!(truncate_body("hello", 8).as_deref(), Some("hello"));
         assert_eq!(truncate_body("éééé", 2).as_deref(), Some("éé…"));
+    }
+
+    #[test]
+    fn envelope_prefers_metadata_sql_then_meta_query() {
+        let with_meta: ApiEnvelope =
+            serde_json::from_str(r#"{"success":true,"data":[],"metadata":{"sql":"SELECT 1"}}"#)
+                .unwrap();
+        assert_eq!(with_meta.query_hint(), Some("SELECT 1"));
+
+        let with_meta_query: ApiEnvelope =
+            serde_json::from_str(r#"{"data":[],"meta":{"query":"SELECT 2"}}"#).unwrap();
+        assert_eq!(with_meta_query.query_hint(), Some("SELECT 2"));
+
+        let bare: ApiEnvelope = serde_json::from_str(r#"{"data":[]}"#).unwrap();
+        assert!(bare.query_hint().is_none());
     }
 }

--- a/rust/ch-monitor-cli/src/commands/auth.rs
+++ b/rust/ch-monitor-cli/src/commands/auth.rs
@@ -1,19 +1,45 @@
-//! `chm auth` — device-code login against the dashboard.
+//! `chm auth` — auto-detect dashboard auth mode, then login.
 
+use std::io::{self, Write};
 use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::{
-    cli::{AuthArgs, AuthCommand},
+    cli::{AuthArgs, AuthCommand, AuthLoginArgs},
     client::apply_auth,
     config::AppConfig,
     credentials,
     output::{self, success},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliAuthMethod {
+    None,
+    Device,
+    ApiKey,
+}
+
+impl CliAuthMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CliAuthMethod::None => "none",
+            CliAuthMethod::Device => "device",
+            CliAuthMethod::ApiKey => "api_key",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CliAuthDiscovery {
+    pub method: CliAuthMethod,
+    pub hint: String,
+    pub device_enabled: bool,
+}
 
 #[derive(Debug, Deserialize)]
 struct DeviceCodeResponse {
@@ -44,9 +70,107 @@ struct TokenResponse {
     error_description: Option<String>,
 }
 
+/// Parse `method` from discovery JSON (`none` | `device` | `api_key`).
+pub fn parse_method(raw: &str) -> Option<CliAuthMethod> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "none" => Some(CliAuthMethod::None),
+        "device" => Some(CliAuthMethod::Device),
+        "api_key" | "apikey" | "api-key" => Some(CliAuthMethod::ApiKey),
+        _ => None,
+    }
+}
+
+/// Build discovery from a `/api/v1/auth/cli` (or fallback) JSON body.
+pub fn discovery_from_json(value: &Value) -> Option<CliAuthDiscovery> {
+    let root = value.get("data").unwrap_or(value);
+    let method_raw = root.get("method")?.as_str()?;
+    let method = parse_method(method_raw)?;
+    let hint = root
+        .get("hint")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let device_enabled = root
+        .pointer("/deviceLogin/enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(method == CliAuthMethod::Device);
+    Some(CliAuthDiscovery {
+        method,
+        hint,
+        device_enabled,
+    })
+}
+
+async fn discover(client: &Client, cfg: &AppConfig) -> Result<CliAuthDiscovery> {
+    let base = cfg.base_url.trim_end_matches('/');
+    let cli_url = format!("{base}/api/v1/auth/cli");
+
+    let resp = client.get(&cli_url).send().await;
+    if let Ok(resp) = resp {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if status.is_success() {
+            let value: Value = serde_json::from_str(&text)
+                .with_context(|| format!("unexpected auth/cli response: {text}"))?;
+            if let Some(d) = discovery_from_json(&value) {
+                return Ok(d);
+            }
+            bail!("auth/cli response missing method: {text}");
+        }
+        if status.as_u16() != 404 {
+            bail!("auth discovery failed (HTTP {status}): {}", text.trim());
+        }
+        // 404 → older dashboard; fall through to legacy probes.
+    }
+
+    discover_fallback(client, base).await
+}
+
+/// Pre-`/auth/cli` dashboards: device/status + anonymous hosts probe.
+async fn discover_fallback(client: &Client, base: &str) -> Result<CliAuthDiscovery> {
+    let status_url = format!("{base}/api/v1/auth/device/status");
+    if let Ok(resp) = client.get(&status_url).send().await {
+        if resp.status().is_success() {
+            if let Ok(value) = resp.json::<Value>().await {
+                let root = value.get("data").cloned().unwrap_or(value);
+                let enabled = root
+                    .get("enabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if enabled {
+                    return Ok(CliAuthDiscovery {
+                        method: CliAuthMethod::Device,
+                        hint: "Device login enabled (legacy discovery).".into(),
+                        device_enabled: true,
+                    });
+                }
+            }
+        }
+    }
+
+    let hosts_url = format!("{base}/api/v1/hosts");
+    let open = match client.get(&hosts_url).send().await {
+        Ok(r) => r.status().is_success(),
+        Err(_) => false,
+    };
+    if open {
+        return Ok(CliAuthDiscovery {
+            method: CliAuthMethod::None,
+            hint: "Dashboard API appears open (no login needed).".into(),
+            device_enabled: false,
+        });
+    }
+
+    Ok(CliAuthDiscovery {
+        method: CliAuthMethod::ApiKey,
+        hint: "API key required. Pass --api-key / CHM_API_KEY.".into(),
+        device_enabled: false,
+    })
+}
+
 pub async fn run(client: &Client, cfg: &AppConfig, args: AuthArgs) -> Result<i32> {
     match args.command {
-        AuthCommand::Login => login(client, cfg).await,
+        AuthCommand::Login(login_args) => login(client, cfg, login_args).await,
         AuthCommand::Logout => {
             credentials::clear_token()?;
             credentials::clear_api_key()?;
@@ -73,10 +197,70 @@ pub async fn run(client: &Client, cfg: &AppConfig, args: AuthArgs) -> Result<i32
             }
             Ok(0)
         }
+        AuthCommand::Token => {
+            let token = credentials::resolve_token(cfg.token.as_deref())?;
+            let Some(token) = token else {
+                bail!("no bearer token stored — run `chm auth login` first");
+            };
+            // stdout only (CI pipes); no success styling.
+            println!("{token}");
+            Ok(0)
+        }
     }
 }
 
-async fn login(client: &Client, cfg: &AppConfig) -> Result<i32> {
+async fn login(client: &Client, cfg: &AppConfig, args: AuthLoginArgs) -> Result<i32> {
+    let discovery = discover(client, cfg).await?;
+    output::info(&format!(
+        "auth method: {} — {}",
+        discovery.method.as_str(),
+        if discovery.hint.is_empty() {
+            "ok"
+        } else {
+            discovery.hint.as_str()
+        }
+    ));
+
+    match discovery.method {
+        CliAuthMethod::None => {
+            success("no login needed — dashboard API is open");
+            Ok(0)
+        }
+        CliAuthMethod::Device => device_login(client, cfg).await,
+        CliAuthMethod::ApiKey => api_key_login(cfg, args).await,
+    }
+}
+
+async fn api_key_login(cfg: &AppConfig, args: AuthLoginArgs) -> Result<i32> {
+    let key = if let Some(k) = args
+        .api_key
+        .or(cfg.api_key.clone())
+        .filter(|s| !s.trim().is_empty())
+    {
+        k
+    } else {
+        eprint!("API key (chm_…): ");
+        let _ = io::stderr().flush();
+        let mut line = String::new();
+        io::stdin()
+            .read_line(&mut line)
+            .context("failed to read API key from stdin")?;
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
+            bail!("empty API key — pass --api-key or set CHM_API_KEY");
+        }
+        trimmed
+    };
+
+    if !key.starts_with("chm_") {
+        output::warn("key does not start with chm_ — storing anyway");
+    }
+    credentials::store_api_key(&key)?;
+    success("API key stored — use `chm auth status` to verify");
+    Ok(0)
+}
+
+async fn device_login(client: &Client, cfg: &AppConfig) -> Result<i32> {
     let base = cfg.base_url.trim_end_matches('/');
     let code_url = format!("{base}/api/v1/auth/device/code");
 
@@ -207,5 +391,61 @@ async fn login(client: &Client, cfg: &AppConfig) -> Result<i32> {
             }
             None => continue,
         }
+    }
+}
+
+/// Re-export discovery for `chm doctor`.
+pub async fn discover_for_doctor(client: &Client, cfg: &AppConfig) -> Result<CliAuthDiscovery> {
+    discover(client, cfg).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_method_accepts_aliases() {
+        assert_eq!(parse_method("none"), Some(CliAuthMethod::None));
+        assert_eq!(parse_method("DEVICE"), Some(CliAuthMethod::Device));
+        assert_eq!(parse_method("api_key"), Some(CliAuthMethod::ApiKey));
+        assert_eq!(parse_method("api-key"), Some(CliAuthMethod::ApiKey));
+        assert_eq!(parse_method("apikey"), Some(CliAuthMethod::ApiKey));
+        assert_eq!(parse_method("wat"), None);
+    }
+
+    #[test]
+    fn discovery_from_json_reads_nested_data() {
+        let v = json!({
+            "data": {
+                "method": "device",
+                "hint": "Device login enabled.",
+                "deviceLogin": { "enabled": true }
+            }
+        });
+        let d = discovery_from_json(&v).expect("parse");
+        assert_eq!(d.method, CliAuthMethod::Device);
+        assert!(d.device_enabled);
+        assert!(d.hint.contains("Device"));
+    }
+
+    #[test]
+    fn discovery_from_json_flat_payload() {
+        let v = json!({
+            "method": "api_key",
+            "hint": "API key required.",
+            "deviceLogin": { "enabled": false }
+        });
+        let d = discovery_from_json(&v).expect("parse");
+        assert_eq!(d.method, CliAuthMethod::ApiKey);
+        assert!(!d.device_enabled);
+    }
+
+    #[test]
+    fn discovery_from_json_none() {
+        let v = json!({ "method": "none", "hint": "open" });
+        let d = discovery_from_json(&v).expect("parse");
+        assert_eq!(d.method, CliAuthMethod::None);
+        assert!(!d.device_enabled);
     }
 }

--- a/rust/ch-monitor-cli/src/commands/chart.rs
+++ b/rust/ch-monitor-cli/src/commands/chart.rs
@@ -30,6 +30,9 @@ pub async fn run(client: &Client, cfg: &AppConfig, name: &str, limit: usize) -> 
         let points: Vec<u64> = rows_raw.iter().map(metrics::row_metric).collect();
         if !cfg.quiet && !points.is_empty() {
             println!("{}", output::braille_sparkline(&points, 40));
+            if let Some(stats) = output::sparkline_stats(&points) {
+                println!("{stats}");
+            }
         }
         output::print_records(&rows, limit);
     }

--- a/rust/ch-monitor-cli/src/commands/doctor.rs
+++ b/rust/ch-monitor-cli/src/commands/doctor.rs
@@ -3,7 +3,12 @@
 use anyhow::Result;
 use reqwest::Client;
 
-use crate::{client, config::AppConfig, credentials, output};
+use crate::{
+    client,
+    commands::auth::{self, CliAuthMethod},
+    config::AppConfig,
+    credentials, output,
+};
 
 pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
     let mut checks: Vec<(String, bool, String)> = Vec::new();
@@ -20,17 +25,46 @@ pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
         cfg.base_url.clone(),
     ));
 
+    let discovery = auth::discover_for_doctor(client, cfg).await.ok();
+    let auth_method = discovery
+        .as_ref()
+        .map(|d| d.method)
+        .unwrap_or(CliAuthMethod::ApiKey);
+    checks.push((
+        "auth_method".into(),
+        discovery.is_some(),
+        match &discovery {
+            Some(d) => {
+                let mut detail = d.method.as_str().to_string();
+                if d.device_enabled {
+                    detail.push_str(", device_enabled");
+                }
+                if !d.hint.is_empty() {
+                    detail.push_str(&format!(" ({})", d.hint));
+                }
+                detail
+            }
+            None => "unreachable".into(),
+        },
+    ));
+
     let token = credentials::resolve_token(cfg.token.as_deref())?;
     let api_key = credentials::resolve_api_key(cfg.api_key.as_deref())?;
+    let creds_ok = match auth_method {
+        CliAuthMethod::None => true,
+        CliAuthMethod::Device | CliAuthMethod::ApiKey => token.is_some() || api_key.is_some(),
+    };
     checks.push((
         "credentials".into(),
-        token.is_some() || api_key.is_some(),
+        creds_ok,
         if token.is_some() {
             "bearer token".into()
         } else if api_key.is_some() {
             "api key".into()
+        } else if auth_method == CliAuthMethod::None {
+            "none (open API)".into()
         } else {
-            "none (public endpoints only)".into()
+            "none — run `chm auth login`".into()
         },
     ));
 

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -62,13 +62,32 @@ pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Re
             chart::run(client, cfg, &name, limit).await?;
             Ok(0)
         }
-        Commands::Table { name, limit } => {
-            table::run(client, cfg, &name, limit).await?;
+        Commands::Table {
+            name,
+            limit,
+            explain,
+        } => {
+            table::run(client, cfg, &name, limit, explain).await?;
             Ok(0)
         }
-        Commands::Tui { chart, overview } => {
+        Commands::Tui {
+            chart,
+            overview,
+            table,
+            page_size,
+        } => {
             let c = chart.unwrap_or_else(|| cfg.default_chart.clone());
-            crate::tui::run(client, cfg, &c, overview).await?;
+            crate::tui::run(
+                client,
+                cfg,
+                crate::tui::TuiOptions {
+                    chart: &c,
+                    table: &table,
+                    page_size,
+                    start_overview: overview,
+                },
+            )
+            .await?;
             Ok(0)
         }
         Commands::Chat { message } => {

--- a/rust/ch-monitor-cli/src/commands/table.rs
+++ b/rust/ch-monitor-cli/src/commands/table.rs
@@ -4,18 +4,30 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::{client, config::AppConfig, output};
 
-pub async fn run(client: &Client, cfg: &AppConfig, name: &str, limit: usize) -> Result<()> {
+pub async fn run(
+    client: &Client,
+    cfg: &AppConfig,
+    name: &str,
+    limit: usize,
+    explain: bool,
+) -> Result<()> {
+    let page_size = if explain { limit.max(1) } else { limit };
     let url = format!(
         "{}/api/v1/tables/{}?hostId={}&pageSize={}",
         cfg.base_url.trim_end_matches('/'),
         name,
         cfg.host_id,
-        limit
+        page_size
     );
+
+    if explain {
+        return run_explain(client, cfg, name, &url, limit).await;
+    }
+
     let data = client::fetch_cfg(client, cfg, url.clone()).await?;
     if cfg.json {
         output::print_json(&data)?;
@@ -29,4 +41,171 @@ pub async fn run(client: &Client, cfg: &AppConfig, name: &str, limit: usize) -> 
         output::print_records(&rows, limit);
     }
     Ok(())
+}
+
+async fn run_explain(
+    client: &Client,
+    cfg: &AppConfig,
+    name: &str,
+    url: &str,
+    limit: usize,
+) -> Result<()> {
+    let envelope = client::fetch_envelope_cfg(client, cfg, url.to_string()).await?;
+    let columns = column_names_from_data(&envelope.data);
+    let sql_hint = envelope.query_hint().map(str::to_string);
+    let openapi_note = if sql_hint.is_none() {
+        try_openapi_table_hint(client, cfg, name).await
+    } else {
+        None
+    };
+
+    if cfg.json {
+        let mut out = json!({
+            "name": name,
+            "hostId": cfg.host_id,
+            "columns": columns,
+            "data": envelope.data,
+        });
+        if let Some(sql) = &sql_hint {
+            out["sql"] = json!(sql);
+        }
+        if let Some(meta) = envelope.meta_object() {
+            out["metadata"] = meta.clone();
+        }
+        if let Some(note) = &openapi_note {
+            out["openapi"] = json!(note);
+        }
+        if sql_hint.is_none() {
+            out["note"] = json!(
+                "No per-column docs from the API. Columns inferred from the first data row; \
+                 SQL is in metadata.sql when the dashboard exposes it."
+            );
+        }
+        output::print_json(&out)?;
+        return Ok(());
+    }
+
+    println!("table: {name}");
+    println!("hostId: {}", cfg.host_id);
+    if columns.is_empty() {
+        println!("columns: (none — empty result; try without --explain or raise --limit)");
+    } else {
+        println!("columns:");
+        for col in &columns {
+            println!("  - {col}");
+        }
+    }
+    match &sql_hint {
+        Some(sql) => {
+            println!("sql:");
+            println!("{sql}");
+        }
+        None => {
+            println!(
+                "note: no query-config column docs endpoint; columns inferred from data. \
+                 SQL appears in the response envelope as metadata.sql when available."
+            );
+            if let Some(note) = &openapi_note {
+                println!("openapi: {note}");
+            }
+        }
+    }
+    if let Some(meta) = envelope.meta_object() {
+        if let Some(duration) = meta.get("duration") {
+            println!("duration: {duration}");
+        }
+        if let Some(rows) = meta.get("rows") {
+            println!("rows: {rows}");
+        }
+        if meta.get("unavailable").and_then(|v| v.as_bool()) == Some(true) {
+            if let Some(reason) = meta.get("unavailableReason").and_then(|v| v.as_str()) {
+                println!("unavailable: {reason}");
+            }
+        }
+    }
+
+    if let Ok(rows) = serde_json::from_value::<Vec<HashMap<String, Value>>>(envelope.data.clone()) {
+        if !rows.is_empty() {
+            println!();
+            output::print_records(&rows, limit);
+        }
+    }
+    Ok(())
+}
+
+fn column_names_from_data(data: &Value) -> Vec<String> {
+    match data {
+        Value::Array(rows) => rows
+            .first()
+            .and_then(|r| r.as_object())
+            .map(|o| o.keys().cloned().collect())
+            .unwrap_or_default(),
+        Value::Object(map) => map.keys().cloned().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Best-effort: pull the OpenAPI description for `/api/v1/tables/{name}`.
+/// OpenAPI is a raw document (not `{data:…}`), so we GET it directly.
+async fn try_openapi_table_hint(client: &Client, cfg: &AppConfig, name: &str) -> Option<String> {
+    let url = format!("{}/api/v1/openapi.json", cfg.base_url.trim_end_matches('/'));
+    let token = crate::credentials::resolve_token(cfg.token.as_deref()).ok()?;
+    let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref()).ok()?;
+    let req = client::apply_auth(client.get(&url), token.as_deref(), api_key.as_deref());
+    let resp = req.send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let doc: Value = resp.json().await.ok()?;
+    extract_openapi_table_description(&doc, name)
+}
+
+fn extract_openapi_table_description(doc: &Value, _name: &str) -> Option<String> {
+    let path = doc.get("paths")?.get("/api/v1/tables/{name}")?;
+    let get = path.get("get").unwrap_or(path);
+    let desc = get
+        .get("description")
+        .or_else(|| get.get("summary"))
+        .and_then(|v| v.as_str())?;
+    let trimmed = desc.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn column_names_from_first_row() {
+        let data = json!([{"query_id": "1", "user": "default"}, {"query_id": "2"}]);
+        let cols = column_names_from_data(&data);
+        assert!(cols.contains(&"query_id".into()));
+        assert!(cols.contains(&"user".into()));
+    }
+
+    #[test]
+    fn column_names_empty_array() {
+        assert!(column_names_from_data(&json!([])).is_empty());
+    }
+
+    #[test]
+    fn openapi_extracts_tables_path_description() {
+        let doc = json!({
+            "paths": {
+                "/api/v1/tables/{name}": {
+                    "get": {
+                        "summary": "Named table page",
+                        "description": "Runs a registered QueryConfig."
+                    }
+                }
+            }
+        });
+        let hint = extract_openapi_table_description(&doc, "running-queries");
+        assert_eq!(hint.as_deref(), Some("Runs a registered QueryConfig."));
+    }
 }

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -183,4 +183,58 @@ mod tests {
             "https://dash.chmonitor.dev"
         );
     }
+
+    #[test]
+    fn table_explain_flag_parses() {
+        let cli = Cli::try_parse_from([
+            "chm",
+            "table",
+            "running-queries",
+            "--explain",
+            "--limit",
+            "5",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Table {
+                name,
+                limit,
+                explain,
+            } => {
+                assert_eq!(name, "running-queries");
+                assert_eq!(limit, 5);
+                assert!(explain);
+            }
+            other => panic!("expected Table, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tui_table_and_page_size_flags_parse() {
+        let cli = Cli::try_parse_from([
+            "chm",
+            "tui",
+            "query-count",
+            "--overview",
+            "--table",
+            "merges",
+            "--page-size",
+            "10",
+        ])
+        .expect("parse");
+        match cli.command {
+            Commands::Tui {
+                chart,
+                overview,
+                table,
+                page_size,
+            } => {
+                assert_eq!(chart.as_deref(), Some("query-count"));
+                assert!(overview);
+                assert_eq!(table, "merges");
+                assert_eq!(page_size, 10);
+            }
+            other => panic!("expected Tui, got {other:?}"),
+        }
+    }
 }

--- a/rust/ch-monitor-cli/src/output.rs
+++ b/rust/ch-monitor-cli/src/output.rs
@@ -71,6 +71,42 @@ pub fn braille_sparkline(values: &[u64], width: usize) -> String {
     out
 }
 
+/// One-line min / max / avg summary for sparkline values.
+pub fn sparkline_stats(values: &[u64]) -> Option<String> {
+    if values.is_empty() {
+        return None;
+    }
+    let min = values.iter().copied().min()?;
+    let max = values.iter().copied().max()?;
+    let sum: u128 = values.iter().map(|&v| u128::from(v)).sum();
+    let avg = sum / values.len() as u128;
+    Some(format!("min={min}  max={max}  avg={avg}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sparkline_stats_empty_is_none() {
+        assert!(sparkline_stats(&[]).is_none());
+    }
+
+    #[test]
+    fn sparkline_stats_reports_min_max_avg() {
+        let s = sparkline_stats(&[1, 2, 3, 4]).unwrap();
+        assert!(s.contains("min=1"), "{s}");
+        assert!(s.contains("max=4"), "{s}");
+        assert!(s.contains("avg=2"), "{s}");
+    }
+
+    #[test]
+    fn braille_sparkline_nonempty() {
+        let line = braille_sparkline(&[0, 5, 10, 5, 0], 5);
+        assert_eq!(line.chars().count(), 5);
+    }
+}
+
 pub fn success(msg: &str) {
     if wants_color() {
         eprintln!("{} {msg}", "✔".green());

--- a/rust/ch-monitor-cli/src/tui/chat.rs
+++ b/rust/ch-monitor-cli/src/tui/chat.rs
@@ -1,4 +1,7 @@
 //! Streaming chat TUI / non-interactive chat against `/api/v1/agent`.
+//!
+//! Interactive TTY sessions enter the alternate screen; piped / `--json`
+//! one-shots do not (TTY rule: only `chm tui` / interactive `chm chat`).
 
 use std::io::{self, IsTerminal, Read, Write};
 

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -1,4 +1,7 @@
-//! Terminal UI: chart overview + streaming chat.
+//! Terminal UI: multi-pane overview / chart / table.
+//!
+//! Alt-screen is entered only by `chm tui` (this module) and `chm chat`
+//! (`tui/chat.rs`). Other commands must never call EnterAlternateScreen.
 
 pub mod chat;
 
@@ -9,7 +12,8 @@ use std::{
 
 use anyhow::Result;
 use crossterm::{
-    event, execute,
+    event::{self, KeyCode},
+    execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{
@@ -18,11 +22,29 @@ use ratatui::{
     Terminal,
 };
 use reqwest::Client;
+use serde_json::Value;
 
 use crate::{client, config::AppConfig, metrics};
 
 const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
 const TUI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TuiMode {
+    Overview,
+    Chart,
+    Table,
+}
+
+impl TuiMode {
+    fn label(self) -> &'static str {
+        match self {
+            TuiMode::Overview => "overview",
+            TuiMode::Chart => "chart",
+            TuiMode::Table => "table",
+        }
+    }
+}
 
 struct TuiGuard;
 
@@ -33,7 +55,14 @@ impl Drop for TuiGuard {
     }
 }
 
-pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) -> Result<()> {
+pub struct TuiOptions<'a> {
+    pub chart: &'a str,
+    pub table: &'a str,
+    pub page_size: usize,
+    pub start_overview: bool,
+}
+
+pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions<'_>) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -41,49 +70,43 @@ pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) 
 
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-    let mut rows = Vec::new();
-    let mut points = Vec::new();
-    let mut error_message = None;
-    let mut next_refresh_at = Instant::now();
+
+    let mut mode = if opts.start_overview {
+        TuiMode::Overview
+    } else {
+        TuiMode::Chart
+    };
+    let mut host_id = cfg.host_id;
+    let mut chart_rows: Vec<Value> = Vec::new();
+    let mut points: Vec<u64> = Vec::new();
+    let mut table_rows: Vec<Value> = Vec::new();
+    let mut table_scroll: usize = 0;
+    let mut error_message: Option<String> = None;
     let mut hosts_summary = String::new();
+    let mut next_refresh_at = Instant::now();
 
     loop {
         let now = Instant::now();
         if now >= next_refresh_at {
-            if overview {
-                let hosts_url = format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
-                match client::fetch_cfg(client, cfg, hosts_url).await {
-                    Ok(data) => {
-                        error_message = None;
-                        if let Some(arr) = data.as_array() {
-                            hosts_summary = format!("{} host(s)", arr.len());
-                        } else {
-                            hosts_summary = "hosts ok".into();
-                        }
-                    }
-                    Err(err) => {
-                        error_message = Some(err.to_string());
-                        hosts_summary.clear();
-                    }
-                }
+            error_message = None;
+            match refresh(
+                client,
+                cfg,
+                mode,
+                host_id,
+                opts.chart,
+                opts.table,
+                opts.page_size,
+                &mut hosts_summary,
+                &mut chart_rows,
+                &mut points,
+                &mut table_rows,
+            )
+            .await
+            {
+                Ok(()) => {}
+                Err(err) => error_message = Some(err.to_string()),
             }
-
-            let url = format!(
-                "{}/api/v1/charts/{}?hostId={}",
-                cfg.base_url.trim_end_matches('/'),
-                chart,
-                cfg.host_id
-            );
-            let rows_result = client::fetch_cfg(client, cfg, url)
-                .await
-                .and_then(client::rows_from_chart_data);
-            if rows_result.is_err() && error_message.is_none() {
-                error_message = rows_result.as_ref().err().map(ToString::to_string);
-            } else if rows_result.is_ok() && !overview {
-                error_message = None;
-            }
-            rows = rows_result.unwrap_or_default();
-            points = rows.iter().take(80).map(metrics::row_metric).collect();
             next_refresh_at = Instant::now() + TUI_REFRESH_INTERVAL;
         }
 
@@ -92,47 +115,34 @@ pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) 
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Length(3), Constraint::Min(5)].as_ref())
                 .split(f.area());
-            let mode = if overview { "overview" } else { "chart" };
-            f.render_widget(
-                Paragraph::new(format!(
-                    "chm tui ({mode}) | chart={chart} | q=quit | r=refresh | host={}{}{}",
-                    cfg.host_id,
-                    if hosts_summary.is_empty() {
-                        String::new()
-                    } else {
-                        format!(" | {hosts_summary}")
-                    },
-                    error_message
-                        .as_ref()
-                        .map(|message| format!(" | error={message}"))
-                        .unwrap_or_default()
-                )),
-                chunks[0],
+
+            let header = format!(
+                "chm tui | mode={} | host={} | channel={} | chart={} | table={} | \
+                 1/2/3 panes  h/l or [/] host  r refresh  q quit{}{}",
+                mode.label(),
+                host_id,
+                cfg.channel,
+                opts.chart,
+                opts.table,
+                if hosts_summary.is_empty() {
+                    String::new()
+                } else {
+                    format!(" | {hosts_summary}")
+                },
+                error_message
+                    .as_ref()
+                    .map(|message| format!(" | error={message}"))
+                    .unwrap_or_default()
             );
-            let rows_widget: Vec<Row> = rows
-                .iter()
-                .take(10)
-                .filter_map(|r| r.as_object())
-                .map(|o| {
-                    let kv = o
-                        .iter()
-                        .map(|(k, v)| format!("{k}:{v}"))
-                        .collect::<Vec<_>>()
-                        .join(" | ");
-                    Row::new(vec![kv])
-                })
-                .collect();
-            let inner = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Length(5), Constraint::Min(5)])
-                .split(chunks[1]);
-            let spark = Sparkline::default()
-                .block(Block::default().title("Trend").borders(Borders::ALL))
-                .data(&points);
-            f.render_widget(spark, inner[0]);
-            let table = TuiTable::new(rows_widget, [Constraint::Percentage(100)])
-                .block(Block::default().title("Recent rows").borders(Borders::ALL));
-            f.render_widget(table, inner[1]);
+            f.render_widget(Paragraph::new(header), chunks[0]);
+
+            match mode {
+                TuiMode::Overview => {
+                    draw_overview(f, chunks[1], &hosts_summary, &points, &chart_rows)
+                }
+                TuiMode::Chart => draw_chart(f, chunks[1], &points, &chart_rows),
+                TuiMode::Table => draw_table(f, chunks[1], &table_rows, table_scroll),
+            }
         })?;
 
         let poll_timeout = next_refresh_at
@@ -140,10 +150,43 @@ pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) 
             .min(TUI_EVENT_POLL_INTERVAL);
         if event::poll(poll_timeout)? {
             match event::read()? {
-                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('q')) => break,
-                event::Event::Key(k) if matches!(k.code, event::KeyCode::Char('r')) => {
-                    next_refresh_at = Instant::now()
-                }
+                event::Event::Key(k) => match k.code {
+                    KeyCode::Char('q') => break,
+                    KeyCode::Char('r') => next_refresh_at = Instant::now(),
+                    KeyCode::Char('1') => {
+                        mode = TuiMode::Overview;
+                        next_refresh_at = Instant::now();
+                    }
+                    KeyCode::Char('2') => {
+                        mode = TuiMode::Chart;
+                        next_refresh_at = Instant::now();
+                    }
+                    KeyCode::Char('3') => {
+                        mode = TuiMode::Table;
+                        table_scroll = 0;
+                        next_refresh_at = Instant::now();
+                    }
+                    KeyCode::Char('h') | KeyCode::Char('[') => {
+                        host_id = host_id.saturating_sub(1);
+                        next_refresh_at = Instant::now();
+                    }
+                    KeyCode::Char('l') | KeyCode::Char(']') => {
+                        host_id = host_id.saturating_add(1);
+                        next_refresh_at = Instant::now();
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if mode == TuiMode::Table {
+                            let max_scroll = table_rows.len().saturating_sub(1);
+                            table_scroll = (table_scroll + 1).min(max_scroll);
+                        }
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        if mode == TuiMode::Table {
+                            table_scroll = table_scroll.saturating_sub(1);
+                        }
+                    }
+                    _ => {}
+                },
                 event::Event::Resize(_, _) => continue,
                 _ => {}
             }
@@ -151,4 +194,196 @@ pub async fn run(client: &Client, cfg: &AppConfig, chart: &str, overview: bool) 
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn refresh(
+    client: &Client,
+    cfg: &AppConfig,
+    mode: TuiMode,
+    host_id: u32,
+    chart: &str,
+    table: &str,
+    page_size: usize,
+    hosts_summary: &mut String,
+    chart_rows: &mut Vec<Value>,
+    points: &mut Vec<u64>,
+    table_rows: &mut Vec<Value>,
+) -> Result<()> {
+    match mode {
+        TuiMode::Overview => {
+            let hosts_url = format!("{}/api/v1/hosts", cfg.base_url.trim_end_matches('/'));
+            match client::fetch_cfg(client, cfg, hosts_url).await {
+                Ok(data) => {
+                    if let Some(arr) = data.as_array() {
+                        *hosts_summary = format!("{} host(s)", arr.len());
+                    } else {
+                        *hosts_summary = "hosts ok".into();
+                    }
+                }
+                Err(err) => {
+                    hosts_summary.clear();
+                    return Err(err);
+                }
+            }
+            fetch_chart(client, cfg, chart, host_id, chart_rows, points).await?;
+        }
+        TuiMode::Chart => {
+            hosts_summary.clear();
+            fetch_chart(client, cfg, chart, host_id, chart_rows, points).await?;
+        }
+        TuiMode::Table => {
+            hosts_summary.clear();
+            let url = format!(
+                "{}/api/v1/tables/{}?hostId={}&pageSize={}",
+                cfg.base_url.trim_end_matches('/'),
+                table,
+                host_id,
+                page_size
+            );
+            let data = client::fetch_cfg(client, cfg, url).await?;
+            *table_rows = match data {
+                Value::Array(rows) => rows,
+                other => vec![other],
+            };
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_chart(
+    client: &Client,
+    cfg: &AppConfig,
+    chart: &str,
+    host_id: u32,
+    chart_rows: &mut Vec<Value>,
+    points: &mut Vec<u64>,
+) -> Result<()> {
+    let url = format!(
+        "{}/api/v1/charts/{}?hostId={}",
+        cfg.base_url.trim_end_matches('/'),
+        chart,
+        host_id
+    );
+    let rows = client::fetch_cfg(client, cfg, url)
+        .await
+        .and_then(client::rows_from_chart_data)?;
+    *points = rows.iter().take(80).map(metrics::row_metric).collect();
+    *chart_rows = rows;
+    Ok(())
+}
+
+fn draw_overview(
+    f: &mut ratatui::Frame<'_>,
+    area: ratatui::layout::Rect,
+    hosts_summary: &str,
+    points: &[u64],
+    chart_rows: &[Value],
+) {
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(5),
+            Constraint::Min(5),
+        ])
+        .split(area);
+    f.render_widget(
+        Paragraph::new(if hosts_summary.is_empty() {
+            "hosts: (loading…)".into()
+        } else {
+            format!("Hosts summary: {hosts_summary}")
+        })
+        .block(Block::default().title("Overview").borders(Borders::ALL)),
+        inner[0],
+    );
+    let spark = Sparkline::default()
+        .block(
+            Block::default()
+                .title("Default chart sparkline")
+                .borders(Borders::ALL),
+        )
+        .data(points);
+    f.render_widget(spark, inner[1]);
+    render_row_list(f, inner[2], "Recent chart rows", chart_rows, 0);
+}
+
+fn draw_chart(
+    f: &mut ratatui::Frame<'_>,
+    area: ratatui::layout::Rect,
+    points: &[u64],
+    chart_rows: &[Value],
+) {
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(5), Constraint::Min(5)])
+        .split(area);
+    let spark = Sparkline::default()
+        .block(Block::default().title("Trend").borders(Borders::ALL))
+        .data(points);
+    f.render_widget(spark, inner[0]);
+    render_row_list(f, inner[1], "Recent rows", chart_rows, 0);
+}
+
+fn draw_table(
+    f: &mut ratatui::Frame<'_>,
+    area: ratatui::layout::Rect,
+    table_rows: &[Value],
+    scroll: usize,
+) {
+    render_row_list(
+        f,
+        area,
+        "Table rows (j/k or ↑/↓ scroll)",
+        table_rows,
+        scroll,
+    );
+}
+
+fn render_row_list(
+    f: &mut ratatui::Frame<'_>,
+    area: ratatui::layout::Rect,
+    title: &str,
+    rows: &[Value],
+    scroll: usize,
+) {
+    let visible = area.height.saturating_sub(2) as usize;
+    let rows_widget: Vec<Row> = rows
+        .iter()
+        .skip(scroll)
+        .take(visible.max(1))
+        .filter_map(|r| r.as_object())
+        .map(|o| {
+            let kv = o
+                .iter()
+                .map(|(k, v)| format!("{k}:{v}"))
+                .collect::<Vec<_>>()
+                .join(" | ");
+            Row::new(vec![kv])
+        })
+        .collect();
+    let table = TuiTable::new(rows_widget, [Constraint::Percentage(100)])
+        .block(Block::default().title(title).borders(Borders::ALL));
+    f.render_widget(table, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_labels() {
+        assert_eq!(TuiMode::Overview.label(), "overview");
+        assert_eq!(TuiMode::Chart.label(), "chart");
+        assert_eq!(TuiMode::Table.label(), "table");
+    }
+
+    #[test]
+    fn host_id_clamps_at_zero() {
+        let mut host_id: u32 = 0;
+        host_id = host_id.saturating_sub(1);
+        assert_eq!(host_id, 0);
+        host_id = host_id.saturating_add(1);
+        assert_eq!(host_id, 1);
+    }
 }

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -174,16 +174,12 @@ pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions<'_>) -> Resu
                         host_id = host_id.saturating_add(1);
                         next_refresh_at = Instant::now();
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if mode == TuiMode::Table {
-                            let max_scroll = table_rows.len().saturating_sub(1);
-                            table_scroll = (table_scroll + 1).min(max_scroll);
-                        }
+                    KeyCode::Down | KeyCode::Char('j') if mode == TuiMode::Table => {
+                        let max_scroll = table_rows.len().saturating_sub(1);
+                        table_scroll = (table_scroll + 1).min(max_scroll);
                     }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if mode == TuiMode::Table {
-                            table_scroll = table_scroll.saturating_sub(1);
-                        }
+                    KeyCode::Up | KeyCode::Char('k') if mode == TuiMode::Table => {
+                        table_scroll = table_scroll.saturating_sub(1);
                     }
                     _ => {}
                 },

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -374,6 +374,7 @@ pub async fn run_channel(client: &Client, pinned: Option<String>, channel: Chann
         .ok_or_else(|| anyhow!("executable has no parent directory"))?;
 
     install_binary(dir, &exe, &bin_bytes).map_err(|e| permission_hint(&exe, &e))?;
+    ensure_chmonitor_alias(dir, &exe);
 
     println!(
         "Updated chm v{} -> {target_tag} ({})",
@@ -391,6 +392,51 @@ fn hex_sha256(bytes: &[u8]) -> String {
         .iter()
         .map(|b| format!("{b:02x}"))
         .collect()
+}
+
+/// Keep a `chmonitor` sibling pointing at `chm` after self-update (install.sh
+/// does the same). If the user ran update via the full `chmonitor` cargo bin,
+/// sync bytes onto `chm` first so the alias never points at a stale primary.
+/// Best-effort: never fails the update if the alias cannot be created.
+fn ensure_chmonitor_alias(dir: &Path, exe: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let chm = dir.join("chm");
+        let name = exe.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+        if name != "chm" {
+            match exe.symlink_metadata() {
+                Ok(meta) if meta.file_type().is_symlink() => {}
+                Ok(_) => {
+                    let same = exe
+                        .canonicalize()
+                        .ok()
+                        .zip(chm.canonicalize().ok())
+                        .is_some_and(|(a, b)| a == b);
+                    if !same {
+                        let _ = fs::copy(exe, &chm);
+                        let _ = set_executable(&chm);
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+
+        if !chm.exists() {
+            return;
+        }
+        let alias = dir.join("chmonitor");
+        if alias.symlink_metadata().is_ok() {
+            let _ = fs::remove_file(&alias);
+        }
+        let _ = symlink("chm", &alias);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (dir, exe);
+    }
 }
 
 /// Write the new binary to a temp file in the same directory, chmod 0755, then
@@ -609,5 +655,41 @@ mod tests {
             !msg.contains("sudo "),
             "unsupported-target fallback must not suggest a sudo command: {msg}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_chmonitor_alias_links_to_chm() {
+        let dir = std::env::temp_dir().join(format!("chm-alias-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let chm = dir.join("chm");
+        fs::write(&chm, b"fake").unwrap();
+        ensure_chmonitor_alias(&dir, &chm);
+        let alias = dir.join("chmonitor");
+        assert!(alias.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_link(&alias).unwrap(), Path::new("chm"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_chmonitor_alias_syncs_from_full_chmonitor_bin() {
+        let dir = std::env::temp_dir().join(format!("chm-alias-sync-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let chm = dir.join("chm");
+        let full = dir.join("chmonitor");
+        fs::write(&chm, b"old").unwrap();
+        fs::write(&full, b"new").unwrap();
+        ensure_chmonitor_alias(&dir, &full);
+        assert_eq!(fs::read(&chm).unwrap(), b"new");
+        assert!(dir
+            .join("chmonitor")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# chmonitor CLI (`chm`) installer.
+# chmonitor CLI installer - installs `chm` (short name) and a `chmonitor` alias.
 #
 # Downloads the right prebuilt `chm` binary for your OS/arch from GitHub
 # Releases (tag format `chm-v*`), verifies its sha256 checksum, and installs
@@ -25,6 +25,7 @@ set -euo pipefail
 
 REPO="chmonitor/chmonitor"
 BIN_NAME="chm"
+ALIAS_NAME="chmonitor"
 INSTALL_DIR="${CHM_INSTALL_DIR:-$HOME/.local/bin}"
 
 log() { printf '%s\n' "$*" >&2; }
@@ -311,9 +312,12 @@ if [ ! -w "$INSTALL_DIR" ]; then
 fi
 
 mv "$BIN_PATH" "${INSTALL_DIR}/${BIN_NAME}"
+# Full product name as a sibling symlink so both `chm` and `chmonitor` work.
+ln -sfn "${BIN_NAME}" "${INSTALL_DIR}/${ALIAS_NAME}"
 
 log ""
 log "chmonitor CLI installed to ${INSTALL_DIR}/${BIN_NAME}"
+log "alias: ${INSTALL_DIR}/${ALIAS_NAME} -> ${BIN_NAME}"
 
 case ":$PATH:" in
   *":${INSTALL_DIR}:"*) : ;;
@@ -326,7 +330,8 @@ esac
 
 log ""
 log "Run a zero-signup health check against a ClickHouse host:"
-log "  CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default ${INSTALL_DIR}/${BIN_NAME} diagnose"
+log "  CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default ${BIN_NAME} diagnose" # pragma: allowlist secret
+log "  # or: ${ALIAS_NAME} diagnose"
 log ""
 log "Update later with:"
 log "  ${BIN_NAME} upgrade"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the chmonitor CLI plan follow-ups: auth discovery for `chm auth login`, Phase 2 TUI/table/chart polish, dual command names (`chm` + `chmonitor`), and a hardened multi-arch GitHub Release pipeline (beta from main, stable via release-please).

## Changes

- `GET /api/v1/auth/cli` discovery so the CLI auto-detects `none` / `api_key` / `device`
- CLI `auth login` / doctor wiring for discovery
- Phase 2 TUI panes, `table --explain`, richer chart stats
- Ship **`chm`** (primary) and **`chmonitor`** (alias): second Cargo bin + install.sh symlink
- Harden `cli-rust-release.yml`: matrix **build** → single **publish** with 8-asset assert
  - Platforms: Linux/macOS × x86_64/aarch64
  - **Beta**: main pushes touching CLI paths → `chm-vX.Y.Z-beta.N` prerelease
  - **Stable**: release-please tag + workflow_dispatch (non-prerelease)
- Docs: README channels, diagnostics guide, knowledge release notes

## Test plan

- [x] `cargo test` in `rust/ch-monitor-cli`
- [x] `CHM_INSTALL_SELF_TEST=1 bash scripts/install.sh`
- [x] E2E `CHM_CHANNEL=beta` install from GitHub → `chm-v0.1.2-beta.3`
- [x] `chmonitor` → `chm` symlink
- [x] `chm update --check --channel beta|stable`
- [x] Latest beta release has all 8 assets (4 bins + 4 sha256)
- [ ] CI: `unit-tests`, `dashboard`, `rust-cli`

## Notes for reviewer

- Crate name stays `ch-monitor-cli`; marketed commands are `chm` / `chmonitor`
- Release assets remain `chm-<target>`; installer adds the alias symlink
- Windows is intentionally out of scope (install.sh / update refuse unsupported OS)

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4027962-a860-4751-a3e5-860e1fda24be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4027962-a860-4751-a3e5-860e1fda24be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

