### PR TITLE
feat(dashboard): add search palette tabs, page tree, and highlights

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   "what's new", "changelog", "dialog scroll", "settings gear",
   "schema compare", "settings diff", "add host", "pick a query",
   "query picker", "select labels", "ON CLUSTER", "advisor DDL",
-  "command palette", "cmd k", "ttl partitions".
+  "command palette", "cmd k", "search dialog", "ttl partitions".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -212,6 +212,12 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   fallback). Four states: unsupported / needs-grant / granted / blocked. On
   `denied` disable the switch and explain the unblock — never write `false` into
   storage. Gate "Send test" on the live permission.
+- **⌘K command palette:** category tabs All / Pages / Databases / Tables /
+  Actions under the search input (`CommandPaletteTabs`). Pages nest under
+  sidebar group headings with a left border (tree, not a flat list). Query
+  tokens highlight in the visible title/description (`HighlightText`). All
+  still caps explorer rows; the Databases and Tables tabs show the full
+  fetch. Reset tab + query on close.
 - **Tab strips:** define the tabs as one array and map it — an icon per tab with
   ONE size (`size-3.5`) and NO margin utility; `TabsTrigger` already supplies
   `items-center gap-1.5`. Adding `mr-*` on top of that reads as misalignment.

--- a/apps/dashboard/src/components/controls/command-palette-utils.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   detectQuickNav,
+  matchRanges,
   menuItemPaletteValue,
   parseTableName,
 } from './command-palette-utils'
@@ -86,6 +87,28 @@ describe('parseTableName', () => {
       database: 'system',
       table: 'tables',
     })
+  })
+})
+
+describe('matchRanges', () => {
+  test('empty query yields no ranges', () => {
+    expect(matchRanges('Overview', '')).toEqual([])
+    expect(matchRanges('Overview', '   ')).toEqual([])
+  })
+
+  test('highlights a case-insensitive substring', () => {
+    expect(matchRanges('Insights Settings', 'set')).toEqual([[9, 12]])
+  })
+
+  test('merges overlapping tokens', () => {
+    expect(matchRanges('query_log', 'query query_log')).toEqual([[0, 9]])
+  })
+
+  test('matches every token independently', () => {
+    expect(matchRanges('Agent Settings', 'agent set')).toEqual([
+      [0, 5],
+      [6, 9],
+    ])
   })
 })
 

--- a/apps/dashboard/src/components/controls/command-palette-utils.ts
+++ b/apps/dashboard/src/components/controls/command-palette-utils.ts
@@ -14,6 +14,8 @@ const UUID_PATTERN =
 const UUID_PREFIX_PATTERN = /^(?=[a-f0-9-]{8,}$)(?=.*[a-f0-9])[a-f0-9-]+$/i
 const TABLE_PATTERN = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/i
 
