### PR TITLE
fix(docs): 301 trailing slashes at the asset layer

### DIFF
--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -23,6 +23,12 @@ enabled = true
 [cache]
 enabled = true
 
+# Prerendered HTML is served from Workers Assets before Start middleware.
+# Drop trailing slashes at the asset layer so /guide/ 301s to /guide (GSC
+# "alternate with proper canonical" for slash variants).
+[assets]
+html_handling = "drop-trailing-slash"
+
 [[routes]]
 pattern = "docs.chmonitor.dev"
 custom_domain = true


### PR DESCRIPTION
## Summary

`/guide/` still returned 200 after #3259 because prerendered docs HTML is served from Workers Assets before Start middleware. Set `html_handling = \"drop-trailing-slash\"` so slash URLs 301 to the canonical path Google already uses.

## Test plan

- [ ] After deploy: `curl -sI https://docs.chmonitor.dev/guide/` → 301 `/guide`

Co-Authored-By: duyetbot <bot@duyet.net>