### PR TITLE
feat(seo): list every public URL in sitemap.xml and llms.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,12 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/docs/pnpm-lock.yaml
 
+      # crawler-index.test.ts uses bun:test (same as blog/landing).
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/apps/blog/public/robots.txt
+++ b/apps/blog/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://blog.chmonitor.dev/sitemap.xml
 Sitemap: https://blog.chmonitor.dev/sitemap-index.xml

--- a/apps/blog/src/lib/crawler-index.test.ts
+++ b/apps/blog/src/lib/crawler-index.test.ts
@@ -1,0 +1,62 @@
+import type { CollectionEntry } from 'astro:content'
+
+import { buildLlmsTxt, buildSitemapXml } from './crawler-index'
+import { describe, expect, test } from 'bun:test'
+
+function post(
+  id: string,
+  data: Partial<CollectionEntry<'blog'>['data']> & { title: string }
+): CollectionEntry<'blog'> {
+  return {
+    id,
+    collection: 'blog',
+    data: {
+      description: data.description ?? 'desc',
+      date: data.date ?? new Date('2026-01-01'),
+      tag: data.tag ?? 'Release',
+      draft: data.draft ?? false,
+      version: data.version,
+      title: data.title,
+    },
+  } as CollectionEntry<'blog'>
+}
+
+describe('blog crawler index', () => {
+  const posts = [
+    post('v0.3', {
+      title: 'v0.3',
+      version: 'v0.3',
+      tag: 'Release',
+      date: new Date('2026-01-02'),
+    }),
+    post('too-many-parts', {
+      title: 'Too many parts',
+      tag: '5 min of ClickHouse',
+      date: new Date('2026-01-01'),
+    }),
+    post('future', {
+      title: 'Future',
+      date: new Date('2099-01-01'),
+    }),
+  ]
+
+  test('sitemap lists home, published posts, and categories — not future posts', () => {
+    const xml = buildSitemapXml(posts)
+    expect(xml).toContain('https://blog.chmonitor.dev/')
+    expect(xml).toContain('https://blog.chmonitor.dev/v0.3/')
+    expect(xml).toContain('https://blog.chmonitor.dev/too-many-parts/')
+    expect(xml).toContain(
+      'https://blog.chmonitor.dev/category/5-min-of-clickhouse/'
+    )
+    expect(xml).not.toContain('/future/')
+  })
+
+  test('llms.txt lists every published post and sister sites', () => {
+    const txt = buildLlmsTxt(posts)
+    expect(txt).toContain('# chmonitor blog')
+    expect(txt).toContain('[v0.3]')
+    expect(txt).toContain('## Categories')
+    expect(txt).toContain('https://docs.chmonitor.dev/llms.txt')
+    expect(txt).not.toContain('[Future]')
+  })
+})

