### PR TITLE
fix(cli): assemble nested CLI report metrics json

### DIFF
--- a/scripts/cli-build-report.sh
+++ b/scripts/cli-build-report.sh
@@ -49,7 +49,7 @@ import json, os, sys
 from pathlib import Path
 
 src, dest = Path(sys.argv[1]), Path(sys.argv[2])
-files = sorted(src.glob("*.json"))
+files = sorted(src.rglob("*.json"))
 if not files:
     raise SystemExit(f"no metrics json in {src}")
 rows = [json.loads(p.read_text()) for p in files]


### PR DESCRIPTION
## Summary
The multi-target CLI report job downloaded artifacts into nested dirs, so assemble saw no `*.json`. Walk with `rglob`.