### PR TITLE
style(cli): rustfmt TUI memory-cap changes

### DIFF
--- a/rust/ch-monitor-cli/src/client.rs
+++ b/rust/ch-monitor-cli/src/client.rs
@@ -108,9 +108,7 @@ async fn send_get(
     let status = resp.status().as_u16();
     if let Some(len) = resp.content_length() {
         if len as usize > MAX_RESPONSE_BYTES {
-            bail!(
-                "chmonitor API at {url} returned {len} bytes (limit {MAX_RESPONSE_BYTES})"
-            );
+            bail!("chmonitor API at {url} returned {len} bytes (limit {MAX_RESPONSE_BYTES})");
         }
     }
     let bytes = resp.bytes().await.unwrap_or_default();

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -489,15 +489,14 @@ async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App, force: bool) {
         })
         .collect();
 
-    let charts_fut = futures_util::future::join_all(chart_jobs.into_iter().map(
-        |(fetch, url)| async move {
+    let charts_fut =
+        futures_util::future::join_all(chart_jobs.into_iter().map(|(fetch, url)| async move {
             if !fetch {
                 ChartFetch::Skip
             } else {
                 ChartFetch::Done(client::fetch_optional_cfg(client, cfg, url).await)
             }
-        },
-    ));
+        }));
     let (hosts_res, table_res, chart_results) = tokio::join!(
         client::fetch_cfg(client, cfg, hosts_url),
         client::fetch_cfg(client, cfg, table_url),
@@ -1454,7 +1453,9 @@ mod tests {
         );
         assert_eq!(disk.1.len(), 3);
         let table = bound_table_rows(
-            (0..40).map(|i| json!({"i": i, "query": "SELECT 1"})).collect(),
+            (0..40)
+                .map(|i| json!({"i": i, "query": "SELECT 1"}))
+                .collect(),
             15,
         );
         assert_eq!(table.len(), 15);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up rustfmt for the TUI memory-cap change that failed `cargo fmt --check` on rust-cli after #3204 merged.

## Changes

- Format `rust/ch-monitor-cli/src/client.rs` and `src/tui/mod.rs` to match rustfmt.

## Test plan

- [x] `cargo fmt -- --check` equivalent applied
- [ ] rust-cli CI green

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7436829e-55dd-4e10-aa85-3a190162f4af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7436829e-55dd-4e10-aa85-3a190162f4af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