--- a/apps/blog/src/lib/crawler-index.ts
+++ b/apps/blog/src/lib/crawler-index.ts
@@ -1,0 +1,83 @@
+import type { CollectionEntry } from 'astro:content'
+
+import { isPublished } from './published'
+import { postSlug, tagSlug } from './slug'
+
+const ORIGIN = 'https://blog.chmonitor.dev'
+
+export function publishedPosts(posts: CollectionEntry<'blog'>[]) {
+  return posts
+    .filter((p) => isPublished(p.data))
+    .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+}
+
+export function categoryPaths(posts: CollectionEntry<'blog'>[]): string[] {
+  const tags = [...new Set(publishedPosts(posts).map((p) => p.data.tag))]
+  return tags.map((tag) => `/category/${tagSlug(tag)}/`)
+}
+
+export function buildSitemapXml(
+  posts: CollectionEntry<'blog'>[],
+  origin = ORIGIN
+): string {
+  const locs = [
+    `${origin}/`,
+    ...publishedPosts(posts).map((p) => `${origin}/${postSlug(p)}/`),
+    ...categoryPaths(posts).map((path) => `${origin}${path}`),
+  ]
+  const unique = [...new Set(locs)]
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${unique.map((url) => `  <url><loc>${escapeXml(url)}</loc></url>`).join('\n')}
+</urlset>
+`
+}
+
+export function buildLlmsTxt(
+  posts: CollectionEntry<'blog'>[],
+  origin = ORIGIN
+): string {
+  const published = publishedPosts(posts)
+  const categories = [...new Set(published.map((p) => p.data.tag))].sort(
+    (a, b) => a.localeCompare(b)
+  )
+
+  const lines = [
+    '# chmonitor blog',
+    '',
+    'Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.',
+    '',
+    `> Latest: ${published[0]?.data.title ?? 'n/a'}`,
+    '',
+    `HTML sitemap: ${origin}/sitemap.xml`,
+    '',
+    '## Posts',
+    '',
+    ...published.map((post) => {
+      const url = `${origin}/${postSlug(post)}/`
+      return `- [${post.data.title}](${url}): ${post.data.description}`
+    }),
+    '',
+    '## Categories',
+    '',
+    ...categories.map(
+      (tag) => `- [${tag}](${origin}/category/${tagSlug(tag)}/)`
+    ),
+    '',
+    '## Other chmonitor sites',
+    '',
+    '- [Marketing](https://chmonitor.dev/llms.txt)',
+    '- [Docs](https://docs.chmonitor.dev/llms.txt)',
+    '- [Hosted dashboard](https://dash.chmonitor.dev)',
+    '',
+  ]
+  return lines.join('\n')
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}

--- a/apps/blog/src/pages/llms.txt.ts
+++ b/apps/blog/src/pages/llms.txt.ts
@@ -1,33 +1,12 @@
 import type { APIContext } from 'astro'
 
-import { isPublished } from '../lib/published'
-import { postSlug } from '../lib/slug'
+import { buildLlmsTxt } from '../lib/crawler-index'
 import { getCollection } from 'astro:content'
 
-// /llms.txt — structured index of all blog posts for AI crawlers.
-// Follows the llms.txt convention: https://llmstxt.org
-export async function GET(context: APIContext) {
-  const posts = (
-    await getCollection('blog', ({ data }) => isPublished(data))
-  ).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
-
-  const lines = [
-    '# chmonitor blog',
-    '',
-    'Release notes, product updates, how-to guides, and ClickHouse diagnostic deep-dives from the team building the open-source ClickHouse monitoring dashboard.',
-    '',
-    `> Latest: ${posts[0]?.data.title ?? 'n/a'}`,
-    '',
-    '## Posts',
-    '',
-    ...posts.map((post) => {
-      const url = new URL(`/${postSlug(post)}/`, context.site).toString()
-      return `- [${post.data.title}](${url}): ${post.data.description}`
-    }),
-    '',
-  ]
-
-  return new Response(lines.join('\n'), {
+// /llms.txt — every published post and category. https://llmstxt.org
+export async function GET(_context: APIContext) {
+  const posts = await getCollection('blog')
+  return new Response(buildLlmsTxt(posts), {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   })
 }

--- a/apps/blog/src/pages/sitemap.xml.ts
+++ b/apps/blog/src/pages/sitemap.xml.ts
@@ -1,0 +1,11 @@
+import type { APIContext } from 'astro'
+
+import { buildSitemapXml } from '../lib/crawler-index'
+import { getCollection } from 'astro:content'
+
+export async function GET(_context: APIContext) {
+  const posts = await getCollection('blog')
+  return new Response(buildSitemapXml(posts), {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  })
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
     "types:check": "fumadocs-mdx && tsc --noEmit",
-    "test": "node --test src/styles/*.test.mjs",
+    "test": "node --test src/styles/*.test.mjs && bun test src/lib/crawler-index.test.ts",
     "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {

--- a/apps/docs/src/lib/crawler-index.test.ts
+++ b/apps/docs/src/lib/crawler-index.test.ts
@@ -1,0 +1,59 @@
+import {
+  absoluteDocUrl,
+  buildLlmsTxt,
+  buildSitemapXml,
+  markdownUrl,
+  sectionOf,
+} from './crawler-index'
+import { describe, expect, test } from 'bun:test'
+
+const pages = [
+  {
+    url: '/',
+    title: 'Introduction',
+    description: 'What chmonitor is.',
+  },
+  {
+    url: '/guide/guides/clickhouse-grant-syntax',
+    title: 'GRANT syntax',
+    description: 'CREATE vs CREATE TABLE.',
+  },
+  {
+    url: '/operate/deploy/docker',
+    title: 'Docker',
+    description: 'Compose deploy.',
+  },
+  {
+    url: '/reference/faq',
+    title: 'FAQ',
+  },
+]
+
+describe('crawler-index', () => {
+  test('sitemap lists origin and every HTML page', () => {
+    const xml = buildSitemapXml(pages)
+    expect(xml).toContain('<loc>https://docs.chmonitor.dev</loc>')
+    expect(xml).toContain(
+      '<loc>https://docs.chmonitor.dev/guide/guides/clickhouse-grant-syntax</loc>'
+    )
+    expect(xml).not.toContain('.md</loc>')
+  })
+
+  test('llms.txt lists every page plus markdown twin', () => {
+    const txt = buildLlmsTxt(pages)
+    expect(txt).toContain('# chmonitor documentation')
+    expect(txt).toContain('## Guide')
+    expect(txt).toContain('## Deploy & operate')
+    expect(txt).toContain('## Reference')
+    expect(txt).toContain('clickhouse-grant-syntax.md')
+    expect(txt).toContain('https://docs.chmonitor.dev/index.md')
+    expect(txt).toContain('https://chmonitor.dev/llms.txt')
+  })
+
+  test('url helpers', () => {
+    expect(absoluteDocUrl('/guide')).toBe('https://docs.chmonitor.dev/guide')
+    expect(markdownUrl('/')).toBe('https://docs.chmonitor.dev/index.md')
+    expect(sectionOf('/operate/deploy')).toBe('Deploy & operate')
+    expect(sectionOf('/')).toBe('Guide')
+  })
+})

--- a/apps/docs/src/lib/crawler-index.ts
+++ b/apps/docs/src/lib/crawler-index.ts
@@ -1,0 +1,101 @@
+import { siteUrl } from './shared'
+
+export type CrawlerPage = {
+  url: string
+  title?: string
+  description?: string
+}
+
+export function absoluteDocUrl(pageUrl: string, origin = siteUrl): string {
+  if (pageUrl.startsWith('http')) return pageUrl
+  const path = pageUrl === '/' ? '' : pageUrl
+  return `${origin}${path}`
+}
+
+export function markdownUrl(pageUrl: string, origin = siteUrl): string {
+  const path = pageUrl === '/' || pageUrl === '' ? '/index.md' : `${pageUrl}.md`
+  return `${origin}${path}`
+}
+
+export function sectionOf(pageUrl: string): string {
+  const first = pageUrl.replace(/^\//, '').split('/')[0]
+  if (first === 'guide' || first === '') return 'Guide'
+  if (first === 'operate') return 'Deploy & operate'
+  if (first === 'reference') return 'Reference'
+  return 'Docs'
+}
+
+export function buildSitemapXml(
+  pages: CrawlerPage[],
+  origin = siteUrl
+): string {
+  const locs = new Set<string>()
+  locs.add(origin)
+  for (const page of pages) {
+    locs.add(absoluteDocUrl(page.url, origin))
+  }
+  const urls = [...locs].sort()
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.map((url) => `  <url><loc>${escapeXml(url)}</loc></url>`).join('\n')}
+</urlset>
+`
+}
+
+export function buildLlmsTxt(pages: CrawlerPage[], origin = siteUrl): string {
+  const sorted = [...pages].sort((a, b) => a.url.localeCompare(b.url))
+  const groups = new Map<string, CrawlerPage[]>()
+  for (const page of sorted) {
+    const section = sectionOf(page.url)
+    const list = groups.get(section) ?? []
+    list.push(page)
+    groups.set(section, list)
+  }
+
+  const lines = [
+    '# chmonitor documentation',
+    '',
+    '> Read-only ClickHouse monitoring dashboard with an AI agent and MCP server. Deploy on Docker, Kubernetes, or Cloudflare Workers.',
+    '',
+    `Full concatenated markdown: ${origin}/llms-full.txt`,
+    `HTML sitemap: ${origin}/sitemap.xml`,
+    '',
+    'Each page is also available as markdown by appending `.md` (example: `/guide/getting-started.md`).',
+    '',
+  ]
+
+  for (const section of ['Guide', 'Deploy & operate', 'Reference', 'Docs']) {
+    const list = groups.get(section)
+    if (!list?.length) continue
+    lines.push(`## ${section}`, '')
+    for (const page of list) {
+      const href = absoluteDocUrl(page.url, origin)
+      const title = page.title?.trim() || href
+      const desc = page.description?.trim()
+      lines.push(
+        desc ? `- [${title}](${href}): ${desc}` : `- [${title}](${href})`
+      )
+      lines.push(`  - markdown: ${markdownUrl(page.url, origin)}`)
+    }
+    lines.push('')
+  }
+
+  lines.push(
+    '## Other chmonitor sites',
+    '',
+    '- [Marketing site](https://chmonitor.dev/llms.txt)',
+    '- [Blog](https://blog.chmonitor.dev/llms.txt)',
+    '- [Hosted dashboard](https://dash.chmonitor.dev)',
+    ''
+  )
+
+  return lines.join('\n')
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}

