### PR TITLE
ci(cloudflare): list telemetry preview URL in PR deploy comment

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -525,6 +525,7 @@ jobs:
               '| **MCP** | https://preview.dash.chmonitor.dev/api/mcp |',
               '| **Landing** | https://preview.chmonitor.dev |',
               '| **Docs** | https://preview.docs.chmonitor.dev |',
+              '| **Telemetry** | https://preview.telemetry.chmonitor.dev |',
               '',
               `| Property | Value |`,
               `|----------|-------|`,


### PR DESCRIPTION
Follow-up to #3226: the telemetry collector already deploys a preview to https://preview.telemetry.chmonitor.dev on every PR (Deploy telemetry collector preview step), but the preview-deployment comment table only listed Dashboard/MCP/Landing/Docs — so reviewers never saw the redesigned telemetry stats page preview.

This adds the Telemetry row to the comment table.

**Preview telemetry page:** https://preview.telemetry.chmonitor.dev (deployed on this and every PR touching `apps/telemetry/**`).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: duyetbot <bot@duyet.net>