### PR TITLE
fix(cli): rename crate to chmonitor and stop crates.io publish on main

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -73,7 +73,7 @@
     },
     "rust/ch-monitor-cli": {
       "release-type": "rust",
-      "package-name": "ch-monitor-cli",
+      "package-name": "chmonitor",
       "component": "chm",
       "include-component-in-tag": true,
       "include-v-in-tag": true,

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - 'rust/ch-json/**'
       - 'rust/ch-pivot/**'
-      - 'rust/ch-monitor-cli/**'
       - '.github/workflows/cargo-publish.yml'
   workflow_dispatch:
 
@@ -45,8 +44,6 @@ jobs:
               - 'rust/ch-json/**'
             ch_pivot:
               - 'rust/ch-pivot/**'
-            ch_monitor_cli:
-              - 'rust/ch-monitor-cli/**'
 
       - name: Publish ch-json
         if: steps.filter.outputs.ch_json == 'true' || github.event_name == 'workflow_dispatch'
@@ -92,27 +89,6 @@ jobs:
             echo "ch-pivot v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
           fi
 
-      # The user-facing CLI (#2699): publishing it makes `cargo install
-      # ch-monitor-cli` work for Rust-toolchain users, complementing the
-      # binary install script (scripts/install.sh → chm-v* GitHub Releases).
-      - name: Publish ch-monitor-cli
-        if: steps.filter.outputs.ch_monitor_cli == 'true' || github.event_name == 'workflow_dispatch'
-        working-directory: rust/ch-monitor-cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          VERSION=$(grep -m 1 '^version = ' Cargo.toml | cut -d '"' -f 2)
-          echo "Checking ch-monitor-cli v$VERSION on crates.io..."
-
-          # crates.io API requires a User-Agent header (returns 403 otherwise).
-          # Publish ONLY on a definitive 404; treat 200/403/5xx as "skip" so a
-          # transient API quirk never triggers a doomed `cargo publish`.
-          STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "User-Agent: clickhouse-monitoring-ci (https://github.com/chmonitor/chmonitor)" \
-            "https://crates.io/api/v1/crates/ch-monitor-cli/$VERSION" || true)
-          if [ "$STATUS_CODE" = "404" ]; then
-            echo "ch-monitor-cli v$VERSION not found on crates.io. Publishing..."
-            cargo publish
-          else
-            echo "ch-monitor-cli v$VERSION already published or check inconclusive (HTTP $STATUS_CODE). Skipping publish."
-          fi
+      # CLI crate (`chmonitor`) is published from cli-rust-release.yml on
+      # stable `chm-vX.Y.Z` tags only — not from main (main ships GitHub
+      # beta binaries, not crates.io).

--- a/.github/workflows/cli-rust-ci.yml
+++ b/.github/workflows/cli-rust-ci.yml
@@ -34,3 +34,5 @@ jobs:
       - run: cargo clippy -- -D warnings
       - run: cargo build --release
       - run: cargo test
+      - name: crates.io metadata dry-run
+        run: cargo publish --dry-run --allow-dirty

--- a/.github/workflows/cli-rust-release.yml
+++ b/.github/workflows/cli-rust-release.yml
@@ -146,6 +146,11 @@ jobs:
     if: needs.meta.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.meta.outputs.checkout_ref }}
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.meta.outputs.channel == 'stable'
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -235,3 +240,20 @@ jobs:
           echo "Found:" >&2
           printf '%s\n' "$assets" >&2
           exit 1
+      - name: Publish chmonitor crate to crates.io
+        if: needs.meta.outputs.channel == 'stable'
+        working-directory: rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' ch-monitor-cli/Cargo.toml | head -n1)"
+          STATUS_CODE="$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "User-Agent: chmonitor-ci (https://github.com/chmonitor/chmonitor)" \
+            "https://crates.io/api/v1/crates/chmonitor/${VERSION}" || true)"
+          if [ "$STATUS_CODE" != "404" ]; then
+            echo "chmonitor v${VERSION} already published or check inconclusive (HTTP ${STATUS_CODE}). Skipping crates.io."
+            exit 0
+          fi
+          echo "Publishing chmonitor v${VERSION} to crates.io..."
+          cargo publish -p chmonitor --locked

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -4,7 +4,7 @@ description: Install and use the chm / chmonitor CLI — dashboard API client, T
 icon: Terminal
 ---
 
