### PR TITLE
fix(telemetry): merge empty and unknown ClickHouse versions

### DIFF
--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -217,6 +217,41 @@ describe('GET /v1/summary — double WHERE regression (#2466)', () => {
     )
   })
 
+  it('merges empty and unknown ClickHouse versions into one unknown bucket', async () => {
+    seed()
+    const insert = db.query(
+      `INSERT INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    insert.run('2026-07-02', hex64('d'), 'docker', '', 'oss', 'us', 'linux', '0.3.1', null)
+    insert.run(
+      '2026-07-02',
+      hex64('e'),
+      'docker',
+      'unknown',
+      'oss',
+      'us',
+      'linux',
+      '0.3.1',
+      null
+    )
+    const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }
+    const res = await worker.fetch(
+      new Request('https://telemetry.chmonitor.dev/v1/summary'),
+      env,
+      makeCtx()
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      by_ch_version: { ch_version: string; installs: number }[]
+    }
+    const versions = body.by_ch_version.map((r) => r.ch_version)
+    expect(versions).not.toContain('')
+    expect(versions.filter((v) => v === 'unknown')).toHaveLength(1)
+    expect(body.by_ch_version.find((r) => r.ch_version === 'unknown')?.installs).toBe(2)
+    expect(body.by_ch_version.find((r) => r.ch_version === '24.8')?.installs).toBe(2)
+  })
+
   it('returns 200 (not 500) for ?deploy_target=docker and scopes total_places', async () => {
     seed()
     const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -350,7 +350,7 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
         )
         .all<{ deploy_target: string; n: number }>(),
       stmt(
-        `SELECT COALESCE(ch_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+        `SELECT COALESCE(NULLIF(TRIM(ch_version), ''), 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
       ).all<{ v: string; n: number }>(),
       stmt(
         `SELECT COALESCE(NULLIF(TRIM(ch_flavor), ''), 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`

--- a/apps/telemetry/src/page.ts
+++ b/apps/telemetry/src/page.ts
@@ -410,8 +410,9 @@ export const TELEMETRY_PAGE = `<!DOCTYPE html>
           const share = data.total_installs > 0 ? Math.round((topTarget.installs / data.total_installs) * 100) : 0
           document.getElementById('top-target-sub').textContent = share + '% of installs'
         }
-        renderBarChart('ch-versions', data.by_ch_version)
-        const topVersion = [...(data.by_ch_version || [])].filter(v => v.ch_version !== 'unknown').sort((a, b) => b.installs - a.installs)[0]
+        const chVersions = collapseBlankUnknown(data.by_ch_version || [], 'ch_version')
+        renderBarChart('ch-versions', chVersions)
+        const topVersion = [...chVersions].filter(v => v.ch_version !== 'unknown').sort((a, b) => b.installs - a.installs)[0]
         if (topVersion) {
           document.getElementById('top-version').textContent = topVersion.ch_version
           document.getElementById('top-version-sub').textContent = topVersion.installs.toLocaleString() + ' installs'
@@ -441,6 +442,18 @@ export const TELEMETRY_PAGE = `<!DOCTYPE html>
         error.style.display = 'block'
         error.textContent = 'Failed to load analytics: ' + err.message
       }
+    }
+
+    function collapseBlankUnknown(rows, key) {
+      const merged = new Map()
+      for (const row of rows) {
+        const raw = String(row[key] ?? '').trim()
+        const k = !raw || raw.toLowerCase() === 'unknown' ? 'unknown' : raw
+        const prev = merged.get(k) || { ...row, [key]: k, installs: 0 }
+        prev.installs += Number(row.installs) || 0
+        merged.set(k, prev)
+      }
+      return [...merged.values()]
     }
 
     function renderBarChart(containerId, data, sortByValue = true) {


### PR DESCRIPTION
## Summary

ClickHouse Versions listed a blank row and **Unknown** separately. Both mean the ping had no version. They now merge into one Unknown bucket.

## Changes

- Summary SQL: `COALESCE(NULLIF(TRIM(ch_version), ''), 'unknown')`
- Chart also collapses blank/`unknown` so a cached API response still shows one row

## Test plan

- [x] `cd apps/telemetry && bun test src/ --isolate`
- [ ] After deploy, Versions chart has one Unknown row, not empty + Unknown

---

Co-Authored-By: duyetbot <bot@duyet.net>