### PR TITLE
fix(blog): pass host/port to astro preview without extra --

### DIFF
--- a/.github/workflows/blog.yml
+++ b/.github/workflows/blog.yml
@@ -61,7 +61,9 @@ jobs:
           set -euo pipefail
           SERVER_PID=""
           trap '[ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null' EXIT
-          pnpm run preview -- --host 127.0.0.1 --port 4322 &
+          # pnpm forwards args after the script name; do not insert an extra `--`
+          # or Astro receives a literal `--` and ignores --host/--port (stays on :4321).
+          pnpm run preview --host 127.0.0.1 --port 4322 &
           SERVER_PID=$!
           npx --yes wait-on http://127.0.0.1:4322 --timeout 30000
           curl -fsS http://127.0.0.1:4322/ >/dev/null


### PR DESCRIPTION
## Summary
Follow-up to #3257. Blog CI `Preview smoke` failed because `pnpm run preview -- --host … --port …` left a literal `--` in the Astro argv, so host/port were ignored and wait-on timed out on `:4322` while Astro listened on `:4321`.

## Change
- Use `pnpm run preview --host 127.0.0.1 --port 4322` (no extra `--`).
- Verified locally: home, `/sitemap.xml` (`<urlset`), and `/llms.txt` (`chmonitor blog`) all pass.

## Test plan
- [x] Local preview smoke with fixed invocation
- [ ] Blog workflow `build` Preview smoke green on this PR