### PR TITLE
fix(cli): cap live dashboard refresh and prune today query count

### DIFF
--- a/apps/dashboard/src/lib/api/__tests__/charts/query-charts.test.ts
+++ b/apps/dashboard/src/lib/api/__tests__/charts/query-charts.test.ts
@@ -24,6 +24,16 @@ describe('queryCharts', () => {
       }
     })
 
+    if (name === 'query-count-today') {
+      test('filters today with event_time so query_log can prune partitions', () => {
+        const result = builder({})
+        if ('query' in result) {
+          expect(result.query).toContain('event_time >= toStartOfDay(now())')
+          expect(result.query).not.toContain('toDate(event_time)')
+        }
+      })
+    }
+
     if (name === 'query-cache-usage') {
       test('has VersionedSql array in sql property', () => {
         const result = builder({})

--- a/apps/dashboard/src/lib/api/charts/query-charts.ts
+++ b/apps/dashboard/src/lib/api/charts/query-charts.ts
@@ -13,7 +13,7 @@ export const queryCharts: Record<string, ChartQueryBuilder> = {
       SELECT COUNT() AS count
       FROM merge('system', '^query_log')
       WHERE type = 'QueryFinish'
-        AND toDate(event_time) = today()
+        AND event_time >= toStartOfDay(now())
       SETTINGS max_execution_time = 25
     `,
   }),

--- a/apps/dashboard/src/routes/api/v1/overview.ts
+++ b/apps/dashboard/src/routes/api/v1/overview.ts
@@ -89,7 +89,7 @@ export const Route = createFileRoute('/api/v1/overview')({
               -- Today's query count
               SELECT 'today_queries' as metric, COUNT() as value, COUNT() as value_num
               FROM merge('system', '^query_log')
-              WHERE type = 'QueryFinish' AND toDate(event_time) = today()
+              WHERE type = 'QueryFinish' AND event_time >= toStartOfDay(now())
 
               UNION ALL
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -3,7 +3,7 @@ id: standalone-cli
 title: Standalone CLI (Rust)
 type: reference
 status: active
-updated: 2026-08-20
+updated: 2026-08-21
 tags:
   - rust
   - cli
@@ -100,14 +100,18 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merge
 
 Live UI (ratatui + crossterm). Bare `chm` and `chm tui` are the same command
 (telemetry `cli_run` / `tui`). The default view is the **Overview dashboard**:
-`query-count`, `query-count-today`, `running-queries-count`, `database-count`,
-`table-count`, and `disk-size-single` (or `disk-size-all`) via
-`GET /api/v1/charts/{name}?hostId=`. Each chart is a KPI and/or sparkline in a
-grid; HTTP 404 charts are skipped. The running-queries table stays a secondary
-pane. `chm dashboard list` (and `chm dashboard open <name>`) open the same TUI
-bound to Overview or a saved dashboard's `layout.widgets[].chartName`. **Only**
-this TUI, interactive `chm chat`, and `chm config` (dialog) enter the terminal
-alternate screen; `dashboard list`'s picker stays on the normal screen.
+`query-count`, `running-queries-count`, `database-count`, `table-count`, and
+`disk-size-single` (or `disk-size-all`) via
+`GET /api/v1/charts/{name}` with `hostId`, a one-day `lastHours` window, and
+hourly `interval`.
+Live tiles refresh every fifteen seconds; query-log charts refresh every two
+minutes so the TUI cannot hammer the cluster. Chart JSON is capped (sparkline
+points plus the latest row). HTTP 404 charts are skipped. The running-queries
+table stays a secondary pane (page size plus string truncation). `chm dashboard
+list` (and `chm dashboard open <name>`) open the same TUI bound to Overview or a
+saved dashboard's `layout.widgets[].chartName`. **Only** this TUI, interactive
+`chm chat`, and `chm config` (dialog) enter the terminal alternate screen;
+`dashboard list`'s picker stays on the normal screen.
 
 One screen: hosts + chart grid **and** the table together when the terminal is
 tall/wide enough (`≥72×24`). Smaller terminals collapse to a focused pane with

--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -7,6 +7,9 @@ use serde_json::Value;
 
 use crate::config::AppConfig;
 
+/// Hard cap on dashboard API bodies so a huge chart/table payload cannot OOM `chm`.
+pub const MAX_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+
 #[derive(Debug, Deserialize)]
 struct ApiResponse {
     data: Value,
@@ -103,7 +106,21 @@ async fn send_get(
         }
     };
     let status = resp.status().as_u16();
-    let text = resp.text().await.unwrap_or_default();
+    if let Some(len) = resp.content_length() {
+        if len as usize > MAX_RESPONSE_BYTES {
+            bail!(
+                "chmonitor API at {url} returned {len} bytes (limit {MAX_RESPONSE_BYTES})"
+            );
+        }
+    }
+    let bytes = resp.bytes().await.unwrap_or_default();
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        bail!(
+            "chmonitor API at {url} returned {} bytes (limit {MAX_RESPONSE_BYTES})",
+            bytes.len()
+        );
+    }
+    let text = String::from_utf8_lossy(&bytes).into_owned();
     Ok((status, text))
 }
 
@@ -249,5 +266,10 @@ mod tests {
 
         let bare: ApiEnvelope = serde_json::from_str(r#"{"data":[]}"#).unwrap();
         assert!(bare.query_hint().is_none());
+    }
+
+    #[test]
+    fn response_body_cap_is_two_mib() {
+        assert_eq!(MAX_RESPONSE_BYTES, 2 * 1024 * 1024);
     }
 }

--- a/rust/ch-monitor-cli/src/dashboards.rs
+++ b/rust/ch-monitor-cli/src/dashboards.rs
@@ -11,7 +11,6 @@ pub const OVERVIEW_NAME: &str = "Overview";
 /// `disk-size-all` is only shown when `disk-size-single` is missing.
 pub const OVERVIEW_CHARTS: &[&str] = &[
     "query-count",
-    "query-count-today",
     "running-queries-count",
     "database-count",
     "table-count",
@@ -222,6 +221,7 @@ mod tests {
         assert_eq!(d.name, "Overview");
         assert_eq!(d.source, "builtin");
         assert!(d.charts.contains(&"query-count".into()));
+        assert!(!d.charts.contains(&"query-count-today".into()));
         assert!(d.charts.contains(&"database-count".into()));
         assert!(d.charts.contains(&"table-count".into()));
         assert!(d.charts.contains(&"disk-size-single".into()));

--- a/rust/ch-monitor-cli/src/tui/chat.rs
+++ b/rust/ch-monitor-cli/src/tui/chat.rs
@@ -166,6 +166,11 @@ async fn run_tui(client: &Client, cfg: &AppConfig, seed: Option<String>) -> Resu
                 Ok(reply) => log.push(format!("agent> {reply}")),
                 Err(err) => log.push(format!("error> {err}")),
             }
+            const MAX_CHAT_LOG: usize = 40;
+            if log.len() > MAX_CHAT_LOG {
+                let drop_n = log.len() - MAX_CHAT_LOG;
+                log.drain(0..drop_n);
+            }
             busy = false;
         }
 

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -36,8 +36,14 @@ use crate::{
     dashboards, metrics, output,
 };
 
-const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
+const TUI_REFRESH_INTERVAL: Duration = Duration::from_secs(15);
+const TUI_HISTORICAL_REFRESH_INTERVAL: Duration = Duration::from_secs(120);
 const TUI_EVENT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const MAX_CHART_POINTS: usize = 80;
+const MAX_DISK_ROWS: usize = 8;
+const MAX_ROW_STRING_CHARS: usize = 512;
+const TUI_CHART_LAST_HOURS: u32 = 24;
+const TUI_CHART_INTERVAL: &str = "toStartOfHour";
 const COMBINED_MIN_WIDTH: u16 = 72;
 const COMBINED_MIN_HEIGHT: u16 = 24;
 const ORANGE: Color = Color::Rgb(249, 115, 22);
@@ -158,6 +164,7 @@ struct App {
     error: Option<String>,
     auth_required: bool,
     last_ok_refresh: Option<Instant>,
+    last_historical_refresh: Option<Instant>,
 }
 
 impl App {
@@ -199,6 +206,7 @@ impl App {
             error: None,
             auth_required: false,
             last_ok_refresh: None,
+            last_historical_refresh: None,
         }
     }
 
@@ -246,10 +254,12 @@ pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions) -> Result<T
 
     let mut app = App::new(&opts);
     let mut next_refresh_at = Instant::now();
+    let mut force_refresh = true;
 
     loop {
-        if Instant::now() >= next_refresh_at {
-            refresh(client, cfg, &mut app).await;
+        if force_refresh || Instant::now() >= next_refresh_at {
+            refresh(client, cfg, &mut app, force_refresh).await;
+            force_refresh = false;
             next_refresh_at = Instant::now() + TUI_REFRESH_INTERVAL;
         }
 
@@ -265,7 +275,7 @@ pub async fn run(client: &Client, cfg: &AppConfig, opts: TuiOptions) -> Result<T
             event::Event::Resize(_, _) => continue,
             event::Event::Key(key) => match handle_key(&mut app, key) {
                 KeyAction::None => {}
-                KeyAction::Refresh => next_refresh_at = Instant::now(),
+                KeyAction::Refresh => force_refresh = true,
                 KeyAction::Quit => return Ok(TuiExit::Quit),
                 KeyAction::Chat => {
                     return Ok(TuiExit::Chat {
@@ -385,24 +395,109 @@ fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
     }
 }
 
-async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
+/// Cheap tiles that are safe to poll with the live cadence.
+fn is_live_chart(name: &str) -> bool {
+    matches!(
+        name,
+        "running-queries-count"
+            | "database-count"
+            | "table-count"
+            | "disk-size-single"
+            | "disk-size-all"
+            | "merge-active-count"
+    )
+}
+
+fn chart_fetch_url(base: &str, name: &str, host_id: u32) -> String {
+    format!(
+        "{base}/api/v1/charts/{name}?hostId={host_id}&lastHours={TUI_CHART_LAST_HOURS}&interval={TUI_CHART_INTERVAL}"
+    )
+}
+
+fn should_fetch_chart(name: &str, force: bool, last_historical: Option<Instant>) -> bool {
+    if force || is_live_chart(name) {
+        return true;
+    }
+    match last_historical {
+        None => true,
+        Some(t) => t.elapsed() >= TUI_HISTORICAL_REFRESH_INTERVAL,
+    }
+}
+
+enum ChartFetch {
+    Skip,
+    Done(Result<Option<Value>>),
+}
+
+fn compact_chart_rows(name: &str, mut rows: Vec<Value>) -> (Vec<u64>, Vec<Value>) {
+    if rows.len() > MAX_CHART_POINTS {
+        rows = rows[rows.len() - MAX_CHART_POINTS..].to_vec();
+    }
+    truncate_row_strings(&mut rows);
+    let points: Vec<u64> = rows.iter().map(metrics::row_metric).collect();
+    let kept = if name.starts_with("disk-size") {
+        rows.truncate(MAX_DISK_ROWS);
+        rows
+    } else if let Some(last) = rows.pop() {
+        vec![last]
+    } else {
+        Vec::new()
+    };
+    (points, kept)
+}
+
+fn truncate_row_strings(rows: &mut [Value]) {
+    for row in rows {
+        let Value::Object(map) = row else {
+            continue;
+        };
+        for value in map.values_mut() {
+            if let Value::String(s) = value {
+                if s.chars().count() > MAX_ROW_STRING_CHARS {
+                    *s = truncate_chars(s, MAX_ROW_STRING_CHARS);
+                }
+            }
+        }
+    }
+}
+
+fn bound_table_rows(mut rows: Vec<Value>, page_size: usize) -> Vec<Value> {
+    let cap = page_size.max(1).min(100);
+    if rows.len() > cap {
+        rows.truncate(cap);
+    }
+    truncate_row_strings(&mut rows);
+    rows
+}
+
+async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App, force: bool) {
     let base = cfg.base_url.trim_end_matches('/');
     let hosts_url = format!("{base}/api/v1/hosts");
     let table_url = format!(
         "{base}/api/v1/tables/{}?hostId={}&pageSize={}",
         app.table, app.host_id, app.page_size
     );
-    let chart_urls: Vec<String> = app
+    let last_historical = app.last_historical_refresh;
+    let chart_jobs: Vec<(bool, String)> = app
         .charts
         .iter()
-        .map(|c| format!("{base}/api/v1/charts/{}?hostId={}", c.name, app.host_id))
+        .map(|c| {
+            (
+                should_fetch_chart(&c.name, force, last_historical),
+                chart_fetch_url(base, &c.name, app.host_id),
+            )
+        })
         .collect();
 
-    let charts_fut = futures_util::future::join_all(
-        chart_urls
-            .into_iter()
-            .map(|url| client::fetch_optional_cfg(client, cfg, url)),
-    );
+    let charts_fut = futures_util::future::join_all(chart_jobs.into_iter().map(
+        |(fetch, url)| async move {
+            if !fetch {
+                ChartFetch::Skip
+            } else {
+                ChartFetch::Done(client::fetch_optional_cfg(client, cfg, url).await)
+            }
+        },
+    ));
     let (hosts_res, table_res, chart_results) = tokio::join!(
         client::fetch_cfg(client, cfg, hosts_url),
         client::fetch_cfg(client, cfg, table_url),
@@ -411,6 +506,7 @@ async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
 
     let mut auth = false;
     let mut errors: Vec<String> = Vec::new();
+    let mut fetched_historical = false;
 
     match hosts_res {
         Ok(data) => app.hosts = parse_hosts(&data),
@@ -422,23 +518,36 @@ async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
 
     for (pane, result) in app.charts.iter_mut().zip(chart_results) {
         match result {
-            Ok(None) => {
+            ChartFetch::Skip => {}
+            ChartFetch::Done(Ok(None)) => {
+                if !is_live_chart(&pane.name) {
+                    fetched_historical = true;
+                }
                 pane.missing = true;
                 pane.points.clear();
                 pane.rows.clear();
             }
-            Ok(Some(data)) => match client::rows_from_chart_data(data) {
-                Ok(rows) => {
-                    pane.missing = rows.is_empty();
-                    pane.points = rows.iter().take(80).map(metrics::row_metric).collect();
-                    pane.rows = rows;
+            ChartFetch::Done(Ok(Some(data))) => {
+                if !is_live_chart(&pane.name) {
+                    fetched_historical = true;
                 }
-                Err(err) => {
-                    pane.missing = true;
-                    errors.push(short_error(&pane.name, &err));
+                match client::rows_from_chart_data(data) {
+                    Ok(rows) => {
+                        pane.missing = rows.is_empty();
+                        let (points, kept) = compact_chart_rows(&pane.name, rows);
+                        pane.points = points;
+                        pane.rows = kept;
+                    }
+                    Err(err) => {
+                        pane.missing = true;
+                        errors.push(short_error(&pane.name, &err));
+                    }
                 }
-            },
-            Err(err) => {
+            }
+            ChartFetch::Done(Err(err)) => {
+                if !is_live_chart(&pane.name) {
+                    fetched_historical = true;
+                }
                 auth |= is_auth_error(&err);
                 pane.missing = true;
                 pane.points.clear();
@@ -450,12 +559,17 @@ async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App) {
         }
     }
 
+    if fetched_historical {
+        app.last_historical_refresh = Some(Instant::now());
+    }
+
     match table_res {
         Ok(data) => {
-            app.table_rows = match data {
+            let rows = match data {
                 Value::Array(rows) => rows,
                 other => vec![other],
             };
+            app.table_rows = bound_table_rows(rows, app.page_size);
             app.clamp_scroll();
         }
         Err(err) => {
@@ -758,7 +872,13 @@ fn draw_table_pane(f: &mut Frame<'_>, area: Rect, app: &App) {
     let header = Row::new(cols.iter().cloned().map(Cell::from))
         .style(Style::default().fg(ORANGE).add_modifier(Modifier::BOLD));
     let widths = column_constraints(cols.len());
-    let rows: Vec<Row> = filtered
+    let vis = (area.height.saturating_sub(4) as usize).max(1);
+    let start = app
+        .table_scroll
+        .saturating_sub(vis.saturating_sub(1))
+        .min(filtered.len().saturating_sub(1));
+    let end = (start + vis).min(filtered.len());
+    let rows: Vec<Row> = filtered[start..end]
         .iter()
         .map(|row| {
             let obj = row.as_object();
@@ -773,7 +893,7 @@ fn draw_table_pane(f: &mut Frame<'_>, area: Rect, app: &App) {
         .collect();
 
     let mut state = TableState::default();
-    state.select(Some(app.table_scroll));
+    state.select(Some(app.table_scroll.saturating_sub(start)));
     let table = TuiTable::new(rows, widths)
         .header(header)
         .block(Block::bordered().title(title))
@@ -1256,6 +1376,7 @@ mod tests {
         assert!(app.charts.iter().any(|c| c.name == "query-count"));
         assert!(app.charts.iter().any(|c| c.name == "database-count"));
         assert!(app.charts.iter().any(|c| c.name == "disk-size-single"));
+        assert!(!app.charts.iter().any(|c| c.name == "query-count-today"));
         assert_eq!(app.table, "running-queries");
         assert_eq!(app.focused, Pane::Overview);
     }
@@ -1293,5 +1414,49 @@ mod tests {
             .map(|c| c.name.as_str())
             .collect();
         assert_eq!(names, vec!["query-count", "disk-size-all"]);
+    }
+
+    #[test]
+    fn chart_urls_cap_the_query_window() {
+        let url = chart_fetch_url("https://dash.example", "query-count", 2);
+        assert_eq!(
+            url,
+            "https://dash.example/api/v1/charts/query-count?hostId=2&lastHours=24&interval=toStartOfHour"
+        );
+        assert!(is_live_chart("running-queries-count"));
+        assert!(!is_live_chart("query-count"));
+        assert!(should_fetch_chart("query-count", true, None));
+        assert!(!should_fetch_chart(
+            "query-count",
+            false,
+            Some(Instant::now())
+        ));
+    }
+
+    #[test]
+    fn compact_chart_rows_drops_history_json() {
+        let rows: Vec<Value> = (0..120)
+            .map(|i| json!({"query_count": i, "query": "x".repeat(800)}))
+            .collect();
+        let (points, kept) = compact_chart_rows("query-count", rows);
+        assert_eq!(points.len(), MAX_CHART_POINTS);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0]["query_count"], 119);
+        let query_len = kept[0]["query"].as_str().unwrap().chars().count();
+        assert!(query_len <= MAX_ROW_STRING_CHARS + 1);
+        let disk = compact_chart_rows(
+            "disk-size-all",
+            vec![
+                json!({"name": "a"}),
+                json!({"name": "b"}),
+                json!({"name": "c"}),
+            ],
+        );
+        assert_eq!(disk.1.len(), 3);
+        let table = bound_table_rows(
+            (0..40).map(|i| json!({"i": i, "query": "SELECT 1"})).collect(),
+            15,
+        );
+        assert_eq!(table.len(), 15);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The live CLI dashboard was polling `query_log` charts every 5 seconds with unbounded windows, which can OOM ClickHouse. This caps poll cadence and payload size, and prunes “today” counts on `event_time` so partitions can be used.

## Changes

- Default overview no longer fetches `query-count-today` (duplicate of `query-count` and a full-day log scan).
- Chart requests use a one-day window and hourly buckets; live tiles refresh every 15s, historical charts every 2 minutes.
- Keep sparkline points plus the latest JSON row (and a small disk row cap); cap HTTP bodies at 2 MiB; truncate table strings.
- `query-count-today` and overview `today_queries` filter with `event_time >= toStartOfDay(now())` instead of `toDate(event_time) = today()`.
- Chat log capped at 40 entries.

## Test plan

- [x] `cargo test` for CLI (`tui`, `client`, `dashboards`) — 30 tests pass
- [x] `bun test src/lib/api/__tests__/charts/query-charts.test.ts` — 39 tests pass
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Knowledge doc `docs/knowledge/standalone-cli.md` updated
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Manual `r` still forces a full refresh. Extra chart names from `chm tui <name>` or saved dashboards inherit the one-day `lastHours` cap.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7436829e-55dd-4e10-aa85-3a190162f4af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7436829e-55dd-4e10-aa85-3a190162f4af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

