### PR TITLE
ci(cli): multi-target linux/macos build report

### DIFF
--- a/.github/workflows/cli-report.yml
+++ b/.github/workflows/cli-report.yml
@@ -23,21 +23,65 @@ permissions:
   pull-requests: write
 
 jobs:
-  report:
-    name: cli-report
-    runs-on: ubuntu-latest
+  build:
+    name: ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust -> target
           prefix-key: cli-report
+          key: ${{ matrix.target }}
+      - name: Install Linux ARM64 linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
       - name: Build CLI only and measure
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash scripts/cli-build-report.sh
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: bash scripts/cli-build-report.sh --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cli-metrics-${{ matrix.target }}
+          path: cli-report-metrics/${{ matrix.target }}.json
+          if-no-files-found: error
+          retention-days: 7
+
+  report:
+    name: cli-report
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: cli-metrics-*
+          path: cli-report-metrics
+          merge-multiple: true
+      - name: Assemble markdown
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/cli-build-report.sh --assemble cli-report-metrics --report cli-report.md
       - name: Keep a single sticky PR comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -100,12 +100,13 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
 ## CI report (size / time)
 
 `.github/workflows/cli-report.yml` builds **only** `-p chmonitor` on rust
-PRs (including the rolling release-please CLI PR). It posts one sticky
-comment (`header: cli-build-report`) and recreates it on each push so only
-the latest numbers stay. Local:
+PRs (including the rolling release-please CLI PR) for the four release
+targets: linux gnu x86_64/aarch64 and macOS x86_64/aarch64. It posts one
+sticky comment (`header: cli-build-report`) and recreates it on each push
+so only the latest numbers stay. Local:
 
 ```bash
-bash scripts/cli-build-report.sh
+bash scripts/cli-build-report.sh --target x86_64-unknown-linux-gnu
 ```
 
 ## TUI (`chm` / `chm tui`)

--- a/scripts/cli-build-report.sh
+++ b/scripts/cli-build-report.sh
@@ -1,42 +1,167 @@
 #!/usr/bin/env bash
-# Build only the chm CLI crate and write a markdown report (size / time / startup).
+# Build only the chm CLI crate (optionally --target) and emit JSON metrics,
+# or assemble a markdown report from those JSON files.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT/rust"
 
-BIN_DIR="${CARGO_TARGET_DIR:-$ROOT/rust/target}/release"
-REPORT="${CLI_REPORT_PATH:-$ROOT/cli-report.md}"
-mkdir -p "$(dirname "$BIN_DIR")"
+usage() {
+  echo "usage: $0 [--target TRIPLE] [--out DIR] [--assemble DIR] [--report PATH]" >&2
+  exit 2
+}
 
