### PR TITLE
feat(dashboard): polish search, what's new, settings, and mobile nav

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -95,7 +95,8 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `initialFocus` on the title (`tabIndex={-1}`) and reset the body
   `scrollTop` on open — default focus would otherwise land on the first
   markdown link deep in an older note and `scrollIntoView` the list to the
-  middle.
+  middle. Screenshot thumbs (`WhatsNewScreenshotGallery`) open a full-size
+  overlay in the same dialog; Escape closes the overlay before the dialog.
 - **Base UI Select labels:** pass `items={{ value: 'Human label' }}` on
   `Select` (the Root) so `SelectValue` shows the label, not the raw value.
   `placeholder` only appears when nothing is selected — a selected `24` /
@@ -213,8 +214,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `denied` disable the switch and explain the unblock — never write `false` into
   storage. Gate "Send test" on the live permission.
 - **⌘K command palette:** category tabs All / Pages / Databases / Tables /
-  Actions under the search input (`CommandPaletteTabs`). Pages nest under
-  sidebar group headings with a left border (tree, not a flat list). Query
+  Actions under the search input (`CommandPaletteTabs`: `h-9 px-3`, strip
+  `px-3 pt-1.5`). Pages nest under sidebar group headings with a continuous
+  left rail on `cmdk-group-items` (not a per-row `border-l`). Query
   tokens highlight in the visible title/description (`HighlightText`). All
   still caps explorer rows; the Databases and Tables tabs show the full
   fetch. Reset tab + query on close.
@@ -367,7 +369,7 @@ The Settings dialog (`components/settings/settings-form.tsx`) exposes units
 (`tableDensity`), default time range, and workspace preset
 (`workspacePreset`, `hiddenMenuHrefs`) on `UserSettings`. Header is Settings
 icon + title + one-line "Local to this browser"; surface is
