### PR TITLE
fix(rust): format output.rs chain for stable rustfmt

### DIFF
--- a/rust/ch-monitor-cli/src/output.rs
+++ b/rust/ch-monitor-cli/src/output.rs
@@ -56,7 +56,9 @@ pub fn braille_sparkline(values: &[u64], width: usize) -> String {
     let mut out = String::with_capacity(width);
     for i in 0..width {
         let start = (i as f64 * step) as usize;
-        let end = (((i + 1) as f64 * step) as usize).min(values.len()).max(start + 1);
+        let end = (((i + 1) as f64 * step) as usize)
+            .min(values.len())
+            .max(start + 1);
         let window = &values[start..end.min(values.len())];
         let avg = if window.is_empty() {
             0


### PR DESCRIPTION
Re-applies the multi-line .min()/.max() chain split for cargo fmt --all -- --check on stable rustfmt.

Context: PR #3238 was squash-merged but the resulting merge commit on main (4e81bb5f) contains the single-line version from the base commit, not the split version from the PR HEAD (00249cef). This re-applies the correct formatting directly.