+target=""
+out_dir="${CLI_METRICS_DIR:-$ROOT/cli-report-metrics}"
+assemble_dir=""
+report="${CLI_REPORT_PATH:-$ROOT/cli-report.md}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target) target="${2:-}"; shift 2 ;;
+    --out) out_dir="${2:-}"; shift 2 ;;
+    --assemble) assemble_dir="${2:-}"; shift 2 ;;
+    --report) report="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+done
+
+host_triple() {
+  rustc -vV | awk '/^host:/{print $2}'
+}
+
+now_s() {
+  python3 -c 'import time; print(f"{time.time():.3f}")'
+}
+
+elapsed() {
+  python3 -c 'import sys; print(f"{float(sys.argv[2])-float(sys.argv[1]):.2f}")' "$1" "$2"
+}
+
+file_size() {
+  python3 -c 'import os,sys; print(os.path.getsize(sys.argv[1]))' "$1"
+}
+
+if [[ -n "$assemble_dir" ]]; then
+  python3 - "$assemble_dir" "$report" <<'PY'
+import json, os, sys
+from pathlib import Path
+
+src, dest = Path(sys.argv[1]), Path(sys.argv[2])
+files = sorted(src.glob("*.json"))
+if not files:
+    raise SystemExit(f"no metrics json in {src}")
+rows = [json.loads(p.read_text()) for p in files]
+rows.sort(key=lambda r: r.get("target") or "")
+head = rows[0]
+sha = os.environ.get("GITHUB_SHA") or head.get("sha") or ""
+short = sha[:12]
+ref = os.environ.get("GITHUB_HEAD_REF") or os.environ.get("GITHUB_REF_NAME") or "local"
+version = head.get("version", "?")
+
+def cell(v, suffix=""):
+    if v is None or v == "":
+        return "—"
+    return f"{v}{suffix}"
+
+lines = [
+    "<!-- cli-build-report -->",
+    f"## CLI build report (`chm` {version})",
+    "",
+    "_Always rebuilt on each push. This comment is updated in place (latest only)._",
+    "",
+    f"Ref `{ref}` @ `{short}`. CLI crate only — Linux + macOS release targets.",
+    "",
+    "| Target | Runner | Bytes | MiB | Build s | Tests s | `--version` p50 | `--help` p50 | vs last stable |",
+    "|---|---|---:|---:|---:|---:|---:|---:|---|",
+]
+for r in rows:
+    bytes_ = int(r.get("bytes") or 0)
+    mib = bytes_ / 1024 / 1024
+    delta = r.get("delta_line") or "—"
+    lines.append(
+        "| `{target}` | {runner} | {bytes:,} | {mib:.2f} | {build} | {tests} | {vp} | {hp} | {delta} |".format(
+            target=r.get("target") or "",
+            runner=r.get("runner") or "",
+            bytes=bytes_,
+            mib=mib,
+            build=cell(r.get("build_s")),
+            tests=cell(r.get("test_s")),
+            vp=cell(r.get("version_p50_ms"), " ms"),
+            hp=cell(r.get("help_p50_ms"), " ms"),
+            delta=delta,
+        )
+    )
+ver = next((r.get("chm_version") for r in rows if r.get("chm_version")), "")
+if ver:
+    lines += ["", f"`chm --version` (native): `{ver}`"]
+lines += [
+    "",
+    "Cross-compiled targets skip tests and startup benches. Network snapshot (`chm --no-tui`) is not timed in CI.",
+    "",
+]
+text = "\n".join(lines)
+dest.write_text(text)
+summary = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary:
+    with open(summary, "a", encoding="utf-8") as fh:
+        fh.write(text)
+        fh.write("\n")
+print(f"Wrote {dest}")
+PY
+  exit 0
+fi
+
+host="$(host_triple)"
+if [[ -z "$target" ]]; then
+  target="$host"
+fi
+
+mkdir -p "$out_dir"
 version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' ch-monitor-cli/Cargo.toml | head -n1)"
 rustc_v="$(rustc --version)"
 cargo_v="$(cargo --version)"
-host="$(uname -m)-$(uname -s)"
+sha="${GITHUB_SHA:-$(git -C "$ROOT" rev-parse HEAD)}"
+runner="${RUNNER_OS:-$(uname -s)}/${RUNNER_ARCH:-$(uname -m)}"
 
-start_ns="$(date +%s%N)"
-cargo build --release -p chmonitor
-end_ns="$(date +%s%N)"
-build_s="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.2f", (e-s)/1000000000 }')"
+bin_dir="$ROOT/rust/target/${target}/release"
+chm="$bin_dir/chm"
+if [[ "$target" == *windows* ]]; then
+  chm="${chm}.exe"
+fi
 
-chm="$BIN_DIR/chm"
-if [[ ! -x "$chm" ]]; then
+t0="$(now_s)"
+cargo build --release -p chmonitor --target "$target"
+t1="$(now_s)"
+build_s="$(elapsed "$t0" "$t1")"
+
+if [[ ! -f "$chm" ]]; then
   echo "missing release binary $chm" >&2
   exit 1
 fi
+bytes="$(file_size "$chm")"
 
