### PR TITLE
fix(cli): drop diagnose, upgrade, and completions

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -13,7 +13,7 @@ open the live TUI (`chm tui` is the same UI) on the Overview dashboard charts.
 `--base-url` / `CHM_BASE_URL` / `chm config set base_url` at your self-hosted
 dashboard when needed.
 
-`chm doctor --ch-host` (alias `chm diagnose`) is a separate mode: it connects
+`chm doctor --ch-host` (no dashboard account or backend) is a separate mode: it connects
 **straight to a ClickHouse host** with no dashboard account or backend.
 
 <Callout type="info" title="Binary names and platforms">
@@ -56,7 +56,7 @@ cargo install chmonitor
 | `stable` (default) | omit, or `CHM_CHANNEL=stable` / `--channel stable` | Latest non-prerelease `chm-v*` |
 | `beta` | `CHM_CHANNEL=beta` / `--channel beta` / config `channel = "beta"` | Prefer prereleases (`chm-vX.Y.Z-beta.N`) |
 
-`install.sh`, `chm update`, and `chm upgrade` all honour the same channel.
+`install.sh` and `chm update` honour the same channel.
 
 ## Auth (`chm auth login`)
 
@@ -83,17 +83,16 @@ and [Environment variables — CLI client](/reference/environment-variables#cli-
 
 ## Update
 
-`chm update` and `chm upgrade` are the same command (`upgrade` is a first-class
-alias). Both print current → target version and update in place from GitHub
-Releases — no re-running the install script, and they never invoke `sudo`:
+`chm update` prints current → target version and updates in place from GitHub
+Releases — no re-running the install script, and it never invokes `sudo`:
 
 ```bash
-chm upgrade                    # alias of update
+chm update                     # latest stable
 chm update --check             # report only (exit 1 if newer exists)
 chm update --beta              # install latest beta and save channel=beta
 chm update --stable            # install latest stable and save channel=stable
 chm update --channel beta      # this run only
-chm upgrade --version chm-v0.2.0
+chm update --version chm-v0.2.0
 ```
 
 Checksum verification is mandatory. Failures print a copy-pasteable fallback
@@ -139,8 +138,7 @@ contents, env/flag overrides, and the resolved values.
 `chm doctor --ch-host` is a one-shot health check for a ClickHouse cluster that
 needs **no chmonitor account and no backend** — the binary talks directly to
 ClickHouse's HTTP interface, runs a fixed set of read-only checks, and prints a
-scored report to your terminal. `chm diagnose` is a first-class alias of this
-path (same flags).
+scored report to your terminal.
 
 Without `--ch-host` / `CLICKHOUSE_HOST`, `chm doctor` stays a local CLI +
 dashboard connectivity check and prints a one-line hint for the cluster scan.
@@ -154,7 +152,6 @@ it at a ClickHouse host and it works with nothing else installed or configured.
 ```bash
 CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm doctor # pragma: allowlist secret
 chm doctor --ch-host http://localhost:8123
-# alias: chm diagnose --ch-host http://localhost:8123
 # same binary: chmonitor doctor --ch-host http://localhost:8123
 ```
 
@@ -177,7 +174,7 @@ CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default \ # pragma: allowl
 Same env var names the dashboard uses, so if you already have
 `CLICKHOUSE_HOST` / `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` set for a {/* pragma: allowlist secret */}
 self-hosted deploy, `chm doctor` picks them up as-is and runs the cluster scan.
-Flags override env vars. `chm diagnose` accepts the same flags.
+Flags override env vars.
 
 | Env var | Flag | Default | Notes |
 |---|---|---|---|

--- a/docs/content/operate/advanced/telemetry.mdx
+++ b/docs/content/operate/advanced/telemetry.mdx
@@ -173,8 +173,8 @@ The `install.sh` install ping additionally **skips automatically when `CI=true`*
 | Field | Values | Notes |
 |---|---|---|
 | `install_id` | 64-char opaque hex | Random id persisted at `$XDG_CONFIG_HOME/chmonitor/cli-id` (default `~/.config/chmonitor/cli-id`). Counts distinct installs only; maps to no identity. |
-| `event` | `cli_install`, `cli_run`, `cli_diagnose` | Install ping vs. a command run vs. a `diagnose` run. |
-| `command` | `hosts`, `chart`, `table`, `tui`, `diagnose`, `update`, `auth`, `config`, `link`, `chat`, `agent`, `doctor`, `completions`, `install`, … | Subcommand name (`chm` and `chmonitor` report the same names). |
+| `event` | `cli_install`, `cli_run`, `cli_diagnose` | Install ping vs. a command run vs. a `doctor --ch-host` scan. |
+| `command` | `hosts`, `chart`, `table`, `tui`, `update`, `auth`, `config`, `link`, `chat`, `agent`, `doctor`, `install`, … | Subcommand name (`chm` and `chmonitor` report the same names). |
 | `cli_version` | semver (e.g. `0.1.0`) | The `chm` version. |
 | `os` | `linux`, `macos`, `windows`, `unknown` | Shipped prebuilts are Linux/macOS only; `windows` appears for source builds. |
 | `arch` | `x86_64`, `aarch64`, `unknown` | |

--- a/docs/content/operate/index.mdx
+++ b/docs/content/operate/index.mdx
@@ -25,7 +25,7 @@ authentication and advanced configuration.
   <Card
     title="chm CLI"
     href="/guide/guides/diagnostics-cli"
-    description="Install chm / chmonitor, channels, auth discovery, and diagnose."
+    description="Install chm / chmonitor, channels, auth discovery, and update."
   />
   <Card
     title="Advanced"

--- a/docs/content/reference/environment-variables.mdx
+++ b/docs/content/reference/environment-variables.mdx
@@ -543,7 +543,7 @@ not by the dashboard server. Flags override env; env overrides
 | Variable | Default | Purpose |
 |---|---|---|
 | `CHM_BASE_URL` | `https://dash.chmonitor.dev` | Dashboard API origin for `hosts` / `chart` / `table` / `tui` / `auth` / … |
-| `CHM_CHANNEL` | `stable` | Release channel for `install.sh` and `chm update`/`upgrade`: `stable` or `beta`. Also `--channel` / config `channel`. `chm update --beta` installs from beta and writes `channel = "beta"` to the user config (`--stable` writes `stable`). |
+| `CHM_CHANNEL` | `stable` | Release channel for `install.sh` and `chm update`: `stable` or `beta`. Also `--channel` / config `channel`. `chm update --beta` installs from beta and writes `channel = "beta"` to the user config (`--stable` writes `stable`). |
 | `CHM_API_KEY` | — | `chm_` API key (also `--api-key`). Used when discovery returns `api_key`, or alongside device login. |
 | `CHM_TOKEN` | — | Bearer token from device login (also `--token`). Usually stored in the OS keyring. |
 | `CHM_HOST_ID` | `0` | Host index for dashboard API calls (`?host=`). |

--- a/docs/content/reference/index.mdx
+++ b/docs/content/reference/index.mdx
@@ -20,7 +20,7 @@ and how to lock down the connection.
 <Card title="Settings" href="/reference/settings" description="In-app settings page and its server-side counterparts." />
 <Card title="Connection presets" href="/reference/connection-presets" description="Create a least-privilege read-only ClickHouse user." />
 <Card title="Support matrix" href="/reference/support-matrix" description="ClickHouse version and distribution coverage." />
-<Card title="chm CLI" href="/guide/guides/diagnostics-cli" description="chm / chmonitor install, channels, auth discovery, update, and diagnose." />
+<Card title="chm CLI" href="/guide/guides/diagnostics-cli" description="chm / chmonitor install, channels, auth discovery, and update." />
 </Cards>
 
 ## MCP

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -3,7 +3,7 @@ id: standalone-cli
 title: Standalone CLI (Rust)
 type: reference
 status: active
-updated: 2026-08-20
+updated: 2026-08-21
 tags:
   - rust
   - cli
@@ -29,7 +29,7 @@ of the same UI) showing the **Overview dashboard** charts. `chm --help` /
 By default it talks to **chmonitor
 Cloud** at `https://dash.chmonitor.dev` (hosts / charts / tables / TUI / agent).
 Self-hosted dashboards work the same way — point `--base-url` /
