### PR TITLE
fix(cli): use clamp for TUI table page size

### DIFF
--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -464,7 +464,7 @@ fn truncate_row_strings(rows: &mut [Value]) {
 }
 
 fn bound_table_rows(mut rows: Vec<Value>, page_size: usize) -> Vec<Value> {
-    let cap = page_size.max(1).min(100);
+    let cap = page_size.clamp(1, 100);
     if rows.len() > cap {
         rows.truncate(cap);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`rust-cli` clippy (`-D warnings`) failed on a manual clamp in the TUI table row cap.

## Changes

- `page_size.max(1).min(100)` → `page_size.clamp(1, 100)` in `bound_table_rows`

## Test plan

- [x] `cargo clippy -- -D warnings` on `ch-monitor-cli`
- [x] `cargo fmt --all -- --check`
- [ ] rust-cli CI green

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7436829e-55dd-4e10-aa85-3a190162f4af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7436829e-55dd-4e10-aa85-3a190162f4af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

