### PR TITLE
fix(telemetry): accurate instance ping dimensions

### DIFF
--- a/apps/dashboard/src/lib/telemetry/environment.test.ts
+++ b/apps/dashboard/src/lib/telemetry/environment.test.ts
@@ -30,6 +30,10 @@ describe('parseMajorMinor', () => {
   test('returns undefined for non-version strings', () => {
     expect(parseMajorMinor('not-a-version')).toBeUndefined()
   })
+
+  test('extracts major.minor when a prefix is present', () => {
+    expect(parseMajorMinor('ClickHouse 24.8.1.2')).toBe('24.8')
+  })
 })
 
 describe('detectChFlavor', () => {
@@ -54,6 +58,12 @@ describe('detectChFlavor', () => {
 
   test('returns unknown for undefined', () => {
     expect(detectChFlavor(undefined)).toBe('unknown')
+  })
+
+  test('returns cloud when hostname is ClickHouse Cloud', () => {
+    expect(detectChFlavor('24.8.1.2', 'abc.us-east-1.aws.clickhouse.cloud')).toBe(
+      'cloud'
+    )
   })
 })
 

--- a/apps/dashboard/src/lib/telemetry/environment.ts
+++ b/apps/dashboard/src/lib/telemetry/environment.ts
@@ -28,9 +28,11 @@ export function getDeployTarget(): DeployTarget {
     if (VALID.includes(injected)) return injected
   }
 
-  // 2. Build-time env variable override
+  // 2. Build-time env variable override. 'unknown' is treated as unset so a
+  // defaulted vite `?? 'unknown'` does not skip hostname heuristics (that
+  // was tagging almost every ping as unknown).
   const raw = import.meta.env.VITE_DEPLOY_TARGET?.trim().toLowerCase()
-  const VALID: DeployTarget[] = ['docker', 'helm', 'cf', 'dev', 'unknown']
+  const VALID: DeployTarget[] = ['docker', 'helm', 'cf', 'dev']
   if (raw && (VALID as string[]).includes(raw)) return raw as DeployTarget
 
   // 3. Fallback: server-side process env inspection (SSR)
@@ -89,7 +91,7 @@ export function parseMajorMinor(
   version: string | null | undefined
 ): string | undefined {
   if (!version) return undefined
-  const match = version.match(/^(\d+)\.(\d+)/)
+  const match = version.match(/(\d+)\.(\d+)/)
   if (!match) return undefined
   return `${match[1]}.${match[2]}`
 }
@@ -106,11 +108,24 @@ export function parseMajorMinor(
  * normal 4-part versions). We do NOT guess 'cloud' here to avoid false
  * positives — if a reliable cloud marker is found in the future, add it then.
  */
-export function detectChFlavor(version: string | null | undefined): ChFlavor {
+export function detectChFlavor(
+  version: string | null | undefined,
+  hostname?: string | null
+): ChFlavor {
+  const host = hostname?.toLowerCase() ?? ''
+  if (
+    host.includes('clickhouse.cloud') ||
+    host.includes('.aws.clickhouse.') ||
+    host.includes('.gcp.clickhouse.') ||
+    host.includes('.azure.clickhouse.')
+  ) {
+    return 'cloud'
+  }
   if (!version) return 'unknown'
   if (version.toLowerCase().includes('altinity')) return 'altinity'
-  // Accept any string that starts with digits (a version number)
-  if (/^\d/.test(version.trim())) return 'oss'
+  if (version.toLowerCase().includes('cloud')) return 'cloud'
+  // Accept any string that contains a leading version number
+  if (/\d+\.\d+/.test(version)) return 'oss'
   return 'unknown'
 }
 

--- a/apps/dashboard/src/lib/telemetry/instance-ping.ts
+++ b/apps/dashboard/src/lib/telemetry/instance-ping.ts
@@ -11,6 +11,7 @@
 //   - ClickHouse version is truncated to MAJOR.MINOR (e.g. '24.8') so it cannot
 //     be mistaken for an IPv4 address and cannot fingerprint a specific patch release.
 
+import { APP_VERSION } from '@/lib/whats-new/app-version'
 import { isTelemetryEnabled } from './config'
 import {
   detectChFlavor,
@@ -164,7 +165,10 @@ export interface PingDeps {
   /** Deploy target string */
   deployTarget: string
   /** Detect ClickHouse flavor (oss/altinity/cloud/unknown) */
-  detectFlavor: (version: string | null | undefined) => string
+  detectFlavor: (
+    version: string | null | undefined,
+    hostname?: string | null
+  ) => string
   /** Detect country from timezone (privacy-safe) */
   detectCountry: () => string
   /** Detect platform/OS from userAgent (generic categories only) */
@@ -245,7 +249,7 @@ export async function runInstancePing(deps: PingDeps): Promise<PingResult> {
   }
 
   const instanceHash = await hash(instanceId)
-  const chFlavor = version ? detectFlavor(version) : undefined
+  const chFlavor = detectFlavor(version, deps.chHostname)
   const country = detectCountry()
   const platform = detectPlatform()
   const installPlace = await computeInstallPlace()
@@ -384,8 +388,9 @@ export function maybePingInstance(
     detectFlavor: detectChFlavor,
     detectCountry: detectCountry,
     detectPlatform: detectPlatform,
-    // CHM product version from the build-time env var
-    chmVersion: import.meta.env.VITE_GIT_REF?.replace(/^v/, '') || undefined,
+    // Product version from package.json (semver). Git refs are not accepted
+    // by the collector and were stored as empty chm_version.
+    chmVersion: APP_VERSION.replace(/^v/, '') || undefined,
     licenseKey: getLicenseKey(runtimeEnv),
     resolveLicenseKey: fetchRuntimeLicenseKey,
     computeInstallPlace: async () => {

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -186,7 +186,7 @@ const CLIENT_ENV = {
   VITE_DO_NOT_TRACK: e.VITE_DO_NOT_TRACK ?? e.DO_NOT_TRACK ?? '',
   // Deployment target (docker | helm | cf | dev | unknown). Set in CI build
   // steps so telemetry can distinguish deployment environments.
-  VITE_DEPLOY_TARGET: e.VITE_DEPLOY_TARGET ?? 'unknown',
+  VITE_DEPLOY_TARGET: e.VITE_DEPLOY_TARGET ?? e.CHM_DEPLOY_TARGET ?? '',
   // Collection endpoint for the daily instance ping. Defaults to the project
   // collector (must match DEFAULT_TELEMETRY_ENDPOINT in lib/telemetry/instance-ping.ts);
   // set to a different URL to self-host, or to '' as a hard no-network kill-switch.

--- a/apps/telemetry/src/index.test.ts
+++ b/apps/telemetry/src/index.test.ts
@@ -567,6 +567,40 @@ describe('POST /v1/ping — optional license_key', () => {
     expect(row.license_key).toBe(POLAR_CHECKOUT_ID)
   })
 
+  it('upgrades an empty same-day ping when a later ping has version and flavor', async () => {
+    seed()
+    await post({
+      instance_hash: hex64('f'),
+      deploy_target: 'unknown',
+    })
+    await post({
+      instance_hash: hex64('f'),
+      deploy_target: 'docker',
+      ch_version: '24.8',
+      ch_flavor: 'oss',
+      chm_version: '0.3.3',
+      platform: 'linux',
+      country: 'us',
+    })
+    const row = db.query('SELECT * FROM ping_daily').get() as {
+      deploy_target: string
+      ch_version: string | null
+      ch_flavor: string | null
+      chm_version: string | null
+      platform: string | null
+      country: string | null
+    }
+    expect(db.query('SELECT COUNT(*) AS n FROM ping_daily').get()).toEqual({
+      n: 1,
+    })
+    expect(row.deploy_target).toBe('docker')
+    expect(row.ch_version).toBe('24.8')
+    expect(row.ch_flavor).toBe('oss')
+    expect(row.chm_version).toBe('0.3.3')
+    expect(row.platform).toBe('linux')
+    expect(row.country).toBe('us')
+  })
+
   it('stores null license_key when unset', async () => {
     seed()
     const res = await post({

--- a/apps/telemetry/src/index.ts
+++ b/apps/telemetry/src/index.ts
@@ -190,7 +190,28 @@ export default {
       const day = new Date().toISOString().slice(0, 10)
       ctx.waitUntil(
         env.CHM_TELEMETRY_DB.prepare(
-          'INSERT OR IGNORE INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place, license_key) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+          `INSERT INTO ping_daily (day, instance_hash, deploy_target, ch_version, ch_flavor, country, platform, chm_version, install_place, license_key)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(day, instance_hash) DO UPDATE SET
+             deploy_target = CASE
+               WHEN ping_daily.deploy_target IN ('unknown', '')
+                 AND excluded.deploy_target NOT IN ('unknown', '')
+               THEN excluded.deploy_target ELSE ping_daily.deploy_target END,
+             ch_version = COALESCE(NULLIF(ping_daily.ch_version, ''), excluded.ch_version),
+             ch_flavor = CASE
+               WHEN COALESCE(ping_daily.ch_flavor, 'unknown') IN ('unknown', '')
+                 AND COALESCE(excluded.ch_flavor, 'unknown') NOT IN ('unknown', '')
+               THEN excluded.ch_flavor
+               ELSE COALESCE(NULLIF(ping_daily.ch_flavor, ''), excluded.ch_flavor) END,
+             country = CASE
+               WHEN COALESCE(ping_daily.country, 'unknown') IN ('unknown', '')
+               THEN excluded.country ELSE ping_daily.country END,
+             platform = CASE
+               WHEN COALESCE(ping_daily.platform, 'unknown') IN ('unknown', '')
+               THEN excluded.platform ELSE ping_daily.platform END,
+             chm_version = COALESCE(NULLIF(ping_daily.chm_version, ''), excluded.chm_version),
+             install_place = COALESCE(NULLIF(ping_daily.install_place, ''), excluded.install_place),
+             license_key = COALESCE(NULLIF(ping_daily.license_key, ''), excluded.license_key)`
         )
           .bind(
             day,


### PR DESCRIPTION
## Summary

Public telemetry was mostly empty/unknown because the first ping of the day ran before a cluster connected, then \`INSERT OR IGNORE\` locked that blank row. Deploy target was also defaulted to \`unknown\` at build time, and product version was sent as a git ref the collector dropped.

## Changes

- Upsert same-day pings: fill \`ch_version\`, \`ch_flavor\`, \`chm_version\`, platform, country, and deploy target when a later ping has real values
- Send \`APP_VERSION\` (semver) instead of \`VITE_GIT_REF\`
- Treat vite \`unknown\` deploy target as unset and fall through to hostname heuristics (docker / cf / dev)
- Detect ClickHouse Cloud from hostname; parse MAJOR.MINOR even with a version prefix

## Test plan

- [x] \`cd apps/telemetry && bun test src/ --isolate\`
- [x] \`cd apps/dashboard && bun test src/lib/telemetry/ --isolate\`
- [ ] After deploy, new pings that later learn CH version update the same-day row

---

Co-Authored-By: duyetbot <bot@duyet.net>