-`CHM_BASE_URL` / `chm config set base_url` at your instance. `chm doctor --ch-host` (alias `diagnose`)
+`CHM_BASE_URL` / `chm config set base_url` at your instance. `chm doctor --ch-host`
 connects **directly to a ClickHouse host** with no chmonitor backend or account
 (see [Zero-signup cluster health](#zero-signup-cluster-health-doctor) below).
 
@@ -56,30 +56,28 @@ Credentials (device-login token / API key) live in the OS keyring, with a
 ## Command tree
 
 ```text
-chm                # live TUI (default; Overview charts; same as `chm tui`)
+chm                # live TUI (default; same as `chm tui`)
 ├── tui [chart]    # explicit TUI alias (alt-screen)
-├── dashboard
-│   ├── list       # pick a dashboard (Overview + saved); Enter opens TUI
-│   └── open <name>
 ├── auth
-│   ├── login [--api-key]  # auto-detect none|device|api_key
-│   ├── logout     # clear keyring credentials
-│   ├── status     # whether a token / API key is present
-│   └── token      # print stored bearer token (CI)
+│   ├── login [--api-key]
+│   ├── logout
+│   ├── status
+│   └── token
 ├── config         # interactive dialog (no subcommand)
-│   ├── show       # files + contents + inherit order + resolved
+│   ├── show
 │   ├── path
 │   └── set KEY VALUE
-├── hosts          # GET /api/v1/hosts
-├── link [path]    # open dashboard in browser
-├── chart <name>   # GET /api/v1/charts/{name} (+ braille sparkline + min/max/avg)
-├── table <name>   # GET /api/v1/tables/{name} (--explain for columns / SQL)
-├── chat [msg]     # stream AI agent reply (alt-screen when interactive)
-├── agent [msg]    # alias of chat
-├── doctor         # cluster scan with --ch-host; else CLI + API connectivity
-├── diagnose       # alias of doctor cluster scan (same flags)
-├── update|upgrade # self-update from GitHub Releases
-└── completions    # shell completions
+├── dashboard
+│   ├── list
+│   └── open <name>
+├── hosts
+├── link [path]
+├── chart <name>
+├── table <name>
+├── chat [msg]
+├── agent [msg]
+├── doctor         # cluster scan with --ch-host; else connectivity
+└── update         # self-update from GitHub Releases
 ```
 
 ```bash
@@ -93,7 +91,6 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- chart query-count --
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --limit 30
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- table running-queries --explain
 cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
-cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- agent "why are merges slow?"
 ```
 
 ## TUI (`chm` / `chm tui`)
@@ -232,8 +229,7 @@ Response shape: `{ data: { apiKey, sub, scopes, expiresInDays } }`.
 `chm doctor --ch-host` is a **separate connection mode** from the rest of the CLI: it
 talks straight to the ClickHouse HTTP interface (`reqwest` + basic auth), not
 through the dashboard's `/api/v1/*` (no `base_url`/`api_key`/`host_id`, no
-account, no chmonitor backend required at all). `chm diagnose` is a first-class
-alias of this path (same flags). Without a host, `chm doctor` keeps the local
+account, no chmonitor backend required at all). Without a host, `chm doctor` keeps the local
 CLI + dashboard connectivity check. Implementation:
 `rust/ch-monitor-cli/src/diagnose.rs` (scan) and `src/commands/doctor.rs`
 (connectivity).