-`chm` is the standalone terminal CLI for chmonitor (crate `ch-monitor-cli`). The
+`chm` is the standalone terminal CLI for chmonitor (crate `chmonitor`). The
 full alias `chmonitor` is the same binary. By default it talks to **chmonitor
 Cloud** at `https://dash.chmonitor.dev` (hosts, charts, tables, TUI, agent).
 Point `--base-url` / `CHM_BASE_URL` at your self-hosted dashboard when needed.
@@ -14,7 +14,7 @@ host** with no dashboard account or backend.
 
 <Callout type="info" title="Binary names and platforms">
 Shipped release assets are Linux and macOS only (`x86_64` / `aarch64`). There
-is no Windows binary — use `cargo install ch-monitor-cli` on unsupported
+is no Windows binary — use `cargo install chmonitor` on unsupported
 targets. Release tags use `chm-v*`; assets are named `chm-<target>` (+
 `.sha256`).
 </Callout>
@@ -41,7 +41,7 @@ Override the install directory with `CHM_INSTALL_DIR` (default
 Already have a Rust toolchain?
 
 ```bash
-cargo install ch-monitor-cli
+cargo install chmonitor
 # both `chm` and `chmonitor` land in ~/.cargo/bin
 ```
 
@@ -91,7 +91,7 @@ chm upgrade --version chm-v0.2.0
 ```
 
 Checksum verification is mandatory. Failures print a copy-pasteable fallback
-(`scripts/install.sh` or `cargo install ch-monitor-cli --force`).
+(`scripts/install.sh` or `cargo install chmonitor --force`).
 
 <Callout type="info" title="Update reminder">
 After some commands (including `chm diagnose`), `chm` does a fast, best-effort

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -531,7 +531,7 @@ Build-time branding overrides (optional; do not set unless you custom-build):
 ## CLI client
 
 Env vars for the standalone [`chm` / `chmonitor` CLI](/guide/guides/diagnostics-cli)
-(crate `ch-monitor-cli`). These are read by the binary and `scripts/install.sh`,
+(crate `chmonitor`). These are read by the binary and `scripts/install.sh`,
 not by the dashboard server. Flags override env; env overrides
 `./chm.toml` / `~/.config/chm/config.toml`. Default API base is
 `https://dash.chmonitor.dev`.

--- a/docs/knowledge/release-automation.md
+++ b/docs/knowledge/release-automation.md
@@ -164,8 +164,8 @@ asserts exactly **8** assets before upload (and re-checks the Release API).
 
 | Channel | Trigger | Tag shape | Notes |
 |---------|---------|-----------|-------|
-| **beta** | Push to `main` touching `rust/ch-monitor-cli/**` (and lockfile / `install.sh` / the workflow) | `chm-vX.Y.Z-beta.<run_number>` from `Cargo.toml` version | `prerelease=true`, `make_latest=false` |
-| **stable** | release-please / `workflow_dispatch` with `tag=chm-v…`, or push of a stable `chm-vX.Y.Z` tag | `chm-vX.Y.Z` | `prerelease=false`, `make_latest=true` |
+| **beta** | Push to `main` touching `rust/ch-monitor-cli/**` (and lockfile / `install.sh` / the workflow) | `chm-vX.Y.Z-beta.<run_number>` from `Cargo.toml` version | GitHub prerelease only (`prerelease=true`, `make_latest=false`). Does **not** publish to crates.io. |
+| **stable** | release-please / `workflow_dispatch` with `tag=chm-v…`, or push of a stable `chm-vX.Y.Z` tag | `chm-vX.Y.Z` | GitHub latest + `cargo publish -p chmonitor` (`prerelease=false`, `make_latest=true`) |
 
 Installers and `chm update`/`upgrade` select channel via `CHM_CHANNEL` /
 `--channel` / config (`stable` default). See

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -20,7 +20,7 @@ related:
 `rust/ch-monitor-cli` ships two command names for the same binary: **`chm`**
 (short, preferred) and **`chmonitor`** (full alias). Release assets stay
 `chm-<target>`; `scripts/install.sh` installs `chm` and symlinks `chmonitor`.
-`cargo install ch-monitor-cli` installs both binaries.
+`cargo install chmonitor` installs both binaries.
 
 By default it talks to **chmonitor
 Cloud** at `https://dash.chmonitor.dev` (hosts / charts / tables / TUI / agent).
@@ -234,7 +234,7 @@ binary. They never invoke sudo. Homebrew-managed installs are refused
 `stable` skips prereleases; `beta` includes them and prefers a prerelease
 when semver cores tie. Checksum, permission, download, and
 unsupported-target failures print a copy-pasteable fallback (`scripts/install.sh`
-or `cargo install ch-monitor-cli --force`; unsupported targets point at cargo
+or `cargo install chmonitor --force`; unsupported targets point at cargo
 only). `--version` accepts `chm-v0.2.0`, `v0.2.0`, `0.2.0`, or `chm-0.2.0`.
 Implementation: `src/update.rs`. Latest-tag lookup pages past dashboard/Helm
 releases and ranks published `chm-v*` tags by semver.
@@ -305,5 +305,5 @@ CHM_CHANNEL=beta curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor
   `CHM_CHANNEL` / config `channel`) pull from the same GitHub Releases.
 - `rust/ch-monitor-cli/Cargo.toml` carries `authors`/`repository`/`readme`/
   `keywords`/`categories`. `cargo-publish.yml` publishes the crate so