-`rounded-xl border bg-card p-0` with a **stable height** (`h-[min(36rem,85vh)]`)
+`rounded-xl border bg-card p-0` with a **stable height** (`h-[min(42rem,90vh)]`, `sm:max-w-4xl`)
 and `select-text` so labels copy. Left rail is a flat column (no boxed
 tab well): section labels + icon rows, selected = muted pill, `border-r`
 divider. Content pane shows the active tab title. Theme (Light / Dark /

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -44,7 +44,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon" variant="inset">
-      <SidebarHeader>
+      <SidebarHeader className="gap-1 p-1.5">
         <HostSwitcher />
         <SampleClusterBanner />
       </SidebarHeader>
@@ -53,7 +53,7 @@ export function AppSidebar() {
         <NavMain items={menuItems} />
       </SidebarContent>
 
-      <SidebarFooter className="pt-0">
+      <SidebarFooter className="p-1.5 pt-0">
         {/* App-level links (Billing / Organization / About) and the external
             Docs link share ONE menu so every footer row has the same rhythm —
             separate SidebarMenu blocks would pick up the footer's gap-2 and

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -126,7 +126,7 @@ export function CommandPaletteTabs({
     <div
       role="tablist"
       aria-label="Search category"
-      className="scrollbar-hide flex w-full min-w-0 overflow-x-auto border-b px-2"
+      className="scrollbar-hide flex w-full min-w-0 gap-1 overflow-x-auto border-b px-3 pt-1.5"
     >
       {PALETTE_TABS.map((tab) => {
         const Icon = tab.icon
@@ -139,7 +139,7 @@ export function CommandPaletteTabs({
             aria-selected={active}
             onClick={() => onChange(tab.value)}
             className={cn(
-              'inline-flex h-8 shrink-0 items-center gap-1.5 border-b-2 px-2.5 text-[13px] font-medium whitespace-nowrap transition-colors',
+              'inline-flex h-9 shrink-0 items-center gap-1.5 border-b-2 px-3 text-[13px] font-medium whitespace-nowrap transition-colors',
               active
                 ? 'border-foreground text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
@@ -365,13 +365,17 @@ export function CommandPaletteResults({
 
       {showPages &&
         sectionedItems.map((group) => (
-          <CommandGroup key={group.title} heading={group.title}>
+          <CommandGroup
+            key={group.title}
+            heading={group.title}
+            className="[&_[cmdk-group-items]]:ml-3 [&_[cmdk-group-items]]:border-l [&_[cmdk-group-items]]:border-border [&_[cmdk-group-items]]:pl-2.5"
+          >
             {group.items?.map((item) => (
               <CommandItem
                 key={item.href}
                 onSelect={() => onSelectMenuItem(item)}
                 value={menuItemPaletteValue(item, group.title)}
-                className="group ml-1 flex-col items-start gap-0.5 border-l border-border py-2 pl-3"
+                className="group flex-col items-start gap-0.5 rounded-md"
               >
                 <div className="flex w-full items-center gap-2">
                   {item.icon && <item.icon className="size-4 shrink-0" />}

--- a/apps/dashboard/src/components/host/host-switcher.tsx
+++ b/apps/dashboard/src/components/host/host-switcher.tsx
@@ -275,7 +275,7 @@ export function HostSwitcher() {
                 </div>
                 {showExpanded && (
                   <>
-                    <div className="grid min-w-0 flex-1 gap-2 py-1.5 text-left text-sm leading-tight">
+                    <div className="grid min-w-0 flex-1 gap-0.5 py-0.5 text-left text-sm leading-tight">
                       <span className="flex min-w-0 items-center gap-1.5 font-semibold">
                         <span className="truncate">
                           {activeHost.name || getHost(activeHost.host)}

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -47,7 +47,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           <AppSidebar />
           <SidebarInset className="min-w-0 overflow-hidden">
             <header className="relative z-10 flex min-h-16 shrink-0 flex-wrap items-center gap-x-2 gap-y-2 transition-[width,height] ease-linear sm:h-16 sm:flex-nowrap sm:group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 sm:group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12">
-              <div className="flex min-w-0 flex-1 items-center gap-2 px-4 pt-3 sm:pt-0">
+              <div className="flex min-w-0 flex-1 items-center gap-2 px-3 pt-2 sm:px-4 sm:pt-0">
                 <SidebarTrigger className="-ml-1 size-11 lg:size-7" />
                 <Separator orientation="vertical" className="h-4" />
                 <Suspense fallback={<Skeleton className="h-4 w-32" />}>
@@ -56,7 +56,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
               </div>
               {/* scrollbar-hide: stays swipe-scrollable on narrow viewports
                 without a visible scrollbar under the header controls. */}
-              <div className="scrollbar-hide w-full min-w-0 overflow-x-auto px-4 pb-3 sm:ml-auto sm:w-auto sm:overflow-visible sm:pb-0">
+              <div className="scrollbar-hide w-full min-w-0 overflow-x-auto px-3 pb-2 sm:ml-auto sm:w-auto sm:overflow-visible sm:px-4 sm:pb-0">
                 <HeaderActions />
               </div>
             </header>

--- a/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-group.tsx
@@ -34,8 +34,8 @@ export const MenuGroup = function MenuGroup({
   const label = SECTION_LABELS[section]
 
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground px-3 py-2">
+    <SidebarGroup className="p-1">
+      <SidebarGroupLabel className="h-7 px-2 py-0 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         {label}
       </SidebarGroupLabel>
       <SidebarMenu>

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -358,7 +358,7 @@ const CollapsibleMenuItem = function CollapsibleMenuItem({
         </SidebarMenuBadge>
       )}
       <CollapsibleContent>
-        <SidebarMenuSub>
+        <SidebarMenuSub className="ml-2.5 gap-0 py-0 pl-1.5">
           {item.items?.map((subItem) => (
             <SubMenuItem
               key={subItem.href}

--- a/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/nav-favorites.tsx
@@ -153,8 +153,8 @@ export function NavFavorites({ items, pathname }: NavFavoritesProps) {
   const itemIds = favoriteItems.map((item) => item.href)
 
   return (
-    <SidebarGroup>
-      <SidebarGroupLabel className="text-xs font-semibold uppercase tracking-wider text-muted-foreground px-3 py-2">
+    <SidebarGroup className="p-1">
+      <SidebarGroupLabel className="h-7 px-2 py-0 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
         Favorites
       </SidebarGroupLabel>
       <DndContext

--- a/apps/dashboard/src/components/settings/settings-dialog.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog.tsx
@@ -52,7 +52,7 @@ export function SettingsDialog({
         />
       )}
       <DialogContent
-        className="flex h-[min(36rem,85vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 select-text sm:max-w-3xl"
+        className="flex h-[min(42rem,90vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 select-text sm:max-w-4xl"
         data-testid="settings-dialog"
       >
         <DialogHeader className="sr-only">

--- a/apps/dashboard/src/components/ui/sidebar.tsx
+++ b/apps/dashboard/src/components/ui/sidebar.tsx
@@ -26,7 +26,7 @@ import { cn } from '@/lib/utils'
 const SIDEBAR_COOKIE_NAME = 'sidebar_state'
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = '16rem'
-const SIDEBAR_WIDTH_MOBILE = '18rem'
+const SIDEBAR_WIDTH_MOBILE = '16rem'
 const SIDEBAR_WIDTH_ICON = '3rem'
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b'
 
@@ -187,7 +187,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="w-(--sidebar-width) isolate bg-sidebar p-0 text-sidebar-foreground opacity-100 backdrop-blur-none [&>button]:hidden"
+          className="w-(--sidebar-width) max-w-[16rem] gap-0 isolate bg-sidebar p-0 text-sidebar-foreground opacity-100 backdrop-blur-none sm:max-w-[16rem] [&>button]:hidden"
           style={
             {
               '--sidebar-width': SIDEBAR_WIDTH_MOBILE,

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
@@ -182,6 +182,10 @@ describe("What's new dialog layout", () => {
       expect(body?.contains(github as Node)).toBe(false)
       expect(body?.contains(changelog as Node)).toBe(false)
 
+      expect(
+        document.querySelector('[data-testid="whats-new-screenshots"]')
+      ).toBeNull()
+
       const { act } = await import('react')
       await act(async () => {
         ;(gotIt as HTMLButtonElement).click()
@@ -227,6 +231,65 @@ describe("What's new dialog layout", () => {
       expect(body?.scrollTop).toBe(0)
       expect(title?.tabIndex).toBe(-1)
       expect(document.activeElement === deepLink).toBe(false)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('screenshot thumbs open a full-size overlay inside the dialog', async () => {
+    const { WhatsNewDialog } = await import('./whats-new-dialog')
+    const withShots: ReleaseNote = {
+      ...tallNote('0.3.3', ['guest AI caps']),
+      screenshots: [
+        {
+          src: '/assets/screenshots/overview-dark.png',
+          alt: 'Overview',
+        },
+      ],
+    }
+
+    const { cleanup } = await renderInto(
+      <WhatsNewDialog
+        open
+        onOpenChange={() => {}}
+        onGotIt={() => {}}
+        releases={[withShots]}
+        isLoading={false}
+      />
+    )
+
+    try {
+      const thumb = document.querySelector(
+        '[data-testid="whats-new-screenshot-thumb"]'
+      ) as HTMLButtonElement | null
+      expect(thumb).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="whats-new-lightbox"]')
+      ).toBeNull()
+
+      const { act } = await import('react')
+      await act(async () => {
+        thumb?.click()
+      })
+
+      const lightbox = document.querySelector(
+        '[data-testid="whats-new-lightbox"]'
+      )
+      expect(lightbox).not.toBeNull()
+      expect(lightbox?.querySelector('img')?.getAttribute('src')).toBe(
+        '/assets/screenshots/overview-dark.png'
+      )
+
+      await act(async () => {
+        ;(
+          document.querySelector(
+            '[data-testid="whats-new-lightbox-close"]'
+          ) as HTMLButtonElement
+        ).click()
+      })
+      expect(
+        document.querySelector('[data-testid="whats-new-lightbox"]')
+      ).toBeNull()
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
@@ -1,9 +1,14 @@
 import { ExternalLink } from 'lucide-react'
 
-import type { ReleaseNote } from '@/lib/whats-new/types'
+import type { ReleaseNote, ReleaseNoteScreenshot } from '@/lib/whats-new/types'
 
 import { WhatsNewMarkdown } from './whats-new-markdown'
-import { useLayoutEffect, useRef } from 'react'
+import {
+  WhatsNewScreenshotGallery,
+  WhatsNewScreenshotLightbox,
+} from './whats-new-screenshots'
+import { useLayoutEffect, useRef, useState } from 'react'
+import { collectReleaseScreenshots } from '@/lib/whats-new/images'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -73,19 +78,32 @@ export function WhatsNewDialog({
   // scroll container) and reset scroll whenever content settles.
   const titleRef = useRef<HTMLHeadingElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
+  const [lightbox, setLightbox] = useState<ReleaseNoteScreenshot | null>(null)
 
   // isLoading/releases are content-settle triggers: re-run the scroll reset
   // when notes finish loading or the list changes, not just on open.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset scroll when content settles
   useLayoutEffect(() => {
-    if (!open) return
+    if (!open) {
+      setLightbox(null)
+      return
+    }
     bodyRef.current?.scrollTo(0, 0)
   }, [open, isLoading, releases])
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && lightbox) {
+      setLightbox(null)
+      return
+    }
+    if (!next) setLightbox(null)
+    onOpenChange(next)
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="flex max-h-[min(36rem,85vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-lg"
+        className="relative flex max-h-[min(40rem,90vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-xl"
         data-testid="whats-new-dialog"
         initialFocus={titleRef}
       >
@@ -135,16 +153,23 @@ export function WhatsNewDialog({
               />
             ) : null}
 
-            {releases.map((note) => (
-              <section
-                key={note.tag}
-                className="flex flex-col gap-2"
-                data-testid="whats-new-version"
-              >
-                <VersionHeading note={note} />
-                <WhatsNewMarkdown markdown={note.markdown} />
-              </section>
-            ))}
+            {releases.map((note) => {
+              const shots = collectReleaseScreenshots(note)
+              return (
+                <section
+                  key={note.tag}
+                  className="flex flex-col gap-2"
+                  data-testid="whats-new-version"
+                >
+                  <VersionHeading note={note} />
+                  <WhatsNewMarkdown markdown={note.markdown} />
+                  <WhatsNewScreenshotGallery
+                    shots={shots}
+                    onOpen={setLightbox}
+                  />
+                </section>
+              )
+            })}
           </div>
         </div>
 
@@ -183,6 +208,11 @@ export function WhatsNewDialog({
             Got it
           </Button>
         </DialogFooter>
+
+        <WhatsNewScreenshotLightbox
+          shot={lightbox}
+          onClose={() => setLightbox(null)}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/apps/dashboard/src/components/whats-new/whats-new-markdown.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-markdown.tsx
@@ -15,15 +15,8 @@ const markdownComponents: Components = {
       {children}
     </a>
   ),
-  img: ({ src, alt }) =>
-    src ? (
-      <img
-        src={src}
-        alt={alt ?? ''}
-        className="my-2 max-h-64 w-full rounded-md border border-border object-contain"
-        loading="lazy"
-      />
-    ) : null,
+  // Images render as clickable thumbs in WhatsNewScreenshotGallery.
+  img: () => null,
 }
 
 interface WhatsNewMarkdownProps {

--- a/apps/dashboard/src/components/whats-new/whats-new-screenshots.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-screenshots.tsx
@@ -1,0 +1,100 @@
+import { XIcon } from 'lucide-react'
+
+import type { ReleaseNoteScreenshot } from '@/lib/whats-new/types'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+export function WhatsNewScreenshotGallery({
+  shots,
+  onOpen,
+}: {
+  shots: readonly ReleaseNoteScreenshot[]
+  onOpen: (shot: ReleaseNoteScreenshot) => void
+}) {
+  if (shots.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        'scrollbar-hide mt-1 flex gap-2 overflow-x-auto py-1',
+        shots.length === 1 && 'grid grid-cols-1 overflow-visible'
+      )}
+      data-testid="whats-new-screenshots"
+    >
+      {shots.map((shot) => (
+        <button
+          key={shot.src}
+          type="button"
+          onClick={() => onOpen(shot)}
+          className={cn(
+            'group relative overflow-hidden rounded-md border border-border bg-muted/30 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            shots.length === 1 ? 'w-full max-w-xs' : 'w-40 shrink-0'
+          )}
+          data-testid="whats-new-screenshot-thumb"
+          aria-label={
+            shot.alt
+              ? `View screenshot: ${shot.alt}`
+              : 'View screenshot full size'
+          }
+        >
+          <img
+            src={shot.src}
+            alt={shot.alt || ''}
+            loading="lazy"
+            decoding="async"
+            className="aspect-[16/10] w-full object-cover object-top transition-opacity group-hover:opacity-90"
+          />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function WhatsNewScreenshotLightbox({
+  shot,
+  onClose,
+}: {
+  shot: ReleaseNoteScreenshot | null
+  onClose: () => void
+}) {
+  if (!shot) return null
+
+  return (
+    <div
+      className="absolute inset-0 z-10 flex flex-col bg-background/95"
+      data-testid="whats-new-lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label={shot.alt || 'Screenshot'}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <p className="truncate text-xs text-muted-foreground">
+          {shot.alt || 'Screenshot'}
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close screenshot"
+          data-testid="whats-new-lightbox-close"
+          onClick={onClose}
+        >
+          <XIcon className="size-4" />
+        </Button>
+      </div>
+      <button
+        type="button"
+        className="flex min-h-0 flex-1 cursor-zoom-out items-center justify-center p-3"
+        onClick={onClose}
+        aria-label="Close screenshot"
+      >
+        <img
+          src={shot.src}
+          alt={shot.alt || ''}
+          className="max-h-full max-w-full rounded-md object-contain"
+        />
+      </button>
+    </div>
+  )
+}

--- a/apps/dashboard/src/lib/whats-new/friendly-notes.json
+++ b/apps/dashboard/src/lib/whats-new/friendly-notes.json
@@ -12,7 +12,16 @@
         "Drag to reorder pinned favorites in the sidebar.",
         "Open Settings from the icon next to Sign in."
       ],
-      "screenshots": []
+      "screenshots": [
+        {
+          "src": "/assets/screenshots/overview-insights-dark.webp",
+          "alt": "Overview insights"
+        },
+        {
+          "src": "/assets/screenshots/query-heatmap-dark.webp",
+          "alt": "Query activity heatmap"
+        }
+      ]
     },
     {
       "version": "0.3.2",
@@ -25,7 +34,16 @@
         "Fleet summary strip with richer host metrics and sparklines.",
         "MCP Playground talks to a live client and covers the 2026-07-28 spec gaps."
       ],
-      "screenshots": []
+      "screenshots": [
+        {
+          "src": "/assets/screenshots/mcp-server-dark.png",
+          "alt": "MCP playground"
+        },
+        {
+          "src": "/assets/screenshots/data-explorer-new-dark.webp",
+          "alt": "Data Explorer table overview"
+        }
+      ]
     },
     {
       "version": "0.3.1",

--- a/apps/dashboard/src/lib/whats-new/images.test.ts
+++ b/apps/dashboard/src/lib/whats-new/images.test.ts
@@ -1,0 +1,32 @@
+import { collectReleaseScreenshots, extractMarkdownImages } from './images'
+import { describe, expect, test } from 'bun:test'
+
+describe('collectReleaseScreenshots', () => {
+  test('merges frontmatter shots with markdown images and drops dupes', () => {
+    const shots = collectReleaseScreenshots({
+      screenshots: [
+        { src: '/assets/screenshots/overview-dark.png', alt: 'Overview' },
+      ],
+      markdown:
+        'Hello\n\n![Overview](/assets/screenshots/overview-dark.png)\n![Health](/assets/screenshots/health-summary.png)',
+    })
+    expect(shots).toEqual([
+      { src: '/assets/screenshots/overview-dark.png', alt: 'Overview' },
+      { src: '/assets/screenshots/health-summary.png', alt: 'Health' },
+    ])
+  })
+
+  test('empty note has no shots', () => {
+    expect(
+      collectReleaseScreenshots({ markdown: '- a bullet', screenshots: [] })
+    ).toEqual([])
+  })
+})
+
+describe('extractMarkdownImages', () => {
+  test('reads alt and url', () => {
+    expect(extractMarkdownImages('![Nav](/assets/whats-new/nav.png)')).toEqual([
+      { alt: 'Nav', url: '/assets/whats-new/nav.png' },
+    ])
+  })
+})

--- a/apps/dashboard/src/lib/whats-new/images.ts
+++ b/apps/dashboard/src/lib/whats-new/images.ts
@@ -1,3 +1,5 @@
+import type { ReleaseNote, ReleaseNoteScreenshot } from './types'
+
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)]+)\)/g
 
 export const IMAGE_RE = /!\[[^\]]*\]\([^)]+\)/
@@ -13,4 +15,28 @@ export function extractMarkdownImages(
     match = re.exec(markdown)
   }
   return images
+}
+
+/**
+ * Unique screenshots for a release: frontmatter list first, then markdown
+ * images not already listed. Empty `src` is dropped.
+ */
+export function collectReleaseScreenshots(
+  note: Pick<ReleaseNote, 'markdown' | 'screenshots'>
+): ReleaseNoteScreenshot[] {
+  const seen = new Set<string>()
+  const shots: ReleaseNoteScreenshot[] = []
+  const push = (src: string, alt: string) => {
+    const trimmed = src.trim()
+    if (!trimmed || seen.has(trimmed)) return
+    seen.add(trimmed)
+    shots.push({ src: trimmed, alt: alt.trim() })
+  }
+  for (const shot of note.screenshots ?? []) {
+    push(shot.src, shot.alt)
+  }
+  for (const image of extractMarkdownImages(note.markdown)) {
+    push(image.url, image.alt)
+  }
+  return shots
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -97,7 +97,10 @@ tall list cannot paint under GitHub Releases / Changelog / Got it. Footer
 resets the primitive's `-mx-4 -mb-4` (`mx-0 mb-0`) because the dialog is
 `p-0`. Initial focus is the title (`tabIndex={-1}` + `initialFocus`), and the
 body `scrollTop` resets on open, so markdown links in older notes cannot
-`scrollIntoView` the list to the middle. Notes come from `GET /api/v1/releases` (server-side GitHub Releases with
+`scrollIntoView` the list to the middle. Each version can show a row of
+screenshot **thumbnails** (`WhatsNewScreenshotGallery`); click one to
+open a full-size overlay inside the same dialog (`WhatsNewScreenshotLightbox`).
+Escape / close dismisses the overlay first, then the dialog. Notes come from `GET /api/v1/releases` (server-side GitHub Releases with
 `docs/whats-new` friendly copy first). Airgap fallback is a **build-time
 snapshot** of latest `v*` notes, not the full CHANGELOG.md. Settings icon is lucide `Settings` (`size-4`, `strokeWidth={1.5}`),
 `aria-label="Open settings"`, `data-testid="nav-settings-button"`, tooltip
@@ -117,7 +120,7 @@ timezone/theme plus **units** (`byteUnit`, `numberFormat`), **colors**
 Settings dialog (`components/settings/settings-dialog.tsx` +
 `settings-form.tsx`) uses `rounded-xl border bg-card`, a Settings icon + title
 + "Local to this browser" header, a **stable height**
-(`h-[min(36rem,85vh)]`) so tabs do not resize the panel, and `select-text`
+(`h-[min(42rem,90vh)]`, `sm:max-w-4xl`) so tabs do not resize the panel, and `select-text`
 so labels copy. Layout is `p-0`: a flat left rail (section labels
 Preferences / Display / Workspace, icon + label rows, selected as a muted
 pill, `border-r`) and a content pane whose heading is the active tab.
@@ -593,7 +596,10 @@ would clip it.
   typical values in full.
 - **App sidebar overlays below `lg` (1024)**, not `md`. A docked 16rem rail at
   768 / landscape crushes the card grid. `SidebarProvider` uses `useIsLgDown()`;
-  the desktop rail + resize handle are `lg:flex` / `lg:block`.
+  the desktop rail + resize handle are `lg:flex` / `lg:block`. The mobile
+  sheet is the same 16rem as the desktop rail (`SIDEBAR_WIDTH_MOBILE`), with
+  `gap-0` / `p-0` so the default Sheet `gap-4` and `sm:max-w-sm` do not pad
+  the drawer. Menu groups use `p-1` (not `px-3 py-2` labels).
 - **Mobile sidebar sheet is opaque.** Drawer `bg-sidebar` + `isolate`; overlay
   is a solid dim (`oklch(0 0 0 / 0.55)`), no `backdrop-blur`, so the overview
   heatmap cannot frost through the menu (`styles.css` + sheet classes).
@@ -770,11 +776,12 @@ OG `headTitle`/`title`), href, description, and optional `keywords` on
 Settings Diff, TTL & Partitions) declare aliases so searches like
 `ddl`, `schema diff`, `config diff`, `ttl inventory`, or the tab title
 `TTL & Partition Health` hit them. The dialog has category tabs
-(**All / Pages / Databases / Tables / Actions**): Pages is a sidebar-like
-tree (group heading + left-border nested leaves); Databases and Tables
-tabs list the full fetched explorer set (All still caps at
-`EXPLORER_GROUP_MAX`). Query tokens highlight in titles and descriptions
-(`HighlightText` + `matchRanges`).
+(**All / Pages / Databases / Tables / Actions**, `h-9 px-3` with strip
+`px-3 pt-1.5`): Pages is a sidebar-like tree (group heading + one
+continuous left rail on the group's item list, not a broken per-row
+border); Databases and Tables tabs list the full fetched explorer set
+(All still caps at `EXPLORER_GROUP_MAX`). Query tokens highlight in
+titles and descriptions (`HighlightText` + `matchRanges`).
 
 Leave `engines` **absent** on the Tools parent and children. Absent already
 means the default source-engine family, so `filterMenuItemsByEngine` drops

--- a/docs/whats-new/v0.3.2.md
+++ b/docs/whats-new/v0.3.2.md
@@ -2,6 +2,11 @@
 version: 0.3.2
 date: 2026-08-12
 summary: A denser fleet view, a live MCP playground, and alert channels that start from what you already configured.
+screenshots:
+  - src: /assets/screenshots/mcp-server-dark.png
+    alt: MCP playground
+  - src: /assets/screenshots/data-explorer-new-dark.webp
+    alt: Data Explorer table overview
 ---
 
 - Alert channels show as a configured-first card grid.

--- a/docs/whats-new/v0.3.3.md
+++ b/docs/whats-new/v0.3.3.md
@@ -2,6 +2,11 @@
 version: 0.3.3
 date: 2026-08-16
 summary: Guest AI caps, simpler alerts, and pinned favorites you can drag.
+screenshots:
+  - src: /assets/screenshots/overview-insights-dark.webp
+    alt: Overview insights
+  - src: /assets/screenshots/query-heatmap-dark.webp
+    alt: Query activity heatmap
 ---
 
 - Cap and track guest AI usage on Cloud.


### PR DESCRIPTION
## Summary

Follow-up polish after the search palette tabs:

- What's new shows screenshot thumbnails; click to open full size in the same dialog
- Settings dialog is a bit larger (`42rem` / `max-w-4xl`)
- Mobile sidebar sheet matches the 16rem rail and uses tighter padding
- Search dialog nested pages use a continuous left rail; category tabs get more padding

## Changes

- `WhatsNewScreenshotGallery` + lightbox overlay
- Screenshot lists on v0.3.2 / v0.3.3 from existing product captures
- Mobile sheet `SIDEBAR_WIDTH_MOBILE=16rem`, `gap-0`, denser groups
- Command palette tabs `h-9 px-3`; tree rail on `cmdk-group-items`

## Test plan

- [ ] Open What's new, click a thumb, close overlay with X / click / Escape
- [ ] Settings dialog is taller and wider
- [ ] Phone/tablet: hamburger sidebar is not overly padded
- [ ] ⌘K Pages groups have one continuous left line; tabs have room around labels