### PR TITLE
feat(blog): marketing llms listing and CI preview

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -39,8 +39,32 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/blog/pnpm-lock.yaml
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test
+        run: pnpm test
+
+      - name: Generate OG images
+        run: pnpm run build:og
+
       - name: Build
         run: pnpm run build
+
+      - name: Preview smoke
+        run: |
+          set -euo pipefail
+          SERVER_PID=""
+          trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null' EXIT
+          pnpm run preview -- --host 127.0.0.1 --port 4322 &
+          SERVER_PID=$!
+          npx --yes wait-on http://127.0.0.1:4322 --timeout 30000
+          curl -fsS http://127.0.0.1:4322/ >/dev/null
+          curl -fsS http://127.0.0.1:4322/sitemap.xml | grep -q '<urlset'
+          curl -fsS http://127.0.0.1:4322/llms.txt | grep -q 'chmonitor blog'
+          echo "preview smoke ok"

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -31,10 +31,10 @@ permissions:
 
 # ────────────────────────────────────────────────────────────────────────────
 # Per-worker path change-detection (dorny/paths-filter, mirrors
-# cargo-publish.yml). This workflow deploys 6 workers across 4 jobs — dashboard
-# / mcp / telemetry (in the `dashboard` job), plus `landing`, `docs`,
+# cargo-publish.yml). This workflow deploys 7 workers across 5 jobs — dashboard
+# / mcp / telemetry (in the `dashboard` job), plus `landing`, `docs`, `blog`,
 # `bug-handler`. Without filtering, every push to main and every PR rebuilt &
-# redeployed all 6. Each job now runs a `filter` step and gates its own
+# redeployed all 7. Each job now runs a `filter` step and gates its own
 # build/deploy steps so a worker is touched ONLY when its own app dir (or a
 # shared dep — packages/**, root lockfile, this workflow) changed. Landing also
 # rebuilds when `apps/blog/src/content/blog/**` changes: the hero pill is the
@@ -525,6 +525,7 @@ jobs:
               '| **MCP** | https://preview.dash.chmonitor.dev/api/mcp |',
               '| **Landing** | https://preview.chmonitor.dev |',
               '| **Docs** | https://preview.docs.chmonitor.dev |',
+              '| **Blog** | https://preview.blog.chmonitor.dev |',
               '| **Telemetry** | https://preview.telemetry.chmonitor.dev |',
               '',
               `| Property | Value |`,
@@ -793,7 +794,20 @@ jobs:
           filters: |
             blog:
               - 'apps/blog/**'
+              - 'assets/**'
+              - 'scripts/sync-shared-assets.mjs'
+              - 'scripts/og-builder.ts'
               - '.github/workflows/cloudflare.yml'
+
+      - name: Setup Bun
+        if: >-
+          steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
 
       - name: Install dependencies
         if: >-
@@ -802,6 +816,22 @@ jobs:
           github.event_name == 'release' ||
           github.ref_type == 'tag'
         run: pnpm install --frozen-lockfile
+
+      - name: Generate OG images
+        if: >-
+          steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag'
+        run: pnpm run build:og
+
+      - name: Test
+        if: >-
+          steps.filter.outputs.blog == 'true' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'release' ||
+          github.ref_type == 'tag'
+        run: pnpm test
 
       - name: Build
         if: >-