-bytes="$(stat -c '%s' "$chm" 2>/dev/null || stat -f '%z' "$chm")"
-kib="$(awk -v b="$bytes" 'BEGIN { printf "%.1f", b/1024 }')"
-mib="$(awk -v b="$bytes" 'BEGIN { printf "%.2f", b/1024/1024 }')"
-file_out="$(file -b "$chm" | tr '\n' ' ')"
-chm_ver="$("$chm" --version | head -n1)"
+can_run=0
+chm_ver=""
+test_s=""
+ver_p50=""
+help_p50=""
+if [[ "$target" == "$host" ]]; then
+  can_run=1
+elif [[ "$(uname -s)" == Darwin && "$target" == "x86_64-apple-darwin" ]]; then
+  if "$chm" --version >/dev/null 2>&1; then
+    can_run=1
+  fi
+fi
 
-start_ns="$(date +%s%N)"
-cargo test --release -p chmonitor -- --test-threads=4
-end_ns="$(date +%s%N)"
-test_s="$(awk -v s="$start_ns" -v e="$end_ns" 'BEGIN { printf "%.2f", (e-s)/1000000000 }')"
-
-bench="$(python3 - "$chm" <<'PY'
+if [[ "$can_run" -eq 1 ]]; then
+  chm_ver="$("$chm" --version | head -n1)"
+  t0="$(now_s)"
+  cargo test --release -p chmonitor --target "$target" -- --test-threads=4
+  t1="$(now_s)"
+  test_s="$(elapsed "$t0" "$t1")"
+  bench="$(python3 - "$chm" <<'PY'
 import json, statistics, subprocess, sys, time
 chm = sys.argv[1]
 
@@ -47,68 +172,82 @@ def run(args, n=25):
         subprocess.run([chm, *args], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
         times.append((time.perf_counter() - t) * 1000)
     times.sort()
-    return {
-        "n": n,
-        "min": round(times[0], 2),
-        "p50": round(statistics.median(times), 2),
-        "p95": round(times[int(0.95 * (n - 1))], 2),
-    }
+    return {"p50": round(statistics.median(times), 2)}
 
 print(json.dumps({"version": run(["--version"]), "help": run(["--help"])}))
 PY
 )"
-ver_p50="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["version"]["p50"])' "$bench")"
-ver_p95="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["version"]["p95"])' "$bench")"
-help_p50="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["help"]["p50"])' "$bench")"
-help_p95="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["help"]["p95"])' "$bench")"
+  ver_p50="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["version"]["p50"])' "$bench")"
+  help_p50="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["help"]["p50"])' "$bench")"
+fi
 
-prev_line="_No previous stable linux-gnu asset found._"
+delta_line=""
 if command -v gh >/dev/null 2>&1; then
+  asset="chm-${target}"
   prev="$(gh api "repos/${GITHUB_REPOSITORY:-chmonitor/chmonitor}/releases" --paginate \
-    --jq '[.[] | select(.tag_name|test("^chm-v[0-9]+\\.[0-9]+\\.[0-9]+$")) | {tag:.tag_name, size:(.assets[] | select(.name=="chm-x86_64-unknown-linux-gnu") | .size)}] | .[0]' \
+    --jq "[.[] | select(.tag_name|test(\"^chm-v[0-9]+\\\\.[0-9]+\\\\.[0-9]+$\")) | {tag:.tag_name, size:(.assets[]? | select(.name==\"${asset}\") | .size)}] | map(select(.size != null)) | .[0]" \
     2>/dev/null || true)"
   if [[ -n "${prev:-}" && "$prev" != "null" ]]; then
-    prev_tag="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("tag") or "")' "$prev")"
-    prev_size="$(python3 -c 'import json,sys; v=json.loads(sys.argv[1]).get("size"); print(v if v is not None else "")' "$prev")"
-    if [[ -n "$prev_tag" && -n "$prev_size" ]]; then
+    prev_tag="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("tag") or "")' "$prev" 2>/dev/null || true)"
+    prev_size="$(python3 -c 'import json,sys; v=json.loads(sys.argv[1]).get("size"); print("" if v is None else v)' "$prev" 2>/dev/null || true)"
+    if [[ -n "${prev_tag:-}" && -n "${prev_size:-}" ]]; then
       delta=$((bytes - prev_size))
       sign="+"
       if [[ "$delta" -lt 0 ]]; then sign=""; fi
-      prev_line="vs \`${prev_tag}\` linux-gnu **${prev_size} B** → **${sign}${delta} B**"
+      delta_line="\`${prev_tag}\` ${sign}${delta} B"
     fi
   fi
 fi
 
-sha="${GITHUB_SHA:-$(git -C "$ROOT" rev-parse HEAD)}"
-short="${sha:0:12}"
-ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-local}}"
+export METRICS_PATH="$out_dir/${target}.json"
+export METRICS_TARGET="$target"
+export METRICS_VERSION="$version"
+export METRICS_SHA="$sha"
+export METRICS_RUNNER="$runner"
+export METRICS_HOST="$host"
+export METRICS_RUSTC="$rustc_v"
+export METRICS_CARGO="$cargo_v"
+export METRICS_BYTES="$bytes"
+export METRICS_BUILD_S="$build_s"
+export METRICS_TEST_S="$test_s"
+export METRICS_CHM_VER="$chm_ver"
+export METRICS_VER_P50="$ver_p50"
+export METRICS_HELP_P50="$help_p50"
+export METRICS_DELTA="$delta_line"
+export METRICS_CAN_RUN="$can_run"
 