--- a/apps/docs/src/routes/llms[.]txt.ts
+++ b/apps/docs/src/routes/llms[.]txt.ts
@@ -1,15 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { llms } from 'fumadocs-core/source'
+import { buildLlmsTxt } from '@/lib/crawler-index'
 import { source } from '@/lib/source'
 
-// /llms.txt — structured index of all documentation pages for AI crawlers.
+// /llms.txt — every documentation page (title, URL, description, .md twin).
 // Follows the llms.txt convention: https://llmstxt.org
 export const Route = createFileRoute('/llms.txt')({
   server: {
     handlers: {
       GET() {
-        return new Response(llms(source).index(), {
+        const pages = source.getPages().map((page) => ({
+          url: page.url,
+          title: page.data.title,
+          description: page.data.description,
+        }))
+        return new Response(buildLlmsTxt(pages), {
           headers: { 'Content-Type': 'text/plain; charset=utf-8' },
         })
       },

--- a/apps/docs/src/routes/sitemap[.]xml.ts
+++ b/apps/docs/src/routes/sitemap[.]xml.ts
@@ -1,24 +1,20 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { siteUrl } from '@/lib/shared'
+import { buildSitemapXml } from '@/lib/crawler-index'
 import { source } from '@/lib/source'
 
-// /sitemap.xml — the home page plus every documentation page, for search
-// engine crawlers. robots.txt points here.
+// /sitemap.xml — every documentation HTML page, for search engine crawlers.
+// robots.txt points here.
 export const Route = createFileRoute('/sitemap.xml')({
   server: {
     handlers: {
       GET() {
-        const urls = [
-          siteUrl,
-          ...source.getPages().map((page) => `${siteUrl}${page.url}`),
-        ]
-        const body = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map((url) => `  <url><loc>${url}</loc></url>`).join('\n')}
-</urlset>
-`
-        return new Response(body, {
+        const pages = source.getPages().map((page) => ({
+          url: page.url,
+          title: page.data.title,
+          description: page.data.description,
+        }))
+        return new Response(buildSitemapXml(pages), {
           headers: { 'Content-Type': 'application/xml; charset=utf-8' },
         })
       },

--- a/apps/landing/public/robots.txt
+++ b/apps/landing/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://chmonitor.dev/sitemap.xml
 Sitemap: https://chmonitor.dev/sitemap-index.xml

--- a/apps/landing/src/lib/site-urls.test.ts
+++ b/apps/landing/src/lib/site-urls.test.ts
@@ -1,0 +1,33 @@
+import { FEATURE_PAGES } from '../data/feature-pages'
+import { allLandingPages, buildLlmsTxt, buildSitemapXml } from './site-urls'
+import { describe, expect, test } from 'bun:test'
+
+describe('landing crawler index', () => {
+  test('lists every static page and feature slug', () => {
+    const pages = allLandingPages()
+    const paths = pages.map((p) => p.path)
+    expect(paths).toContain('/')
+    expect(paths).toContain('/pricing')
+    expect(paths).toContain('/vs-datadog')
+    expect(paths).toContain('/clickhouse-vs-druid-pinot')
+    for (const feature of FEATURE_PAGES) {
+      expect(paths).toContain(`/features/${feature.slug}`)
+    }
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  test('sitemap.xml is a urlset of every loc', () => {
+    const xml = buildSitemapXml()
+    expect(xml).toContain('https://chmonitor.dev/features/ai-agent')
+    expect(xml.startsWith('<?xml')).toBe(true)
+    expect(xml).toContain('</urlset>')
+  })
+
+  test('llms.txt lists every page and sister sites', () => {
+    const txt = buildLlmsTxt()
+    expect(txt).toContain('# chmonitor')
+    expect(txt).toContain('https://docs.chmonitor.dev/llms.txt')
+    expect(txt).toContain('https://blog.chmonitor.dev/llms.txt')
+    expect(txt).toContain('/features/postgres')
+  })
+})

--- a/apps/landing/src/lib/site-urls.ts
+++ b/apps/landing/src/lib/site-urls.ts
@@ -1,0 +1,175 @@
+import { FEATURE_PAGES } from '../data/feature-pages'
+
+export type ListedPage = {
+  path: string
+  title: string
+  description: string
+}
+
+const ORIGIN = 'https://chmonitor.dev'
+
+/** Static marketing routes (not 404). Feature slugs come from FEATURE_PAGES. */
+export const STATIC_PAGES: ListedPage[] = [
+  {
+    path: '/',
+    title: 'chmonitor',
+    description:
+      'Open-source ClickHouse monitoring dashboard with an AI agent.',
+  },
+  {
+    path: '/pricing',
+    title: 'Pricing',
+    description: 'Self-hosted licenses and hosted cloud pricing.',
+  },
+  {
+    path: '/changelog',
+    title: 'Changelog',
+    description: 'What shipped in each chmonitor release.',
+  },
+  {
+    path: '/cli',
+    title: 'CLI',
+    description: 'chm / chmonitor terminal client.',
+  },
+  {
+    path: '/customers',
+    title: 'Customers',
+    description: 'Who runs ClickHouse with chmonitor.',
+  },
+  {
+    path: '/brand',
+    title: 'Brand',
+    description: 'Logos and brand assets.',
+  },
+  {
+    path: '/performance',
+    title: 'Performance',
+    description: 'How chmonitor stays fast on large clusters.',
+  },
+  {
+    path: '/cluster-health',
+    title: 'Cluster health',
+    description: 'Replication, merges, and node health views.',
+  },
+  {
+    path: '/monitor-queries',
+    title: 'Monitor queries',
+    description: 'Running, slow, and failed ClickHouse queries.',
+  },
+  {
+    path: '/replication',
+    title: 'Replication',
+    description: 'Replication lag and replica health.',
+  },
+  {
+    path: '/vs-datadog',
+    title: 'chmonitor vs Datadog',
+    description: 'ClickHouse-native monitoring compared to Datadog.',
+  },
+  {
+    path: '/vs-grafana',
+    title: 'chmonitor vs Grafana',
+    description: 'Dedicated ClickHouse ops UI vs Grafana panels.',
+  },
+  {
+    path: '/vs-clickhouse-cloud',
+    title: 'chmonitor vs ClickHouse Cloud console',
+    description: 'Monitoring your own clusters vs the Cloud console.',
+  },
+  {
+    path: '/clickhouse-vs-postgres',
+    title: 'ClickHouse vs Postgres',
+    description: 'When analytics belongs in ClickHouse.',
+  },
+  {
+    path: '/clickhouse-vs-timescaledb',
+    title: 'ClickHouse vs TimescaleDB',
+    description: 'OLAP vs time-series Postgres.',
+  },
+  {
+    path: '/clickhouse-vs-druid-pinot',
+    title: 'ClickHouse vs Druid vs Pinot',
+    description: 'Real-time OLAP engine comparison.',
+  },
+  {
+    path: '/license/lookup',
+    title: 'License lookup',
+    description: 'Look up a self-hosted license key.',
+  },
+  {
+    path: '/license/register',
+    title: 'Register license',
+    description: 'Register a self-hosted license.',
+  },
+]
+
+export function allLandingPages(): ListedPage[] {
+  const features: ListedPage[] = FEATURE_PAGES.map((p) => ({
+    path: `/features/${p.slug}`,
+    title: p.h1,
+    description: p.description,
+  }))
+  const seen = new Set<string>()
+  const out: ListedPage[] = []
+  for (const page of [...STATIC_PAGES, ...features]) {
+    if (seen.has(page.path)) continue
+    seen.add(page.path)
+    out.push(page)
+  }
+  return out.sort((a, b) => a.path.localeCompare(b.path))
+}
+
+export function absoluteUrl(path: string, origin = ORIGIN): string {
+  if (path === '/') return origin
+  return `${origin}${path}`
+}
+
+export function buildSitemapXml(
+  pages = allLandingPages(),
+  origin = ORIGIN
+): string {
+  const urls = pages.map((p) => absoluteUrl(p.path, origin))
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.map((url) => `  <url><loc>${escapeXml(url)}</loc></url>`).join('\n')}
+</urlset>
+`
+}
+
+export function buildLlmsTxt(
+  pages = allLandingPages(),
+  origin = ORIGIN
+): string {
+  const lines = [
+    '# chmonitor',
+    '',
+    '> Open-source ClickHouse monitoring dashboard — queries, storage, cluster health, AI agent, and MCP. Same codebase for self-hosted and cloud.',
+    '',
+    `HTML sitemap: ${origin}/sitemap.xml`,
+    '',
+    '## Marketing pages',
+    '',
+    ...pages.map((p) => {
+      const href = absoluteUrl(p.path, origin)
+      return `- [${p.title}](${href}): ${p.description}`
+    }),
+    '',
+    '## Documentation, blog, product',
+    '',
+    '- [Docs (every page)](https://docs.chmonitor.dev/llms.txt)',
+    '- [Docs full markdown](https://docs.chmonitor.dev/llms-full.txt)',
+    '- [Blog (every post)](https://blog.chmonitor.dev/llms.txt)',
+    '- [Hosted dashboard](https://dash.chmonitor.dev)',
+    '- [GitHub](https://github.com/chmonitor/chmonitor)',
+    '',
+  ]
+  return lines.join('\n')
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}

--- a/apps/landing/src/pages/llms.txt.ts
+++ b/apps/landing/src/pages/llms.txt.ts
@@ -1,0 +1,9 @@
+import type { APIContext } from 'astro'
+
+import { buildLlmsTxt } from '../lib/site-urls'
+
+export function GET(_context: APIContext) {
+  return new Response(buildLlmsTxt(), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}

--- a/apps/landing/src/pages/sitemap.xml.ts
+++ b/apps/landing/src/pages/sitemap.xml.ts
@@ -1,0 +1,9 @@
+import type { APIContext } from 'astro'
+
+import { buildSitemapXml } from '../lib/site-urls'
+
+export function GET(_context: APIContext) {
+  return new Response(buildSitemapXml(), {
+    headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
## Summary

Docs, landing, and blog now each expose a complete `/sitemap.xml` (every HTML URL) and `/llms.txt` (every page with title + description). Docs llms.txt also lists the `.md` twin per page. `robots.txt` points at `sitemap.xml`.

## Changes

- Docs: custom sitemap + llms from `source.getPages()` (no fumadocs subset)
- Landing: `/sitemap.xml` + `/llms.txt` covering static pages and every `/features/<slug>`
- Blog: `/sitemap.xml` of published posts + categories; llms.txt lists the same
- Cross-links between marketing, docs, blog, and dash in each llms.txt
- Unit tests for the three builders

## Test plan

- [x] `bun test` on docs/landing/blog crawler-index tests
- [ ] Docs/landing/blog CI builds
- [ ] After deploy: `curl https://docs.chmonitor.dev/sitemap.xml` and `/llms.txt`

Co-Authored-By: duyetbot <bot@duyet.net>