### PR TITLE
fix(cli): exit after chm update; switch channel with --beta/--stable

### DIFF
--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -289,8 +289,10 @@ asset, require a matching `.sha256`, and atomically replace the running
 binary. They never invoke sudo. Homebrew-managed installs are refused
 (`is_brew_managed`). Channel (`--channel` / `CHM_CHANNEL` / config):
 `stable` skips prereleases; `beta` includes them and prefers a prerelease
-when semver cores tie. `chm update --beta` installs from beta **and** writes
-`channel = "beta"` to the user config; `--stable` does the inverse. Checksum, permission, download, and
+when semver cores tie. `chm update --beta` writes `channel = "beta"` to the
+user config **then** installs from beta; `--stable` does the inverse. The
+process always `exit`s after the command (reqwest keep-alives must not stall
+after “already up to date”). Checksum, permission, download, and
 unsupported-target failures print a copy-pasteable fallback (`scripts/install.sh`
 or `cargo install chmonitor --force`; unsupported targets point at cargo
 only). `--version` accepts `chm-v0.2.0`, `v0.2.0`, `0.2.0`, or `chm-0.2.0`.

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -118,7 +118,7 @@ The CLI sends a best-effort, anonymous usage ping (a random install id, CLI
 version, command name, and OS/arch) to `telemetry.chmonitor.dev` — a separate
 stream from the dashboard's telemetry, with **no** cluster host, query text,
 arguments, paths, or IPs. It runs on a background thread with a sub-second