+export type PaletteTab = 'all' | 'pages' | 'databases' | 'tables' | 'actions'
+
 export interface QuickNavMatch {
   /** Looks like a (possibly partial) query/trace UUID. */
   isQueryId: boolean
@@ -62,6 +64,50 @@ export function menuItemPaletteValue(
   ]
     .filter((part): part is string => Boolean(part?.trim()))
     .join(' ')
+}
+
+/**
+ * Inclusive `[start, end)` ranges in `text` that match any whitespace-separated
+ * token from `query` (case-insensitive). Overlapping hits are merged so the
+ * highlight renderer can walk the string once.
+ */
+export function matchRanges(
+  text: string,
+  query: string
+): Array<[number, number]> {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+  if (tokens.length === 0 || text.length === 0) return []
+
+  const lower = text.toLowerCase()
+  const hits: Array<[number, number]> = []
+  for (const token of tokens) {
+    const needle = token.toLowerCase()
+    if (needle.length === 0) continue
+    let from = 0
+    while (from <= lower.length - needle.length) {
+      const index = lower.indexOf(needle, from)
+      if (index === -1) break
+      hits.push([index, index + needle.length])
+      from = index + needle.length
+    }
+  }
+  if (hits.length === 0) return []
+
+  hits.sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const merged: Array<[number, number]> = [[hits[0][0], hits[0][1]]]
+  for (let i = 1; i < hits.length; i++) {
+    const last = merged[merged.length - 1]
+    const current = hits[i]
+    if (current[0] <= last[1]) {
+      last[1] = Math.max(last[1], current[1])
+    } else {
+      merged.push([current[0], current[1]])
+    }
+  }
+  return merged
 }
 
 /**

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate } from '@tanstack/react-router'
 import {
   CommandPaletteFooter,
   CommandPaletteResults,
+  CommandPaletteTabs,
   CommandPaletteTrigger,
 } from './command-palette/command-palette-items'
 import { useCommandPaletteState } from './command-palette/use-command-palette-state'
@@ -59,6 +60,8 @@ export const CommandPalette = function CommandPalette({
     setOpen,
     inputValue,
     setInputValue,
+    tab,
+    setTab,
     recentItems,
     mounted,
     closeAndReset,
@@ -181,7 +184,10 @@ export const CommandPalette = function CommandPalette({
         open={open}
         onOpenChange={(value) => {
           setOpen(value)
-          if (!value) setInputValue('')
+          if (!value) {
+            setInputValue('')
+            setTab('all')
+          }
         }}
         aria-label="Command palette"
         showCloseButton={false}
@@ -193,8 +199,10 @@ export const CommandPalette = function CommandPalette({
           value={inputValue}
           onValueChange={setInputValue}
         />
+        <CommandPaletteTabs value={tab} onChange={setTab} />
         <CommandPaletteResults
           inputValue={inputValue}
+          tab={tab}
           favoriteMenuItems={favoriteMenuItems}
           onSelectFavorite={(item) =>
             navigate(item.href, {

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
@@ -86,7 +86,7 @@ describe('derivePaletteGroups', () => {
     expect(result.favoriteMenuItems.map((i) => i.href)).toEqual(['/b', '/a'])
   })
 
-  test('EXPLORER_GROUP_MAX truncates databases and tables', () => {
+  test('derivation keeps the full explorer listing (All tab slices later)', () => {
     const tableRows = Array.from(
       { length: EXPLORER_GROUP_MAX + 5 },
       (_, i) => ({
@@ -103,8 +103,8 @@ describe('derivePaletteGroups', () => {
       currentHostId: 0,
       query: '',
     })
-    expect(result.databases.length).toBe(EXPLORER_GROUP_MAX)
-    expect(result.tables.length).toBe(EXPLORER_GROUP_MAX)
+    expect(result.databases.length).toBe(EXPLORER_GROUP_MAX + 5)
+    expect(result.tables.length).toBe(EXPLORER_GROUP_MAX + 5)
   })
 
   test('detects query-id and table-name quick-nav from the query string', () => {

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -3,8 +3,10 @@
 import {
   CornerDownLeft,
   Database,
+  FileText,
   GlobeIcon,
   History,
+  LayoutList,
   Moon,
   Pin,
   Search,
@@ -14,14 +16,19 @@ import {
   Sun,
   Table,
   TextSearch,
+  Zap,
 } from 'lucide-react'
 
+import type { LucideIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 import type { MenuItem } from '@/components/menu/types'
+import type { PaletteTab } from '../command-palette-utils'
 import type { RecentPaletteItemKind } from '@/lib/command-palette/recent-items'
 import type { ExplorerTableRow } from './use-palette-groups'
 
+import { HighlightText } from './highlight-text'
 import { menuItemPaletteValue } from '../command-palette-utils'
+import { EXPLORER_GROUP_MAX } from './use-palette-groups'
 import {
   CommandEmpty,
   CommandGroup,
@@ -96,6 +103,57 @@ export function EnterHint() {
   )
 }
 
+export const PALETTE_TABS: {
+  value: PaletteTab
+  label: string
+  icon: LucideIcon
+}[] = [
+  { value: 'all', label: 'All', icon: LayoutList },
+  { value: 'pages', label: 'Pages', icon: FileText },
+  { value: 'databases', label: 'Databases', icon: Database },
+  { value: 'tables', label: 'Tables', icon: Table },
+  { value: 'actions', label: 'Actions', icon: Zap },
+]
+
+export function CommandPaletteTabs({
+  value,
+  onChange,
+}: {
+  value: PaletteTab
+  onChange: (tab: PaletteTab) => void
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Search category"
+      className="scrollbar-hide flex w-full min-w-0 overflow-x-auto border-b px-2"
+    >
+      {PALETTE_TABS.map((tab) => {
+        const Icon = tab.icon
+        const active = value === tab.value
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(tab.value)}
+            className={cn(
+              'inline-flex h-8 shrink-0 items-center gap-1.5 border-b-2 px-2.5 text-[13px] font-medium whitespace-nowrap transition-colors',
+              active
+                ? 'border-foreground text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Icon className="size-3.5" strokeWidth={1.5} />
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 interface RecentItem {
   id: string
   title: string
@@ -112,13 +170,12 @@ interface MergedHostLike {
 
 /**
  * The full palette result list: favorites, recent items, quick-navigation,
- * "Go to" (leaf menu entries), sectioned menu groups, databases, tables, and
- * the trailing Actions group (AI chat, theme toggle, host switch, settings).
- * All selection handlers are owned by the caller (`CommandPalette`) — this
- * component is purely presentational per-group row rendering.
+ * pages (tree), databases, tables, and the trailing Actions group.
+ * Category tabs hide whole groups so keyboard nav only walks the active tab.
  */
 export function CommandPaletteResults({
   inputValue,
+  tab,
   favoriteMenuItems,
   onSelectFavorite,
   recentItems,
@@ -142,6 +199,7 @@ export function CommandPaletteResults({
   onOpenSettings,
 }: {
   inputValue: string
+  tab: PaletteTab
   favoriteMenuItems: readonly MenuItem[]
   onSelectFavorite: (item: MenuItem) => void
   recentItems: readonly RecentItem[]
@@ -164,6 +222,17 @@ export function CommandPaletteResults({
   onSwitchHost: (id: number) => void
   onOpenSettings?: () => void
 }) {
+  const showAll = tab === 'all'
+  const showPages = showAll || tab === 'pages'
+  const showDatabases = showAll || tab === 'databases'
+  const showTables = showAll || tab === 'tables'
+  const showActions = showAll || tab === 'actions'
+  const showChrome = showAll
+  const listedDatabases = showAll
+    ? databases.slice(0, EXPLORER_GROUP_MAX)
+    : databases
+  const listedTables = showAll ? tables.slice(0, EXPLORER_GROUP_MAX) : tables
+
   return (
     <CommandList className="max-h-[60vh] scroll-py-2">
       <CommandEmpty>
@@ -180,7 +249,7 @@ export function CommandPaletteResults({
       {/* Pinned favorites (issue #2769) surface first, above Recent —
           cmdk's own value-based filter still narrows this group when the
           user types, so it isn't gated to the empty-query state. */}
-      {favoriteMenuItems.length > 0 && (
+      {showChrome && favoriteMenuItems.length > 0 && (
         <>
           <CommandGroup heading="Favorites">
             {favoriteMenuItems.map((item) => (
@@ -191,7 +260,11 @@ export function CommandPaletteResults({
                 className="group"
               >
                 <Pin className="size-4 shrink-0 fill-current text-muted-foreground" />
-                <span className="font-medium">{item.title}</span>
+                <HighlightText
+                  text={item.title}
+                  query={inputValue}
+                  className="font-medium"
+                />
                 <EnterHint />
               </CommandItem>
             ))}
@@ -202,7 +275,7 @@ export function CommandPaletteResults({
 
       {/* Recent items only make sense as a starting point — once the user
           is actively searching, cmdk's own filter takes over. */}
-      {inputValue.length === 0 && recentItems.length > 0 && (
+      {showChrome && inputValue.length === 0 && recentItems.length > 0 && (
         <>
           <CommandGroup heading="Recent">
             {recentItems.map((recent) => (
@@ -213,11 +286,17 @@ export function CommandPaletteResults({
                 className="group"
               >
                 <History className="size-4 shrink-0" />
-                <span className="font-medium">{recent.title}</span>
+                <HighlightText
+                  text={recent.title}
+                  query={inputValue}
+                  className="font-medium"
+                />
                 {recent.description && (
-                  <span className="ml-1 truncate text-xs text-muted-foreground">
-                    {recent.description}
-                  </span>
+                  <HighlightText
+                    text={recent.description}
+                    query={inputValue}
+                    className="ml-1 truncate text-xs text-muted-foreground"
+                  />
                 )}
                 <EnterHint />
               </CommandItem>
@@ -227,7 +306,7 @@ export function CommandPaletteResults({
         </>
       )}
 
-      {quickNav.hasMatch && (
+      {showChrome && quickNav.hasMatch && (
         <>
           <CommandGroup heading="Quick Navigation">
             {quickNav.isQueryId && (
@@ -263,7 +342,7 @@ export function CommandPaletteResults({
         </>
       )}
 
-      {leafItems.length > 0 && (
+      {showPages && leafItems.length > 0 && (
         <CommandGroup heading="Go to">
           {leafItems.map((group) => (
             <CommandItem
@@ -273,40 +352,51 @@ export function CommandPaletteResults({
               className="group"
             >
               {group.icon && <group.icon className="size-4 shrink-0" />}
-              <span className="font-medium">{group.title}</span>
+              <HighlightText
+                text={group.title}
+                query={inputValue}
+                className="font-medium"
+              />
               <EnterHint />
             </CommandItem>
           ))}
         </CommandGroup>
       )}
 
-      {sectionedItems.map((group) => (
-        <CommandGroup key={group.title} heading={group.title}>
-          {group.items?.map((item) => (
-            <CommandItem
-              key={item.href}
-              onSelect={() => onSelectMenuItem(item)}
-              value={menuItemPaletteValue(item, group.title)}
-              className="group flex-col items-start gap-0.5"
-            >
-              <div className="flex w-full items-center gap-2">
-                {item.icon && <item.icon className="size-4 shrink-0" />}
-                <span className="font-medium">{item.title}</span>
-                <EnterHint />
-              </div>
-              {item.description && (
-                <span className="w-full truncate pl-6 text-xs text-muted-foreground">
-                  {item.description}
-                </span>
-              )}
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      ))}
+      {showPages &&
+        sectionedItems.map((group) => (
+          <CommandGroup key={group.title} heading={group.title}>
+            {group.items?.map((item) => (
+              <CommandItem
+                key={item.href}
+                onSelect={() => onSelectMenuItem(item)}
+                value={menuItemPaletteValue(item, group.title)}
+                className="group ml-1 flex-col items-start gap-0.5 border-l border-border py-2 pl-3"
+              >
+                <div className="flex w-full items-center gap-2">
+                  {item.icon && <item.icon className="size-4 shrink-0" />}
+                  <HighlightText
+                    text={item.title}
+                    query={inputValue}
+                    className="font-medium"
+                  />
+                  <EnterHint />
+                </div>
+                {item.description && (
+                  <HighlightText
+                    text={item.description}
+                    query={inputValue}
+                    className="w-full truncate pl-6 text-xs text-muted-foreground"
+                  />
+                )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ))}
 
-      {databases.length > 0 && (
+      {showDatabases && listedDatabases.length > 0 && (
         <CommandGroup heading="Databases">
-          {databases.map((database) => (
+          {listedDatabases.map((database) => (
             <CommandItem
               key={`db-${database}`}
               onSelect={() => onSelectDatabase(database)}
@@ -314,16 +404,20 @@ export function CommandPaletteResults({
               className="group"
             >
               <Database className="size-4 shrink-0" />
-              <span className="font-medium">{database}</span>
+              <HighlightText
+                text={database}
+                query={inputValue}
+                className="font-medium"
+              />
               <EnterHint />
             </CommandItem>
           ))}
         </CommandGroup>
       )}
 
-      {tables.length > 0 && (
+      {showTables && listedTables.length > 0 && (
         <CommandGroup heading="Tables">
-          {tables.map((row) => (
+          {listedTables.map((row) => (
             <CommandItem
               key={`table-${row.database}-${row.name}`}
               onSelect={() => onSelectTable(row)}
@@ -331,9 +425,11 @@ export function CommandPaletteResults({
               className="group"
             >
               <Table className="size-4 shrink-0" />
-              <span className="font-medium">
-                {row.database}.{row.name}
-              </span>
+              <HighlightText
+                text={`${row.database}.${row.name}`}
+                query={inputValue}
+                className="font-medium"
+              />
               <span className="ml-1 truncate text-xs text-muted-foreground">
                 {row.engine}
               </span>
@@ -343,8 +439,9 @@ export function CommandPaletteResults({
         </CommandGroup>
       )}
 
-      <CommandSeparator />
-      <CommandGroup heading="Actions">
+      {showActions && <CommandSeparator />}
+      {showActions && (
+        <CommandGroup heading="Actions">
         <CommandItem
           onSelect={onOpenAiChat}
           value="Open AI Agent chat assistant"
@@ -398,6 +495,7 @@ export function CommandPaletteResults({
           </CommandItem>
         )}
       </CommandGroup>
+      )}
     </CommandList>
   )
 }

--- a/apps/dashboard/src/components/controls/command-palette/highlight-text.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/highlight-text.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+
+import { matchRanges } from '../command-palette-utils'
+import { cn } from '@/lib/utils'
+
+/**
+ * Wrap query-token hits in `text` with a token-colored mark so ⌘K matches
+ * are visible in titles and descriptions.
+ */
+export function HighlightText({
+  text,
+  query,
+  className,
+}: {
+  text: string
+  query: string
+  className?: string
+}) {
+  const ranges = matchRanges(text, query)
+  if (ranges.length === 0) {
+    return <span className={className}>{text}</span>
+  }
+
+  const parts: ReactNode[] = []
+  let cursor = 0
+  for (const [start, end] of ranges) {
+    if (start > cursor) {
+      parts.push(text.slice(cursor, start))
+    }
+    parts.push(
+      <mark
+        key={start}
+        className="rounded-sm bg-primary/25 text-foreground"
+      >
+        {text.slice(start, end)}
+      </mark>
+    )
+    cursor = end
+  }
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor))
+  }
+
+  return <span className={cn(className)}>{parts}</span>
+}

--- a/apps/dashboard/src/components/controls/command-palette/use-command-palette-state.ts
+++ b/apps/dashboard/src/components/controls/command-palette/use-command-palette-state.ts
@@ -1,3 +1,4 @@
+import type { PaletteTab } from '../command-palette-utils'
 import type { RecentPaletteItemKind } from '@/lib/command-palette/recent-items'
 
 import * as React from 'react'
@@ -22,6 +23,7 @@ export function useCommandPaletteState({
 }) {
   const [internalOpen, setInternalOpen] = React.useState(false)
   const [inputValue, setInputValue] = useState('')
+  const [tab, setTab] = useState<PaletteTab>('all')
   const [recentItems, setRecentItems] = useState<
     ReturnType<typeof getRecentItems>
   >([])
@@ -57,6 +59,7 @@ export function useCommandPaletteState({
   const closeAndReset = () => {
     setOpen(false)
     setInputValue('')
+    setTab('all')
   }
 
   const rememberSelection = (
@@ -74,6 +77,8 @@ export function useCommandPaletteState({
     setOpen,
     inputValue,
     setInputValue,
+    tab,
+    setTab,
     recentItems,
     mounted,
     closeAndReset,

--- a/apps/dashboard/src/components/controls/command-palette/use-palette-groups.ts
+++ b/apps/dashboard/src/components/controls/command-palette/use-palette-groups.ts
@@ -66,9 +66,10 @@ export function derivePaletteGroups({
 
   const seenDatabases = new Set<string>()
   for (const row of tableRows ?? []) seenDatabases.add(row.database)
-  const databases = [...seenDatabases].slice(0, EXPLORER_GROUP_MAX)
-
-  const tables = (tableRows ?? []).slice(0, EXPLORER_GROUP_MAX)
+  // Full lists — the All tab slices to EXPLORER_GROUP_MAX; dedicated
+  // Databases / Tables tabs show everything fetched.
+  const databases = [...seenDatabases]
+  const tables = [...(tableRows ?? [])]
 
   const otherHosts = hosts.filter((h) => h.id !== currentHostId)
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-21
+updated: 2026-08-23
 tags:
   - design-system
   - ui
@@ -769,7 +769,12 @@ OG `headTitle`/`title`), href, description, and optional `keywords` on
 `MenuItem` (`menuItemPaletteValue`). DBA pages (Advisor, Schema Compare,
 Settings Diff, TTL & Partitions) declare aliases so searches like
 `ddl`, `schema diff`, `config diff`, `ttl inventory`, or the tab title
-`TTL & Partition Health` hit them.
+`TTL & Partition Health` hit them. The dialog has category tabs
+(**All / Pages / Databases / Tables / Actions**): Pages is a sidebar-like
+tree (group heading + left-border nested leaves); Databases and Tables
+tabs list the full fetched explorer set (All still caps at
+`EXPLORER_GROUP_MAX`). Query tokens highlight in titles and descriptions
+(`HighlightText` + `matchRanges`).
 
 Leave `engines` **absent** on the Tools parent and children. Absent already
 means the default source-engine family, so `filterMenuItemsByEngine` drops


### PR DESCRIPTION
## Summary

Improves the dashboard ⌘K search dialog:

- Category tabs: **All**, **Pages**, **Databases**, **Tables**, **Actions**
- Pages render as a sidebar-like tree (group heading + nested leaves)
- Query tokens highlight in titles and descriptions
- Databases / Tables tabs list the full fetched explorer set; All still caps the list

## Changes

- `CommandPaletteTabs` under the search input
- Tree indent + left border on nested page rows
- `matchRanges` + `HighlightText` for match highlighting
- Product-design skill and knowledge doc updated

## Test plan

- [ ] Open ⌘K and switch All / Pages / Databases / Tables / Actions
- [ ] Type a page name and confirm highlighted matches
- [ ] Nested pages stay indented under their group
- [ ] Closing the dialog resets the tab to All