-  `cargo install ch-monitor-cli` works as a self-update fallback. Homebrew
+  `cargo install chmonitor` works as a self-update fallback. Homebrew
   is still out of scope.

--- a/docs/plans/roadmap/17-sdk-and-public-api.md
+++ b/docs/plans/roadmap/17-sdk-and-public-api.md
@@ -166,7 +166,7 @@ bun test packages/sdk/src/__tests__/client.test.ts
 bun run depcruise
 
 # reference consumer still builds against the stable routes
-cargo build -p ch-monitor-cli --manifest-path rust/Cargo.toml
+cargo build -p chmonitor --manifest-path rust/Cargo.toml
 
 # nothing regressed
 bun run lint && bun run build && bun run test:unit

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -196,7 +196,26 @@ name = "ch-json"
 version = "0.1.0"
 
 [[package]]
-name = "ch-monitor-cli"
+name = "ch-pivot"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chmonitor"
 version = "0.1.2"
 dependencies = [
  "anyhow",
@@ -219,25 +238,6 @@ dependencies = [
  "sha2",
  "tokio",
  "toml",
-]
-
-[[package]]
-name = "ch-pivot"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "ch-monitor-cli"
+name = "chmonitor"
 version = "0.1.2"
 edition = "2021"
 authors = ["duyet <bot@duyet.net>"]
-description = "Standalone terminal/TUI CLI for chmonitor, plus a zero-signup `chm diagnose` health scan that connects straight to [REDACTED]."
+description = "Standalone terminal/TUI CLI for chmonitor (`chm` / `chmonitor`), including a zero-signup `chm diagnose` health scan."
 license = "MIT"
 repository = "https://github.com/chmonitor/chmonitor"
 readme = "README.md"
-keywords = ["clickhouse", "cli", "[REDACTED]", "diagnostics"] # pragma: allowlist secret
+keywords = ["cli", "tui", "diagnostics", "monitoring", "database"]
 categories = ["command-line-utilities"]
 exclude = ["/.github"]
 
-# The marketed command is `chm` (docs, install.sh, release assets) — without
-# this, `cargo install ch-monitor-cli` would drop a binary named
-# `ch-monitor-cli` that none of the documentation mentions.
+# Marketed commands are `chm` and `chmonitor`. Without explicit [[bin]]
+# names, `cargo install chmonitor` would drop a binary named after the
+# package only.
 [[bin]]
 name = "chm"
 path = "src/main.rs"

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -3,14 +3,14 @@
 Standalone terminal/TUI CLI for [chmonitor](https://github.com/chmonitor/chmonitor).
 
 **Command names:** `chm` (short, preferred) and `chmonitor` (full alias). Same binary;
-`cargo install ch-monitor-cli` installs both; `scripts/install.sh` installs `chm`
+`cargo install chmonitor` installs both; `scripts/install.sh` installs `chm`
 and symlinks `chmonitor` → `chm`.
 
 **Default API base:** `https://dash.chmonitor.dev` (`--base-url` / `CHM_BASE_URL`
 for self-hosted).
 
 **Platforms:** prebuilt binaries for Linux/macOS × `x86_64`/`aarch64` only (no
-Windows). Other targets: `cargo install ch-monitor-cli`.
+Windows). Other targets: `cargo install chmonitor`.
 
 Two ways to use it:
 
@@ -36,7 +36,7 @@ Downloads and verifies the right prebuilt binary for your OS/arch from
 Or from crates.io / source:
 
 ```bash
-cargo install ch-monitor-cli --force
+cargo install chmonitor --force
 # installs both `chm` and `chmonitor` into ~/.cargo/bin
 
 cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
@@ -63,7 +63,7 @@ alias). Both print current -> target version, download the matching GitHub
 Release binary, verify sha256, and atomically replace the running executable.
 They never invoke sudo: checksum, permission, and unsupported-target failures
 print a copy-pasteable fallback (`scripts/install.sh` or
-`cargo install ch-monitor-cli --force`).
+`cargo install chmonitor --force`).
 
 ```bash
 chm upgrade                      # alias of update — latest stable chm-v* release
@@ -76,7 +76,7 @@ chm upgrade --version chm-v0.2.0 # pin a specific release (`0.2.0` / `v0.2.0` al
 After a `chm diagnose` run, a one-line "update available" hint is printed to
 stderr when a newer release exists (best-effort, sub-second timeout). Silence it
 with `CHM_NO_UPDATE_CHECK=1`. Installed via `cargo install`? Upgrade with
-`cargo install ch-monitor-cli --force` instead.
+`cargo install chmonitor --force` instead.
 
 See [docs.chmonitor.dev/guide/guides/diagnostics-cli](https://docs.chmonitor.dev/guide/guides/diagnostics-cli)
 for the full CLI reference.

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -170,7 +170,7 @@ pub enum Commands {
     /// Prints current -> target version, verifies sha256, and atomically
     /// replaces this binary. Never invokes sudo: checksum, permission, and
     /// unsupported-target failures print a copy-pasteable fallback
-    /// (`scripts/install.sh` or `cargo install ch-monitor-cli`).
+    /// (`scripts/install.sh` or `cargo install chmonitor`).
     Update(UpdateArgs),
     /// Alias of `update`. Same flags (`--check`, `--version`), same behaviour.
     Upgrade(UpdateArgs),

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -19,7 +19,7 @@ const RELEASE_DOWNLOAD: &str = "https://github.com/chmonitor/chmonitor/releases/
 const USER_AGENT: &str = concat!("chm-cli/", env!("CARGO_PKG_VERSION"));
 const INSTALL_SH: &str =
     "curl -sSf https://raw.githubusercontent.com/chmonitor/chmonitor/main/scripts/install.sh | bash";
-const CARGO_INSTALL: &str = "cargo install ch-monitor-cli --force";
+const CARGO_INSTALL: &str = "cargo install chmonitor --force";
 /// GitHub's default page size is 30; this repo also ships dashboard/Helm releases.
 const RELEASES_PER_PAGE: u32 = 100;
 /// Safety cap so a huge releases list cannot loop forever.
@@ -603,7 +603,7 @@ mod tests {
 
     fn assert_copy_pasteable_fallback(msg: &str) {
         assert!(msg.contains("scripts/install.sh"), "{msg}");
-        assert!(msg.contains("cargo install ch-monitor-cli"), "{msg}");
+        assert!(msg.contains("cargo install chmonitor"), "{msg}");
         // Match `sudo ` as a command. The phrase "never invokes sudo" must not trip this.
         assert!(
             !msg.contains("sudo "),
@@ -646,7 +646,7 @@ mod tests {
     fn unsupported_target_points_at_cargo() {
         let msg = unsupported_target_error("wasm32-unknown-unknown").to_string();
         assert!(msg.contains("wasm32-unknown-unknown"), "{msg}");
-        assert!(msg.contains("cargo install ch-monitor-cli"), "{msg}");
+        assert!(msg.contains("cargo install chmonitor"), "{msg}");
         assert!(
             !msg.contains("install.sh"),
             "unsupported-target fallback must not point at install.sh: {msg}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,12 +249,12 @@ resolve_version() {
   log "Looking up latest ${CHANNEL} chm-v* release..."
   releases_json="$(curl -fsSL -H "User-Agent: chmonitor-installer" \
     "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>/dev/null)" \
-    || die "failed to query GitHub releases API for ${REPO}. Fallback: cargo install ch-monitor-cli --force"
+    || die "failed to query GitHub releases API for ${REPO}. Fallback: cargo install chmonitor --force"
 
   tag="$(pick_newest_chm_tag "$releases_json" "$CHANNEL")"
 
   if [ -z "$tag" ]; then
-    die "no published chm-v* release found for ${REPO} (channel=${CHANNEL}) yet. Pin one with CHM_VERSION=chm-vX.Y.Z, or: cargo install ch-monitor-cli --force"
+    die "no published chm-v* release found for ${REPO} (channel=${CHANNEL}) yet. Pin one with CHM_VERSION=chm-vX.Y.Z, or: cargo install chmonitor --force"
   fi
 
   printf '%s\n' "$tag"
@@ -274,7 +274,7 @@ BIN_PATH="${TMP_DIR}/${ASSET_NAME}"
 SHA_PATH="${TMP_DIR}/${ASSET_NAME}.sha256"
 
 if ! curl -fsSL -o "$BIN_PATH" "$BIN_URL"; then
-  die "failed to download ${BIN_URL} — the release may not include a binary for ${TARGET}, or the tag doesn't exist. Set CHM_VERSION=chm-vX.Y.Z to pin a different release, or: cargo install ch-monitor-cli --force"
+  die "failed to download ${BIN_URL} — the release may not include a binary for ${TARGET}, or the tag doesn't exist. Set CHM_VERSION=chm-vX.Y.Z to pin a different release, or: cargo install chmonitor --force"
 fi
 
 if [ ! -s "$BIN_PATH" ]; then
@@ -283,12 +283,12 @@ fi
 
 # --- verify checksum (mandatory; never install an unverified binary) ---
 if ! curl -fsSL -o "$SHA_PATH" "$SHA_URL"; then
-  die "no checksum asset at ${SHA_URL} — refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
+  die "no checksum asset at ${SHA_URL} — refusing to install unverified binary. Fallback: cargo install chmonitor --force"
 fi
 
 expected="$(awk '{print $1}' "$SHA_PATH")"
 if [ -z "$expected" ]; then
-  die "checksum file was empty — refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
+  die "checksum file was empty — refusing to install unverified binary. Fallback: cargo install chmonitor --force"
 fi
 
 if command -v sha256sum >/dev/null 2>&1; then
@@ -296,11 +296,11 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   actual="$(shasum -a 256 "$BIN_PATH" | awk '{print $1}')"
 else
-  die "neither sha256sum nor shasum found — cannot verify checksum, refusing to install unverified binary. Fallback: cargo install ch-monitor-cli --force"
+  die "neither sha256sum nor shasum found — cannot verify checksum, refusing to install unverified binary. Fallback: cargo install chmonitor --force"
 fi
 
 if [ "$expected" != "$actual" ]; then
-  die "checksum mismatch for ${ASSET_NAME}: expected ${expected}, got ${actual}. Download may be corrupt or tampered with — aborting. Fallback: cargo install ch-monitor-cli --force"
+  die "checksum mismatch for ${ASSET_NAME}: expected ${expected}, got ${actual}. Download may be corrupt or tampered with — aborting. Fallback: cargo install chmonitor --force"
 fi
 log "Checksum verified."
 
@@ -308,7 +308,7 @@ chmod +x "$BIN_PATH"
 
 mkdir -p "$INSTALL_DIR" 2>/dev/null || die "could not create install directory '$INSTALL_DIR'"
 if [ ! -w "$INSTALL_DIR" ]; then
-  die "install directory '$INSTALL_DIR' is not writable. This script never invokes sudo. Re-run with CHM_INSTALL_DIR pointing at a writable directory, or: cargo install ch-monitor-cli --force"
+  die "install directory '$INSTALL_DIR' is not writable. This script never invokes sudo. Re-run with CHM_INSTALL_DIR pointing at a writable directory, or: cargo install chmonitor --force"
 fi
 
 mv "$BIN_PATH" "${INSTALL_DIR}/${BIN_NAME}"


### PR DESCRIPTION
## Why
Main CI `Publish Workspace Crates` failed: crates.io 400 because `Cargo.toml` had an invalid keyword (`[REDACTED]`). Main was also publishing the CLI crate on every push.

## What
- Rename package `ch-monitor-cli` → `chmonitor` (`cargo install chmonitor`)
- Valid crates.io keywords only (`cli`, `tui`, `diagnostics`, `monitoring`, `database`)
- Remove CLI from `cargo-publish.yml` on `main`
- GitHub **beta** binaries still from `main` (`cli-rust-release.yml`)
- **crates.io** + GitHub **stable** on `chm-vX.Y.Z` tags only
- `cargo publish --dry-run` in CLI CI so metadata breaks fail the PR

Directory stays `rust/ch-monitor-cli`.

Co-Authored-By: duyetbot <bot@duyet.net>