### PR TITLE
fix(seo): stop GSC 404s and slash/preview duplicates

### DIFF
--- a/apps/dashboard/public/robots.txt
+++ b/apps/dashboard/public/robots.txt
@@ -4,7 +4,10 @@
 # health endpoints, which have no SEO value and only waste crawl budget.
 User-agent: *
 Content-Signal: ai-train=no, search=yes, ai-input=no
-Allow: /
+# The dashboard is the product UI. Do not index host/database/table query
+# strings — those belong on the user's cluster, not in Google.
+Disallow: /
+Allow: /$
 Disallow: /api/
 Disallow: /healthz
 Disallow: /heathz

--- a/apps/dashboard/src/routes/__root.tsx
+++ b/apps/dashboard/src/routes/__root.tsx
@@ -53,6 +53,10 @@ export const Route = createRootRoute({
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      // App UI (host= / database= query URLs) is not a marketing page. Canonical
+      // lives on chmonitor.dev; indexing parameterized explorer URLs created
+      // hundreds of GSC 404s when those paths still resolved on the apex.
+      { name: 'robots', content: 'noindex, follow' },
       { title: 'chmonitor — ClickHouse Monitoring Dashboard & UI' },
       {
         name: 'description',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
     "types:check": "fumadocs-mdx && tsc --noEmit",
-    "test": "node --test src/styles/*.test.mjs && bun test src/lib/crawler-index.test.ts",
+    "test": "node --test src/styles/*.test.mjs && bun test src/lib/crawler-index.test.ts src/lib/canonical-path.test.ts",
     "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {

--- a/apps/docs/src/lib/canonical-path.test.ts
+++ b/apps/docs/src/lib/canonical-path.test.ts
@@ -1,0 +1,17 @@
+import { isPreviewHost, stripTrailingSlash } from './canonical-path'
+import { describe, expect, test } from 'bun:test'
+
+describe('docs canonical path', () => {
+  test('strips trailing slashes except root', () => {
+    expect(stripTrailingSlash('/')).toBe('/')
+    expect(stripTrailingSlash('/guide/')).toBe('/guide')
+    expect(stripTrailingSlash('/operate/authentication/')).toBe(
+      '/operate/authentication'
+    )
+  })
+
+  test('preview hosts are noindexed', () => {
+    expect(isPreviewHost('preview.docs.chmonitor.dev')).toBe(true)
+    expect(isPreviewHost('docs.chmonitor.dev')).toBe(false)
+  })
+})

--- a/apps/docs/src/lib/canonical-path.ts
+++ b/apps/docs/src/lib/canonical-path.ts
@@ -1,0 +1,18 @@
+/** Docs URLs never use a trailing slash (except `/`). */
+export function stripTrailingSlash(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.replace(/\/+$/, '')
+  }
+  return pathname
+}
+
+export function isPreviewHost(hostname: string): boolean {
+  return hostname.startsWith('preview.') || hostname.endsWith('.workers.dev')
+}
+
+export function previewRobotsTxt(): string {
+  return `# Preview deployments are not the canonical docs site.
+User-agent: *
+Disallow: /
+`
+}

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -55,6 +55,7 @@ export const Route = createFileRoute('/$')({
               { name: 'twitter:description', content: description },
             ]
           : []),
+        { name: 'robots', content: 'index, follow' },
       ],
       links: [{ rel: 'canonical', href: canonicalUrl }],
     }

--- a/apps/docs/src/start.ts
+++ b/apps/docs/src/start.ts
@@ -5,6 +5,11 @@ import {
   createStart,
 } from '@tanstack/react-start'
 
+import {
+  isPreviewHost,
+  previewRobotsTxt,
+  stripTrailingSlash,
+} from './lib/canonical-path'
 import { slugsToMarkdownPath } from './lib/source'
 import { isMarkdownPreferred } from 'fumadocs-core/negotiation'
 
