### PR TITLE
fix(telemetry): bind preview Worker to production D1

### DIFF
--- a/apps/telemetry/README.md
+++ b/apps/telemetry/README.md
@@ -114,8 +114,10 @@ pnpm run deploy            # production → telemetry.chmonitor.dev
 pnpm run deploy:preview    # preview    → preview.telemetry.chmonitor.dev
 ```
 
-No secrets required. The D1 database is created on first deploy.
-CI deploys this automatically on push to `main` (see `.github/workflows/cloudflare.yml`).
+No secrets required. Production and `wrangler deploy --env preview` both bind
+the same D1 database (`chm_telemetry`) so preview.telemetry.chmonitor.dev
+reads live aggregate stats. CI deploys this automatically on push to `main`
+(see `.github/workflows/cloudflare.yml`).
 
 ## Querying (active installs, by version / deploy target)
 

--- a/apps/telemetry/wrangler.toml
+++ b/apps/telemetry/wrangler.toml
@@ -48,6 +48,16 @@ custom_domain = true
 [env.preview]
 name = "preview-chmonitor-telemetry"
 
+# Same D1 as production — preview is a Worker deploy of the page/API, not a
+# separate empty database. Without this binding GET /v1/summary returns 503
+# (`enabled: false`) because env-specific configs do not inherit top-level
+# [[d1_databases]].
+[[env.preview.d1_databases]]
+binding = "CHM_TELEMETRY_DB"
+database_name = "chm_telemetry"
+database_id = "4887176b-0181-45bf-970f-a506f514d5a9"
+migrations_dir = "migrations"
+
 [[env.preview.routes]]
 pattern = "preview.telemetry.chmonitor.dev"
 custom_domain = true


### PR DESCRIPTION
## Summary

Point `preview.telemetry.chmonitor.dev` at the same D1 database as production so `/v1/summary` no longer returns HTTP 503 (`enabled: false`).

## Changes

- Redeclare `CHM_TELEMETRY_DB` under `[env.preview]` (wrangler env configs do not inherit top-level D1 bindings)
- Note in `apps/telemetry/README.md` that preview reads live aggregates

## Test plan

- [ ] After preview deploy, `curl https://preview.telemetry.chmonitor.dev/v1/summary` returns 200 with `enabled: true` and install counts
- [ ] Preview analytics page loads without "Failed to load analytics: HTTP 503"

## Notes for reviewer

Preview is a Worker of the UI/API, not a separate empty database. Ingest still targets production `telemetry.chmonitor.dev`.

---

Co-Authored-By: duyetbot <bot@duyet.net>