### PR TITLE
feat(cli): overview chart TUI, dashboard list, interactive config

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -6,8 +6,9 @@ icon: Terminal
 
 `chm` is the standalone terminal CLI for chmonitor (crate `chmonitor`). The
 full alias `chmonitor` is the same binary. Run **`chm` with no subcommand** to
-open the live TUI (`chm tui` is the same UI). `chm --help` / `chm help` /
-`chm -h` still print help. By default it talks to **chmonitor Cloud** at
+open the live TUI (`chm tui` is the same UI) on the Overview dashboard charts.
+`chm --help` / `chm help` / `chm -h` still print help. By default it talks to
+**chmonitor Cloud** at
 `https://dash.chmonitor.dev` (hosts, charts, tables, TUI, agent). Point
 `--base-url` / `CHM_BASE_URL` / `chm config set base_url` at your self-hosted
 dashboard when needed.
@@ -105,8 +106,12 @@ available. Silence it with `CHM_NO_UPDATE_CHECK=1`.
 ## Common dashboard commands
 
 ```bash
-chm                        # live TUI (default)
+chm                        # live TUI (default) — Overview charts
 chm tui                    # same UI
+chm dashboard list         # pick Overview or a saved dashboard
+chm dashboard open Overview
+chm config                 # interactive config dialog
+chm config show            # files + inherit order + resolved
 chm hosts
 chm chart query-count --limit 50
 chm table running-queries --limit 30
@@ -115,9 +120,17 @@ chm agent "why are merges slow?"
 # same binary: chmonitor hosts
 ```
 
+The default TUI fetches Overview charts (`query-count`, counts, disk size) from
+`GET /api/v1/charts/{name}?hostId=` and skips 404s. `chm dashboard list` always
+includes built-in Overview; saved dashboards come from `GET /api/dashboards/list`
+when signed in (401/501 still list Overview). Piped stdout or `--json` prints
+names without a picker.
+
 Config priority: CLI flags → env (`CHM_BASE_URL`, `CHM_HOST_ID`, `CHM_API_KEY`,
-`CHM_TOKEN`, `CHM_CHANNEL`, …) → `./chm.toml` / `~/.config/chm/config.toml` →
-defaults.
+`CHM_TOKEN`, `CHM_CHANNEL`, …) → project `./chm.toml` / `./.chm/config.toml` →
+user `~/.config/chm/config.toml` → defaults (`base_url = https://dash.chmonitor.dev`).
+`chm config show` prints each layer's path, whether it exists, redacted file
+contents, env/flag overrides, and the resolved values.
 
 ## Zero-signup cluster health (`chm doctor`)
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -23,7 +23,8 @@ related:
 `cargo install chmonitor` installs both binaries.
 
 **`chm` with no subcommand opens the live TUI** (`chm tui` is an explicit alias
-of the same UI). `chm --help` / `chm help` / `chm -h` still print help.
+of the same UI) showing the **Overview dashboard** charts. `chm --help` /
+`chm help` / `chm -h` still print help.
 
 By default it talks to **chmonitor
 Cloud** at `https://dash.chmonitor.dev` (hosts / charts / tables / TUI / agent).
@@ -55,14 +56,20 @@ Credentials (device-login token / API key) live in the OS keyring, with a
 ## Command tree
 
 ```text
-chm                # live TUI (default; same as `chm tui`)
+chm                # live TUI (default; Overview charts; same as `chm tui`)
 ├── tui [chart]    # explicit TUI alias (alt-screen)
+├── dashboard
+│   ├── list       # pick a dashboard (Overview + saved); Enter opens TUI
+│   └── open <name>
 ├── auth
 │   ├── login [--api-key]  # auto-detect none|device|api_key
 │   ├── logout     # clear keyring credentials
 │   ├── status     # whether a token / API key is present
 │   └── token      # print stored bearer token (CI)
-├── config         # show / edit local config
+├── config         # interactive dialog (no subcommand)
+│   ├── show       # files + contents + inherit order + resolved
+│   ├── path
+│   └── set KEY VALUE
 ├── hosts          # GET /api/v1/hosts
 ├── link [path]    # open dashboard in browser
 ├── chart <name>   # GET /api/v1/charts/{name} (+ braille sparkline + min/max/avg)
@@ -78,6 +85,8 @@ chm                # live TUI (default; same as `chm tui`)
 ```bash
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- tui
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- dashboard list
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- config show
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- auth login
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- hosts
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- chart query-count --limit 50
@@ -90,12 +99,17 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merge
 ## TUI (`chm` / `chm tui`)
 
 Live UI (ratatui + crossterm). Bare `chm` and `chm tui` are the same command
-(telemetry `cli_run` / `tui`). Default chart is config `default_chart` else
-`query-count`; default table is `running-queries`. **Only** this TUI and
-interactive `chm chat` enter the terminal alternate screen; other commands stay
-on the normal screen.
+(telemetry `cli_run` / `tui`). The default view is the **Overview dashboard**:
+`query-count`, `query-count-today`, `running-queries-count`, `database-count`,
+`table-count`, and `disk-size-single` (or `disk-size-all`) via
+`GET /api/v1/charts/{name}?hostId=`. Each chart is a KPI and/or sparkline in a
+grid; HTTP 404 charts are skipped. The running-queries table stays a secondary
+pane. `chm dashboard list` (and `chm dashboard open <name>`) open the same TUI
+bound to Overview or a saved dashboard's `layout.widgets[].chartName`. **Only**
+this TUI, interactive `chm chat`, and `chm config` (dialog) enter the terminal
+alternate screen; `dashboard list`'s picker stays on the normal screen.
 
-One screen: hosts + sparkline **and** the table together when the terminal is
+One screen: hosts + chart grid **and** the table together when the terminal is
 tall/wide enough (`≥72×24`). Smaller terminals collapse to a focused pane with
 a visible `overview | table` switcher.
 
@@ -112,10 +126,35 @@ a visible `overview | table` switcher.
 | `2` / `3` | Table pane |
 | `/` | Filter table rows |
 
-Header shows host name, short base URL, channel, and live/refresh age. Footer
-lists the keys above. Auth failures (HTTP 401/403) show `chm auth login` in the
-TUI instead of panicking. Start focused on overview (small terminals) with
-`--overview`.
+Header shows dashboard name, host name, short base URL, channel, and live/refresh
+age. Footer lists the keys above. Auth failures (HTTP 401/403) show
+`chm auth login` in the TUI instead of panicking. Default focus is the overview
+chart grid (`--overview` still accepted).
+
+## Dashboards (`chm dashboard list`)
+
+Always lists built-in **Overview** first. When signed in, also fetches
+`GET /api/dashboards/list` and uses each `layout.widgets[].chartName` where
+`type=chart`. HTTP 401/403/501 still lists Overview plus a one-line reason.
+Interactive TTY: j/k/arrows pick, Enter opens the TUI. `--json` or piped stdout
+prints names (no picker). `chm dashboard open <name>` opens by name.
+
+## Config (`chm config` / `chm config show`)
+
+Bare `chm config` opens an interactive dialog (alt-screen) for `base_url`,
+`host_id`, `channel`, `default_chart` and writes `~/.config/chm/config.toml`.
+API key / token are not edited as plaintext in the form (`chm config set` /
+`chm auth login`). Esc cancels; Enter/s saves. `chm config set KEY VALUE`
+stays for scripts.
+
+`chm config show` prints layering (highest file layer wins among files; flags/env
+beat files):
+
+1. User `~/.config/chm/config.toml` — path, exists, full content (`api_key` /
+   `token` redacted as `(set)`)
+2. Project `./chm.toml` and `./.chm/config.toml`
+3. Env / flags that overrode
+4. Resolved config (including default `base_url = https://dash.chmonitor.dev`)
 
 ## Channels
 

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+* **cli:** default TUI shows Overview dashboard charts (KPI/sparkline grid)
+* **cli:** `chm dashboard list` / `open` (Overview + saved dashboards)
+* **cli:** interactive `chm config`; `chm config show` prints file layers
 * **cli:** launch interactive TUI by default (`chm` with no subcommand; `chm tui` stays an alias)
 * **cli:** make `chm doctor` the cluster health command (`diagnose` stays as an alias)
 

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -7,7 +7,8 @@ Standalone terminal/TUI CLI for [chmonitor](https://github.com/chmonitor/chmonit
 and symlinks `chmonitor` → `chm`.
 
 **Default:** `chm` with no subcommand opens the live TUI (`chm tui` is the same
-UI). `chm --help` / `chm help` / `chm -h` still print help.
+UI) on the Overview dashboard charts. `chm --help` / `chm help` / `chm -h`
+still print help.
 
 **Default API base:** `https://dash.chmonitor.dev` (`--base-url` / `CHM_BASE_URL`
 / `chm config set base_url` for self-hosted).
@@ -17,8 +18,9 @@ Windows). Other targets: `cargo install chmonitor`.
 
 Two ways to use it:
 
-- `chm` — **interactive TUI** against a running dashboard (hosts + sparkline +
-  table). `chm tui` is an explicit alias.
+- `chm` — **interactive TUI** against a running dashboard (Overview chart grid +
+  secondary table). `chm tui` is an explicit alias. `chm dashboard list` picks
+  Overview or a saved dashboard.
 - `chm doctor --ch-host …` — **zero-signup** health scan that connects straight
   to a cluster HTTP interface (no chmonitor account or backend needed) and
   prints a scored, read-only report. `chm diagnose` is an alias of this path.
@@ -67,9 +69,16 @@ chm doctor --ch-host http://localhost:8123
 # Connectivity / self-check (no ClickHouse host)
 chm doctor
 
-# Live TUI (default — same as `chm tui`)
+# Live TUI (default — Overview charts; same as `chm tui`)
 chm
 chm tui query-count --table running-queries
