### PR TITLE
fix(dashboard): show overview selected tab underline in light mode

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -212,7 +212,10 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   ONE size (`size-3.5`) and NO margin utility; `TabsTrigger` already supplies
   `items-center gap-1.5`. Adding `mr-*` on top of that reads as misalignment.
   Wrap the list in `scrollbar-hide overflow-x-auto` + `w-max min-w-full` so
-  labels like "Memory & CPU" scroll instead of clipping.
+  labels like "Memory & CPU" scroll instead of clipping. Selected styles use
+  Base UI `data-active:` (trigger `border-b-2`, not Radix
+  `data-[state=active]:`). Do not use `TabsList variant="line"` on an
+  `overflow-x-auto` strip — the hanging `after` underline is clipped.
 - **Responsive chrome:** overview KPIs wrap from `sm` (truncate is `max-sm:`
   only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
   sidebar sheet is opaque — no heatmap-through-frost.   Phone time chips /

--- a/apps/dashboard/src/components/layout/responsive-chrome.test.ts
+++ b/apps/dashboard/src/components/layout/responsive-chrome.test.ts
@@ -47,6 +47,11 @@ describe('responsive chrome', () => {
     expect(overview).toContain('scrollbar-hide overflow-x-auto')
     expect(overview).toContain('w-max min-w-full')
     expect(overview).toContain('shrink-0 whitespace-nowrap')
+    // Base UI selected attr — Radix `data-[state=active]` never matches, so
+    // light mode had no underline (pill `bg-background` on the page surface).
+    expect(overview).toContain('data-active:border-foreground')
+    expect(overview).toContain('data-active:text-foreground')
+    expect(overview).not.toContain('data-[state=active]')
   })
 
   test('phone chrome uses a 44px tap target', () => {

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -27,18 +27,23 @@ const TopologyView = lazy(() =>
 const VALID_TABS = new Set(OVERVIEW_TABS.map((tab) => tab.value))
 const DEFAULT_TAB = 'overview'
 
-/** Underline-active tab styling, overriding the shadcn pill defaults. */
+/** Underline-active tab styling, overriding the shadcn pill defaults.
+ *  Tabs are Base UI: selected is `data-active`, not the Radix state=active attr. */
 const TAB_TRIGGER_CLASS = cn(
   // layout
   'h-auto shrink-0 whitespace-nowrap px-3 py-2',
-  // borders — bottom-only underline
+  // borders — bottom-only underline (on the trigger so overflow-x-auto
+  // on the strip does not clip a hanging `after` bar)
   'rounded-none border-0 border-b-2 border-transparent bg-transparent shadow-none',
+  // kill the default pill: light `data-active:bg-background` is the same as
+  // the page surface so the selected tab vanished; dark still showed
+  // `bg-input/30`.
+  'data-active:border-foreground data-active:bg-transparent data-active:shadow-none',
+  'dark:data-active:border-foreground dark:data-active:bg-transparent',
   // typography
   'text-[13px] font-medium text-muted-foreground',
   // states
-  'transition-colors hover:text-foreground',
-  'data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:shadow-none',
-  'dark:data-[state=active]:border-foreground dark:data-[state=active]:bg-transparent',
+  'transition-colors hover:text-foreground data-active:text-foreground',
   // keyboard focus — inset ring stays inside the bottom-border strip
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
 )

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -576,6 +576,13 @@ utility — `TabsTrigger` already provides `items-center gap-1.5`; a stacked
 `mr-*` is what makes icons look off-baseline. Keep the strip in the
 `scrollbar-hide overflow-x-auto` + `TabsList w-max min-w-full flex-nowrap`
 wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
+Selected state is Base UI `data-active:` (underline via trigger
+`border-b-2` + `data-active:border-foreground`), never Radix
+`data-[state=active]:` — those selectors never match, so light-mode overview
+tabs looked unselected (`data-active:bg-background` on the page surface) while
+dark mode still showed the `bg-input/30` pill. Do not rely on `TabsList
+variant="line"`'s hanging `after` bar here: the strip is `overflow-x-auto` and
+would clip it.
 
 ### Responsive chrome (phones + tablets)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Overview page tab strip used Radix `data-[state=active]` classes, but tabs are Base UI (`data-active`). Those overrides never applied, so light mode kept `data-active:bg-background` — the same as the page surface — and the selected tab had no highlight. Dark mode still looked selected via `bg-input/30`.

## Changes

- `overview.tsx`: selected underline and text use `data-active:`; kill the default pill so both themes show a foreground bottom border.
- Contract test in `responsive-chrome.test.ts` so the Radix selector cannot regress.
- Product-design skill + knowledge note: Base UI `data-active`, do not hang a `variant="line"` `after` bar on an `overflow-x-auto` strip.

## Test plan

- [x] Biome check on changed files
- [x] `bun test src/components/layout/responsive-chrome.test.ts` (8 pass)
- [x] GitHub CI — 24 checks green on `93383f50`
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Do not edit `components/ui/tabs.tsx` — override at the overview call site.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-645dd20d-5ef6-489b-8dce-9997f8bc5b15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-645dd20d-5ef6-489b-8dce-9997f8bc5b15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

