### PR TITLE
style(cli): rustfmt parse tests for update and removed commands

### DIFF
--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -116,8 +116,9 @@ mod tests {
         );
         assert!(!args.check);
         assert_eq!(args.version.as_deref(), Some("chm-v0.2.0"));
-        let short =
-            update_args(Cli::try_parse_from(["chm", "update", "--version", "0.2.0"]).expect("parse"));
+        let short = update_args(
+            Cli::try_parse_from(["chm", "update", "--version", "0.2.0"]).expect("parse"),
+        );
         assert_eq!(short.version.as_deref(), Some("0.2.0"));
     }
 
@@ -218,7 +219,10 @@ mod tests {
         assert_eq!(upgrade.kind(), clap::error::ErrorKind::InvalidSubcommand);
         let completions =
             Cli::try_parse_from(["chm", "completions", "bash"]).expect_err("completions removed");
-        assert_eq!(completions.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        assert_eq!(
+            completions.kind(),
+            clap::error::ErrorKind::InvalidSubcommand
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`rust-cli` is still failing `cargo fmt --check` on `main.rs` parse tests from the CLI simplify change. This formats those tests.

## Changes

- rustfmt `rust/ch-monitor-cli/src/main.rs` (`update --version` and removed `completions` assertions)

## Test plan

- [x] `cargo fmt --all -- --check` clean on this branch
- [ ] rust-cli CI green

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7436829e-55dd-4e10-aa85-3a190162f4af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7436829e-55dd-4e10-aa85-3a190162f4af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