-cat > "$REPORT" <<EOF
-<!-- cli-build-report -->
-## CLI build report (\`chm\` ${version})
+python3 <<'PY'
+import json, os
+from pathlib import Path
 
-_Always rebuilt on each push. This comment is updated in place (latest only)._
+def num(v):
+    if v is None or v == "":
+        return None
+    try:
+        if "." in v:
+            return float(v)
+        return int(v)
+    except ValueError:
+        return v
 
-| | |
-|---|---|
-| Ref | \`${ref}\` @ \`${short}\` |
-| Host | \`${host}\` |
-| Toolchain | \`${rustc_v}\` / \`${cargo_v}\` |
-| Command | \`cargo build --release -p chmonitor\` (CLI crate only) |
-| Build wall | **${build_s} s** |
-| Tests | \`cargo test --release -p chmonitor\` **${test_s} s** |
-| Binary | **${bytes} B** (${kib} KiB / ${mib} MiB) |
-| File | ${file_out} |
-| \`chm --version\` | \`${chm_ver}\` |
-| Startup \`--version\` | p50 **${ver_p50} ms** · p95 ${ver_p95} ms (n=25) |
-| Startup \`--help\` | p50 **${help_p50} ms** · p95 ${help_p95} ms (n=25) |
-| Size delta | ${prev_line} |
-
-Network snapshot (\`chm --no-tui\`) is not timed in CI (flaky / dashboard-bound).
-EOF
-
-if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
-fi
-
-echo "Wrote $REPORT (${bytes} bytes, build ${build_s}s)"
+payload = {
+    "target": os.environ["METRICS_TARGET"],
+    "version": os.environ["METRICS_VERSION"],
+    "sha": os.environ["METRICS_SHA"],
+    "runner": os.environ["METRICS_RUNNER"],
+    "host": os.environ["METRICS_HOST"],
+    "rustc": os.environ["METRICS_RUSTC"],
+    "cargo": os.environ["METRICS_CARGO"],
+    "bytes": int(os.environ["METRICS_BYTES"]),
+    "build_s": os.environ["METRICS_BUILD_S"],
+    "test_s": os.environ["METRICS_TEST_S"] or None,
+    "chm_version": os.environ["METRICS_CHM_VER"] or None,
+    "version_p50_ms": num(os.environ["METRICS_VER_P50"]),
+    "help_p50_ms": num(os.environ["METRICS_HELP_P50"]),
+    "delta_line": os.environ["METRICS_DELTA"] or None,
+    "can_run": os.environ["METRICS_CAN_RUN"] == "1",
+}
+path = Path(os.environ["METRICS_PATH"])
+path.write_text(json.dumps(payload, indent=2) + "\n")
+print(f"wrote {path} {payload['bytes']} bytes build {payload['build_s']}s")
+PY


### PR DESCRIPTION
## Summary
CLI report CI now builds the same four release targets as `cli-rust-release.yml` (linux gnu x86_64/aarch64, macOS x86_64/aarch64). One sticky comment is recreated with a size/time table so rolling release-please PRs keep latest-only.