@@ -274,19 +270,17 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor \
 
 | Library | Purpose |
 |---------|---------|
-| `clap` + `clap_complete` | CLI parser, env support, completions |
+| `clap` | CLI parser, env support |
 | `reqwest` + `tokio` | Async HTTP (JSON + SSE stream) |
 | `keyring` | OS credential store |
 | `comfy-table` / `indicatif` / `owo-colors` | Table + progress + color |
 | `ratatui` + `crossterm` | TUI stack |
 
-## Self-update (`chm update` / `chm upgrade`)
+## Self-update (`chm update`)
 
-`chm upgrade` is a first-class alias of `chm update` (same `--check` /
-`--version` / `--beta` / `--stable` flags, same `cli_run`/`update` telemetry). Both print
-current -> target version, download the matching `chm-<target>` GitHub Release
-asset, require a matching `.sha256`, and atomically replace the running
-binary. They never invoke sudo. Homebrew-managed installs are refused
+`chm update` prints current -> target version, downloads the matching `chm-<target>` GitHub Release
+asset, requires a matching `.sha256`, and atomically replaces the running
+binary. It never invokes sudo. Homebrew-managed installs are refused
 (`is_brew_managed`). Channel (`--channel` / `CHM_CHANNEL` / config):
 `stable` skips prereleases; `beta` includes them and prefers a prerelease
 when semver cores tie. `chm update --beta` writes `channel = "beta"` to the
@@ -300,7 +294,7 @@ Implementation: `src/update.rs`. Latest-tag lookup pages past dashboard/Helm
 releases and ranks published `chm-v*` tags by semver.
 
 ```bash
-cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- upgrade --check
+cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- update --check
 ```
 
 ## CI & Release
@@ -364,7 +358,7 @@ If curl gets a Cloudflare Bot Fight Mode 403, see
   writable it errors with `CHM_INSTALL_DIR` / `cargo install` fallback
   instead of escalating itself.
 - Also installs a `chmonitor` symlink/alias pointing at `chm`.
-- Self-update: `chm update` / `chm upgrade` (`--channel stable|beta`, or
+- Self-update: `chm update` (`--channel stable|beta`, or
   `CHM_CHANNEL` / config `channel`) pull from the same GitHub Releases.
 - `rust/ch-monitor-cli/Cargo.toml` carries `authors`/`repository`/`readme`/
   `keywords`/`categories`. `cargo-publish.yml` publishes the crate so

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
- "clap_complete",
  "comfy-table",
  "crossterm 0.28.1",
  "dirs",
@@ -260,15 +259,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
-]
-
-[[package]]
-name = "clap_complete"
-version = "4.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
-dependencies = [
- "clap",
 ]
 
 [[package]]

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -9,7 +9,8 @@
 * **cli:** `chm dashboard list` / `open` (Overview + saved dashboards)
 * **cli:** interactive `chm config`; `chm config show` prints file layers
 * **cli:** launch interactive TUI by default (`chm` with no subcommand; `chm tui` stays an alias)
-* **cli:** make `chm doctor` the cluster health command (`diagnose` stays as an alias)
+* **cli:** drop `diagnose`, `upgrade`, and `completions` aliases; keep `chm` TUI, `auth`, `config`, and `update`
+* **cli:** make `chm doctor` the cluster health command
 
 ## [0.1.2](https://github.com/chmonitor/chmonitor/compare/chm-v0.1.1...chm-v0.1.2) (2026-08-20)
 

--- a/rust/ch-monitor-cli/Cargo.toml
+++ b/rust/ch-monitor-cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "chmonitor"
 version = "0.1.2"
 edition = "2021"
 authors = ["duyet <bot@duyet.net>"]