@@ -49,6 +54,37 @@ const llmMiddleware = createMiddleware().server(({ next, request }) => {
 // Cache itself. See docs/knowledge/workers-cache.md.
 const PUBLIC_CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=86400'
 
+const canonicalUrlMiddleware = createMiddleware().server(
+  async ({ next, request }) => {
+    const url = new URL(request.url)
+
+    if (isPreviewHost(url.hostname) && url.pathname === '/robots.txt') {
+      return {
+        response: new Response(previewRobotsTxt(), {
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'X-Robots-Tag': 'noindex, nofollow',
+          },
+        }),
+      }
+    }
+
+    // Never strip a file extension path (`/llms.txt`).
+    const stripped =
+      url.pathname.includes('.') && !url.pathname.endsWith('/')
+        ? url.pathname
+        : stripTrailingSlash(url.pathname)
+    if (stripped !== url.pathname) {
+      throw redirect({
+        href: `${stripped}${url.search}`,
+        statusCode: 301,
+      })
+    }
+
+    return next()
+  }
+)
+
 const cacheHeadersMiddleware = createMiddleware().server(
   async ({ next, request }) => {
     const result = await next()
@@ -66,6 +102,10 @@ const cacheHeadersMiddleware = createMiddleware().server(
       response.headers.set('Cache-Control', PUBLIC_CACHE_CONTROL)
     }
 
+    if (response && isPreviewHost(url.hostname)) {
+      response.headers.set('X-Robots-Tag', 'noindex, nofollow')
+    }
+
     return result
   }
 )
@@ -73,5 +113,10 @@ const cacheHeadersMiddleware = createMiddleware().server(
 export const startInstance = createStart(() => ({
   // cacheHeadersMiddleware runs outermost so it can stamp Cache-Control on the
   // final response returned by the inner middlewares/handlers.
-  requestMiddleware: [cacheHeadersMiddleware, csrfMiddleware, llmMiddleware],
+  requestMiddleware: [
+    cacheHeadersMiddleware,
+    canonicalUrlMiddleware,
+    csrfMiddleware,
+    llmMiddleware,
+  ],
 }))

--- a/apps/landing/astro.config.mjs
+++ b/apps/landing/astro.config.mjs
@@ -6,6 +6,7 @@ import { defineConfig } from 'astro/config'
 
 export default defineConfig({
   site: 'https://chmonitor.dev',
+  trailingSlash: 'never',
   // Fully static HTML at build time. Interactivity (billing toggle, screenshot
   // zoom, hero slogans, changelog filter) uses small inline scripts in Astro.
   integrations: [sitemap(), react()],

--- a/apps/landing/public/_redirects
+++ b/apps/landing/public/_redirects
@@ -3,3 +3,18 @@
 /docs    https://docs.chmonitor.dev  301
 /v0.3/*  https://blog.chmonitor.dev/v0.3/:splat  301
 /v0.3    https://blog.chmonitor.dev/v0.3  301
+
+# Pre-cutover dashboard lived on the apex. Google still crawls /explorer?host=
+# and /table?… here (500+ GSC 404s). The seo-worker 301s these too; keep the
+# static rules as a fallback if the Worker is skipped.
+/explorer  https://dash.chmonitor.dev/explorer  301
+/explorer/*  https://dash.chmonitor.dev/explorer/:splat  301
+/table  https://dash.chmonitor.dev/table  301
+/table/*  https://dash.chmonitor.dev/table/:splat  301
+/tables  https://dash.chmonitor.dev/tables  301
+/overview  https://dash.chmonitor.dev/overview  301
+/queries  https://dash.chmonitor.dev/queries  301
+/running-queries  https://dash.chmonitor.dev/running-queries  301
+/health  https://dash.chmonitor.dev/health  301
+/dashboard  https://dash.chmonitor.dev/dashboard  301
+/sql  https://dash.chmonitor.dev/sql  301

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -6,7 +6,8 @@ import '../styles/globals.css'
 import '../styles/nav.css'
 
 const { title = 'chmonitor — The ops dashboard for ClickHouse', description = 'Monitor queries, merges, parts, replication, and health. An AI advisor on top — open source, self-host free.', image = '/og/og.png', noindex = false } = Astro.props
-const canonical = new URL(Astro.url.pathname, Astro.site).toString()
+const path = Astro.url.pathname.replace(/\/+$/, '') || '/'
+const canonical = new URL(path, Astro.site).toString()
 const ogImage = new URL(image, Astro.site).toString()
 ---
 <!doctype html>

--- a/apps/landing/src/seo-routing.test.ts
+++ b/apps/landing/src/seo-routing.test.ts
@@ -1,0 +1,68 @@
+import {
+  DASHBOARD_PREFIXES,
+  landingRedirectUrl,
+  shouldNoindexHost,
+  stripTrailingSlash,
+} from './seo-routing'
+import { describe, expect, test } from 'bun:test'
+
+describe('landing SEO routing', () => {
+  test('explorer and table query URLs 301 to the dashboard', () => {
+    const explorer = landingRedirectUrl(
+      new URL(
+        'https://chmonitor.dev/explorer?host=0&database=system&table=tables'
+      )
+    )
+    expect(explorer).toBe(
+      'https://dash.chmonitor.dev/explorer?host=0&database=system&table=tables'
+    )
+    expect(
+      landingRedirectUrl(
+        new URL(
+          'https://chmonitor.dev/table?host=0&database=system&table=trace_log'
+        )
+      )
+    ).toBe(
+      'https://dash.chmonitor.dev/table?host=0&database=system&table=trace_log'
+    )
+  })
+
+  test('trailing slash on a marketing page canonicalizes on-origin', () => {
+    expect(landingRedirectUrl(new URL('https://chmonitor.dev/pricing/'))).toBe(
+      'https://chmonitor.dev/pricing'
+    )
+  })
+
+  test('does not redirect real marketing paths', () => {
+    expect(landingRedirectUrl(new URL('https://chmonitor.dev/'))).toBeNull()
+    expect(
+      landingRedirectUrl(new URL('https://chmonitor.dev/pricing'))
+    ).toBeNull()
+    expect(
+      landingRedirectUrl(new URL('https://chmonitor.dev/features/storage'))
+    ).toBeNull()
+    expect(
+      landingRedirectUrl(new URL('https://chmonitor.dev/install.sh'))
+    ).toBeNull()
+  })
+
+  test('legacy /docs goes to the docs host', () => {
+    expect(
+      landingRedirectUrl(
+        new URL('https://chmonitor.dev/docs/guide/getting-started')
+      )
+    ).toBe('https://docs.chmonitor.dev/guide/getting-started')
+  })
+
+  test('covers explorer and table prefixes', () => {
+    expect(DASHBOARD_PREFIXES.has('explorer')).toBe(true)
+    expect(DASHBOARD_PREFIXES.has('table')).toBe(true)
+    expect(DASHBOARD_PREFIXES.has('pricing')).toBe(false)
+  })
+
+  test('preview hosts are noindexed', () => {
+    expect(shouldNoindexHost('preview.chmonitor.dev')).toBe(true)
+    expect(shouldNoindexHost('chmonitor.dev')).toBe(false)
+    expect(stripTrailingSlash('/guide/')).toBe('/guide')
+  })
+})

--- a/apps/landing/src/seo-routing.ts
+++ b/apps/landing/src/seo-routing.ts
@@ -1,0 +1,151 @@
+/** First-path-segment dashboard routes that used to live on chmonitor.dev. */
+export const DASHBOARD_PREFIXES = new Set([
+  'about',
+  'advisor',
+  'agents',
+  'ai-chat',
+  'alert-settings',
+  'asynchronous-inserts',
+  'asynchronous-metrics',
+  'background-schedule-pool',
+  'backups',
+  'blob-storage-log',
+  'charts',
+  'cluster',
+  'clusters',
+  'common-errors',
+  'dashboard',
+  'detached-parts',
+  'device',
+  'dictionaries',
+  'disks',
+  'distributed-ddl-queue',
+  'dropped-tables',
+  'errors',
+  'expensive-queries',
+  'expensive-queries-by-memory',
+  'explain',
+  'explorer',
+  'failed-queries',
+  'fleet',
+  'health',
+  'health-settings',
+  'histogram-metrics',
+  'history-queries',
+  'inbound-events',
+  'index-analytics',
+  'insights',
+  'insights-settings',
+  'kafka-consumers',
+  'keeper',
+  'login',
+  'logs',
+  'mcp',
+  'mcp-servers',
+  'merge-performance',
+  'merges',
+  'mergetree-settings',
+  'metrics',
+  'moves',
+  'mutations',
+  'opentelemetry-spans',
+  'overview',
+  'page-views',
+  'part-info',
+  'part-log',
+  'peerdb',
+  'postgres',
+  'profiler',
+  'projections',
+  'queries',
+  'query',
+  'query-cache',
+  'query-condition-cache',
+  'query-metric-log',
+  'query-views-log',
+  'rabbitmq-consumers',
+  'readonly-tables',
+  'recent-queries',
+  'replicas',
+  'replicated-fetches',
+  'replicated-merge-tree-settings',
+  'replication-queue',
+  'report-settings',
+  'roles',
+  'running-queries',
+  'schema-diff',
+  'security',
+  'settings',
+  'settings-diff',
+  'setup',
+  'sign-in',
+  'sign-up',
+  'slow-queries',
+  'slow-query-patterns',
+  'sql',
+  'storage-economics',
+  'table',
+  'tables',
+  'tables-overview',
+  'top-cpu-queries',
+  'top-memory-queries',
+  'top-usage-columns',
+  'top-usage-tables',
+  'traffic',
+  'ttl-partition-health',
+  'user-processes',
+  'users',
+  'view-refreshes',
+  'warnings',
+  'workload-scheduling',
+  'zookeeper',
+])
+
+const DASH_ORIGIN = 'https://dash.chmonitor.dev'
+const DOCS_ORIGIN = 'https://docs.chmonitor.dev'
+const BLOG_ORIGIN = 'https://blog.chmonitor.dev'
+
+export function firstSegment(pathname: string): string {
+  return pathname.split('/').filter(Boolean)[0] ?? ''
+}
+
+export function stripTrailingSlash(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.replace(/\/+$/, '')
+  }
+  return pathname
+}
+
+export function shouldNoindexHost(hostname: string): boolean {
+  return hostname.startsWith('preview.') || hostname.endsWith('.workers.dev')
+}
+
+export function previewRobotsTxt(): string {
+  return `# Preview deployments are not the canonical site.
+User-agent: *
+Disallow: /
+`
+}
+
+/** Absolute 301 target, or null to serve the landing asset. */
+export function landingRedirectUrl(url: URL): string | null {
+  const path = stripTrailingSlash(url.pathname)
+  const first = firstSegment(path)
+  const search = url.search
+
+  if (first === 'docs') {
+    const rest = path.replace(/^\/docs\/?/, '/')
+    const dest = rest === '/' ? DOCS_ORIGIN : `${DOCS_ORIGIN}${rest}`
+    return `${dest}${search}`
+  }
+  if (first === 'v0.3') {
+    return `${BLOG_ORIGIN}${path}${search}`
+  }
+  if (DASHBOARD_PREFIXES.has(first)) {
+    return `${DASH_ORIGIN}${path}${search}`
+  }
+  if (path !== url.pathname) {
+    return `${url.origin}${path}${search}`
+  }
+  return null
+}

--- a/apps/landing/src/seo-worker.ts
+++ b/apps/landing/src/seo-worker.ts
@@ -1,0 +1,36 @@
+import {
+  landingRedirectUrl,
+  previewRobotsTxt,
+  shouldNoindexHost,
+} from './seo-routing'
+
+export interface LandingEnv {
+  ASSETS: { fetch: typeof fetch }
+}
+
+export default {
+  async fetch(request: Request, env: LandingEnv): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (shouldNoindexHost(url.hostname) && url.pathname === '/robots.txt') {
+      return new Response(previewRobotsTxt(), {
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Robots-Tag': 'noindex, nofollow',
+        },
+      })
+    }
+
+    const dest = landingRedirectUrl(url)
+    if (dest) {
+      return Response.redirect(dest, 301)
+    }
+
+    const asset = await env.ASSETS.fetch(request)
+    if (!shouldNoindexHost(url.hostname)) return asset
+
+    const headers = new Headers(asset.headers)
+    headers.set('X-Robots-Tag', 'noindex, nofollow')
+    return new Response(asset.body, { status: asset.status, headers })
+  },
+}

--- a/apps/landing/wrangler.toml
+++ b/apps/landing/wrangler.toml
@@ -11,6 +11,7 @@
 # here claims it (custom domains are exclusive).
 
 name = "chmonitor-landing"
+main = "src/seo-worker.ts"
 compatibility_date = "2026-05-28"
 # Keep workers.dev enabled as a curl-friendly fallback for /install.sh when
 # the apex is behind Bot Fight Mode (see docs/knowledge/install-sh-bot-fight.md).
@@ -27,6 +28,10 @@ enabled = true
 
 [assets]
 directory = "./dist"
+binding = "ASSETS"
+# Worker runs first so preview hosts get X-Robots-Tag / robots Disallow, and
+# old dashboard URLs on the apex 301 to dash.chmonitor.dev before a 404 HTML.
+run_worker_first = true
 
 [[routes]]
 pattern = "chmonitor.dev"
@@ -45,6 +50,8 @@ name = "preview-chmonitor-landing"
 
 [env.preview.assets]
 directory = "./dist"
+binding = "ASSETS"
+run_worker_first = true
 
 [[env.preview.routes]]
 pattern = "preview.chmonitor.dev"


### PR DESCRIPTION
## Summary

Fix Search Console “why pages aren’t indexed” for the domain property: 534 apex 404s were old dashboard URLs (`/explorer?host=…`, `/table?…`) still crawled on **chmonitor.dev** after the marketing/docs split. Trailing-slash docs and `preview.*` hosts showed as “alternate with proper canonical.”

## Changes

- Landing Worker 301s dashboard prefixes (explorer, table, overview, …) to `https://dash.chmonitor.dev` + query string; also 301s trailing slashes on marketing paths
- Preview hosts (`preview.chmonitor.dev`, `preview.docs…`) get `X-Robots-Tag: noindex` and `robots.txt` Disallow `/`
- Docs 301 `/operate/authentication/` → `/operate/authentication` (canonical already had no slash)
- Dashboard `noindex,follow` + `robots.txt` Disallow `/` so parameterized explorer pages are not a second index surface
- `_redirects` fallbacks for the highest-volume apex paths

## What GSC will still show (expected)

- **Alternate with proper canonical** for `?ref=docs` / `?ref=github` — canonical is already the clean URL; those rows are working as designed and drop as Google recrawls
- **Page with redirect** — will rise as 404s become 301s (good)
- **403** — Cloudflare Bot Fight on some assets (e.g. install.sh); not disabled
- **Crawled – currently not indexed** — quality/selection; crawl-budget waste should fall after 404s are 301s

## Test plan

- [x] `bun test` landing `seo-routing.test.ts` and docs `canonical-path.test.ts`
- [ ] After deploy: `curl -I 'https://chmonitor.dev/explorer?host=0'` → 301 dash
- [ ] `curl -I https://docs.chmonitor.dev/guide/` → 301 `/guide`
- [ ] Preview host `curl -sI https://preview.chmonitor.dev/` includes `X-Robots-Tag: noindex`

Co-Authored-By: duyetbot <bot@duyet.net>