### PR TITLE
feat(settings-diff): use full data table toolbar

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -120,13 +120,17 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   table matches** (`MatchOk`), never EmptyState "no data" or
   "Select a table". Keep "No tables match" only for a name-filter
   miss.
-  Settings Diff (`/settings-diff`) uses the same toolbar. The name
-  filter sits on the listing panel (schema-diff table sidebar,
-  settings-diff table card) — not next to Source/Target. Diffs-only
-  with zero deltas still lists matching settings, each with a green
-  `CheckCircle2` in a Match column (`--chart-green`). "Changed from
-  default" is a pressable chip, not a second switch. "No settings
-  match" is only a name/changed-from-default filter miss.
+  Settings Diff (`/settings-diff`) uses the same host toolbar. The
+  listing is the shared `DataTable` (search, Filters, sort, resize,
+  drag-to-reorder, density, column visibility, CSV) — name search
+  lives there, not next to Source/Target. Diffs-only with zero
+  deltas still lists matching settings. The Match column uses the
+  shared boolean check (green) / cross (rose); column headers carry
+  lucide icons (`CheckCircle2`, `SlidersHorizontal`, `Table2`,
+  `Pencil`, `Undo2`, `Server`). "Changed from default" is a
+  pressable chip, not a second switch. Empty catalog copy is
+  DataTable's "No settings found" / "No settings match your
+  filters" — only a name or changed-from-default miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
@@ -57,12 +57,24 @@ async function renderInto(
 ): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
   const { act } = await import('react')
   const { createRoot } = await import('react-dom/client')
+  const {
+    RouterContextProvider,
+    createMemoryHistory,
+    createRootRoute,
+    createRouter,
+  } = await import('@tanstack/react-router')
+  const router = createRouter({
+    routeTree: createRootRoute(),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
 
   await act(async () => {
-    root.render(node)
+    root.render(
+      <RouterContextProvider router={router}>{node}</RouterContextProvider>
+    )
   })
 
   return {
@@ -74,6 +86,22 @@ async function renderInto(
       })
       container.remove()
     },
+  }
+}
+
+function tableToolbar() {
+  const table = document.querySelector('[data-testid="settings-diff-table"]')
+  return {
+    table,
+    search: table?.querySelector(
+      'input[placeholder="Search across all fields..."]'
+    ),
+    filters: Array.from(table?.querySelectorAll('button') ?? []).find((btn) =>
+      btn.textContent?.includes('Filters')
+    ),
+    display: Array.from(table?.querySelectorAll('button') ?? []).find((btn) =>
+      btn.textContent?.includes('Display options')
+    ),
   }
 }
 