-description = "Standalone terminal/TUI CLI for chmonitor (`chm` / `chmonitor`). Run `chm` for the live TUI; includes a zero-signup `chm doctor` health scan."
+description = "Standalone terminal/TUI CLI for chmonitor (`chm` / `chmonitor`). Run `chm` for the live TUI."
 license = "MIT"
 repository = "https://github.com/chmonitor/chmonitor"
 readme = "README.md"
@@ -29,7 +29,6 @@ mermaid = []
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
-clap_complete = "4"
 comfy-table = "7"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -16,17 +16,6 @@ still print help.
 **Platforms:** prebuilt binaries for Linux/macOS × `x86_64`/`aarch64` only (no
 Windows). Other targets: `cargo install chmonitor`.
 
-Two ways to use it:
-
-- `chm` — **interactive TUI** against a running dashboard (Overview chart grid +
-  secondary table). `chm tui` is an explicit alias. `chm dashboard list` picks
-  Overview or a saved dashboard.
-- `chm doctor --ch-host …` — **zero-signup** health scan that connects straight
-  to a cluster HTTP interface (no chmonitor account or backend needed) and
-  prints a scored, read-only report. `chm diagnose` is an alias of this path.
-- `chm doctor` (no host) — local CLI + dashboard API connectivity check.
-- `chm hosts` / `chm chart` / `chm table` — one-shot dashboard API commands.
-
 ## Install
 
 ```bash
@@ -37,18 +26,29 @@ curl -sSf https://chmonitor.dev/install.sh | bash
 CHM_CHANNEL=beta bash <(curl -sSf https://chmonitor.dev/install.sh)
 ```
 
-Downloads and verifies the right prebuilt binary for your OS/arch from
-[GitHub Releases](https://github.com/chmonitor/chmonitor/releases) (tag format
-`chm-v*`). Stable skips prereleases; `CHM_CHANNEL=beta` prefers them.
-
 Or from crates.io / source:
 
 ```bash
 cargo install chmonitor --force
-# installs both `chm` and `chmonitor` into ~/.cargo/bin
-
 cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 ```
+
+## Usage
+
+```bash
+chm                  # live TUI (default)
+chm --help
+chm auth login
+chm auth status
+chm auth logout
+chm config           # interactive dialog
+chm config show
+chm config set host_id 0
+```
+
+`chm tui` is an explicit alias of the default TUI. Dashboard API helpers
+(`hosts`, `chart`, `table`, `dashboard`) and `chm doctor` / `chm update` remain
+available; see `--help`.
 
 ## Auth
 
@@ -57,73 +57,18 @@ cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 `--api-key` / `CHM_API_KEY` when discovery says `api_key`, or complete the
 browser device flow when it says `device`.
 
-## Usage
-
-```bash
-# Zero-signup cluster scan (marketed path)
-CLICKHOUSE_HOST=http://localhost:8123 CLICKHOUSE_USER=default chm doctor # pragma: allowlist secret
-chm doctor --ch-host http://localhost:8123
-# same scan: chm diagnose --ch-host http://localhost:8123
-# same binary: chmonitor doctor --ch-host http://localhost:8123
-
-# Connectivity / self-check (no ClickHouse host)
-chm doctor
-
-# Live TUI (default — Overview charts; same as `chm tui`)
-chm
-chm tui query-count --table running-queries
-chm dashboard list
-chm dashboard open Overview
-
-# Config
-chm config                 # interactive dialog
-chm config show            # files + inherit order + resolved
-chm config set host_id 0
-
-# One-shot dashboard API
-chm auth login
-chm hosts
-```
-
 ## Update
 
-`chm update` and `chm upgrade` are the same command (`upgrade` is a first-class
-alias). Both print current -> target version, download the matching GitHub
-Release binary, verify sha256, and atomically replace the running executable.
-They never invoke sudo: checksum, permission, and unsupported-target failures
-print a copy-pasteable fallback (`scripts/install.sh` or
-`cargo install chmonitor --force`).
-
 ```bash
-chm upgrade                      # alias of update — latest stable chm-v* release
-chm update                       # same behaviour
+chm update                       # latest stable chm-v* release
 chm update --check               # only report if a newer release exists (exit 1 if so)
 chm update --beta                # install latest beta and save channel=beta
 chm update --stable              # install latest stable and save channel=stable
-chm update --channel beta        # this run only (or CHM_CHANNEL=beta)
-chm upgrade --version chm-v0.2.0 # pin a specific release (`0.2.0` / `v0.2.0` also work)
+chm update --version chm-v0.2.0  # pin a specific release
 ```
