### PR TITLE
fix(telemetry): hide empty and unknown ClickHouse flavors

### DIFF
--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -88,6 +88,7 @@ describe('GET / analytics page', () => {
     expect(html).toContain('ANDROID_SVG')
     expect(html).toContain("s === 'ios'")
     expect(html).toContain('UNKNOWN_SVG')
+    expect(html).toContain("['oss', 'altinity', 'cloud']")
     expect(html).not.toContain('dithered-bar')
   })
 })
@@ -176,6 +177,44 @@ describe('GET /v1/summary — double WHERE regression (#2466)', () => {
     expect(body.scoped_to_deploy_target).toBeNull()
     expect(body.total_installs).toBe(3)
     expect(body.total_places).toBe(2)
+  })
+
+  it('omits empty and unknown from by_ch_flavor (only oss/altinity/cloud)', async () => {
+    seed()
+    const insert = db.query(
+      `INSERT INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    insert.run('2026-07-02', hex64('d'), 'docker', '24.8', '', 'us', 'linux', '0.3.1', null)
+    insert.run(
+      '2026-07-02',
+      hex64('e'),
+      'docker',
+      '24.8',
+      'unknown',
+      'us',
+      'linux',
+      '0.3.1',
+      null
+    )
+    const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }
+    const res = await worker.fetch(
+      new Request('https://telemetry.chmonitor.dev/v1/summary'),
+      env,
+      makeCtx()
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      by_ch_flavor: { ch_flavor: string; installs: number }[]
+    }
+    expect(body.by_ch_flavor.map((r) => r.ch_flavor).sort()).toEqual([
+      'altinity',
+      'oss',
+    ])
+    expect(body.by_ch_flavor.find((r) => r.ch_flavor === 'oss')?.installs).toBe(2)
+    expect(body.by_ch_flavor.some((r) => r.ch_flavor === '' || r.ch_flavor === 'unknown')).toBe(
+      false
+    )
   })
 
   it('returns 200 (not 500) for ?deploy_target=docker and scopes total_places', async () => {

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -353,7 +353,7 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
         `SELECT COALESCE(ch_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
       ).all<{ v: string; n: number }>(),
       stmt(
-        `SELECT COALESCE(ch_flavor, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+        `SELECT COALESCE(NULLIF(TRIM(ch_flavor), ''), 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
       ).all<{ v: string; n: number }>(),
       stmt(
         `SELECT COALESCE(country, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC LIMIT 10`
@@ -386,10 +386,14 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
           ch_version: r.v,
           installs: Number(r.n),
         })),
-        byChFlavor: (byFlavor.results ?? []).map((r) => ({
-          ch_flavor: r.v,
-          installs: Number(r.n),
-        })),
+        byChFlavor: (byFlavor.results ?? [])
+          .map((r) => ({
+            ch_flavor: r.v,
+            installs: Number(r.n),
+          }))
+          // Empty / unknown mean "not reported" — not a flavor. The chart
+          // should only list oss / altinity / cloud.
+          .filter((r) => CH_FLAVORS.has(r.ch_flavor) && r.ch_flavor !== 'unknown'),
         byCountry: (byCountry.results ?? []).map((r) => ({
           country: r.v,
           installs: Number(r.n),

--- a/apps/telemetry/src/page.ts
+++ b/apps/telemetry/src/page.ts
@@ -419,9 +419,12 @@ export const TELEMETRY_PAGE = `<!DOCTYPE html>
         renderBarChart('chm-versions', data.by_chm_version || [])
         renderBarChart('countries', data.by_country)
         renderBarChart('platforms', data.by_platform)
-        if (data.by_ch_flavor && data.by_ch_flavor.length > 0) {
+        const flavors = (data.by_ch_flavor || []).filter((f) =>
+          ['oss', 'altinity', 'cloud'].includes(String(f.ch_flavor))
+        )
+        if (flavors.length > 0) {
           document.getElementById('ch-flavor-section').style.display = 'block'
-          renderBarChart('ch-flavors', data.by_ch_flavor)
+          renderBarChart('ch-flavors', flavors)
         }
 
         const cli = data.cli || {}


### PR DESCRIPTION
## Summary

ClickHouse Flavors was listing **empty** and **Unknown** next to ClickHouse OSS and Altinity. Those rows are pings that never sent a flavor (the column was added later, or the client sent nothing) — not real flavors.

## Changes

- Group empty `ch_flavor` with `unknown` in the summary query
- Drop empty/unknown from `by_ch_flavor` so only `oss` / `altinity` / `cloud` remain
- Same filter on the public chart

## Test plan

- [x] `cd apps/telemetry && bun test src/ --isolate`
- [ ] After deploy, Flavors chart shows only ClickHouse OSS / Altinity / Cloud (if present)

---

Co-Authored-By: duyetbot <bot@duyet.net>