### PR TITLE
feat(cli): migrate dashboard list picker to ratatui

### DIFF
--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -124,8 +124,8 @@ chm agent "why are merges slow?"
 The default TUI fetches Overview charts (`query-count`, counts, disk size) from
 `GET /api/v1/charts/{name}?hostId=` and skips 404s. `chm dashboard list` always
 includes built-in Overview; saved dashboards come from `GET /api/dashboards/list`
-when signed in (401/501 still list Overview). Piped stdout or `--json` prints
-names without a picker.
+when signed in (401/501 still list Overview). On a TTY the list is a ratatui
+picker (j/k, Enter, q). Piped stdout or `--json` prints names without a picker.
 
 Config priority: CLI flags → env (`CHM_BASE_URL`, `CHM_HOST_ID`, `CHM_API_KEY`,
 `CHM_TOKEN`, `CHM_CHANNEL`, …) → project `./chm.toml` / `./.chm/config.toml` →

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -106,9 +106,9 @@ minutes so the TUI cannot hammer the cluster. Chart JSON is capped (sparkline
 points plus the latest row). HTTP 404 charts are skipped. The running-queries
 table stays a secondary pane (page size plus string truncation). `chm dashboard
 list` (and `chm dashboard open <name>`) open the same TUI bound to Overview or a
-saved dashboard's `layout.widgets[].chartName`. **Only** this TUI, interactive
-`chm chat`, and `chm config` (dialog) enter the terminal alternate screen;
-`dashboard list`'s picker stays on the normal screen.
+saved dashboard's `layout.widgets[].chartName`. All interactive surfaces use
+ratatui on the alternate screen: live TUI, `chm chat`, `chm config`, and the
+`dashboard list` picker. One-shot commands stay on the normal screen.
 
 One screen: hosts + chart grid **and** the table together when the terminal is
 tall/wide enough (`≥72×24`). Smaller terminals collapse to a focused pane with
@@ -137,8 +137,9 @@ chart grid (`--overview` still accepted).
 Always lists built-in **Overview** first. When signed in, also fetches
 `GET /api/dashboards/list` and uses each `layout.widgets[].chartName` where
 `type=chart`. HTTP 401/403/501 still lists Overview plus a one-line reason.
-Interactive TTY: j/k/arrows pick, Enter opens the TUI. `--json` or piped stdout
-prints names (no picker). `chm dashboard open <name>` opens by name.
+Interactive TTY: ratatui picker (j/k/arrows, Enter opens the TUI, q/Esc
+cancels). `--json` or piped stdout prints names (no picker).
+`chm dashboard open <name>` opens by name.
 
 ## Config (`chm config` / `chm config show`)
 

--- a/rust/ch-monitor-cli/CHANGELOG.md
+++ b/rust/ch-monitor-cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **cli:** `chm update --beta` installs the latest beta and saves `channel = "beta"` (`--stable` switches back)
 * **cli:** default TUI shows Overview dashboard charts (KPI/sparkline grid)
 * **cli:** `chm dashboard list` / `open` (Overview + saved dashboards)