--- a/apps/landing/src/lib/latest-blog-post.ts
+++ b/apps/landing/src/lib/latest-blog-post.ts
@@ -32,30 +32,33 @@ export type LatestBlogPostOptions = {
  * This is build-time. The Cloudflare landing job must rebuild when blog
  * markdown changes (see `.github/workflows/cloudflare.yml` landing filter).
  */
-export function getLatestBlogPost(
+export function getPublishedBlogPosts(
   options: LatestBlogPostOptions = {}
-): LatestBlogPost | null {
+): LatestBlogPost[] {
   const dir = options.dir ?? resolveBlogContentDir()
-  if (!dir) return null
+  if (!dir) return []
   const now = options.now?.valueOf() ?? Date.now()
-
-  let latest: LatestBlogPost | null = null
+  const posts: LatestBlogPost[] = []
   for (const name of readdirSync(dir)) {
     if (!name.endsWith('.md')) continue
     const parsed = parseBlogPostFile(join(dir, name), name)
     if (!parsed) continue
     if (!isPublished(parsed, now)) continue
-    if (!latest || parsed.date.valueOf() > latest.date.valueOf()) {
-      latest = {
-        title: parsed.title,
-        description: parsed.description,
-        date: parsed.date,
-        slug: parsed.slug,
-        href: parsed.href,
-      }
-    }
+    posts.push({
+      title: parsed.title,
+      description: parsed.description,
+      date: parsed.date,
+      slug: parsed.slug,
+      href: parsed.href,
+    })
   }
-  return latest
+  return posts.sort((a, b) => b.date.valueOf() - a.date.valueOf())
+}
+
+export function getLatestBlogPost(
+  options: LatestBlogPostOptions = {}
+): LatestBlogPost | null {
+  return getPublishedBlogPosts(options)[0] ?? null
 }
 
 export function resolveBlogContentDir(): string | null {

--- a/apps/landing/src/lib/site-urls.test.ts
+++ b/apps/landing/src/lib/site-urls.test.ts
@@ -23,11 +23,13 @@ describe('landing crawler index', () => {
     expect(xml).toContain('</urlset>')
   })
 
-  test('llms.txt lists every page and sister sites', () => {
+  test('llms.txt lists every page, sister sites, and published blog posts', () => {
     const txt = buildLlmsTxt()
     expect(txt).toContain('# chmonitor')
     expect(txt).toContain('https://docs.chmonitor.dev/llms.txt')
     expect(txt).toContain('https://blog.chmonitor.dev/llms.txt')
+    expect(txt).toContain('https://blog.chmonitor.dev/sitemap.xml')
     expect(txt).toContain('/features/postgres')
+    expect(txt).toContain('https://blog.chmonitor.dev/')
   })
 })

--- a/apps/landing/src/lib/site-urls.ts
+++ b/apps/landing/src/lib/site-urls.ts
@@ -1,4 +1,5 @@
 import { FEATURE_PAGES } from '../data/feature-pages'
+import { getPublishedBlogPosts } from './latest-blog-post'
 
 export type ListedPage = {
   path: string
@@ -154,11 +155,19 @@ export function buildLlmsTxt(
       return `- [${p.title}](${href}): ${p.description}`
     }),
     '',
-    '## Documentation, blog, product',
+    '## Blog',
+    '',
+    `Index: https://blog.chmonitor.dev/llms.txt`,
+    `Sitemap: https://blog.chmonitor.dev/sitemap.xml`,
+    '',
+    ...getPublishedBlogPosts().map(
+      (post) => `- [${post.title}](${post.href}): ${post.description}`
+    ),
+    '',
+    '## Documentation and product',
     '',
     '- [Docs (every page)](https://docs.chmonitor.dev/llms.txt)',
     '- [Docs full markdown](https://docs.chmonitor.dev/llms-full.txt)',
-    '- [Blog (every post)](https://blog.chmonitor.dev/llms.txt)',
     '- [Hosted dashboard](https://dash.chmonitor.dev)',
     '- [GitHub](https://github.com/chmonitor/chmonitor)',
     '',

--- a/docs/knowledge/deployment.md
+++ b/docs/knowledge/deployment.md
@@ -3,7 +3,7 @@ id: deployment
 title: Deployment Guide
 type: reference
 status: active
-updated: 2026-08-17
+updated: 2026-08-23
 tags:
   - deployment
   - docker
@@ -308,13 +308,14 @@ in `.env.example` for self-hosters. The `[env.preview]` worker declares no
 `[triggers]`, so preview never runs these crons. See
 `docs/content/guide/features/health.mdx` for the full alerting setup.
 
-## Edge Routing & Host Redirects (4-worker topology)
+## Edge Routing & Host Redirects (5-worker topology)
 
-Production runs four workers on the `chmonitor.dev` zone:
+Production runs five workers on the `chmonitor.dev` zone:
 
 | Worker | Host / route |
 |--------|--------------|
 | `chmonitor-landing` | `chmonitor.dev` (apex marketing) |
+| `chmonitor-blog` | `blog.chmonitor.dev` |
 | `chmonitor-dash` | `dash.chmonitor.dev` + `cloud.chmonitor.dev` (custom domains) |
 | `chmonitor-mcp` | `dash.chmonitor.dev/api/mcp*` + `/api/v1/mcp/info*` (Workers Routes) |
 | `chmonitor-docs` | `docs.chmonitor.dev` |
@@ -331,6 +332,7 @@ under `preview.*` subdomains that mirror production exactly:
 | Worker (preview) | Host / route |
 |------------------|--------------|
 | `preview-chmonitor-landing` | `preview.chmonitor.dev` (apex-preview) |
+| `preview-chmonitor-blog` | `preview.blog.chmonitor.dev` |
 | `preview-chmonitor-dash` | `preview.dash.chmonitor.dev` (custom domain) |
 | `preview-chmonitor-mcp` | `preview.dash.chmonitor.dev/api/mcp*` + `/api/v1/mcp/info*` (Workers Routes) |
 | `preview-chmonitor-docs` | `preview.docs.chmonitor.dev` |


### PR DESCRIPTION
## Summary

List every published marketing blog post on chmonitor.dev/llms.txt, and actually build + preview the blog on CI (local Astro preview smoke plus Cloudflare `preview.blog.chmonitor.dev`).

## Changes

- Landing `llms.txt` includes a Blog section of every published post (same publish rules as the hero pill)
- `blog.yml`: bun tests, OG generation, `astro preview` smoke of `/`, `/sitemap.xml`, `/llms.txt`
- `cloudflare.yml` blog job: OG + tests; PR comment lists https://preview.blog.chmonitor.dev
- Deployment knowledge: blog in the production/preview worker table

## Test plan

- [x] `bun test src/lib/site-urls.test.ts` in apps/landing
- [ ] Blog workflow preview smoke on this PR
- [ ] Cloudflare blog preview deploy on this PR (`cloudflare.yml` is in the blog filter)

Co-Authored-By: duyetbot <bot@duyet.net>