-
-After a `chm doctor` cluster scan, a one-line "update available" hint is printed
-to stderr when a newer release exists (best-effort, sub-second timeout). Silence
-it with `CHM_NO_UPDATE_CHECK=1`. Installed via `cargo install`? Upgrade with
-`cargo install chmonitor --force` instead.
 
 See [docs.chmonitor.dev/guide/guides/diagnostics-cli](https://docs.chmonitor.dev/guide/guides/diagnostics-cli)
 for the full CLI reference.
-
-## Anonymous telemetry
-
-The CLI sends a best-effort, anonymous usage ping (a random install id, CLI
-version, command name, and OS/arch) to `telemetry.chmonitor.dev` — a separate
-stream from the dashboard's telemetry, with **no** cluster host, query text,
-arguments, paths, or IPs. It runs on a background thread with a sub-second
-timeout, is aborted if still running at exit, and never blocks or fails a command.
-
-Opt out with any of `CHM_TELEMETRY=off`, `DO_NOT_TRACK=1`, or
-`CHM_TELEMETRY_ENDPOINT=""`. See
-[the telemetry docs](https://docs.chmonitor.dev/operate/advanced/telemetry#cli-telemetry-a-separate-stream)
-and `src/telemetry.rs`.
 
 ## License
 

--- a/rust/ch-monitor-cli/build.rs
+++ b/rust/ch-monitor-cli/build.rs
@@ -1,6 +1,6 @@
 // Expose the compile-time target triple (e.g. `x86_64-unknown-linux-gnu`) to the
 // crate as `env!("CHM_TARGET")`. Cargo sets `TARGET` for build scripts; we re-emit
-// it as a rustc-env so `chm update` / `chm upgrade` can pick the matching release asset.
+// it as a rustc-env so `chm update` can pick the matching release asset.
 fn main() {
     let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
     println!("cargo:rustc-env=CHM_TARGET={target}");

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -8,8 +8,8 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 #[command(
     name = "chm",
     version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
-    about = "chmonitor CLI (`chm` / `chmonitor`) — live TUI by default; dashboard API and zero-signup cluster health (`chm doctor`)",
-    after_help = "Run `chm` with no subcommand to open the live TUI. `chm tui` is the same UI. `chm --help` / `chm help` / `chm -h` print this help."
+    about = "chmonitor CLI (`chm` / `chmonitor`) — live TUI by default",
+    after_help = "Run `chm` with no subcommand to open the live TUI. `chm --help` / `chm help` / `chm -h` print this help. Sign in with `chm auth`; set base URL and host with `chm config`."
 )]
 pub struct Cli {
     /// Path to config.toml (default ~/.config/chm/config.toml)
@@ -136,8 +136,6 @@ pub enum Commands {
     /// With `--ch-host`, runs a zero-signup read-only cluster health report.
     /// Without a host, checks local CLI + dashboard connectivity.
     Doctor(DoctorArgs),
-    /// Alias of `doctor` cluster scan. Same flags; always the health report.
-    Diagnose(DoctorArgs),
     /// Update chm to the latest GitHub release (self-update).
     ///
     /// Prints current -> target version, verifies sha256, and atomically
@@ -146,14 +144,6 @@ pub enum Commands {
     /// (`scripts/install.sh` or `cargo install chmonitor`).
     /// `--beta` / `--stable` switch the saved channel and then update.
     Update(UpdateArgs),
-    /// Alias of `update`. Same flags (`--check`, `--version`, `--beta`, `--stable`).
-    Upgrade(UpdateArgs),
-    /// Generate shell completions
-    Completions {
-        /// Shell to emit completions for
-        #[arg(value_enum)]
-        shell: clap_complete::Shell,
-    },
 }
 
 /// Flags for `chm` / `chm tui`.
@@ -183,7 +173,7 @@ impl Default for TuiArgs {
     }
 }
 
-/// Flags for `chm doctor` / `chm diagnose`.
+/// Flags for `chm doctor`.
 #[derive(Args, Debug, Clone)]
 pub struct DoctorArgs {
     /// ClickHouse HTTP interface URL, e.g. http://localhost:8123.
@@ -216,7 +206,7 @@ impl DoctorArgs {
     }
 }
 
-/// Shared flags for `chm update` and `chm upgrade`.
+/// Flags for `chm update`.
 #[derive(Args, Debug)]
 pub struct UpdateArgs {
     /// Only check whether an update is available; exit 1 if one exists.

--- a/rust/ch-monitor-cli/src/commands/diagnose_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/diagnose_cmd.rs
@@ -1,4 +1,4 @@
-//! Cluster health scan used by `chm doctor --ch-host` and `chm diagnose`.
+//! Cluster health scan used by `chm doctor --ch-host`.
 
 use anyhow::{bail, Result};
 use reqwest::Client;

--- a/rust/ch-monitor-cli/src/commands/doctor.rs
+++ b/rust/ch-monitor-cli/src/commands/doctor.rs
@@ -112,7 +112,7 @@ pub async fn run(client: &Client, cfg: &AppConfig) -> Result<()> {
 
     if !cfg.quiet {
         output::info(
-            "pass --ch-host or set CLICKHOUSE_HOST to run a cluster health scan (alias: chm diagnose)", // pragma: allowlist secret
+            "pass --ch-host or set CLICKHOUSE_HOST to run a cluster health scan", // pragma: allowlist secret
         );
     }
 

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -13,7 +13,6 @@ pub mod table;
 pub mod update_cmd;
 
 use anyhow::Result;
-use clap::CommandFactory;
 use reqwest::Client;
 
 use crate::{
@@ -160,14 +159,6 @@ pub async fn dispatch(
             doctor::run(client, cfg).await?;
             Ok(0)
         }
-        Commands::Diagnose(args) => run_cluster_scan(client, cfg, args).await,
-        Commands::Update(args) | Commands::Upgrade(args) => {
-            update_cmd::run(client, cfg, args).await
-        }
-        Commands::Completions { shell } => {
-            let mut cmd = crate::cli::Cli::command();
-            clap_complete::generate(shell, &mut cmd, "chm", &mut std::io::stdout());
-            Ok(0)
-        }
+        Commands::Update(args) => update_cmd::run(client, cfg, args).await,
     }
 }

--- a/rust/ch-monitor-cli/src/commands/update_cmd.rs
+++ b/rust/ch-monitor-cli/src/commands/update_cmd.rs
@@ -1,4 +1,4 @@
-//! `chm update` / `chm upgrade` wrapper with release-channel support.
+//! `chm update` wrapper with release-channel support.
 
 use anyhow::Result;
 use reqwest::Client;

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -43,14 +43,13 @@ async fn main() -> Result<()> {
     // Anonymous, opt-out CLI telemetry (source=cli). Fires in the background and
     // never blocks or fails the command; see src/telemetry.rs.
     let (tel_event, tel_command): (&'static str, &'static str) = match &command {
-        Commands::Diagnose(_) => ("cli_diagnose", "diagnose"),
         Commands::Doctor(args) if args.has_cluster_host() => ("cli_diagnose", "doctor"),
         Commands::Doctor(_) => ("cli_run", "doctor"),
         Commands::Hosts => ("cli_run", "hosts"),
         Commands::Chart { .. } => ("cli_run", "chart"),
         Commands::Table { .. } => ("cli_run", "table"),
         Commands::Tui(_) => ("cli_run", "tui"),
-        Commands::Update(_) | Commands::Upgrade(_) => ("cli_run", "update"),
+        Commands::Update(_) => ("cli_run", "update"),
         Commands::Auth(_) => ("cli_run", "auth"),
         Commands::Config(_) => ("cli_run", "config"),
         Commands::Dashboard(_) => ("cli_run", "dashboard"),
@@ -59,7 +58,6 @@ async fn main() -> Result<()> {
         Commands::Agent { .. } => ("cli_run", "agent"),
         Commands::Prompt(_) => ("cli_run", "prompt"),
         Commands::Audit(_) => ("cli_run", "audit"),
-        Commands::Completions { .. } => ("cli_run", "completions"),
     };
     let tel_handle = telemetry::spawn(tel_event, tel_command);
 
@@ -80,43 +78,30 @@ mod tests {
 
     fn doctor_args(cli: Cli) -> DoctorArgs {
         match cli.command {
-            Some(Commands::Doctor(args) | Commands::Diagnose(args)) => args,
-            other => panic!("expected doctor/diagnose, got {other:?}"),
+            Some(Commands::Doctor(args)) => args,
+            other => panic!("expected doctor, got {other:?}"),
         }
     }
 
     fn update_args(cli: Cli) -> UpdateArgs {
         match cli.command {
-            Some(Commands::Update(args) | Commands::Upgrade(args)) => args,
-            other => panic!("expected update/upgrade, got {other:?}"),
+            Some(Commands::Update(args)) => args,
+            other => panic!("expected update, got {other:?}"),
         }
     }
 
     #[test]
-    fn upgrade_is_first_class_alias_of_update() {
-        for argv in [["chm", "update"], ["chm", "upgrade"]] {
-            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
-            assert!(!args.check);
-            assert!(args.version.is_none());
-        }
-    }
-
-    #[test]
-    fn upgrade_and_update_share_check_flag() {
-        for argv in [["chm", "update", "--check"], ["chm", "upgrade", "--check"]] {
-            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
-            assert!(args.check);
-            assert!(args.version.is_none());
-        }
+    fn update_parses_check_flag() {
+        let args = update_args(Cli::try_parse_from(["chm", "update", "--check"]).expect("parse"));
+        assert!(args.check);
+        assert!(args.version.is_none());
     }
 
     #[test]
     fn update_beta_and_stable_flags() {
-        for argv in [["chm", "update", "--beta"], ["chm", "upgrade", "--beta"]] {
-            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
-            assert!(args.beta);
-            assert!(!args.stable);
-        }
+        let beta = update_args(Cli::try_parse_from(["chm", "update", "--beta"]).expect("parse"));
+        assert!(beta.beta);
+        assert!(!beta.stable);
         let stable =
             update_args(Cli::try_parse_from(["chm", "update", "--stable"]).expect("parse"));
         assert!(stable.stable);
@@ -125,30 +110,25 @@ mod tests {
     }
 
     #[test]
-    fn upgrade_and_update_share_version_flag() {
-        for argv in [
-            ["chm", "update", "--version", "chm-v0.2.0"],
-            ["chm", "upgrade", "--version", "chm-v0.2.0"],
-        ] {
-            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
-            assert!(!args.check);
-            assert_eq!(args.version.as_deref(), Some("chm-v0.2.0"));
-        }
-        for argv in [
-            ["chm", "update", "--version", "0.2.0"],
-            ["chm", "upgrade", "--version", "0.2.0"],
-        ] {
-            let args = update_args(Cli::try_parse_from(argv).expect("parse"));
-            assert_eq!(args.version.as_deref(), Some("0.2.0"));
-        }
+    fn update_version_flag() {
+        let args = update_args(
+            Cli::try_parse_from(["chm", "update", "--version", "chm-v0.2.0"]).expect("parse"),
+        );
+        assert!(!args.check);
+        assert_eq!(args.version.as_deref(), Some("chm-v0.2.0"));
+        let short =
+            update_args(Cli::try_parse_from(["chm", "update", "--version", "0.2.0"]).expect("parse"));
+        assert_eq!(short.version.as_deref(), Some("0.2.0"));
     }
 
     #[test]
-    fn help_lists_update_and_upgrade() {
+    fn help_lists_update_not_upgrade() {
         let mut cmd = Cli::command();
         let help = cmd.render_long_help().to_string();
         assert!(help.contains("update"), "{help}");
-        assert!(help.contains("upgrade"), "{help}");
+        assert!(!help.contains("upgrade"), "{help}");
+        assert!(!help.contains("diagnose"), "{help}");
+        assert!(!help.contains("completions"), "{help}");
     }
 
     #[test]
@@ -185,10 +165,11 @@ mod tests {
         assert!(help.contains("List hosts"), "{help}");
         assert!(help.contains("named chart"), "{help}");
         assert!(help.contains("named table"), "{help}");
-        assert!(help.contains("zero-signup"), "{help}");
         assert!(help.contains("doctor"), "{help}");
-        assert!(help.contains("diagnose"), "{help}");
+        assert!(help.contains("auth"), "{help}");
+        assert!(help.contains("config"), "{help}");
         assert!(help.contains("--base-url"), "{help}");
+        assert!(!help.contains("diagnose"), "{help}");
     }
 
     #[test]
@@ -202,13 +183,9 @@ mod tests {
     }
 
     #[test]
-    fn diagnose_without_host_still_parses_as_alias() {
-        let cli = Cli::try_parse_from(["chm", "diagnose"]).expect("parse");
-        assert!(
-            matches!(cli.command, Some(Commands::Diagnose(_))),
-            "expected Diagnose, got {:?}",
-            cli.command
-        );
+    fn diagnose_is_removed() {
+        let err = Cli::try_parse_from(["chm", "diagnose"]).expect_err("diagnose removed");
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidSubcommand);
     }
 
     #[test]
@@ -236,20 +213,12 @@ mod tests {
     }
 
     #[test]
-    fn diagnose_is_alias_of_doctor_cluster_scan() {
-        let args = doctor_args(
-            Cli::try_parse_from(["chm", "diagnose", "--ch-host", "http://127.0.0.1:8123"])
-                .expect("parse"),
-        );
-        assert!(matches!(
-            Cli::try_parse_from(["chm", "diagnose", "--ch-host", "http://127.0.0.1:8123"])
-                .expect("parse")
-                .command,
-            Some(Commands::Diagnose(_))
-        ));
-        assert_eq!(args.ch_host.as_deref(), Some("http://127.0.0.1:8123"));
-        assert!(args.has_cluster_host());
-        assert!(!args.json);
+    fn upgrade_and_completions_are_removed() {
+        let upgrade = Cli::try_parse_from(["chm", "upgrade"]).expect_err("upgrade removed");
+        assert_eq!(upgrade.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        let completions =
+            Cli::try_parse_from(["chm", "completions", "bash"]).expect_err("completions removed");
+        assert_eq!(completions.kind(), clap::error::ErrorKind::InvalidSubcommand);
     }
 
     #[test]
@@ -275,71 +244,49 @@ mod tests {
     }
 
     #[test]
-    fn diagnose_and_doctor_share_scan_flags() {
-        for argv in [
-            [
+    fn doctor_scan_flags() {
+        let args = doctor_args(
+            Cli::try_parse_from([
                 "chm",
                 "doctor",
                 "--ch-host",
                 "http://localhost:8123",
                 "--json",
-            ],
-            [
-                "chm",
-                "diagnose",
-                "--ch-host",
-                "http://localhost:8123",
-                "--json",
-            ],
-        ] {
-            let args = doctor_args(Cli::try_parse_from(argv).expect("parse"));
-            assert_eq!(args.ch_host.as_deref(), Some("http://localhost:8123"));
-            assert!(args.json);
-        }
+            ])
+            .expect("parse"),
+        );
+        assert_eq!(args.ch_host.as_deref(), Some("http://localhost:8123"));
+        assert!(args.json);
     }
 
     #[test]
-    fn doctor_and_diagnose_help_share_ch_host() {
+    fn doctor_help_has_ch_host() {
         let mut cmd = Cli::command();
         let doctor_help = cmd
             .find_subcommand_mut("doctor")
             .expect("doctor subcommand")
             .render_long_help()
             .to_string();
-        let mut cmd = Cli::command();
-        let diagnose_help = cmd
-            .find_subcommand_mut("diagnose")
-            .expect("diagnose subcommand")
-            .render_long_help()
-            .to_string();
-        for help in [&doctor_help, &diagnose_help] {
-            assert!(help.contains("--ch-host"), "{help}");
-            assert!(help.contains("--ch-user"), "{help}");
-            assert!(help.contains("--json"), "{help}");
-        }
+        assert!(doctor_help.contains("--ch-host"), "{doctor_help}");
+        assert!(doctor_help.contains("--ch-user"), "{doctor_help}");
+        assert!(doctor_help.contains("--json"), "{doctor_help}");
+        assert!(cmd.find_subcommand_mut("diagnose").is_none());
     }
 
     #[test]
-    fn update_and_upgrade_help_share_flags() {
-        // clap 4's render_long_help takes &mut self.
+    fn update_help_has_flags() {
         let mut cmd = Cli::command();
         let update_help = cmd
             .find_subcommand_mut("update")
             .expect("update subcommand")
             .render_long_help()
             .to_string();
-        let mut cmd = Cli::command();
-        let upgrade_help = cmd
-            .find_subcommand_mut("upgrade")
-            .expect("upgrade subcommand")
-            .render_long_help()
-            .to_string();
-        for help in [&update_help, &upgrade_help] {
-            assert!(help.contains("--check"), "{help}");
-            assert!(help.contains("--version"), "{help}");
-            assert!(help.contains("--beta"), "{help}");
-            assert!(help.contains("--stable"), "{help}");
-        }
+        assert!(update_help.contains("--check"), "{update_help}");
+        assert!(update_help.contains("--version"), "{update_help}");
+        assert!(update_help.contains("--beta"), "{update_help}");
+        assert!(update_help.contains("--stable"), "{update_help}");
+        assert!(cmd.find_subcommand_mut("upgrade").is_none());
+        assert!(cmd.find_subcommand_mut("completions").is_none());
     }
 
     #[test]

--- a/rust/ch-monitor-cli/src/update.rs
+++ b/rust/ch-monitor-cli/src/update.rs
@@ -1,4 +1,4 @@
-//! Self-update: `chm update` / `chm upgrade`.
+//! Self-update: `chm update`.
 //!
 //! Downloads the newest (or a pinned) `chm-v*` release from GitHub, verifies its
 //! sha256 checksum, and atomically replaces the running executable. Never
@@ -201,7 +201,7 @@ fn ensure_supported_target() -> Result<()> {
     Ok(())
 }
 
-/// `chm update --check` / `chm upgrade --check`: report whether a newer release exists.
+/// `chm update --check`: report whether a newer release exists.
 /// Returns `true` when an update is available.
 #[allow(dead_code)]
 pub async fn check(client: &Client) -> Result<bool> {
@@ -220,7 +220,7 @@ pub async fn check_channel(client: &Client, channel: Channel) -> Result<bool> {
         channel.as_str()
     );
     if latest > current {
-        println!("update available (run `chm update` or `chm upgrade`)");
+        println!("update available (run `chm update`)");
         Ok(true)
     } else {
         println!("chm is up to date");
@@ -248,13 +248,13 @@ pub async fn hint(client: &Client) {
     };
     if let Ok(Some(tag)) = tokio::time::timeout(Duration::from_millis(900), fut).await {
         eprintln!(
-            "note: a newer chm is available (v{} -> {tag}). Run `chm update` or `chm upgrade`. (set CHM_NO_UPDATE_CHECK=1 to silence)",
+            "note: a newer chm is available (v{} -> {tag}). Run `chm update`. (set CHM_NO_UPDATE_CHECK=1 to silence)",
             env!("CARGO_PKG_VERSION")
         );
     }
 }
 
-/// `chm update` / `chm upgrade` (and `--version <tag>`): download, verify, replace.
+/// `chm update` (and `--version <tag>`): download, verify, replace.
 #[allow(dead_code)]
 pub async fn run(client: &Client, pinned: Option<String>) -> Result<()> {
     run_channel(client, pinned, Channel::Stable).await


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Simplify the CLI surface: `chm` still opens the live TUI, `chm --help` prints help, and `chm auth` / `chm config` stay. Remove `diagnose`, `upgrade`, and `completions`.

## Changes

- Drop `chm diagnose` (use `chm doctor --ch-host`).
- Drop `chm upgrade` (use `chm update`).
- Drop `chm completions` and the `clap_complete` dependency.
- Trim help copy, crate README, knowledge doc, and user-facing CLI docs.

## Test plan

- [x] `cargo test` for the CLI (121 tests)
- [x] `chm diagnose` / `chm upgrade` / `chm completions bash` parse as unknown subcommands
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

`chm tui`, dashboard API helpers, `chm doctor`, and `chm update` remain. Historical changelog / release notes still mention the old aliases.

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7436829e-55dd-4e10-aa85-3a190162f4af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7436829e-55dd-4e10-aa85-3a190162f4af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