+* **cli:** `chm dashboard list` picker uses ratatui (same alt-screen chrome as TUI/config)
 * **cli:** interactive `chm config`; `chm config show` prints file layers
 * **cli:** launch interactive TUI by default (`chm` with no subcommand; `chm tui` stays an alias)
 * **cli:** drop `diagnose`, `upgrade`, and `completions` aliases; keep `chm` TUI, `auth`, `config`, and `update`

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -46,7 +46,8 @@ chm config show
 chm config set host_id 0
 ```
 
-`chm tui` is an explicit alias of the default TUI. Dashboard API helpers
+`chm tui` is an explicit alias of the default TUI. `chm dashboard list` opens a
+ratatui picker for Overview or a saved dashboard. Dashboard API helpers
 (`hosts`, `chart`, `table`, `dashboard`) and `chm doctor` / `chm update` remain
 available; see `--help`.
 

--- a/rust/ch-monitor-cli/src/commands/dashboard.rs
+++ b/rust/ch-monitor-cli/src/commands/dashboard.rs
@@ -1,14 +1,8 @@
 //! `chm dashboard list` / `chm dashboard open`.
 
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal};
 
 use anyhow::{bail, Result};
-use crossterm::{
-    cursor,
-    event::{self, KeyCode, KeyEventKind, KeyModifiers},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
-};
 use reqwest::Client;
 use serde_json::json;
 
@@ -60,10 +54,12 @@ async fn list(client: &Client, cfg: &AppConfig) -> Result<i32> {
     if cfg.json || !wants_picker() {
         return print_list(&entries, reason.as_deref(), cfg.json);
     }
-    if let Some(reason) = &reason {
-        output::warn(reason);
-    }
-    match pick(&entries)? {
+    match crate::tui::picker::run(
+        "dashboard list",
+        entries.iter().map(|e| e.label()).collect(),
+        " j/k select  Enter open  q quit",
+        reason,
+    )? {
         Some(idx) => open_entry(client, cfg, &entries[idx]).await,
         None => Ok(0),
     }
@@ -134,90 +130,6 @@ fn print_list(entries: &[DashboardEntry], reason: Option<&str>, json_out: bool) 
         eprintln!("{reason}");
     }
     Ok(0)
-}
-
-struct PickerGuard;
-
-impl Drop for PickerGuard {
-    fn drop(&mut self) {
-        let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), cursor::Show);
-    }
-}
-
-/// Inline picker (no alt-screen). Alt-screen is reserved for the live TUI and chat.
-fn pick(entries: &[DashboardEntry]) -> Result<Option<usize>> {
-    if entries.is_empty() {
-        bail!("no dashboards to list");
-    }
-    enable_raw_mode()?;
-    let _guard = PickerGuard;
-    let mut stdout = io::stdout();
-    execute!(stdout, cursor::Hide)?;
-    let mut selected = 0usize;
-    let n = entries.len();
-    loop {
-        for (i, entry) in entries.iter().enumerate() {
-            let mark = if i == selected { '>' } else { ' ' };
-            write!(stdout, "{mark} {}\r\n", entry.label())?;
-        }
-        write!(stdout, " j/k select  Enter open  q quit\r\n")?;
-        stdout.flush()?;
-
-        let rows = (n + 1) as u16;
-        execute!(stdout, cursor::MoveToPreviousLine(rows))?;
-
-        loop {
-            if !event::poll(std::time::Duration::from_millis(250))? {
-                continue;
-            }
-            match event::read()? {
-                event::Event::Resize(_, _) => break,
-                event::Event::Key(key)
-                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
-                {
-                    if key.modifiers.contains(KeyModifiers::CONTROL)
-                        && key.code == KeyCode::Char('c')
-                    {
-                        finish_picker(&mut stdout, rows)?;
-                        return Ok(None);
-                    }
-                    match key.code {
-                        KeyCode::Enter => {
-                            finish_picker(&mut stdout, rows)?;
-                            return Ok(Some(selected));
-                        }
-                        KeyCode::Esc | KeyCode::Char('q') => {
-                            finish_picker(&mut stdout, rows)?;
-                            return Ok(None);
-                        }
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            selected = (selected + 1) % n;
-                            break;
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => {
-                            selected = selected.checked_sub(1).unwrap_or(n - 1);
-                            break;
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            }
-        }
-        execute!(stdout, Clear(ClearType::FromCursorDown))?;
-    }
-}
-
-fn finish_picker(stdout: &mut io::Stdout, rows: u16) -> Result<()> {
-    execute!(
-        stdout,
-        Clear(ClearType::FromCursorDown),
-        cursor::MoveToNextLine(rows),
-        cursor::Show
-    )?;
-    let _ = disable_raw_mode();
-    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -1,10 +1,12 @@
 //! Live dashboard TUI — the default `chm` product path.
 //!
-//! Alt-screen is entered only by this TUI (`chm` / `chm tui`) and interactive
-//! `chm chat` (`tui/chat.rs`). Other commands must never call EnterAlternateScreen.
+//! Alt-screen: live TUI (`chm` / `chm tui`), interactive `chm chat`,
+//! `chm config`, and `chm dashboard list`. One-shot commands stay on the
+//! normal screen.
 
 pub mod chat;
 pub mod config_form;
+pub mod picker;
 
 use std::{
     io,

--- a/rust/ch-monitor-cli/src/tui/picker.rs
+++ b/rust/ch-monitor-cli/src/tui/picker.rs
@@ -1,0 +1,198 @@
+//! Ratatui list picker (alt-screen). Used by `chm dashboard list`.
+
+use std::io::{self, IsTerminal};
+
+use anyhow::{bail, Result};
+use crossterm::{
+    event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, List, ListItem, ListState, Paragraph},
+    Frame, Terminal,
+};
+
+const ORANGE: Color = Color::Rgb(249, 115, 22);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PickerAction {
+    None,
+    Confirm,
+    Cancel,
+}
+
+#[derive(Debug, Clone)]
+pub struct Picker {
+    pub title: String,
+    pub items: Vec<String>,
+    pub hints: String,
+    pub selected: usize,
+    pub note: Option<String>,
+}
+
+impl Picker {
+    pub fn new(
+        title: impl Into<String>,
+        items: Vec<String>,
+        hints: impl Into<String>,
+        note: Option<String>,
+    ) -> Result<Self> {
+        if items.is_empty() {
+            bail!("no items to pick");
+        }
+        Ok(Self {
+            title: title.into(),
+            items,
+            hints: hints.into(),
+            selected: 0,
+            note,
+        })
+    }
+
+    pub fn apply_key(&mut self, key: KeyEvent) -> PickerAction {
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return PickerAction::None;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return PickerAction::Cancel;
+        }
+        let n = self.items.len();
+        match key.code {
+            KeyCode::Enter => PickerAction::Confirm,
+            KeyCode::Esc | KeyCode::Char('q') => PickerAction::Cancel,
+            KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('l') => {
+                self.selected = (self.selected + 1) % n;
+                PickerAction::None
+            }
+            KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('h') => {
+                self.selected = self.selected.checked_sub(1).unwrap_or(n - 1);
+                PickerAction::None
+            }
+            _ => PickerAction::None,
+        }
+    }
+}
+
+struct PickerGuard;
+
+impl Drop for PickerGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+pub fn run(
+    title: &str,
+    items: Vec<String>,
+    hints: &str,
+    note: Option<String>,
+) -> Result<Option<usize>> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        bail!("interactive picker needs a terminal");
+    }
+    let mut picker = Picker::new(title, items, hints, note)?;
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let _guard = PickerGuard;
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    loop {
+        terminal.draw(|f| draw(f, &picker))?;
+        if !event::poll(std::time::Duration::from_millis(250))? {
+            continue;
+        }
+        let event::Event::Key(key) = event::read()? else {
+            continue;
+        };
+        match picker.apply_key(key) {
+            PickerAction::None => {}
+            PickerAction::Cancel => return Ok(None),
+            PickerAction::Confirm => return Ok(Some(picker.selected)),
+        }
+    }
+}
+
+fn draw(f: &mut Frame<'_>, picker: &Picker) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    let title = Line::from(vec![
+        Span::styled(
+            " chmonitor ",
+            Style::default().fg(ORANGE).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::raw(&picker.title),
+    ]);
+    f.render_widget(Paragraph::new(title).block(Block::bordered()), chunks[0]);
+
+    let items: Vec<ListItem> = picker
+        .items
+        .iter()
+        .map(|s| ListItem::new(s.as_str()))
+        .collect();
+    let mut state = ListState::default();
+    state.select(Some(picker.selected));
+    let mut block = Block::bordered();
+    if let Some(note) = &picker.note {
+        block = block.title(note.as_str());
+    }
+    let list = List::new(items)
+        .block(block)
+        .highlight_symbol("▸ ")
+        .highlight_style(Style::default().fg(ORANGE).add_modifier(Modifier::BOLD));
+    f.render_stateful_widget(list, chunks[1], &mut state);
+
+    f.render_widget(
+        Paragraph::new(picker.hints.as_str()).style(Style::default().fg(Color::DarkGray)),
+        chunks[2],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn j_and_enter_select_second() {
+        let mut p = Picker::new(
+            "dashboards",
+            vec!["Overview".into(), "Queries".into()],
+            "",
+            None,
+        )
+        .unwrap();
+        assert_eq!(p.apply_key(key(KeyCode::Char('j'))), PickerAction::None);
+        assert_eq!(p.selected, 1);
+        assert_eq!(p.apply_key(key(KeyCode::Enter)), PickerAction::Confirm);
+    }
+
+    #[test]
+    fn q_cancels() {
+        let mut p = Picker::new("dashboards", vec!["Overview".into()], "", None).unwrap();
+        assert_eq!(p.apply_key(key(KeyCode::Char('q'))), PickerAction::Cancel);
+    }
+
+    #[test]
+    fn empty_items_error() {
+        assert!(Picker::new("x", Vec::<String>::new(), "", None).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

`chm dashboard list` now uses the same ratatui alt-screen as the live TUI and `chm config`, instead of a raw crossterm inline picker.

## Changes

- Add `tui/picker.rs` (j/k, Enter, q/Esc; orange highlight)
- Wire `chm dashboard list` to the picker; `--json` / piped stdout still print names
- Docs: all interactive CLI surfaces use ratatui on the alternate screen

One-shot commands (`hosts`, `chart`, `table`, `doctor`) stay on the normal screen.