@@ -127,15 +155,20 @@ describe('Settings Diff one-host vs default', () => {
     try {
       expect(document.body.textContent).toContain('Comparing against defaults')
       expect(document.body.textContent).toContain('max_threads')
-      expect(document.body.textContent).toContain('Default')
+      expect(document.body.textContent).toContain('default')
       expect(document.body.textContent).toContain('prod')
       expect(document.body.textContent).not.toContain('Host A')
-      const faded = document.querySelector('.opacity-40')
-      expect(faded).toBeNull()
+      expect(
+        document.querySelector('[data-testid="settings-diff-table"]')
+      ).not.toBeNull()
       expect(document.querySelector('[data-testid="add-host"]')).not.toBeNull()
       expect(
         document.querySelector('[data-testid="add-host"]')?.className
       ).toContain('min-h-11')
+      const { search, filters, display } = tableToolbar()
+      expect(search).not.toBeNull()
+      expect(filters).toBeDefined()
+      expect(display).toBeDefined()
     } finally {
       await cleanup()
     }
@@ -205,10 +238,11 @@ describe('Settings Diff matching rows', () => {
     try {
       expect(document.body.textContent).toContain('max_memory_usage')
       expect(document.body.textContent).toContain('max_threads')
-      expect(
-        document.querySelectorAll('[data-testid="settings-diff-matched-icon"]')
-          .length
-      ).toBe(1)
+      const grid = document.querySelector(
+        '[data-testid="settings-diff-table"] table'
+      )
+      expect(grid?.querySelectorAll('[aria-label="yes"]').length).toBe(1)
+      expect(grid?.querySelectorAll('[aria-label="no"]').length).toBe(1)
       expect(document.body.textContent).not.toContain('All matched')
     } finally {
       await cleanup()
@@ -262,12 +296,12 @@ describe('Settings Diff matching rows', () => {
 
     try {
       expect(document.body.textContent).toContain('max_threads')
-      expect(
-        document.querySelectorAll('[data-testid="settings-diff-matched-icon"]')
-          .length
-      ).toBe(1)
+      const grid = document.querySelector(
+        '[data-testid="settings-diff-table"] table'
+      )
+      expect(grid?.querySelectorAll('[aria-label="yes"]').length).toBe(1)
       expect(document.body.textContent).not.toContain('All matched')
-      expect(document.body.textContent).not.toContain('No settings match')
+      expect(document.body.textContent).not.toContain('No settings found')
       expect(document.body.textContent).not.toContain('Show matching settings')
     } finally {
       await cleanup()
@@ -278,22 +312,14 @@ describe('Settings Diff matching rows', () => {
     const { SettingsDiffTable } = await import('./settings-diff-table')
 
     const { cleanup } = await renderInto(
-      <SettingsDiffTable
-        columns={[{ id: 0, name: 'prod' }]}
-        rows={[]}
-        nameFilter="no-such"
-        onNameFilterChange={() => {}}
-      />
+      <SettingsDiffTable columns={[{ id: 0, name: 'prod' }]} rows={[]} />
     )
 
     try {
-      const table = document.querySelector(
-        '[data-testid="settings-diff-table"]'
-      )
-      expect(
-        table?.querySelector('[data-testid="settings-diff-table-filter"]')
-      ).not.toBeNull()
-      expect(document.body.textContent).toContain('No settings match')
+      const { table, search } = tableToolbar()
+      expect(table).not.toBeNull()
+      expect(search).not.toBeNull()
+      expect(document.body.textContent).toMatch(/No settings (match|found)/i)
       expect(document.body.textContent).not.toContain('All matched')
     } finally {
       await cleanup()

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -8,7 +8,7 @@ import type {
   SettingsDiffView,
 } from '@/lib/settings-diff/types'
 
-import { SettingsCsvButton, SettingsDiffTable } from './settings-diff-table'
+import { SettingsDiffTable } from './settings-diff-table'
 import { useState } from 'react'
 import { AddHostButton } from '@/components/compare/add-host-button'
 import { CompareScopeToggle } from '@/components/compare/compare-scope-toggle'
@@ -46,7 +46,6 @@ export function SettingsDiffPage() {
 
   const [showDiffsOnly, setShowDiffsOnly] = useState(true)
   const [showChangedOnly, setShowChangedOnly] = useState(false)
-  const [nameFilter, setNameFilter] = useState('')
 
   const sourceParam = Number.isFinite(search.source) ? search.source : undefined
   const targetParam = Number.isFinite(search.target) ? search.target : undefined
@@ -189,7 +188,7 @@ export function SettingsDiffPage() {
   const filteredRows = filterSettingsDiffRows(data.rows ?? [], {
     showDiffsOnly: diffsOnly,
     showChangedOnly,
-    nameFilter,
+    nameFilter: '',
   })
   const oneHostVsDefault = hostCount === 1 && scope === 'hosts'
 
@@ -202,7 +201,6 @@ export function SettingsDiffPage() {
             ? 'Comparing this host against setting defaults'
             : PAGE_DESCRIPTION
         }
-        actions={<SettingsCsvButton columns={columns} rows={filteredRows} />}
       />
 
       {oneHostVsDefault ? (
@@ -333,21 +331,7 @@ export function SettingsDiffPage() {
           />
         </div>
       ) : (
-        <>
-          <SettingsDiffTable
-            columns={columns}
-            rows={filteredRows}
-            nameFilter={nameFilter}
-            onNameFilterChange={setNameFilter}
-          />
-
-          <p className="text-xs text-muted-foreground">
-            {filteredRows.length.toLocaleString()} row
-            {filteredRows.length !== 1 ? 's' : ''}
-            {filteredRows.length !== (data?.rows?.length ?? 0) &&
-              ` (filtered from ${(data?.rows?.length ?? 0).toLocaleString()})`}
-          </p>
-        </>
+        <SettingsDiffTable columns={columns} rows={filteredRows} />
       )}
     </div>
   )

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -1,234 +1,49 @@
-import { DownloadIcon } from '@radix-ui/react-icons'
-import { CheckCircle2Icon, SearchIcon } from 'lucide-react'
-
 import type {
   SettingsDiffHostInfo,
   SettingsDiffRow,
 } from '@/lib/settings-diff/types'
 
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import { EmptyState } from '@/components/ui/empty-state'
-import { Input } from '@/components/ui/input'
+import { useMemo } from 'react'
+import { DataTable } from '@/components/data-table/data-table'
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+  buildSettingsDiffQueryConfig,
+  toSettingsDiffTableRows,
+  uniqueHostColumnKeys,
+} from '@/lib/settings-diff/table-rows'
 
-export function exportSettingsCsv(
-  columns: SettingsDiffHostInfo[],
-  rows: SettingsDiffRow[]
-) {
-  const hostHeaders = columns.map((h) => h.name)
-  const defaultHeader = columns.length > 0 ? 'Default' : ''
-  const header = [
-    'Name',
-    'Table',
-    defaultHeader,
-    ...hostHeaders,
-    'Has Diff',
-    'Changed From Default',
-  ]
-    .filter(Boolean)
-    .join(',')
-
-  const lines = rows.map((row) => {
-    const defaultValue =
-      columns.length > 0 ? (row.values[columns[0].id]?.defaultValue ?? '') : ''
-    const hostValues = columns.map(
-      (h) => `"${(row.values[h.id]?.value ?? '').replace(/"/g, '""')}"`
-    )
-    return [
-      `"${row.name}"`,
-      row.table,
-      `"${defaultValue.replace(/"/g, '""')}"`,
-      ...hostValues,
-      row.hasDiff ? 'true' : 'false',
-      row.changedFromDefault ? 'true' : 'false',
-    ].join(',')
-  })
-
-  const csv = [header, ...lines].join('\n')
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'settings-diff.csv'
-  a.click()
-  URL.revokeObjectURL(url)
-}
+const EMPTY_TABLE_CONTEXT: Record<string, string> = {}
 
 interface SettingsDiffTableProps {
   columns: SettingsDiffHostInfo[]
   rows: SettingsDiffRow[]
-  nameFilter?: string
-  onNameFilterChange?: (value: string) => void
-  nameFilterPlaceholder?: string
 }
 
-export function SettingsDiffTable({
-  columns,
-  rows,
-  nameFilter,
-  onNameFilterChange,
-  nameFilterPlaceholder = 'Filter by name…',
-}: SettingsDiffTableProps) {
+export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
   const showMatchColumn = columns.length > 1
-  const colSpan = (showMatchColumn ? 4 : 3) + columns.length
-
-  return (
-    <Card data-testid="settings-diff-table">
-      {onNameFilterChange ? (
-        <div className="border-b border-border px-3 py-2">
-          <div className="relative">
-            <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={nameFilter ?? ''}
-              onChange={(e) => onNameFilterChange(e.target.value)}
-              placeholder={nameFilterPlaceholder}
-              className="h-8 pl-7 text-[13px]"
-              data-testid="settings-diff-table-filter"
-            />
-          </div>
-        </div>
-      ) : null}
-      <CardContent className="p-0">
-        <div className="overflow-x-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                {showMatchColumn ? (
-                  <TableHead className="w-8 px-2">
-                    <span className="sr-only">Match</span>
-                  </TableHead>
-                ) : null}
-                <TableHead className="w-64 min-w-48">Name</TableHead>
-                <TableHead className="w-40">Table</TableHead>
-                <TableHead className="w-36 text-muted-foreground">
-                  Default
-                </TableHead>
-                {columns.map((host) => (
-                  <TableHead key={host.id} className="w-36">
-                    {host.name}
-                  </TableHead>
-                ))}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={colSpan} className="py-10">
-                    <EmptyState
-                      variant="filtered-empty"
-                      compact
-                      title="No settings match"
-                      description="Try a different name filter or switch to All."
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : (
-                rows.map((row) => {
-                  const defaultValue =
-                    columns.length > 0
-                      ? (row.values[columns[0].id]?.defaultValue ?? '—')
-                      : '—'
-                  return (
-                    <TableRow
-                      key={`${row.table}::${row.name}`}
-                      className={
-                        row.hasDiff
-                          ? 'bg-amber-50 dark:bg-amber-950/20'
-                          : undefined
-                      }
-                    >
-                      {showMatchColumn ? (
-                        <TableCell className="w-8 px-2">
-                          {row.hasDiff ? null : (
-                            <CheckCircle2Icon
-                              className="size-3.5 text-[var(--chart-green)]"
-                              strokeWidth={1.5}
-                              aria-label="matched"
-                              data-testid="settings-diff-matched-icon"
-                            />
-                          )}
-                        </TableCell>
-                      ) : null}
-                      <TableCell className="font-mono text-xs">
-                        <div className="flex items-center gap-2">
-                          {row.name}
-                          {row.changedFromDefault && (
-                            <Badge
-                              variant="outline"
-                              className="shrink-0 border-orange-300 text-orange-600 dark:border-orange-700 dark:text-orange-400"
-                            >
-                              modified
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
-                        {row.table === 'merge_tree_settings'
-                          ? 'merge_tree'
-                          : 'settings'}
-                      </TableCell>
-                      <TableCell className="font-mono text-xs text-muted-foreground">
-                        {defaultValue}
-                      </TableCell>
-                      {columns.map((host) => {
-                        const cell = row.values[host.id]
-                        const isDifferent =
-                          row.hasDiff &&
-                          columns.some(
-                            (h) =>
-                              h.id !== host.id &&
-                              row.values[h.id]?.value !== cell?.value
-                          )
-                        return (
-                          <TableCell
-                            key={host.id}
-                            className={`font-mono text-xs${isDifferent ? ' font-semibold text-amber-700 dark:text-amber-400' : ''}`}
-                          >
-                            {cell?.value ?? (
-                              <span className="text-muted-foreground/50">
-                                n/a
-                              </span>
-                            )}
-                          </TableCell>
-                        )
-                      })}
-                    </TableRow>
-                  )
-                })
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      </CardContent>
-    </Card>
+  const hostColumns = useMemo(() => uniqueHostColumnKeys(columns), [columns])
+  const data = useMemo(
+    () => toSettingsDiffTableRows(rows, hostColumns, showMatchColumn),
+    [rows, hostColumns, showMatchColumn]
   )
-}
+  const queryConfig = useMemo(
+    () => buildSettingsDiffQueryConfig(hostColumns, showMatchColumn),
+    [hostColumns, showMatchColumn]
+  )
 
-export function SettingsCsvButton({
-  columns,
-  rows,
-}: {
-  columns: SettingsDiffHostInfo[]
-  rows: SettingsDiffRow[]
-}) {
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={() => exportSettingsCsv(columns, rows)}
-      disabled={rows.length === 0}
-    >
-      <DownloadIcon className="mr-2 h-3.5 w-3.5" />
-      Export CSV
-    </Button>
+    <div data-testid="settings-diff-table">
+      <DataTable
+        title="Settings"
+        data={data}
+        queryConfig={queryConfig}
+        context={EMPTY_TABLE_CONTEXT}
+        defaultPageSize={100}
+        showSQL={false}
+        enableColumnReordering
+        columnOrderStorageKey="settings-diff"
+        enableColumnFilters
+        filterableColumns={queryConfig.columns.filter((col) => col !== 'match')}
+      />
+    </div>
   )
 }

--- a/apps/dashboard/src/lib/settings-diff/table-rows.test.ts
+++ b/apps/dashboard/src/lib/settings-diff/table-rows.test.ts
@@ -1,0 +1,128 @@
+import {
+  buildSettingsDiffQueryConfig,
+  toSettingsDiffTableRows,
+  uniqueHostColumnKeys,
+} from './table-rows'
+import { describe, expect, test } from 'bun:test'
+import { ColumnFormat } from '@/types/column-format'
+
+describe('uniqueHostColumnKeys', () => {
+  test('uses host names as column keys', () => {
+    expect(
+      uniqueHostColumnKeys([
+        { id: 0, name: 'node-0' },
+        { id: 1, name: 'node-1' },
+      ])
+    ).toEqual([
+      { id: 0, key: 'node-0' },
+      { id: 1, key: 'node-1' },
+    ])
+  })
+
+  test('suffixes reserved names and collisions', () => {
+    expect(
+      uniqueHostColumnKeys([
+        { id: 0, name: 'name' },
+        { id: 1, name: 'prod' },
+        { id: 2, name: 'prod' },
+      ])
+    ).toEqual([
+      { id: 0, key: 'name (0)' },
+      { id: 1, key: 'prod' },
+      { id: 2, key: 'prod (2)' },
+    ])
+  })
+})
+
+describe('toSettingsDiffTableRows', () => {
+  const hosts = uniqueHostColumnKeys([
+    { id: 0, name: 'node-0' },
+    { id: 1, name: 'node-1' },
+  ])
+
+  test('flattens match, changed, default, and host values', () => {
+    const [row] = toSettingsDiffTableRows(
+      [
+        {
+          name: 'max_threads',
+          table: 'settings',
+          values: {
+            0: { value: '8', changed: 0, defaultValue: '0' },
+            1: { value: '16', changed: 1, defaultValue: '0' },
+          },
+          hasDiff: true,
+          changedFromDefault: true,
+        },
+      ],
+      hosts,
+      true
+    )
+
+    expect(row).toEqual({
+      match: false,
+      name: 'max_threads',
+      table: 'settings',
+      changed: 'modified',
+      default: '0',
+      _hasDiff: true,
+      'node-0': '8',
+      'node-1': '16',
+    })
+  })
+
+  test('omits match for a single host and labels merge_tree', () => {
+    const oneHost = uniqueHostColumnKeys([{ id: 0, name: 'prod' }])
+    const [row] = toSettingsDiffTableRows(
+      [
+        {
+          name: 'max_bytes_to_merge_at_max_space_in_pool',
+          table: 'merge_tree_settings',
+          values: {
+            0: { value: '16384', changed: 0, defaultValue: '16384' },
+          },
+          hasDiff: false,
+          changedFromDefault: false,
+        },
+      ],
+      oneHost,
+      false
+    )
+
+    expect(row.match).toBeUndefined()
+    expect(row.table).toBe('merge_tree')
+    expect(row.changed).toBe('')
+    expect(row.prod).toBe('16384')
+  })
+})
+
+describe('buildSettingsDiffQueryConfig', () => {
+  test('enables sort, resize, reorder, and host columns', () => {
+    const hosts = uniqueHostColumnKeys([
+      { id: 0, name: 'node-0' },
+      { id: 1, name: 'node-1' },
+    ])
+    const config = buildSettingsDiffQueryConfig(hosts, true)
+
+    expect(config.columns).toEqual([
+      'match',
+      'name',
+      'table',
+      'changed',
+      'default',
+      'node-0',
+      'node-1',
+    ])
+    expect(config.columnFormats?.match).toBe(ColumnFormat.Boolean)
+    expect(config.columnFormats?.name).toBe(ColumnFormat.Code)
+    expect(config.columnFormats?.['node-0']).toBe(ColumnFormat.Code)
+    expect(config.tableBehavior).toEqual({
+      enableColumnResizing: true,
+      enableSorting: true,
+      enableColumnReordering: true,
+    })
+    expect(config.defaultView).toBe('table')
+    expect(config.columnIcons?.match).toBeDefined()
+    expect(config.columnIcons?.name).toBeDefined()
+    expect(config.columnIcons?.['node-0']).toBeDefined()
+  })
+})

--- a/apps/dashboard/src/lib/settings-diff/table-rows.ts
+++ b/apps/dashboard/src/lib/settings-diff/table-rows.ts
@@ -1,0 +1,178 @@
+import {
+  CheckCircle2Icon,
+  PencilIcon,
+  ServerIcon,
+  SlidersHorizontalIcon,
+  Table2Icon,
+  Undo2Icon,
+} from 'lucide-react'
+
+import type { QueryConfig } from '@/types/query-config'
+import type { SettingsDiffHostInfo, SettingsDiffRow } from './types'
+
+import { ColumnFormat } from '@/types/column-format'
+
+const RESERVED_COLUMN_KEYS = new Set([
+  'match',
+  'name',
+  'table',
+  'changed',
+  'default',
+  '_hasdiff',
+])
+
+export type SettingsDiffHostColumn = {
+  id: number
+  key: string
+}
+
+export type SettingsDiffTableRow = Record<string, unknown>
+
+function tableLabel(table: SettingsDiffRow['table']): string {
+  return table === 'merge_tree_settings' ? 'merge_tree' : 'settings'
+}
+
+/**
+ * Stable, unique DataTable column keys for compared hosts.
+ * Host names are used as headers; collisions with reserved keys or other
+ * hosts get a `(id)` suffix.
+ */
+export function uniqueHostColumnKeys(
+  hosts: SettingsDiffHostInfo[]
+): SettingsDiffHostColumn[] {
+  const used = new Set<string>()
+  return hosts.map((host) => {
+    let key = host.name.trim() || `host-${host.id}`
+    const taken = (candidate: string) => {
+      const lower = candidate.toLocaleLowerCase()
+      return reservedOrUsed(lower, used)
+    }
+    if (taken(key)) {
+      key = `${key} (${host.id})`
+    }
+    used.add(key.toLocaleLowerCase())
+    return { id: host.id, key }
+  })
+}
+
+function reservedOrUsed(lower: string, used: Set<string>): boolean {
+  return RESERVED_COLUMN_KEYS.has(lower) || used.has(lower)
+}
+
+export function toSettingsDiffTableRows(
+  rows: SettingsDiffRow[],
+  hostColumns: SettingsDiffHostColumn[],
+  showMatchColumn: boolean
+): SettingsDiffTableRow[] {
+  return rows.map((row) => {
+    const defaultValue =
+      hostColumns.length > 0
+        ? (row.values[hostColumns[0].id]?.defaultValue ?? '—')
+        : '—'
+    const next: SettingsDiffTableRow = {
+      name: row.name,
+      table: tableLabel(row.table),
+      changed: row.changedFromDefault ? 'modified' : '',
+      default: defaultValue,
+      _hasDiff: row.hasDiff,
+    }
+    if (showMatchColumn) {
+      next.match = !row.hasDiff
+    }
+    for (const host of hostColumns) {
+      next[host.key] = row.values[host.id]?.value ?? 'n/a'
+    }
+    return next
+  })
+}
+
+export function buildSettingsDiffQueryConfig(
+  hostColumns: SettingsDiffHostColumn[],
+  showMatchColumn: boolean
+): QueryConfig {
+  const hostKeys = hostColumns.map((h) => h.key)
+  const columns = [
+    ...(showMatchColumn ? ['match'] : []),
+    'name',
+    'table',
+    'changed',
+    'default',
+    ...hostKeys,
+  ]
+
+  const columnFormats: QueryConfig['columnFormats'] = {
+    name: ColumnFormat.Code,
+    table: ColumnFormat.ColoredBadge,
+    changed: ColumnFormat.ColoredBadge,
+    default: ColumnFormat.Code,
+  }
+  if (showMatchColumn) {
+    columnFormats.match = ColumnFormat.Boolean
+  }
+  for (const key of hostKeys) {
+    columnFormats[key] = ColumnFormat.Code
+  }
+
+  const columnIcons: NonNullable<QueryConfig['columnIcons']> = {
+    name: SlidersHorizontalIcon,
+    table: Table2Icon,
+    changed: PencilIcon,
+    default: Undo2Icon,
+  }
+  if (showMatchColumn) {
+    columnIcons.match = CheckCircle2Icon
+  }
+  for (const key of hostKeys) {
+    columnIcons[key] = ServerIcon
+  }
+
+  const columnSizing: NonNullable<QueryConfig['columnSizing']> = {
+    match: { size: 72, minSize: 56, maxSize: 96 },
+    name: { size: 280, minSize: 160 },
+    table: { size: 140, minSize: 100 },
+    changed: { size: 120, minSize: 88 },
+    default: { size: 140, minSize: 88 },
+  }
+  for (const key of hostKeys) {
+    columnSizing[key] = { size: 160, minSize: 96 }
+  }
+
+  const columnDescriptions: Record<string, string> = {
+    match: 'Whether every compared host has the same value.',
+    name: 'Setting name.',
+    table: 'system.settings or system.merge_tree_settings.',
+    changed: 'Value differs from the server default.',
+    default: 'Default value for this setting.',
+  }
+  for (const host of hostColumns) {
+    columnDescriptions[host.key] = `Current value on ${host.key}.`
+  }
+
+  return {
+    name: 'settings-diff',
+    description:
+      'system.settings and merge_tree_settings compared across the selected hosts',
+    sql: '-- client-side settings diff',
+    disableSqlValidation: true,
+    columns,
+    columnFormats,
+    columnIcons,
+    columnSizing,
+    columnDescriptions,
+    defaultView: 'table',
+    card: {
+      primary: 'name',
+      badges: showMatchColumn
+        ? ['match', 'table', 'changed']
+        : ['table', 'changed'],
+      metrics: ['default', ...hostKeys],
+    },
+    tableBehavior: {
+      enableColumnResizing: true,
+      enableSorting: true,
+      enableColumnReordering: true,
+    },
+    rowClassName: (row) =>
+      row._hasDiff ? 'bg-amber-50 dark:bg-amber-950/20' : undefined,
+  }
+}

--- a/docs/content/guide/features/settings.mdx
+++ b/docs/content/guide/features/settings.mdx
@@ -41,7 +41,7 @@ This section covers **ClickHouse server** settings (read-only, from system table
 
 - Open `/settings` to review all server settings; non-default values are highlighted so you can spot unexpected overrides or confirm a change took effect.
 - Open `/mergetree-settings` to inspect MergeTree engine settings, and `/replicated-merge-tree-settings` for Replicated MergeTree settings with changed-from-default values flagged.
-- Open `/settings-diff` to compare `system.settings` and `system.merge_tree_settings` across saved hosts (env, per-user, and browser connections), or node vs node on the current cluster. One saved host compares against setting defaults — add another host to diff a second node. Two or more hosts keep an all-hosts matrix, with an optional pair picker.
+- Open `/settings-diff` to compare `system.settings` and `system.merge_tree_settings` across saved hosts (env, per-user, and browser connections), or node vs node on the current cluster. One saved host compares against setting defaults — add another host to diff a second node. Two or more hosts keep an all-hosts matrix, with an optional pair picker. The comparison table supports search, filters, sort, column resize and reorder, density, and CSV export.
 - To change a setting, use ClickHouse SQL (`SET`, `ALTER TABLE ... MODIFY SETTING`) or edit the server config — these pages are read-only. chmonitor never writes `config.xml`.
 
 ## Permissions & access

--- a/docs/content/guide/guides/dba-workflows.mdx
+++ b/docs/content/guide/guides/dba-workflows.mdx
@@ -24,7 +24,7 @@ chmonitor does **not** apply schema changes and does **not** edit `config.xml` (
 
 ### Settings compare (`/settings-diff`)
 
-Open **Tools → Settings Diff**. Compare saved hosts (env, per-user, and browser connections), or pick two cluster nodes when the current host has 2+ replicas. Filter to rows that differ, or to settings changed from default. One saved host compares against setting defaults; use **Add host** to diff another node. Two or more hosts keep an all-hosts matrix with an optional pair picker. The page is gated by the `settings` feature id — see [Settings](/guide/features/settings).
+Open **Tools → Settings Diff**. Compare saved hosts (env, per-user, and browser connections), or pick two cluster nodes when the current host has 2+ replicas. Filter to rows that differ, or to settings changed from default. Search, column filters, sort, resize, reorder, and density live on the comparison table. One saved host compares against setting defaults; use **Add host** to diff another node. Two or more hosts keep an all-hosts matrix with an optional pair picker. The page is gated by the `settings` feature id — see [Settings](/guide/features/settings).
 
 Nothing on this page writes to ClickHouse. To change a setting, use `SET`, `ALTER TABLE … MODIFY SETTING`, or edit the server config yourself.
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -684,16 +684,18 @@ wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
   matching table's detail is **All matched** / **This table matches**
   (`MatchOk`) plus side-by-side DDL — never EmptyState "no data" /
   "Select a table" / "No recommended statements". "No tables match"
-  is only for a name-filter miss. Settings Diff (`/settings-diff`)
+  is only for a name-filter miss.   Settings Diff (`/settings-diff`)
   with one host keeps the live vs-default matrix and a banner to add
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair
-  mode (`HostPairFilter` + URL `source`/`target`). Name filter lives
-  on the listing panel (schema-diff sidebar, settings-diff table),
-  not the host toolbar. Diffs-only with zero
-  deltas still lists matching settings with a green `CheckCircle2` in
-  a Match column (`--chart-green`); "No settings match" is only a
-  name/changed-from-default filter miss. Compare APIs resolve
+  mode (`HostPairFilter` + URL `source`/`target`). The listing is the
+  shared `DataTable` (search, Filters, sort, resize, drag-to-reorder,
+  density, column visibility, CSV). Name search lives on that table,
+  not the host toolbar. Diffs-only with zero deltas still lists
+  matching settings; the Match column uses the shared boolean check
+  (green) / cross (rose). Empty catalog copy is DataTable's "No
+  settings found" / "No settings match your filters" (a name or
+  changed-from-default miss). Compare APIs resolve
   merged hosts the same way charts do (`resolve-host-fetch.ts` /
   `use-merged-hosts.ts`).
 - Overflow strip: for a single-row scroller that must not wrap, use


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings Diff now uses the shared data table, so the comparison matrix has the same toolbar as other dashboard tables: search, filters, sort, column resize and reorder, density, visibility, and CSV export.

## Changes

- Replace the custom settings matrix in `settings-diff-table.tsx` with `DataTable`
- Flatten host values into table rows in `lib/settings-diff/table-rows.ts` (unique host column keys, match/changed columns, row highlight for diffs)
- Column header icons for match, name, table, changed, default, and host values
- Move CSV export into the table toolbar; name search is the table search box (still on the listing, not the host toolbar)
- Keep compare-page chips (Differences / All, Changed from default) unchanged
- Update product-design skill, knowledge doc, and user-facing settings docs

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run type-check:test` passes
- [x] Biome check on changed files
- [x] `bun test` for settings-diff table, page, and search suites (18 passing)
- [ ] `pnpm run lint` / `pnpm run build` in CI
- [ ] Manual check on `/settings-diff`: sort, filter, resize, drag columns, density, CSV

## Notes for reviewer

Match uses the shared boolean check/cross (green/rose). Diff rows still get the amber row highlight. One-host vs-default hides the Match column. Host names that collide with reserved keys (`name`, `default`, …) get an `(id)` suffix.

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2916954-c2f9-42c8-810a-e7fc6b345a78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2916954-c2f9-42c8-810a-e7fc6b345a78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