+chm dashboard list
+chm dashboard open Overview
+
+# Config
+chm config                 # interactive dialog
+chm config show            # files + inherit order + resolved
+chm config set host_id 0
 
 # One-shot dashboard API
 chm auth login

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -82,8 +82,10 @@ impl std::fmt::Display for Channel {
 pub enum Commands {
     /// Sign in / out — auto-detects open API, device login, or API key
     Auth(AuthArgs),
-    /// Show or edit local CLI config
+    /// Show or edit local CLI config (no subcommand: interactive dialog)
     Config(ConfigArgs),
+    /// List or open Overview / saved dashboards
+    Dashboard(DashboardArgs),
     /// List hosts from a running chmonitor dashboard
     Hosts,
     /// Open the dashboard (or a path) in the browser
@@ -156,7 +158,7 @@ pub enum Commands {
 /// Flags for `chm` / `chm tui`.
 #[derive(Args, Debug, Clone)]
 pub struct TuiArgs {
-    /// Chart name (default: config `default_chart`, else query-count)
+    /// Extra chart to include on the Overview grid
     pub chart: Option<String>,
     /// On a small terminal, start focused on the overview pane
     #[arg(long)]
@@ -251,13 +253,31 @@ pub struct AuthLoginArgs {
 
 #[derive(Args, Debug)]
 pub struct ConfigArgs {
+    /// Omit to open the interactive config dialog.
     #[command(subcommand)]
-    pub command: ConfigCommand,
+    pub command: Option<ConfigCommand>,
+}
+
+#[derive(Args, Debug)]
+pub struct DashboardArgs {
+    #[command(subcommand)]
+    pub command: DashboardCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DashboardCommand {
+    /// List dashboards; Enter opens the TUI (or print names when piped / --json)
+    List,
+    /// Open a dashboard by name in the TUI
+    Open {
+        /// Dashboard name (`Overview` or a saved name)
+        name: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
 pub enum ConfigCommand {
-    /// Print the resolved config
+    /// Print config files, inherit order, and resolved values
     Show,
     /// Print the user config file path
     Path,

--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -162,6 +162,39 @@ pub async fn fetch_envelope_cfg(
     fetch_envelope(client, url, token.as_deref(), api_key.as_deref()).await
 }
 
+fn auth_pair(cfg: &AppConfig) -> Result<(Option<String>, Option<String>)> {
+    let token = crate::credentials::resolve_token(cfg.token.as_deref())?;
+    let api_key = crate::credentials::resolve_api_key(cfg.api_key.as_deref())?;
+    Ok((token, api_key))
+}
+
+/// Raw GET (status + body). Caller decides how to treat 4xx/5xx.
+pub async fn fetch_status_cfg(
+    client: &Client,
+    cfg: &AppConfig,
+    url: String,
+) -> Result<(u16, String)> {
+    let (token, api_key) = auth_pair(cfg)?;
+    send_get(client, &url, token.as_deref(), api_key.as_deref()).await
+}
+
+/// Like [`fetch_cfg`], but HTTP 404 is `Ok(None)` so callers can skip missing charts.
+pub async fn fetch_optional_cfg(
+    client: &Client,
+    cfg: &AppConfig,
+    url: String,
+) -> Result<Option<Value>> {
+    let (status, text) = fetch_status_cfg(client, cfg, url.clone()).await?;
+    if status == 404 {
+        return Ok(None);
+    }
+    ensure_success(&url, status, &text)?;
+    let parsed: ApiResponse = serde_json::from_str(&text).with_context(|| {
+        format!("chmonitor API at {url} returned a non-JSON body (HTTP {status})")
+    })?;
+    Ok(Some(parsed.data))
+}
+
 pub fn rows_from_chart_data(data: Value) -> Result<Vec<Value>> {
     match data {
         Value::Array(rows) => Ok(rows),

--- a/rust/ch-monitor-cli/src/commands/config_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/config_cmd.rs
@@ -3,55 +3,28 @@
 use anyhow::{bail, Result};
 
 use crate::{
-    cli::{ConfigArgs, ConfigCommand},
+    cli::{Cli, ConfigArgs, ConfigCommand},
     config::{self, AppConfig, FileConfig},
     output,
 };
 
-pub fn run(cfg: &AppConfig, args: ConfigArgs) -> Result<()> {
+pub fn run(cli: &Cli, cfg: &AppConfig, args: ConfigArgs) -> Result<()> {
     match args.command {
-        ConfigCommand::Show => {
-            let v = serde_json::json!({
-                "base_url": cfg.base_url,
-                "host_id": cfg.host_id,
-                "api_key_set": cfg.api_key.as_ref().map(|k| !k.is_empty()).unwrap_or(false),
-                "token_set": cfg.token.as_ref().map(|t| !t.is_empty()).unwrap_or(false),
-                "default_chart": cfg.default_chart,
-                "channel": cfg.channel.as_str(),
-                "user_config_path": cfg.user_config_path.display().to_string(),
-            });
+        None => crate::tui::config_form::run(cfg),
+        Some(ConfigCommand::Show) => {
+            let snap = config::current_snapshot(cli, cfg);
             if cfg.json {
-                output::print_json(&v)?;
+                output::print_json(&config::format_snapshot_json(&snap))?;
             } else {
-                println!("base_url        = {}", cfg.base_url);
-                println!("host_id         = {}", cfg.host_id);
-                println!(
-                    "api_key         = {}",
-                    if cfg.api_key.as_ref().is_some_and(|k| !k.is_empty()) {
-                        "(set)"
-                    } else {
-                        "(unset)"
-                    }
-                );
-                println!(
-                    "token           = {}",
-                    if cfg.token.as_ref().is_some_and(|t| !t.is_empty()) {
-                        "(set)"
-                    } else {
-                        "(unset)"
-                    }
-                );
-                println!("default_chart   = {}", cfg.default_chart);
-                println!("channel         = {}", cfg.channel);
-                println!("user_config     = {}", cfg.user_config_path.display());
+                print!("{}", config::format_snapshot_text(&snap));
             }
             Ok(())
         }
-        ConfigCommand::Path => {
+        Some(ConfigCommand::Path) => {
             println!("{}", cfg.user_config_path.display());
             Ok(())
         }
-        ConfigCommand::Set { key, value } => {
+        Some(ConfigCommand::Set { key, value }) => {
             let mut file = config::load_user_file_config(&cfg.user_config_path)?;
             apply_set(&mut file, &key, &value)?;
             config::save_user_config(&cfg.user_config_path, &file)?;

--- a/rust/ch-monitor-cli/src/commands/dashboard.rs
+++ b/rust/ch-monitor-cli/src/commands/dashboard.rs
@@ -1,0 +1,248 @@
+//! `chm dashboard list` / `chm dashboard open`.
+
+use std::io::{self, IsTerminal, Write};
+
+use anyhow::{bail, Result};
+use crossterm::{
+    cursor,
+    event::{self, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+use reqwest::Client;
+use serde_json::json;
+
+use crate::{
+    cli::DashboardCommand,
+    client,
+    config::AppConfig,
+    dashboards::{self, DashboardEntry},
+    output,
+};
+
+pub async fn run(client: &Client, cfg: &AppConfig, command: DashboardCommand) -> Result<i32> {
+    match command {
+        DashboardCommand::List => list(client, cfg).await,
+        DashboardCommand::Open { name } => open(client, cfg, &name).await,
+    }
+}
+
+async fn load_entries(client: &Client, cfg: &AppConfig) -> (Vec<DashboardEntry>, Option<String>) {
+    let mut entries = vec![DashboardEntry::overview()];
+    let url = format!("{}/api/dashboards/list", cfg.base_url.trim_end_matches('/'));
+    match client::fetch_status_cfg(client, cfg, url).await {
+        Ok((status, body)) if (200..300).contains(&status) => {
+            match serde_json::from_str::<serde_json::Value>(&body) {
+                Ok(v) => {
+                    let data = v.get("data").unwrap_or(&v);
+                    entries.extend(dashboards::parse_saved_dashboards(data));
+                    (entries, None)
+                }
+                Err(err) => (
+                    entries,
+                    Some(format!("saved dashboards: invalid JSON ({err})")),
+                ),
+            }
+        }
+        Ok((status, body)) => (entries, Some(dashboards::format_list_reason(status, &body))),
+        Err(err) => (
+            entries,
+            Some(format!(
+                "saved dashboards unavailable: {}",
+                err.to_string().replace('\n', " ")
+            )),
+        ),
+    }
+}
+
+async fn list(client: &Client, cfg: &AppConfig) -> Result<i32> {
+    let (entries, reason) = load_entries(client, cfg).await;
+    if cfg.json || !wants_picker() {
+        return print_list(&entries, reason.as_deref(), cfg.json);
+    }
+    if let Some(reason) = &reason {
+        output::warn(reason);
+    }
+    match pick(&entries)? {
+        Some(idx) => open_entry(client, cfg, &entries[idx]).await,
+        None => Ok(0),
+    }
+}
+
+async fn open(client: &Client, cfg: &AppConfig, name: &str) -> Result<i32> {
+    let (entries, reason) = load_entries(client, cfg).await;
+    let Some(entry) = dashboards::find_dashboard(&entries, name).cloned() else {
+        if let Some(reason) = reason {
+            output::warn(&reason);
+        }
+        let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+        bail!(
+            "unknown dashboard '{name}'. Available: {}",
+            names.join(", ")
+        );
+    };
+    if let Some(reason) = reason {
+        if entry.source == "builtin" {
+            output::warn(&reason);
+        }
+    }
+    open_entry(client, cfg, &entry).await
+}
+
+async fn open_entry(client: &Client, cfg: &AppConfig, entry: &DashboardEntry) -> Result<i32> {
+    let charts = if entry.charts.is_empty() {
+        dashboards::overview_chart_names()
+    } else {
+        entry.charts.clone()
+    };
+    crate::commands::run_tui_session(
+        client,
+        cfg,
+        crate::tui::TuiOptions {
+            dashboard: entry.name.clone(),
+            charts,
+            table: crate::config::DEFAULT_TABLE.to_string(),
+            page_size: 15,
+            start_overview: true,
+            host_id: cfg.host_id,
+        },
+    )
+    .await?;
+    Ok(0)
+}
+
+fn wants_picker() -> bool {
+    io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+fn print_list(entries: &[DashboardEntry], reason: Option<&str>, json_out: bool) -> Result<i32> {
+    if json_out {
+        output::print_json(&json!({
+            "dashboards": entries.iter().map(|e| json!({
+                "name": e.name,
+                "source": e.source,
+                "charts": e.charts,
+            })).collect::<Vec<_>>(),
+            "saved_error": reason,
+        }))?;
+        return Ok(0);
+    }
+    for e in entries {
+        println!("{}", e.name);
+    }
+    if let Some(reason) = reason {
+        eprintln!("{reason}");
+    }
+    Ok(0)
+}
+
+struct PickerGuard;
+
+impl Drop for PickerGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), cursor::Show);
+    }
+}
+
+/// Inline picker (no alt-screen). Alt-screen is reserved for the live TUI and chat.
+fn pick(entries: &[DashboardEntry]) -> Result<Option<usize>> {
+    if entries.is_empty() {
+        bail!("no dashboards to list");
+    }
+    enable_raw_mode()?;
+    let _guard = PickerGuard;
+    let mut stdout = io::stdout();
+    execute!(stdout, cursor::Hide)?;
+    let mut selected = 0usize;
+    let n = entries.len();
+    loop {
+        for (i, entry) in entries.iter().enumerate() {
+            let mark = if i == selected { '>' } else { ' ' };
+            write!(stdout, "{mark} {}\r\n", entry.label())?;
+        }
+        write!(stdout, " j/k select  Enter open  q quit\r\n")?;
+        stdout.flush()?;
+
+        let rows = (n + 1) as u16;
+        execute!(stdout, cursor::MoveToPreviousLine(rows))?;
+
+        loop {
+            if !event::poll(std::time::Duration::from_millis(250))? {
+                continue;
+            }
+            match event::read()? {
+                event::Event::Resize(_, _) => break,
+                event::Event::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
+                    if key.modifiers.contains(KeyModifiers::CONTROL)
+                        && key.code == KeyCode::Char('c')
+                    {
+                        finish_picker(&mut stdout, rows)?;
+                        return Ok(None);
+                    }
+                    match key.code {
+                        KeyCode::Enter => {
+                            finish_picker(&mut stdout, rows)?;
+                            return Ok(Some(selected));
+                        }
+                        KeyCode::Esc | KeyCode::Char('q') => {
+                            finish_picker(&mut stdout, rows)?;
+                            return Ok(None);
+                        }
+                        KeyCode::Down | KeyCode::Char('j') => {
+                            selected = (selected + 1) % n;
+                            break;
+                        }
+                        KeyCode::Up | KeyCode::Char('k') => {
+                            selected = selected.checked_sub(1).unwrap_or(n - 1);
+                            break;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        execute!(stdout, Clear(ClearType::FromCursorDown))?;
+    }
+}
+
+fn finish_picker(stdout: &mut io::Stdout, rows: u16) -> Result<()> {
+    execute!(
+        stdout,
+        Clear(ClearType::FromCursorDown),
+        cursor::MoveToNextLine(rows),
+        cursor::Show
+    )?;
+    let _ = disable_raw_mode();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn print_list_json_includes_overview() {
+        let entries = [DashboardEntry::overview()];
+        // just exercise label / json shape
+        let v = json!({
+            "dashboards": entries.iter().map(|e| json!({
+                "name": e.name,
+                "source": e.source,
+                "charts": e.charts,
+            })).collect::<Vec<_>>(),
+            "saved_error": "HTTP 501",
+        });
+        assert_eq!(v["dashboards"][0]["name"], "Overview");
+        assert_eq!(v["dashboards"][0]["source"], "builtin");
+        assert!(v["dashboards"][0]["charts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c == "query-count"));
+    }
+}

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod auth;
 pub mod chart;
 pub mod config_cmd;
+pub mod dashboard;
 pub mod diagnose_cmd;
 pub mod doctor;
 pub mod hosts;
@@ -16,9 +17,10 @@ use clap::CommandFactory;
 use reqwest::Client;
 
 use crate::{
-    cli::{Commands, DoctorArgs, PromptCommand},
+    cli::{Cli, Commands, DoctorArgs, PromptCommand},
     config::AppConfig,
     prompts,
+    tui::TuiOptions,
 };
 
 async fn run_cluster_scan(client: &Client, cfg: &AppConfig, args: DoctorArgs) -> Result<i32> {
@@ -33,7 +35,29 @@ async fn run_cluster_scan(client: &Client, cfg: &AppConfig, args: DoctorArgs) ->
     .await
 }
 
-pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Result<i32> {
+pub(crate) async fn run_tui_session(
+    client: &Client,
+    cfg: &AppConfig,
+    mut opts: TuiOptions,
+) -> Result<()> {
+    loop {
+        match crate::tui::run(client, cfg, opts.clone()).await? {
+            crate::tui::TuiExit::Quit => break,
+            crate::tui::TuiExit::Chat { host_id: hid } => {
+                opts.host_id = hid;
+                crate::tui::chat::run(client, cfg, None).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn dispatch(
+    client: &Client,
+    cfg: &AppConfig,
+    cli: &Cli,
+    command: Commands,
+) -> Result<i32> {
     if cfg.debug {
         eprintln!(
             "[debug] base_url={} host_id={} channel={} json={}",
@@ -43,9 +67,10 @@ pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Re
     match command {
         Commands::Auth(args) => auth::run(client, cfg, args).await,
         Commands::Config(args) => {
-            config_cmd::run(cfg, args)?;
+            config_cmd::run(cli, cfg, args)?;
             Ok(0)
         }
+        Commands::Dashboard(args) => dashboard::run(client, cfg, args.command).await,
         Commands::Hosts => {
             hosts::run(client, cfg).await?;
             Ok(0)
@@ -83,29 +108,19 @@ pub async fn dispatch(client: &Client, cfg: &AppConfig, command: Commands) -> Re
             Ok(0)
         }
         Commands::Tui(args) => {
-            let c = args.chart.unwrap_or_else(|| cfg.default_chart.clone());
-            let mut host_id = cfg.host_id;
-            loop {
-                match crate::tui::run(
-                    client,
-                    cfg,
-                    crate::tui::TuiOptions {
-                        chart: &c,
-                        table: &args.table,
-                        page_size: args.page_size,
-                        start_overview: args.overview,
-                        host_id,
-                    },
-                )
-                .await?
-                {
-                    crate::tui::TuiExit::Quit => break,
-                    crate::tui::TuiExit::Chat { host_id: hid } => {
-                        host_id = hid;
-                        crate::tui::chat::run(client, cfg, None).await?;
-                    }
-                }
-            }
+            run_tui_session(
+                client,
+                cfg,
+                TuiOptions {
+                    dashboard: crate::dashboards::OVERVIEW_NAME.to_string(),
+                    charts: crate::dashboards::tui_chart_names(args.chart.as_deref()),
+                    table: args.table,
+                    page_size: args.page_size,
+                    start_overview: args.overview,
+                    host_id: cfg.host_id,
+                },
+            )
+            .await?;
             Ok(0)
         }
         Commands::Chat { message } => {

--- a/rust/ch-monitor-cli/src/config.rs
+++ b/rust/ch-monitor-cli/src/config.rs
@@ -57,13 +57,14 @@ pub fn default_config_path() -> Option<PathBuf> {
     user_config_path()
 }
 
+pub fn project_config_paths_from(cwd: &std::path::Path) -> Vec<PathBuf> {
+    vec![cwd.join("chm.toml"), cwd.join(".chm").join("config.toml")]
+}
+
 fn project_config_candidates() -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    if let Ok(cwd) = env::current_dir() {
-        out.push(cwd.join("chm.toml"));
-        out.push(cwd.join(".chm").join("config.toml"));
-    }
-    out
+    env::current_dir()
+        .map(|cwd| project_config_paths_from(&cwd))
+        .unwrap_or_default()
 }
 
 fn load_toml_file(path: &PathBuf) -> Result<Option<FileConfig>> {
@@ -79,18 +80,26 @@ fn load_toml_file(path: &PathBuf) -> Result<Option<FileConfig>> {
 
 fn load_file_config(explicit: Option<PathBuf>) -> Result<(FileConfig, PathBuf)> {
     let user_path = default_config_path().unwrap_or_else(|| PathBuf::from("config.toml"));
+    load_layered_files(user_path, project_config_candidates(), explicit)
+}
 
+/// Merge user then project (project wins among files). `--config` replaces both.
+pub fn load_layered_files(
+    user_path: PathBuf,
+    project_paths: Vec<PathBuf>,
+    explicit: Option<PathBuf>,
+) -> Result<(FileConfig, PathBuf)> {
     if let Some(path) = explicit {
         let cfg = load_toml_file(&path)?.unwrap_or_default();
         return Ok((cfg, path));
     }
 
-    // Layer: project over user (project fills gaps only when merging below).
+    // Layer: project over user (project wins when both set the same key).
     let mut merged = FileConfig::default();
     if let Some(user) = load_toml_file(&user_path)? {
         merge_file(&mut merged, user);
     }
-    for candidate in project_config_candidates() {
+    for candidate in project_paths {
         if let Some(project) = load_toml_file(&candidate)? {
             merge_file(&mut merged, project);
         }
@@ -186,9 +195,272 @@ pub fn load_user_file_config(path: &PathBuf) -> Result<FileConfig> {
     Ok(load_toml_file(path)?.unwrap_or_default())
 }
 
+const SECRET_KEYS: &[&str] = &["api_key", "token"];
+
+/// Redact `api_key` / `token` values as `(set)` so `config show` is safe to print.
+pub fn redact_toml(content: &str) -> String {
+    let Ok(mut value) = toml::from_str::<toml::Value>(content) else {
+        return content.to_string();
+    };
+    if let Some(table) = value.as_table_mut() {
+        for key in SECRET_KEYS {
+            if let Some(toml::Value::String(s)) = table.get(*key) {
+                if !s.is_empty() && s != "(set)" {
+                    table.insert((*key).to_string(), toml::Value::String("(set)".into()));
+                }
+            }
+        }
+    }
+    toml::to_string_pretty(&value).unwrap_or_else(|_| content.to_string())
+}
+
+#[derive(Debug, Clone)]
+pub struct FileLayer {
+    pub path: PathBuf,
+    pub exists: bool,
+    pub content: Option<String>,
+}
+
+impl FileLayer {
+    pub fn load(path: PathBuf) -> Self {
+        if !path.exists() {
+            return Self {
+                path,
+                exists: false,
+                content: None,
+            };
+        }
+        match fs::read_to_string(&path) {
+            Ok(raw) => Self {
+                path,
+                exists: true,
+                content: Some(redact_toml(&raw)),
+            },
+            Err(err) => Self {
+                path,
+                exists: true,
+                content: Some(format!("# failed to read: {err}")),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigOverride {
+    pub key: String,
+    pub value: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigSnapshot {
+    pub user: FileLayer,
+    pub projects: Vec<FileLayer>,
+    pub explicit: Option<FileLayer>,
+    pub overrides: Vec<ConfigOverride>,
+    pub resolved: AppConfig,
+}
+
+fn args_have_flag(flag: &str) -> bool {
+    env::args().any(|a| a == flag || a.starts_with(&format!("{flag}=")))
+}
+
+fn override_source(flag: &str, env_name: &str) -> String {
+    let has_flag = args_have_flag(flag);
+    let has_env = env::var_os(env_name).is_some_and(|v| !v.is_empty());
+    match (has_flag, has_env) {
+        (true, true) => format!("flag {flag} (env {env_name} also set)"),
+        (true, false) => format!("flag {flag}"),
+        (false, true) => format!("env {env_name}"),
+        (false, false) => "flag/env".to_string(),
+    }
+}
+
+pub fn collect_overrides(cli: &Cli) -> Vec<ConfigOverride> {
+    let mut out = Vec::new();
+    if let Some(v) = &cli.base_url {
+        out.push(ConfigOverride {
+            key: "base_url".into(),
+            value: v.clone(),
+            source: override_source("--base-url", "CHM_BASE_URL"),
+        });
+    }
+    if let Some(v) = cli.host_id {
+        out.push(ConfigOverride {
+            key: "host_id".into(),
+            value: v.to_string(),
+            source: override_source("--host-id", "CHM_HOST_ID"),
+        });
+    }
+    if cli.api_key.as_ref().is_some_and(|k| !k.is_empty()) {
+        out.push(ConfigOverride {
+            key: "api_key".into(),
+            value: "(set)".into(),
+            source: override_source("--api-key", "CHM_API_KEY"),
+        });
+    }
+    if cli.token.as_ref().is_some_and(|t| !t.is_empty()) {
+        out.push(ConfigOverride {
+            key: "token".into(),
+            value: "(set)".into(),
+            source: override_source("--token", "CHM_TOKEN"),
+        });
+    }
+    if let Some(ch) = cli.channel {
+        out.push(ConfigOverride {
+            key: "channel".into(),
+            value: ch.as_str().to_string(),
+            source: override_source("--channel", "CHM_CHANNEL"),
+        });
+    }
+    if let Some(path) = &cli.config {
+        out.push(ConfigOverride {
+            key: "config".into(),
+            value: path.display().to_string(),
+            source: override_source("--config", "CHM_CONFIG"),
+        });
+    }
+    out
+}
+
+pub fn snapshot_layers(
+    cli: &Cli,
+    cfg: &AppConfig,
+    user_path: PathBuf,
+    project_paths: Vec<PathBuf>,
+) -> ConfigSnapshot {
+    ConfigSnapshot {
+        user: FileLayer::load(user_path),
+        projects: project_paths.into_iter().map(FileLayer::load).collect(),
+        explicit: cli.config.clone().map(FileLayer::load),
+        overrides: collect_overrides(cli),
+        resolved: cfg.clone(),
+    }
+}
+
+pub fn current_snapshot(cli: &Cli, cfg: &AppConfig) -> ConfigSnapshot {
+    let user_path =
+        user_config_path().unwrap_or_else(|| PathBuf::from("~/.config/chm/config.toml"));
+    snapshot_layers(cli, cfg, user_path, project_config_candidates())
+}
+
+pub fn format_snapshot_text(snap: &ConfigSnapshot) -> String {
+    let mut out = String::new();
+    out.push_str("# chm config\n");
+    out.push_str("# Highest file layer wins among files (project over user).\n");
+    out.push_str(
+        "# Flags / env beat files. Built-in default base_url is https://dash.chmonitor.dev.\n\n",
+    );
+
+    out.push_str("## 1. User\n");
+    push_layer(&mut out, &snap.user);
+
+    out.push_str("\n## 2. Project\n");
+    if snap.projects.is_empty() {
+        out.push_str("(no project paths — cwd unavailable)\n");
+    } else {
+        for layer in &snap.projects {
+            push_layer(&mut out, layer);
+        }
+    }
+
+    if let Some(explicit) = &snap.explicit {
+        out.push_str("\n## --config (replaces user + project file merge)\n");
+        push_layer(&mut out, explicit);
+    }
+
+    out.push_str("\n## 3. Env / flags that overrode\n");
+    if snap.overrides.is_empty() {
+        out.push_str("(none)\n");
+    } else {
+        for ov in &snap.overrides {
+            out.push_str(&format!("{} = {}  ({})\n", ov.key, ov.value, ov.source));
+        }
+    }
+
+    out.push_str("\n## 4. Resolved (what the CLI uses)\n");
+    let cfg = &snap.resolved;
+    out.push_str(&format!("base_url        = {}\n", cfg.base_url));
+    out.push_str(&format!("host_id         = {}\n", cfg.host_id));
+    out.push_str(&format!(
+        "api_key         = {}\n",
+        if cfg.api_key.as_ref().is_some_and(|k| !k.is_empty()) {
+            "(set)"
+        } else {
+            "(unset)"
+        }
+    ));
+    out.push_str(&format!(
+        "token           = {}\n",
+        if cfg.token.as_ref().is_some_and(|t| !t.is_empty()) {
+            "(set)"
+        } else {
+            "(unset)"
+        }
+    ));
+    out.push_str(&format!("default_chart   = {}\n", cfg.default_chart));
+    out.push_str(&format!("channel         = {}\n", cfg.channel));
+    out.push_str(&format!(
+        "user_config     = {}\n",
+        cfg.user_config_path.display()
+    ));
+    out
+}
+
+fn push_layer(out: &mut String, layer: &FileLayer) {
+    out.push_str(&format!("path: {}\n", layer.path.display()));
+    out.push_str(&format!(
+        "exists: {}\n",
+        if layer.exists { "yes" } else { "no" }
+    ));
+    match &layer.content {
+        Some(content) if !content.trim().is_empty() => {
+            out.push_str("---\n");
+            out.push_str(content);
+            if !content.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str("---\n");
+        }
+        Some(_) | None if layer.exists => out.push_str("(empty file)\n"),
+        _ => {}
+    }
+}
+
+pub fn format_snapshot_json(snap: &ConfigSnapshot) -> serde_json::Value {
+    let cfg = &snap.resolved;
+    let layer_json = |layer: &FileLayer| {
+        serde_json::json!({
+            "path": layer.path.display().to_string(),
+            "exists": layer.exists,
+            "content": layer.content,
+        })
+    };
+    serde_json::json!({
+        "user": layer_json(&snap.user),
+        "project": snap.projects.iter().map(layer_json).collect::<Vec<_>>(),
+        "explicit": snap.explicit.as_ref().map(layer_json),
+        "overrides": snap.overrides.iter().map(|o| serde_json::json!({
+            "key": o.key,
+            "value": o.value,
+            "source": o.source,
+        })).collect::<Vec<_>>(),
+        "resolved": {
+            "base_url": cfg.base_url,
+            "host_id": cfg.host_id,
+            "api_key_set": cfg.api_key.as_ref().is_some_and(|k| !k.is_empty()),
+            "token_set": cfg.token.as_ref().is_some_and(|t| !t.is_empty()),
+            "default_chart": cfg.default_chart,
+            "channel": cfg.channel.as_str(),
+            "user_config_path": cfg.user_config_path.display().to_string(),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn default_base_url_is_cloud() {
@@ -201,5 +473,129 @@ mod tests {
     fn default_chart_and_table() {
         assert_eq!(DEFAULT_CHART, "query-count");
         assert_eq!(DEFAULT_TABLE, "running-queries");
+    }
+
+    #[test]
+    fn redact_toml_hides_secrets() {
+        let raw = r#"
+base_url = "https://dash.chmonitor.dev"
+api_key = "chm_secret"
+token = "tok"
+host_id = 1
+"#;
+        let redacted = redact_toml(raw);
+        assert!(redacted.contains("chmonitor.dev"), "{redacted}");
+        assert!(!redacted.contains("chm_secret"), "{redacted}");
+        assert!(
+            !redacted.contains("tok\n") && !redacted.contains("\"tok\""),
+            "{redacted}"
+        );
+        assert!(redacted.contains("(set)"), "{redacted}");
+        assert!(redacted.contains("host_id"), "{redacted}");
+    }
+
+    #[test]
+    fn project_file_overrides_user_file() {
+        let root = std::env::temp_dir().join(format!(
+            "chm-cfg-merge-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let user = root.join("user.toml");
+        let project = root.join("chm.toml");
+        fs::write(&user, "host_id = 1\nbase_url = \"http://user.example\"\n").unwrap();
+        fs::write(&project, "host_id = 2\n").unwrap();
+        let (merged, path) = load_layered_files(user.clone(), vec![project], None).unwrap();
+        assert_eq!(path, user);
+        assert_eq!(merged.host_id, Some(2));
+        assert_eq!(merged.base_url.as_deref(), Some("http://user.example"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn explicit_config_skips_user_and_project() {
+        let root = std::env::temp_dir().join(format!(
+            "chm-cfg-explicit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let user = root.join("user.toml");
+        let project = root.join("chm.toml");
+        let explicit = root.join("explicit.toml");
+        fs::write(&user, "host_id = 1\n").unwrap();
+        fs::write(&project, "host_id = 2\n").unwrap();
+        fs::write(&explicit, "host_id = 9\nbase_url = \"http://explicit\"\n").unwrap();
+        let (merged, path) =
+            load_layered_files(user, vec![project], Some(explicit.clone())).unwrap();
+        assert_eq!(path, explicit);
+        assert_eq!(merged.host_id, Some(9));
+        assert_eq!(merged.base_url.as_deref(), Some("http://explicit"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn snapshot_prints_file_contents_and_resolved_default() {
+        let root = std::env::temp_dir().join(format!(
+            "chm-cfg-show-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let proj = root.join("proj");
+        fs::create_dir_all(proj.join(".chm")).unwrap();
+        let user = root.join("user.toml");
+        fs::write(
+            &user,
+            "base_url = \"http://user\"\napi_key = \"secret-key\"\n",
+        )
+        .unwrap();
+        let project = proj.join("chm.toml");
+        fs::write(&project, "host_id = 3\n").unwrap();
+        let nested = proj.join(".chm").join("config.toml");
+        fs::write(&nested, "channel = \"beta\"\n").unwrap();
+
+        let cfg = AppConfig {
+            base_url: DEFAULT_BASE_URL.to_string(),
+            host_id: 3,
+            api_key: Some("secret-key".into()),
+            token: None,
+            default_chart: DEFAULT_CHART.to_string(),
+            channel: Channel::Beta,
+            json: false,
+            quiet: false,
+            yes: false,
+            debug: false,
+            user_config_path: user.clone(),
+        };
+        let cli = crate::cli::Cli::try_parse_from(["chm", "config", "show"]).unwrap();
+        let snap = snapshot_layers(&cli, &cfg, user, vec![project, nested]);
+        let text = format_snapshot_text(&snap);
+        assert!(text.contains("## 1. User"), "{text}");
+        assert!(text.contains("## 2. Project"), "{text}");
+        assert!(text.contains("## 3. Env / flags"), "{text}");
+        assert!(text.contains("## 4. Resolved"), "{text}");
+        assert!(text.contains("http://user"), "{text}");
+        assert!(!text.contains("secret-key"), "{text}");
+        assert!(text.contains("(set)"), "{text}");
+        assert!(text.contains("host_id = 3"), "{text}");
+        assert!(
+            text.contains("channel = \"beta\"") || text.contains("channel = 'beta'"),
+            "{text}"
+        );
+        assert!(text.contains(DEFAULT_BASE_URL), "{text}");
+        let json = format_snapshot_json(&snap);
+        assert_eq!(json["resolved"]["host_id"], 3);
+        assert_eq!(json["resolved"]["api_key_set"], true);
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/rust/ch-monitor-cli/src/dashboards.rs
+++ b/rust/ch-monitor-cli/src/dashboards.rs
@@ -1,0 +1,323 @@
+//! Built-in Overview dashboard + saved-dashboard list parsing.
+
+use serde_json::Value;
+
+use crate::metrics;
+
+/// Built-in dashboard always listed first.
+pub const OVERVIEW_NAME: &str = "Overview";
+
+/// Charts on the web Overview page. 404 / empty results are skipped at fetch time.
+/// `disk-size-all` is only shown when `disk-size-single` is missing.
+pub const OVERVIEW_CHARTS: &[&str] = &[
+    "query-count",
+    "query-count-today",
+    "running-queries-count",
+    "database-count",
+    "table-count",
+    "disk-size-single",
+    "disk-size-all",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DashboardEntry {
+    pub name: String,
+    pub source: &'static str,
+    pub charts: Vec<String>,
+}
+
+impl DashboardEntry {
+    pub fn overview() -> Self {
+        Self {
+            name: OVERVIEW_NAME.to_string(),
+            source: "builtin",
+            charts: overview_chart_names(),
+        }
+    }
+
+    pub fn label(&self) -> String {
+        let n = self.charts.len();
+        match self.source {
+            "builtin" => format!("{}  (builtin, {n} charts)", self.name),
+            _ => format!("{}  (saved, {n} charts)", self.name),
+        }
+    }
+}
+
+pub fn overview_chart_names() -> Vec<String> {
+    OVERVIEW_CHARTS.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// Charts to fetch for `chm` / `chm tui` (Overview, plus an extra name if given).
+pub fn tui_chart_names(extra: Option<&str>) -> Vec<String> {
+    let mut charts = overview_chart_names();
+    if let Some(c) = extra.map(str::trim).filter(|c| !c.is_empty()) {
+        if !charts.iter().any(|x| x == c) {
+            charts.insert(0, c.to_string());
+        }
+    }
+    charts
+}
+
+/// `layout.widgets[].chartName` for `type=chart`.
+pub fn chart_names_from_layout(layout: &Value) -> Vec<String> {
+    let Some(widgets) = layout.get("widgets").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for widget in widgets {
+        let obj = widget.as_object();
+        let kind = obj
+            .and_then(|o| o.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if kind != "chart" {
+            continue;
+        }
+        if let Some(name) = obj
+            .and_then(|o| o.get("chartName"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            if !names.iter().any(|n| n == name) {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// Parse `GET /api/dashboards/list` `data` (`{ dashboards: [...] }` or a bare array).
+pub fn parse_saved_dashboards(data: &Value) -> Vec<DashboardEntry> {
+    let arr = data
+        .get("dashboards")
+        .and_then(Value::as_array)
+        .or_else(|| data.as_array());
+    let Some(arr) = arr else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|item| {
+            let name = item
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())?
+                .to_string();
+            let layout = item.get("layout").unwrap_or(&Value::Null);
+            Some(DashboardEntry {
+                name,
+                source: "saved",
+                charts: chart_names_from_layout(layout),
+            })
+        })
+        .collect()
+}
+
+pub fn find_dashboard<'a>(entries: &'a [DashboardEntry], name: &str) -> Option<&'a DashboardEntry> {
+    let needle = name.trim();
+    entries
+        .iter()
+        .find(|e| e.name == needle)
+        .or_else(|| entries.iter().find(|e| e.name.eq_ignore_ascii_case(needle)))
+}
+
+/// Best-effort message from a dashboard API error body.
+pub fn api_error_message(text: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(text).ok()?;
+    v.pointer("/error/message")
+        .or_else(|| v.pointer("/error/msg"))
+        .or_else(|| v.get("message"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
+pub fn format_list_reason(status: u16, body: &str) -> String {
+    let detail = api_error_message(body)
+        .or_else(|| crate::client::truncate_body(body.trim(), 120))
+        .unwrap_or_default();
+    if detail.is_empty() {
+        format!("saved dashboards unavailable (HTTP {status})")
+    } else {
+        format!("saved dashboards unavailable (HTTP {status}): {detail}")
+    }
+}
+
+/// KPI / sparkline caption for a chart's rows.
+pub fn chart_kpi(name: &str, rows: &[Value]) -> String {
+    if rows.is_empty() {
+        return "no data".to_string();
+    }
+    if name.starts_with("disk-size") {
+        return disk_kpi(&rows[0]);
+    }
+    if let Some(obj) = rows.last().and_then(Value::as_object) {
+        for key in ["count", "query_count", "value", "total"] {
+            if let Some(v) = obj.get(key) {
+                return json_cell(v);
+            }
+        }
+    }
+    metrics::row_metric(rows.last().unwrap()).to_string()
+}
+
+fn disk_kpi(row: &Value) -> String {
+    let used = row
+        .get("readable_used_space")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let total = row
+        .get("readable_total_space")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match (used, total) {
+        (Some(u), Some(t)) => format!("{u} / {t}"),
+        (Some(u), None) => u.to_string(),
+        _ => {
+            let u = row.get("used_space").map(json_cell);
+            let t = row.get("total_space").map(json_cell);
+            match (u, t) {
+                (Some(u), Some(t)) => format!("{u} / {t}"),
+                (Some(u), None) => u,
+                _ => metrics::row_metric(row).to_string(),
+            }
+        }
+    }
+}
+
+fn json_cell(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Prefer `disk-size-single`; hide `disk-size-all` when single returned rows.
+pub fn should_show_chart(name: &str, has_data: bool, single_has_data: bool) -> bool {
+    if !has_data {
+        return false;
+    }
+    if name == "disk-size-all" && single_has_data {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn overview_is_first_and_has_web_charts() {
+        let d = DashboardEntry::overview();
+        assert_eq!(d.name, "Overview");
+        assert_eq!(d.source, "builtin");
+        assert!(d.charts.contains(&"query-count".into()));
+        assert!(d.charts.contains(&"database-count".into()));
+        assert!(d.charts.contains(&"table-count".into()));
+        assert!(d.charts.contains(&"disk-size-single".into()));
+    }
+
+    #[test]
+    fn extra_tui_chart_is_prepended_once() {
+        let names = tui_chart_names(Some("query-count"));
+        assert_eq!(names.iter().filter(|n| *n == "query-count").count(), 1);
+        let names = tui_chart_names(Some("custom-chart"));
+        assert_eq!(names[0], "custom-chart");
+        assert!(names.contains(&"query-count".into()));
+    }
+
+    #[test]
+    fn layout_widgets_collect_chart_names() {
+        let layout = json!({
+            "widgets": [
+                {"type": "chart", "chartName": "query-count"},
+                {"type": "table", "queryConfigName": "running-queries"},
+                {"type": "chart", "chartName": "merges"},
+                {"type": "chart", "chartName": "query-count"},
+                {"type": "stat", "chartName": "ignored"}
+            ]
+        });
+        assert_eq!(
+            chart_names_from_layout(&layout),
+            vec!["query-count", "merges"]
+        );
+    }
+
+    #[test]
+    fn parse_saved_dashboards_reads_name_and_widgets() {
+        let data = json!({
+            "dashboards": [
+                {
+                    "name": "Nightly",
+                    "layout": {
+                        "widgets": [
+                            {"type": "chart", "chartName": "cpu"}
+                        ]
+                    }
+                }
+            ]
+        });
+        let list = parse_saved_dashboards(&data);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "Nightly");
+        assert_eq!(list[0].source, "saved");
+        assert_eq!(list[0].charts, vec!["cpu"]);
+    }
+
+    #[test]
+    fn find_dashboard_is_case_insensitive() {
+        let list = vec![DashboardEntry::overview()];
+        assert!(find_dashboard(&list, "overview").is_some());
+        assert!(find_dashboard(&list, " missing ").is_none());
+    }
+
+    #[test]
+    fn kpi_prefers_count_and_disk_readable() {
+        assert_eq!(
+            chart_kpi("running-queries-count", &[json!({"count": 12})]),
+            "12"
+        );
+        assert_eq!(
+            chart_kpi(
+                "disk-size-single",
+                &[json!({
+                    "readable_used_space": "42.0 GiB",
+                    "readable_total_space": "100 GiB"
+                })]
+            ),
+            "42.0 GiB / 100 GiB"
+        );
+        assert_eq!(chart_kpi("query-count", &[]), "no data");
+    }
+
+    #[test]
+    fn hide_disk_all_when_single_has_data() {
+        assert!(should_show_chart("disk-size-single", true, true));
+        assert!(!should_show_chart("disk-size-all", true, true));
+        assert!(should_show_chart("disk-size-all", true, false));
+        assert!(!should_show_chart("query-count", false, false));
+    }
+
+    #[test]
+    fn api_error_message_reads_nested_error() {
+        assert_eq!(
+            api_error_message(r#"{"error":{"message":"Dashboard storage is not enabled."}}"#)
+                .as_deref(),
+            Some("Dashboard storage is not enabled.")
+        );
+        assert_eq!(
+            format_list_reason(501, r#"{"error":{"message":"off"}}"#),
+            "saved dashboards unavailable (HTTP 501): off"
+        );
+    }
+}

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -5,6 +5,7 @@ mod client;
 mod commands;
 mod config;
 mod credentials;
+mod dashboards;
 mod diagnose;
 mod mermaid;
 mod metrics;
@@ -24,13 +25,14 @@ use crate::cli::{Cli, Commands, TuiArgs};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let mut cli = Cli::parse();
     let cfg = config::resolve_config(&cli)?;
     let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
 
     // Bare `chm` (no subcommand) is the live TUI — same as `chm tui`.
     let command = cli
         .command
+        .take()
         .unwrap_or_else(|| Commands::Tui(TuiArgs::default()));
 
     // Anonymous, opt-out CLI telemetry (source=cli). Fires in the background and
@@ -46,6 +48,7 @@ async fn main() -> Result<()> {
         Commands::Update(_) | Commands::Upgrade(_) => ("cli_run", "update"),
         Commands::Auth(_) => ("cli_run", "auth"),
         Commands::Config(_) => ("cli_run", "config"),
+        Commands::Dashboard(_) => ("cli_run", "dashboard"),
         Commands::Link { .. } => ("cli_run", "link"),
         Commands::Chat { .. } => ("cli_run", "chat"),
         Commands::Agent { .. } => ("cli_run", "agent"),
@@ -55,7 +58,7 @@ async fn main() -> Result<()> {
     };
     let tel_handle = telemetry::spawn(tel_event, tel_command);
 
-    let exit = commands::dispatch(&client, &cfg, command).await?;
+    let exit = commands::dispatch(&client, &cfg, &cli, command).await?;
 
     telemetry::finish(tel_handle).await;
     if exit != 0 {
@@ -439,5 +442,70 @@ mod tests {
         let help = cmd.render_long_help().to_string();
         assert!(help.contains("live TUI"), "{help}");
         assert!(help.contains("no subcommand"), "{help}");
+    }
+
+    #[test]
+    fn dashboard_list_parses() {
+        let cli = Cli::try_parse_from(["chm", "dashboard", "list"]).expect("parse");
+        match cli.command {
+            Some(Commands::Dashboard(args)) => {
+                assert!(matches!(args.command, crate::cli::DashboardCommand::List));
+            }
+            other => panic!("expected Dashboard list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dashboard_open_parses_name() {
+        let cli = Cli::try_parse_from(["chm", "dashboard", "open", "Overview"]).expect("parse");
+        match cli.command {
+            Some(Commands::Dashboard(args)) => match args.command {
+                crate::cli::DashboardCommand::Open { name } => {
+                    assert_eq!(name, "Overview");
+                }
+                other => panic!("expected Open, got {other:?}"),
+            },
+            other => panic!("expected Dashboard, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn json_before_dashboard_list_is_global() {
+        let cli = Cli::try_parse_from(["chm", "--json", "dashboard", "list"]).expect("parse");
+        assert!(cli.json);
+        assert!(matches!(cli.command, Some(Commands::Dashboard(_))));
+    }
+
+    #[test]
+    fn config_without_subcommand_is_interactive() {
+        let cli = Cli::try_parse_from(["chm", "config"]).expect("parse");
+        match cli.command {
+            Some(Commands::Config(args)) => {
+                assert!(args.command.is_none(), "expected no subcommand");
+            }
+            other => panic!("expected Config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_show_still_parses() {
+        let cli = Cli::try_parse_from(["chm", "config", "show"]).expect("parse");
+        match cli.command {
+            Some(Commands::Config(args)) => {
+                assert!(matches!(
+                    args.command,
+                    Some(crate::cli::ConfigCommand::Show)
+                ));
+            }
+            other => panic!("expected Config show, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_lists_dashboard_and_config() {
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(help.contains("dashboard"), "{help}");
+        assert!(help.contains("config"), "{help}");
     }
 }

--- a/rust/ch-monitor-cli/src/tui/config_form.rs
+++ b/rust/ch-monitor-cli/src/tui/config_form.rs
@@ -1,0 +1,471 @@
+//! Interactive `chm config` dialog (alt-screen). Secrets stay out of the form body.
+
+use std::io::{self, IsTerminal};
+
+use anyhow::{bail, Result};
+use crossterm::{
+    event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Paragraph, Wrap},
+    Frame, Terminal,
+};
+
+use crate::{
+    cli::Channel,
+    config::{self, AppConfig, FileConfig, DEFAULT_BASE_URL, DEFAULT_CHART},
+};
+
+const ORANGE: Color = Color::Rgb(249, 115, 22);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    BaseUrl,
+    HostId,
+    Channel,
+    DefaultChart,
+    Save,
+    Cancel,
+}
+
+impl Field {
+    fn next(self) -> Self {
+        match self {
+            Field::BaseUrl => Field::HostId,
+            Field::HostId => Field::Channel,
+            Field::Channel => Field::DefaultChart,
+            Field::DefaultChart => Field::Save,
+            Field::Save => Field::Cancel,
+            Field::Cancel => Field::BaseUrl,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            Field::BaseUrl => Field::Cancel,
+            Field::HostId => Field::BaseUrl,
+            Field::Channel => Field::HostId,
+            Field::DefaultChart => Field::Channel,
+            Field::Save => Field::DefaultChart,
+            Field::Cancel => Field::Save,
+        }
+    }
+
+    fn is_text(self) -> bool {
+        matches!(self, Field::BaseUrl | Field::HostId | Field::DefaultChart)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigForm {
+    pub base_url: String,
+    pub host_id: String,
+    pub channel: Channel,
+    pub default_chart: String,
+    selected: Field,
+    error: Option<String>,
+}
+
+impl ConfigForm {
+    pub fn from_config(cfg: &AppConfig, file: &FileConfig) -> Self {
+        Self {
+            base_url: file
+                .base_url
+                .clone()
+                .unwrap_or_else(|| cfg.base_url.clone()),
+            host_id: file.host_id.unwrap_or(cfg.host_id).to_string(),
+            channel: file
+                .channel
+                .as_deref()
+                .and_then(|c| match c {
+                    "beta" => Some(Channel::Beta),
+                    "stable" => Some(Channel::Stable),
+                    _ => None,
+                })
+                .unwrap_or(cfg.channel),
+            default_chart: file
+                .default_chart
+                .clone()
+                .unwrap_or_else(|| cfg.default_chart.clone()),
+            selected: Field::BaseUrl,
+            error: None,
+        }
+    }
+
+    pub fn apply_key(&mut self, key: KeyEvent) -> FormAction {
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return FormAction::None;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return FormAction::Cancel;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+            return self.try_save();
+        }
+        match key.code {
+            KeyCode::Esc => FormAction::Cancel,
+            KeyCode::Enter => match self.selected {
+                Field::Cancel => FormAction::Cancel,
+                Field::Save
+                | Field::BaseUrl
+                | Field::HostId
+                | Field::Channel
+                | Field::DefaultChart => self.try_save(),
+            },
+            KeyCode::Char('s') if !self.selected.is_text() => self.try_save(),
+            KeyCode::Tab | KeyCode::Down => {
+                self.selected = self.selected.next();
+                FormAction::None
+            }
+            KeyCode::Char('j') if !self.selected.is_text() => {
+                self.selected = self.selected.next();
+                FormAction::None
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.selected = self.selected.prev();
+                FormAction::None
+            }
+            KeyCode::Char('k') if !self.selected.is_text() => {
+                self.selected = self.selected.prev();
+                FormAction::None
+            }
+            KeyCode::Left | KeyCode::Char('h') if self.selected == Field::Channel => {
+                self.channel = match self.channel {
+                    Channel::Stable => Channel::Beta,
+                    Channel::Beta => Channel::Stable,
+                };
+                FormAction::None
+            }
+            KeyCode::Right | KeyCode::Char('l') if self.selected == Field::Channel => {
+                self.channel = match self.channel {
+                    Channel::Stable => Channel::Beta,
+                    Channel::Beta => Channel::Stable,
+                };
+                FormAction::None
+            }
+            KeyCode::Backspace if self.selected.is_text() => {
+                self.edit_buf().pop();
+                FormAction::None
+            }
+            KeyCode::Char(c)
+                if self.selected.is_text() && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.insert_char(c);
+                FormAction::None
+            }
+            _ => FormAction::None,
+        }
+    }
+
+    fn insert_char(&mut self, c: char) {
+        if c.is_control() {
+            return;
+        }
+        self.edit_buf().push(c);
+    }
+
+    fn edit_buf(&mut self) -> &mut String {
+        match self.selected {
+            Field::BaseUrl => &mut self.base_url,
+            Field::HostId => &mut self.host_id,
+            Field::DefaultChart => &mut self.default_chart,
+            Field::Channel | Field::Save | Field::Cancel => unreachable!(),
+        }
+    }
+
+    fn try_save(&mut self) -> FormAction {
+        match self.to_file_patch() {
+            Ok(_) => FormAction::Save,
+            Err(err) => {
+                self.error = Some(err);
+                FormAction::None
+            }
+        }
+    }
+
+    pub fn to_file_patch(&self) -> Result<FileConfig, String> {
+        let base_url = self.base_url.trim();
+        if base_url.is_empty() {
+            return Err("base_url must not be empty".into());
+        }
+        let host_id: u32 = self
+            .host_id
+            .trim()
+            .parse()
+            .map_err(|_| "host_id must be an integer".to_string())?;
+        let default_chart = self.default_chart.trim();
+        if default_chart.is_empty() {
+            return Err("default_chart must not be empty".into());
+        }
+        Ok(FileConfig {
+            base_url: Some(base_url.to_string()),
+            host_id: Some(host_id),
+            api_key: None,
+            token: None,
+            default_chart: Some(default_chart.to_string()),
+            channel: Some(self.channel.as_str().to_string()),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormAction {
+    None,
+    Save,
+    Cancel,
+}
+
+struct FormGuard;
+
+impl Drop for FormGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+pub fn run(cfg: &AppConfig) -> Result<()> {
+    if !io::stdout().is_terminal() || cfg.json {
+        bail!(
+            "interactive config needs a terminal (or use `chm config show` / `chm config set KEY VALUE`)"
+        );
+    }
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let _guard = FormGuard;
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let existing = config::load_user_file_config(&cfg.user_config_path)?;
+    let mut form = ConfigForm::from_config(cfg, &existing);
+    let mut saved = false;
+
+    loop {
+        terminal.draw(|f| draw(f, cfg, &form, &existing))?;
+        if !event::poll(std::time::Duration::from_millis(250))? {
+            continue;
+        }
+        let event::Event::Key(key) = event::read()? else {
+            continue;
+        };
+        match form.apply_key(key) {
+            FormAction::None => {}
+            FormAction::Cancel => break,
+            FormAction::Save => {
+                let patch = form.to_file_patch().map_err(|e| anyhow::anyhow!(e))?;
+                let mut file = existing.clone();
+                file.base_url = patch.base_url;
+                file.host_id = patch.host_id;
+                file.default_chart = patch.default_chart;
+                file.channel = patch.channel;
+                config::save_user_config(&cfg.user_config_path, &file)?;
+                saved = true;
+                break;
+            }
+        }
+    }
+    drop(terminal);
+    drop(_guard);
+    if saved {
+        crate::output::success(&format!("saved {}", cfg.user_config_path.display()));
+    }
+    Ok(())
+}
+
+fn draw(f: &mut Frame<'_>, cfg: &AppConfig, form: &ConfigForm, file: &FileConfig) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(12),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                " chm config ",
+                Style::default().fg(ORANGE).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                cfg.user_config_path.display().to_string(),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]))
+        .block(Block::bordered()),
+        chunks[0],
+    );
+
+    let api = if file.api_key.as_ref().is_some_and(|k| !k.is_empty()) {
+        "(set)  — not edited here"
+    } else {
+        "(unset)  — use `chm config set api_key …` or `chm auth login`"
+    };
+    let token = if file.token.as_ref().is_some_and(|t| !t.is_empty()) {
+        "(set)  — not edited here"
+    } else {
+        "(unset)  — use `chm auth login`"
+    };
+
+    let mut lines = vec![
+        field_line("base_url", &form.base_url, form.selected == Field::BaseUrl),
+        field_line("host_id", &form.host_id, form.selected == Field::HostId),
+        field_line(
+            "channel",
+            form.channel.as_str(),
+            form.selected == Field::Channel,
+        ),
+        field_line(
+            "default_chart",
+            &form.default_chart,
+            form.selected == Field::DefaultChart,
+        ),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("api_key   {api}"),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            format!("token     {token}"),
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(""),
+        action_line("[ Save ]", form.selected == Field::Save),
+        action_line("[ Cancel ]", form.selected == Field::Cancel),
+    ];
+    if let Some(err) = &form.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            err.clone(),
+            Style::default().fg(Color::Red),
+        )));
+    }
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .block(Block::bordered().title("user config (no secrets in form)")),
+        chunks[1],
+    );
+
+    f.render_widget(
+        Paragraph::new(format!(
+            " Tab/↑↓ field  type to edit  h/l channel  Enter/s save  Esc cancel  · default {DEFAULT_BASE_URL} / {DEFAULT_CHART}"
+        ))
+        .style(Style::default().fg(Color::DarkGray)),
+        chunks[2],
+    );
+}
+
+fn field_line<'a>(label: &'a str, value: &'a str, selected: bool) -> Line<'a> {
+    let style = if selected {
+        Style::default()
+            .fg(ORANGE)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default()
+    };
+    Line::from(vec![
+        Span::raw(format!("{label:<14} ")),
+        Span::styled(format!(" {value} "), style),
+    ])
+}
+
+fn action_line(label: &str, selected: bool) -> Line<'static> {
+    let style = if selected {
+        Style::default()
+            .fg(ORANGE)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    Line::from(Span::styled(label.to_string(), style))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DEFAULT_HOST_ID;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn sample_cfg() -> AppConfig {
+        AppConfig {
+            base_url: DEFAULT_BASE_URL.to_string(),
+            host_id: DEFAULT_HOST_ID,
+            api_key: None,
+            token: None,
+            default_chart: DEFAULT_CHART.to_string(),
+            channel: Channel::Stable,
+            json: false,
+            quiet: false,
+            yes: false,
+            debug: false,
+            user_config_path: std::path::PathBuf::from("/tmp/chm-test-config.toml"),
+        }
+    }
+
+    #[test]
+    fn save_writes_fields_without_secrets() {
+        let cfg = sample_cfg();
+        let file = FileConfig {
+            api_key: Some("secret".into()),
+            token: Some("tok".into()),
+            ..FileConfig::default()
+        };
+        let form = ConfigForm::from_config(&cfg, &file);
+        let patch = form.to_file_patch().unwrap();
+        assert_eq!(patch.base_url.as_deref(), Some(DEFAULT_BASE_URL));
+        assert_eq!(patch.host_id, Some(0));
+        assert_eq!(patch.channel.as_deref(), Some("stable"));
+        assert_eq!(patch.default_chart.as_deref(), Some(DEFAULT_CHART));
+        assert!(patch.api_key.is_none());
+        assert!(patch.token.is_none());
+    }
+
+    #[test]
+    fn host_id_must_be_integer() {
+        let mut form = ConfigForm::from_config(&sample_cfg(), &FileConfig::default());
+        form.host_id = "nope".into();
+        assert!(form.to_file_patch().is_err());
+        form.host_id = "4".into();
+        assert_eq!(form.to_file_patch().unwrap().host_id, Some(4));
+    }
+
+    #[test]
+    fn enter_saves_and_esc_cancels() {
+        let mut form = ConfigForm::from_config(&sample_cfg(), &FileConfig::default());
+        assert_eq!(form.apply_key(key(KeyCode::Esc)), FormAction::Cancel);
+        assert_eq!(form.apply_key(key(KeyCode::Enter)), FormAction::Save);
+        form.selected = Field::Save;
+        assert_eq!(form.apply_key(key(KeyCode::Char('s'))), FormAction::Save);
+        form.selected = Field::Cancel;
+        assert_eq!(form.apply_key(key(KeyCode::Enter)), FormAction::Cancel);
+    }
+
+    #[test]
+    fn typing_edits_selected_text_field() {
+        let mut form = ConfigForm::from_config(&sample_cfg(), &FileConfig::default());
+        form.base_url.clear();
+        form.apply_key(key(KeyCode::Char('h')));
+        form.apply_key(key(KeyCode::Char('t')));
+        form.apply_key(key(KeyCode::Char('t')));
+        form.apply_key(key(KeyCode::Backspace));
+        assert_eq!(form.base_url, "ht");
+        form.selected = Field::Channel;
+        form.apply_key(key(KeyCode::Right));
+        assert_eq!(form.channel, Channel::Beta);
+    }
+}

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -4,6 +4,7 @@
 //! `chm chat` (`tui/chat.rs`). Other commands must never call EnterAlternateScreen.
 
 pub mod chat;
+pub mod config_form;
 
 use std::{
     io,
@@ -32,7 +33,7 @@ use serde_json::Value;
 use crate::{
     client,
     config::{AppConfig, DEFAULT_TABLE},
-    metrics, output,
+    dashboards, metrics, output,
 };
 
 const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
@@ -54,13 +55,14 @@ chmonitor keys
   j / ↓       scroll table down
   k / ↑       scroll table up
   Tab         switch pane (small terminals)
-  1           overview pane
+  1           overview charts
   2 / 3       table pane
   /           filter table
 
-Default chart is config `default_chart` (else query-count).
-Default table is running-queries. Point --base-url / CHM_BASE_URL
-at a self-hosted dashboard when not using dash.chmonitor.dev.";
+Default TUI is the Overview dashboard (query-count, counts, disk).
+A 404 chart is skipped. Table pane stays secondary (running-queries).
+Point --base-url / CHM_BASE_URL at a self-hosted dashboard when not
+using dash.chmonitor.dev.";
 
 const PREFERRED_TABLE_COLUMNS: &[&str] = &[
     "query_id",
@@ -109,12 +111,22 @@ struct HostEntry {
     host: String,
 }
 
-pub struct TuiOptions<'a> {
-    pub chart: &'a str,
-    pub table: &'a str,
+#[derive(Clone)]
+pub struct TuiOptions {
+    pub dashboard: String,
+    pub charts: Vec<String>,
+    pub table: String,
     pub page_size: usize,
     pub start_overview: bool,
     pub host_id: u32,
+}
+
+#[derive(Debug, Clone)]
+struct ChartPane {
+    name: String,
+    points: Vec<u64>,
+    rows: Vec<Value>,
+    missing: bool,
 }
 
 pub enum TuiExit {
@@ -132,13 +144,12 @@ impl Drop for TuiGuard {
 }
 
 struct App {
-    chart: String,
+    dashboard: String,
     table: String,
     page_size: usize,
     host_id: u32,
     hosts: Vec<HostEntry>,
-    points: Vec<u64>,
-    chart_rows: Vec<Value>,
+    charts: Vec<ChartPane>,
     table_rows: Vec<Value>,
     table_scroll: usize,
     table_filter: String,
@@ -150,32 +161,62 @@ struct App {
 }
 
 impl App {
-    fn new(opts: &TuiOptions<'_>) -> Self {
+    fn new(opts: &TuiOptions) -> Self {
+        let charts = if opts.charts.is_empty() {
+            dashboards::overview_chart_names()
+        } else {
+            opts.charts.clone()
+        };
+        let _ = opts.start_overview;
         Self {
-            chart: opts.chart.to_string(),
+            dashboard: if opts.dashboard.trim().is_empty() {
+                dashboards::OVERVIEW_NAME.to_string()
+            } else {
+                opts.dashboard.clone()
+            },
             table: if opts.table.is_empty() {
                 DEFAULT_TABLE.to_string()
             } else {
-                opts.table.to_string()
+                opts.table.clone()
             },
             page_size: opts.page_size,
             host_id: opts.host_id,
             hosts: Vec::new(),
-            points: Vec::new(),
-            chart_rows: Vec::new(),
+            charts: charts
+                .into_iter()
+                .map(|name| ChartPane {
+                    name,
+                    points: Vec::new(),
+                    rows: Vec::new(),
+                    missing: false,
+                })
+                .collect(),
             table_rows: Vec::new(),
             table_scroll: 0,
             table_filter: String::new(),
-            focused: if opts.start_overview {
-                Pane::Overview
-            } else {
-                Pane::Table
-            },
+            focused: Pane::Overview,
             overlay: Overlay::None,
             error: None,
             auth_required: false,
             last_ok_refresh: None,
         }
+    }
+
+    fn visible_charts(&self) -> Vec<&ChartPane> {
+        let single_has_data = self
+            .charts
+            .iter()
+            .any(|c| c.name == "disk-size-single" && !c.missing && !c.rows.is_empty());
+        self.charts
+            .iter()
+            .filter(|c| {
+                dashboards::should_show_chart(
+                    &c.name,
+                    !c.missing && !c.rows.is_empty(),
+                    single_has_data,
+                )
+            })
+            .collect()
     }
 
     fn host_label(&self) -> String {
@@ -194,7 +235,7 @@ impl App {
     }
 }
 
-pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions<'_>) -> Result<TuiExit> {
+pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions) -> Result<TuiExit> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -347,16 +388,25 @@ fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
 async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
     let base = cfg.base_url.trim_end_matches('/');
     let hosts_url = format!("{base}/api/v1/hosts");
-    let chart_url = format!("{base}/api/v1/charts/{}?hostId={}", app.chart, app.host_id);
     let table_url = format!(
         "{base}/api/v1/tables/{}?hostId={}&pageSize={}",
         app.table, app.host_id, app.page_size
     );
+    let chart_urls: Vec<String> = app
+        .charts
+        .iter()
+        .map(|c| format!("{base}/api/v1/charts/{}?hostId={}", c.name, app.host_id))
+        .collect();
 
-    let (hosts_res, chart_res, table_res) = tokio::join!(
+    let charts_fut = futures_util::future::join_all(
+        chart_urls
+            .into_iter()
+            .map(|url| client::fetch_optional_cfg(client, cfg, url)),
+    );
+    let (hosts_res, table_res, chart_results) = tokio::join!(
         client::fetch_cfg(client, cfg, hosts_url),
-        client::fetch_cfg(client, cfg, chart_url),
         client::fetch_cfg(client, cfg, table_url),
+        charts_fut,
     );
 
     let mut auth = false;
@@ -370,17 +420,33 @@ async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
         }
     }
 
-    match chart_res {
-        Ok(data) => match client::rows_from_chart_data(data) {
-            Ok(rows) => {
-                app.points = rows.iter().take(80).map(metrics::row_metric).collect();
-                app.chart_rows = rows;
+    for (pane, result) in app.charts.iter_mut().zip(chart_results) {
+        match result {
+            Ok(None) => {
+                pane.missing = true;
+                pane.points.clear();
+                pane.rows.clear();
             }
-            Err(err) => errors.push(short_error("chart", &err)),
-        },
-        Err(err) => {
-            auth |= is_auth_error(&err);
-            errors.push(short_error("chart", &err));
+            Ok(Some(data)) => match client::rows_from_chart_data(data) {
+                Ok(rows) => {
+                    pane.missing = rows.is_empty();
+                    pane.points = rows.iter().take(80).map(metrics::row_metric).collect();
+                    pane.rows = rows;
+                }
+                Err(err) => {
+                    pane.missing = true;
+                    errors.push(short_error(&pane.name, &err));
+                }
+            },
+            Err(err) => {
+                auth |= is_auth_error(&err);
+                pane.missing = true;
+                pane.points.clear();
+                pane.rows.clear();
+                if !is_auth_error(&err) {
+                    errors.push(short_error(&pane.name, &err));
+                }
+            }
         }
     }
 
@@ -470,9 +536,7 @@ fn draw(f: &mut Frame<'_>, cfg: &AppConfig, app: &App) {
 fn draw_header(f: &mut Frame<'_>, area: Rect, cfg: &AppConfig, app: &App, combined: bool) {
     let age = refresh_age_label(app.last_ok_refresh, Instant::now());
     let age_style = if age == "live" {
-        Style::default()
-            .fg(EMERALD)
-            .add_modifier(Modifier::BOLD)
+        Style::default().fg(EMERALD).add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::DarkGray)
     };
@@ -484,11 +548,11 @@ fn draw_header(f: &mut Frame<'_>, area: Rect, cfg: &AppConfig, app: &App, combin
     let line = Line::from(vec![
         Span::styled(
             " chmonitor ",
-            Style::default()
-                .fg(ORANGE)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(ORANGE).add_modifier(Modifier::BOLD),
         ),
         Span::raw(" "),
+        Span::styled(app.dashboard.clone(), Style::default().fg(ORANGE)),
+        Span::raw("  "),
         Span::styled(
             app.host_label(),
             Style::default()
@@ -533,24 +597,91 @@ fn draw_switcher(f: &mut Frame<'_>, area: Rect, focused: Pane) {
 fn draw_combined(f: &mut Frame<'_>, area: Rect, app: &App) {
     let cols = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(24), Constraint::Min(40)])
+        .constraints([Constraint::Length(22), Constraint::Min(40)])
         .split(area);
     draw_hosts(f, cols[0], app);
+    let table_h = (area.height / 3).clamp(5, 10);
     let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(7), Constraint::Min(6)])
+        .constraints([Constraint::Min(8), Constraint::Length(table_h)])
         .split(cols[1]);
-    draw_chart(f, rows[0], app);
+    draw_chart_grid(f, rows[0], app);
     draw_table_pane(f, rows[1], app);
 }
 
 fn draw_overview(f: &mut Frame<'_>, area: Rect, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(38), Constraint::Percentage(62)])
+    draw_chart_grid(f, area, app);
+}
+
+fn draw_chart_grid(f: &mut Frame<'_>, area: Rect, app: &App) {
+    let charts = app.visible_charts();
+    if charts.is_empty() {
+        let body = if app.auth_required {
+            "sign in to load charts — `chm auth login`"
+        } else {
+            "no overview charts (404s skipped)"
+        };
+        f.render_widget(
+            Paragraph::new(body).block(Block::bordered().title(app.dashboard.as_str())),
+            area,
+        );
+        return;
+    }
+    let cols = if area.width >= 90 {
+        3
+    } else if area.width >= 48 {
+        2
+    } else {
+        1
+    };
+    let cols = cols.min(charts.len()).max(1);
+    let rows_n = charts.len().div_ceil(cols);
+    let row_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(vec![Constraint::Fill(1); rows_n])
         .split(area);
-    draw_hosts(f, chunks[0], app);
-    draw_chart(f, chunks[1], app);
+    for (r, row_area) in row_chunks.iter().enumerate() {
+        let start = r * cols;
+        let end = (start + cols).min(charts.len());
+        let n_in_row = end.saturating_sub(start);
+        if n_in_row == 0 {
+            continue;
+        }
+        let col_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Fill(1); n_in_row])
+            .split(*row_area);
+        for (c, cell) in col_chunks.iter().enumerate() {
+            draw_chart_cell(f, *cell, charts[start + c]);
+        }
+    }
+}
+
+fn draw_chart_cell(f: &mut Frame<'_>, area: Rect, pane: &ChartPane) {
+    let kpi = dashboards::chart_kpi(&pane.name, &pane.rows);
+    if pane.points.len() >= 2 && area.height >= 4 {
+        let stats = output::sparkline_stats(&pane.points).unwrap_or_default();
+        let title = if stats.is_empty() {
+            format!("{}  {kpi}", pane.name)
+        } else {
+            format!("{}  {kpi}  {stats}", pane.name)
+        };
+        let spark = Sparkline::default()
+            .block(Block::bordered().title(title))
+            .data(&pane.points)
+            .style(Style::default().fg(ORANGE));
+        f.render_widget(spark, area);
+        return;
+    }
+    f.render_widget(
+        Paragraph::new(if pane.rows.is_empty() {
+            "no data".to_string()
+        } else {
+            kpi
+        })
+        .block(Block::bordered().title(pane.name.as_str())),
+        area,
+    );
 }
 
 fn draw_hosts(f: &mut Frame<'_>, area: Rect, app: &App) {
@@ -585,34 +716,8 @@ fn draw_hosts(f: &mut Frame<'_>, area: Rect, app: &App) {
     let list = List::new(items)
         .block(Block::bordered().title(format!("hosts  {}", app.hosts.len())))
         .highlight_symbol("● ")
-        .highlight_style(
-            Style::default()
-                .fg(ORANGE)
-                .add_modifier(Modifier::BOLD),
-        );
+        .highlight_style(Style::default().fg(ORANGE).add_modifier(Modifier::BOLD));
     f.render_stateful_widget(list, area, &mut state);
-}
-
-fn draw_chart(f: &mut Frame<'_>, area: Rect, app: &App) {
-    let stats = output::sparkline_stats(&app.points).unwrap_or_else(|| "no data".into());
-    let title = format!("{}  {stats}", app.chart);
-    if app.points.is_empty() {
-        f.render_widget(
-            Paragraph::new(if app.auth_required {
-                "sign in to load chart"
-            } else {
-                "no chart data"
-            })
-            .block(Block::bordered().title(title)),
-            area,
-        );
-        return;
-    }
-    let spark = Sparkline::default()
-        .block(Block::bordered().title(title))
-        .data(&app.points)
-        .style(Style::default().fg(ORANGE));
-    f.render_widget(spark, area);
 }
 
 fn draw_table_pane(f: &mut Frame<'_>, area: Rect, app: &App) {
@@ -650,11 +755,8 @@ fn draw_table_pane(f: &mut Frame<'_>, area: Rect, app: &App) {
         return;
     }
 
-    let header = Row::new(cols.iter().cloned().map(Cell::from)).style(
-        Style::default()
-            .fg(ORANGE)
-            .add_modifier(Modifier::BOLD),
-    );
+    let header = Row::new(cols.iter().cloned().map(Cell::from))
+        .style(Style::default().fg(ORANGE).add_modifier(Modifier::BOLD));
     let widths = column_constraints(cols.len());
     let rows: Vec<Row> = filtered
         .iter()
@@ -1063,14 +1165,15 @@ mod tests {
     #[test]
     fn question_mark_opens_help_and_slash_opens_search() {
         let opts = TuiOptions {
-            chart: "query-count",
-            table: "running-queries",
+            dashboard: "Overview".into(),
+            charts: vec!["query-count".into()],
+            table: "running-queries".into(),
             page_size: 15,
             start_overview: false,
             host_id: 0,
         };
         let mut app = App::new(&opts);
-        assert_eq!(app.focused, Pane::Table);
+        assert_eq!(app.focused, Pane::Overview);
         assert_eq!(
             handle_key(&mut app, key(KeyCode::Char('?'))),
             KeyAction::None
@@ -1108,8 +1211,9 @@ mod tests {
     #[test]
     fn host_keys_request_refresh() {
         let opts = TuiOptions {
-            chart: "query-count",
-            table: "running-queries",
+            dashboard: "Overview".into(),
+            charts: vec!["query-count".into()],
+            table: "running-queries".into(),
             page_size: 15,
             start_overview: true,
             host_id: 0,
@@ -1135,5 +1239,59 @@ mod tests {
     fn default_table_matches_config() {
         assert_eq!(crate::config::DEFAULT_TABLE, "running-queries");
         assert_eq!(crate::config::DEFAULT_CHART, "query-count");
+    }
+
+    #[test]
+    fn default_tui_lists_overview_charts() {
+        let opts = TuiOptions {
+            dashboard: String::new(),
+            charts: Vec::new(),
+            table: String::new(),
+            page_size: 15,
+            start_overview: false,
+            host_id: 0,
+        };
+        let app = App::new(&opts);
+        assert_eq!(app.dashboard, "Overview");
+        assert!(app.charts.iter().any(|c| c.name == "query-count"));
+        assert!(app.charts.iter().any(|c| c.name == "database-count"));
+        assert!(app.charts.iter().any(|c| c.name == "disk-size-single"));
+        assert_eq!(app.table, "running-queries");
+        assert_eq!(app.focused, Pane::Overview);
+    }
+
+    #[test]
+    fn visible_charts_skip_missing_and_duplicate_disk() {
+        let opts = TuiOptions {
+            dashboard: "Overview".into(),
+            charts: vec![
+                "query-count".into(),
+                "disk-size-single".into(),
+                "disk-size-all".into(),
+            ],
+            table: "running-queries".into(),
+            page_size: 15,
+            start_overview: true,
+            host_id: 0,
+        };
+        let mut app = App::new(&opts);
+        app.charts[0].rows = vec![json!({"query_count": 1})];
+        app.charts[1].rows = vec![json!({"readable_used_space": "1 GiB"})];
+        app.charts[2].rows = vec![json!({"name": "default"})];
+        app.charts[0].missing = false;
+        let names: Vec<&str> = app
+            .visible_charts()
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["query-count", "disk-size-single"]);
+        app.charts[1].missing = true;
+        app.charts[1].rows.clear();
+        let names: Vec<&str> = app
+            .visible_charts()
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["query-count", "disk-size-all"]);
     }
 }


### PR DESCRIPTION
## Summary

- Default `chm` TUI is the Overview dashboard: chart grid (KPI/sparkline) for `query-count`, counts, and disk size via `GET /api/v1/charts/{name}?hostId=`. 404s are skipped; the running-queries table stays a secondary pane.
- `chm dashboard list` (and `open <name>`): built-in Overview first, then saved dashboards from `GET /api/dashboards/list`. 401/501 still lists Overview. TTY picker; `--json` / piped stdout prints names.
- Bare `chm config` is an interactive dialog (no secrets in the form). `chm config show` prints user/project files, env/flag overrides, and resolved config. `chm config set` stays for scripts.

Default API base remains `https://dash.chmonitor.dev`. Alt-screen is still only the live TUI, interactive chat, and the config dialog.

## Test plan

- [x] `cargo test` in `rust/ch-monitor-cli` (119 tests)
- [x] clap: bare `chm`, `chm dashboard list`, `chm config`, `chm config show`
- [x] config show layering with temp files (secrets redacted)