-timeout and never blocks or fails a command.
+timeout, is aborted if still running at exit, and never blocks or fails a command.
 
 Opt out with any of `CHM_TELEMETRY=off`, `DO_NOT_TRACK=1`, or
 `CHM_TELEMETRY_ENDPOINT=""`. See

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -144,8 +144,9 @@ pub enum Commands {
     /// replaces this binary. Never invokes sudo: checksum, permission, and
     /// unsupported-target failures print a copy-pasteable fallback
     /// (`scripts/install.sh` or `cargo install chmonitor`).
+    /// `--beta` / `--stable` switch the saved channel and then update.
     Update(UpdateArgs),
-    /// Alias of `update`. Same flags (`--check`, `--version`), same behaviour.
+    /// Alias of `update`. Same flags (`--check`, `--version`, `--beta`, `--stable`).
     Upgrade(UpdateArgs),
     /// Generate shell completions
     Completions {

--- a/rust/ch-monitor-cli/src/commands/update_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/update_cmd.rs
@@ -26,6 +26,11 @@ pub async fn run(client: &Client, cfg: &AppConfig, args: UpdateArgs) -> Result<i
         cfg.channel
     };
     let persist = args.beta || args.stable;
+    // Persist first so `--beta` / `--stable` still switch channel when GitHub
+    // is unreachable or the binary is already current.
+    if persist && !args.check {
+        persist_channel(cfg, channel)?;
+    }
 
     if args.check {
         let available = update::check_channel(client, channel).await?;
@@ -36,9 +41,6 @@ pub async fn run(client: &Client, cfg: &AppConfig, args: UpdateArgs) -> Result<i
         }
     } else {
         update::run_channel(client, args.version, channel).await?;
-        if persist {
-            persist_channel(cfg, channel)?;
-        }
         Ok(0)
     }
 }

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -27,7 +27,12 @@ use crate::cli::{Cli, Commands, TuiArgs};
 async fn main() -> Result<()> {
     let mut cli = Cli::parse();
     let cfg = config::resolve_config(&cli)?;
-    let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
+    let client = Client::builder()
+        .timeout(Duration::from_secs(60))
+        // CLI is one-shot: idle keep-alives would leave hyper pool tasks
+        // running after `chm update` prints "already up to date".
+        .pool_max_idle_per_host(0)
+        .build()?;
 
     // Bare `chm` (no subcommand) is the live TUI — same as `chm tui`.
     let command = cli
@@ -61,10 +66,9 @@ async fn main() -> Result<()> {
     let exit = commands::dispatch(&client, &cfg, &cli, command).await?;
 
     telemetry::finish(tel_handle).await;
-    if exit != 0 {
-        std::process::exit(exit);
-    }
-    Ok(())
+    // Always exit the process: returning from `#[tokio::main]` waits for every
+    // leftover background task (reqwest pool, detached telemetry).
+    std::process::exit(exit);
 }
 
 #[cfg(test)]
@@ -107,14 +111,14 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn update_beta_and_stable_flags() {
         for argv in [["chm", "update", "--beta"], ["chm", "upgrade", "--beta"]] {
             let args = update_args(Cli::try_parse_from(argv).expect("parse"));
             assert!(args.beta);
             assert!(!args.stable);
         }
-        let stable = update_args(Cli::try_parse_from(["chm", "update", "--stable"]).expect("parse"));
+        let stable =
+            update_args(Cli::try_parse_from(["chm", "update", "--stable"]).expect("parse"));
         assert!(stable.stable);
         assert!(!stable.beta);
         assert!(Cli::try_parse_from(["chm", "update", "--beta", "--stable"]).is_err());
@@ -333,6 +337,8 @@ mod tests {
         for help in [&update_help, &upgrade_help] {
             assert!(help.contains("--check"), "{help}");
             assert!(help.contains("--version"), "{help}");
+            assert!(help.contains("--beta"), "{help}");
+            assert!(help.contains("--stable"), "{help}");
         }
     }
 

--- a/rust/ch-monitor-cli/src/telemetry.rs
+++ b/rust/ch-monitor-cli/src/telemetry.rs
@@ -208,7 +208,13 @@ pub fn spawn(event: &'static str, command: &'static str) -> Option<JoinHandle<()
             arch: arch(),
             license_key: license_key_from_env(),
         };
-        let Ok(client) = Client::builder().timeout(REQUEST_TIMEOUT).build() else {
+        let Ok(client) = Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            // Do not keep idle connections: they spawn pool tasks that outlive
+            // the request and can stall process exit.
+            .pool_max_idle_per_host(0)
+            .build()
+        else {
             return;
         };
         // Errors are intentionally ignored — telemetry must never surface.
@@ -217,16 +223,42 @@ pub fn spawn(event: &'static str, command: &'static str) -> Option<JoinHandle<()
 }
 
 /// Await the spawned ping, but never block exit longer than `EXIT_BUDGET`.
+///
+/// Dropping a [`JoinHandle`] *detaches* the task (it keeps running). A
+/// timed-out ping must be [`abort`](JoinHandle::abort)ed so reqwest's
+/// connection-pool workers cannot keep the Tokio runtime alive after the
+/// command has already printed its result.
 pub async fn finish(handle: Option<JoinHandle<()>>) {
-    if let Some(handle) = handle {
-        let _ = tokio::time::timeout(EXIT_BUDGET, handle).await;
+    let Some(mut handle) = handle else {
+        return;
+    };
+    tokio::select! {
+        _ = &mut handle => {}
+        () = tokio::time::sleep(EXIT_BUDGET) => {
+            handle.abort();
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_license_key, CliPing};
+    use super::{finish, parse_license_key, CliPing, EXIT_BUDGET};
     use serde_json::{json, Value};
+    use std::time::{Duration, Instant};
+
+    #[tokio::test]
+    async fn finish_aborts_slow_task_instead_of_waiting() {
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+        let started = Instant::now();
+        finish(Some(handle)).await;
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < EXIT_BUDGET + Duration::from_millis(400),
+            "finish waited {elapsed:?} (budget {EXIT_BUDGET:?})"
+        );
+    }
 
     #[test]
     fn parse_license_key_accepts_polar_checkout_uuid() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`chm update` printed `chm is already up to date` and then hung until the Tokio runtime drained leftover HTTP tasks. `--beta` / `--stable` now switch the saved channel and then update.

## Changes

- Abort timed-out telemetry tasks (dropping a `JoinHandle` only detaches) and disable reqwest idle connection pools
- Always `process::exit` after the command so keep-alives cannot stall `#[tokio::main]`
- `chm update --beta` / `--stable` write `channel` in the user config first, then install from that channel
- Docs in `docs/knowledge/standalone-cli.md` and the CLI README

## Test plan

- [x] `cargo test -p chmonitor --bins` (122 tests)
- [x] `timeout 25 chm update` returns immediately with `already up to date` / exit 0
- [x] `chm update --stable` persists `channel = "stable"` and exits
- [x] `chm update --beta` persists `channel = "beta"` and installs the latest beta
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

The hang was not the GitHub lookup: the command had already printed success. Detached telemetry plus hyper pool workers kept the runtime alive.

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abb5de02-d4a0-41e4-95ce-17486dac5389?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abb5de02-d4a0-41e4-95ce-17486dac5389&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

