### PR TITLE
feat(cli): chm update --beta switches channel and upgrades

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -90,7 +90,9 @@ Releases — no re-running the install script, and they never invoke `sudo`:
 ```bash
 chm upgrade                    # alias of update
 chm update --check             # report only (exit 1 if newer exists)
-chm update --channel beta      # prefer prereleases
+chm update --beta              # install latest beta and save channel=beta
+chm update --stable            # install latest stable and save channel=stable
+chm update --channel beta      # this run only
 chm upgrade --version chm-v0.2.0
 ```
 

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -543,7 +543,7 @@ not by the dashboard server. Flags override env; env overrides
 | Variable | Default | Purpose |
 |---|---|---|
 | `CHM_BASE_URL` | `https://dash.chmonitor.dev` | Dashboard API origin for `hosts` / `chart` / `table` / `tui` / `auth` / … |
-| `CHM_CHANNEL` | `stable` | Release channel for `install.sh` and `chm update`/`upgrade`: `stable` or `beta`. Also `--channel` / config `channel`. |
+| `CHM_CHANNEL` | `stable` | Release channel for `install.sh` and `chm update`/`upgrade`: `stable` or `beta`. Also `--channel` / config `channel`. `chm update --beta` installs from beta and writes `channel = "beta"` to the user config (`--stable` writes `stable`). |
 | `CHM_API_KEY` | — | `chm_` API key (also `--api-key`). Used when discovery returns `api_key`, or alongside device login. |
 | `CHM_TOKEN` | — | Bearer token from device login (also `--token`). Usually stored in the OS keyring. |
 | `CHM_HOST_ID` | `0` | Host index for dashboard API calls (`?host=`). |

--- a/docs/content/reference/releases.mdx
+++ b/docs/content/reference/releases.mdx
@@ -43,7 +43,7 @@ dashboard `vX.Y.Z` line):
 | Channel | How it ships | Install / update |
 |---|---|---|
 | `stable` (default) | release-please → tag + dispatch `cli-rust-release.yml` | `install.sh` / `chm update` |
-| `beta` | CLI path pushes on `main` → prerelease `chm-vX.Y.Z-beta.N` | `CHM_CHANNEL=beta` / `chm update --channel beta` |
+| `beta` | CLI path pushes on `main` → prerelease `chm-vX.Y.Z-beta.N` | `chm update --beta` (also saves the channel) / `CHM_CHANNEL=beta` |
 
 See the [chm CLI guide](/guide/guides/diagnostics-cli).
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -283,13 +283,14 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor \
 ## Self-update (`chm update` / `chm upgrade`)
 
 `chm upgrade` is a first-class alias of `chm update` (same `--check` /
-`--version` flags, same `cli_run`/`update` telemetry). Both print
+`--version` / `--beta` / `--stable` flags, same `cli_run`/`update` telemetry). Both print
 current -> target version, download the matching `chm-<target>` GitHub Release
 asset, require a matching `.sha256`, and atomically replace the running
 binary. They never invoke sudo. Homebrew-managed installs are refused
 (`is_brew_managed`). Channel (`--channel` / `CHM_CHANNEL` / config):
 `stable` skips prereleases; `beta` includes them and prefers a prerelease
