### PR TITLE
fix(telemetry): merge empty and unknown chmonitor versions

### DIFF
--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -252,6 +252,41 @@ describe('GET /v1/summary — double WHERE regression (#2466)', () => {
     expect(body.by_ch_version.find((r) => r.ch_version === '24.8')?.installs).toBe(2)
   })
 
+  it('merges empty and unknown chmonitor versions into one unknown bucket', async () => {
+    seed()
+    const insert = db.query(
+      `INSERT INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    insert.run('2026-07-02', hex64('d'), 'docker', '24.8', 'oss', 'us', 'linux', '', null)
+    insert.run(
+      '2026-07-02',
+      hex64('e'),
+      'docker',
+      '24.8',
+      'oss',
+      'us',
+      'linux',
+      'unknown',
+      null
+    )
+    const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }
+    const res = await worker.fetch(
+      new Request('https://telemetry.chmonitor.dev/v1/summary'),
+      env,
+      makeCtx()
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      by_chm_version: { chm_version: string; installs: number }[]
+    }
+    const versions = body.by_chm_version.map((r) => r.chm_version)
+    expect(versions).not.toContain('')
+    expect(versions.filter((v) => v === 'unknown')).toHaveLength(1)
+    expect(body.by_chm_version.find((r) => r.chm_version === 'unknown')?.installs).toBe(2)
+    expect(body.by_chm_version.find((r) => r.chm_version === '0.3.1')?.installs).toBe(2)
+  })
+
   it('returns 200 (not 500) for ?deploy_target=docker and scopes total_places', async () => {
     seed()
     const env: Env = { CHM_TELEMETRY_DB: makeMockD1(db) }

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -362,7 +362,7 @@ async function handleSummary(env: Env, req: Request): Promise<Response> {
         `SELECT COALESCE(platform, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
       ).all<{ v: string; n: number }>(),
       stmt(
-        `SELECT COALESCE(chm_version, 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
+        `SELECT COALESCE(NULLIF(TRIM(chm_version), ''), 'unknown') AS v, COUNT(DISTINCT instance_hash) AS n FROM ping_daily ${where} GROUP BY v ORDER BY n DESC`
       ).all<{ v: string; n: number }>(),
       stmt(
         `SELECT COUNT(DISTINCT install_place) AS n FROM ping_daily ${installPlacesWhere}`

--- a/apps/telemetry/src/page.ts
+++ b/apps/telemetry/src/page.ts
@@ -417,7 +417,7 @@ export const TELEMETRY_PAGE = `<!DOCTYPE html>
           document.getElementById('top-version').textContent = topVersion.ch_version
           document.getElementById('top-version-sub').textContent = topVersion.installs.toLocaleString() + ' installs'
         }
-        renderBarChart('chm-versions', data.by_chm_version || [])
+        renderBarChart('chm-versions', collapseBlankUnknown(data.by_chm_version || [], 'chm_version'))
         renderBarChart('countries', data.by_country)
         renderBarChart('platforms', data.by_platform)
         const flavors = (data.by_ch_flavor || []).filter((f) =>


### PR DESCRIPTION
## Summary

chmonitor Versions listed a blank row and Unknown separately. Both mean no product version was reported. They now merge into one Unknown bucket.

## Changes

- Summary SQL coalesces empty `chm_version` to `unknown`
- Chart uses the same blank/unknown collapse as ClickHouse versions

## Test plan

- [x] `cd apps/telemetry && bun test src/ --isolate`
- [ ] After deploy, chmonitor Versions has one Unknown row

---

Co-Authored-By: duyetbot <bot@duyet.net>