### PR TITLE
fix(dashboard): drop id fallback from dynamic model descriptions

### DIFF
--- a/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
+++ b/apps/dashboard/src/lib/ai/anyrouter-dynamic-models.ts
@@ -327,11 +327,7 @@ function listItemToRanked(
     modelId: model.id,
     id: `anyrouter:${model.id}`,
     name: model.id,
-    description:
-      model.description?.trim() ||
-      (opts.isRouterAlias
-        ? `AnyRouter router: ${model.id}`
-        : `AnyRouter: ${model.id}`),
+    description: model.description?.trim() ?? '',
     contextLength: model.context_length ?? 128_000,
     ...(typeof maxOut === 'number' && maxOut > 0
       ? { maxOutputTokens: maxOut }

--- a/apps/dashboard/src/lib/ai/openrouter-dynamic-models.ts
+++ b/apps/dashboard/src/lib/ai/openrouter-dynamic-models.ts
@@ -254,7 +254,7 @@ function toRanked(
     modelId: model.id,
     id: `openrouter:${model.id}`,
     name: model.id,
-    description: model.description?.trim() || `OpenRouter: ${model.id}`,
+    description: model.description?.trim() ?? '',
     contextLength:
       model.context_length ?? model.top_provider?.context_length ?? 128_000,
     ...(typeof maxOut === 'number' && maxOut > 0


### PR DESCRIPTION
## Summary

AnyRouter/OpenRouter dynamic model entries now use **only** the trimmed catalog description (`model.description?.trim()`) — the synthetic `"AnyRouter: <id>"` / `"OpenRouter: <id>"` fallback text is removed (empty string when the catalog has no description).

Follow-up to #3212 (raw model ids in the picker): keeps ids as the primary label, and descriptions stay purely the upstream description.

## Verification

- 81 dynamic-model tests pass; `tsc --noEmit` clean; biome clean.