-when semver cores tie. Checksum, permission, download, and
+when semver cores tie. `chm update --beta` installs from beta **and** writes
+`channel = "beta"` to the user config; `--stable` does the inverse. Checksum, permission, download, and
 unsupported-target failures print a copy-pasteable fallback (`scripts/install.sh`
 or `cargo install chmonitor --force`; unsupported targets point at cargo
 only). `--version` accepts `chm-v0.2.0`, `v0.2.0`, `0.2.0`, or `chm-0.2.0`.

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+* **cli:** `chm update --beta` installs the latest beta and saves `channel = "beta"` (`--stable` switches back)
 * **cli:** default TUI shows Overview dashboard charts (KPI/sparkline grid)
 * **cli:** `chm dashboard list` / `open` (Overview + saved dashboards)
 * **cli:** interactive `chm config`; `chm config show` prints file layers

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -98,7 +98,9 @@ print a copy-pasteable fallback (`scripts/install.sh` or
 chm upgrade                      # alias of update — latest stable chm-v* release
 chm update                       # same behaviour
 chm update --check               # only report if a newer release exists (exit 1 if so)
-chm update --channel beta        # prefer prereleases (or CHM_CHANNEL=beta)
+chm update --beta                # install latest beta and save channel=beta
+chm update --stable              # install latest stable and save channel=stable
+chm update --channel beta        # this run only (or CHM_CHANNEL=beta)
 chm upgrade --version chm-v0.2.0 # pin a specific release (`0.2.0` / `v0.2.0` also work)
 ```
 

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -224,6 +224,12 @@ pub struct UpdateArgs {
     /// Install a specific release tag, e.g. chm-v0.2.0.
     #[arg(long)]
     pub version: Option<String>,
+    /// Install from the beta channel and persist `channel = "beta"` in user config.
+    #[arg(long, conflicts_with = "stable")]
+    pub beta: bool,
+    /// Install from stable and persist `channel = "stable"` in user config.
+    #[arg(long, conflicts_with = "beta")]
+    pub stable: bool,
 }
 
 #[derive(Args, Debug)]

--- a/rust/ch-monitor-cli/src/commands/update_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/update_cmd.rs
@@ -4,8 +4,9 @@ use anyhow::Result;
 use reqwest::Client;
 
 use crate::{
-    cli::UpdateArgs,
-    config::AppConfig,
+    cli::{Channel, UpdateArgs},
+    config::{self, AppConfig},
+    output,
     update::{self, is_brew_managed},
 };
 
@@ -17,15 +18,71 @@ pub async fn run(client: &Client, cfg: &AppConfig, args: UpdateArgs) -> Result<i
         );
     }
 
+    let channel = if args.beta {
+        Channel::Beta
+    } else if args.stable {
+        Channel::Stable
+    } else {
+        cfg.channel
+    };
+    let persist = args.beta || args.stable;
+
     if args.check {
-        let available = update::check_channel(client, cfg.channel).await?;
+        let available = update::check_channel(client, channel).await?;
         if available {
             Ok(1)
         } else {
             Ok(0)
         }
     } else {
-        update::run_channel(client, args.version, cfg.channel).await?;
+        update::run_channel(client, args.version, channel).await?;
+        if persist {
+            persist_channel(cfg, channel)?;
+        }
         Ok(0)
+    }
+}
+
+fn persist_channel(cfg: &AppConfig, channel: Channel) -> Result<()> {
+    let mut file = config::load_user_file_config(&cfg.user_config_path)?;
+    file.channel = Some(channel.as_str().to_string());
+    config::save_user_config(&cfg.user_config_path, &file)?;
+    output::success(&format!(
+        "channel {channel} saved in {}",
+        cfg.user_config_path.display()
+    ));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use crate::cli::Channel;
+    use crate::config::{AppConfig, DEFAULT_CHANNEL, DEFAULT_CHART, DEFAULT_HOST_ID};
+
+    #[test]
+    fn persist_channel_writes_user_toml() {
+        let dir = std::env::temp_dir().join(format!("chm-update-beta-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let path = dir.join("config.toml");
+        let cfg = AppConfig {
+            base_url: "https://dash.chmonitor.dev".into(),
+            host_id: DEFAULT_HOST_ID,
+            api_key: None,
+            token: None,
+            default_chart: DEFAULT_CHART.into(),
+            channel: DEFAULT_CHANNEL,
+            json: false,
+            quiet: true,
+            yes: false,
+            debug: false,
+            user_config_path: path.clone(),
+        };
+        persist_channel(&cfg, Channel::Beta).expect("persist");
+        let text = fs::read_to_string(&path).expect("read");
+        assert!(text.contains("beta"), "{text}");
+        let _ = fs::remove_file(&path);
     }
 }

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -107,6 +107,20 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn update_beta_and_stable_flags() {
+        for argv in [["chm", "update", "--beta"], ["chm", "upgrade", "--beta"]] {
+            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
+            assert!(args.beta);
+            assert!(!args.stable);
+        }
+        let stable = update_args(Cli::try_parse_from(["chm", "update", "--stable"]).expect("parse"));
+        assert!(stable.stable);
+        assert!(!stable.beta);
+        assert!(Cli::try_parse_from(["chm", "update", "--beta", "--stable"]).is_err());
+    }
+
+    #[test]
     fn upgrade_and_update_share_version_flag() {
         for argv in [
             ["chm", "update", "--version", "chm-v0.2.0"],


### PR DESCRIPTION
## Summary

`chm update --beta` (and `chm upgrade --beta`) installs the latest beta **and** writes `channel = "beta"` to `~/.config/chm/config.toml`. `--stable` switches back. `--channel beta` remains this-run-only.

## Test plan

- [x] Clap tests: `--beta` / `--stable` parse; both together error
- [x] persist writes `beta` into a temp user config
- [ ] CI `rust-cli` / `unit-tests`

---

Co-Authored-By: duyetbot <bot@duyet.net>