### PR TITLE
feat(seo): watch pages so launch films can be indexed as video

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3.md
@@ -12,11 +12,11 @@ that answers questions about your cluster, live query monitoring, a data
 explorer, cluster topology, AI insights, and self-hosting that's a single command
 on Cloudflare Workers, Docker or Kubernetes.
 
-Here's the ~28-second launch film — every scene is the real product:
+Here's the ~28-second launch film — every scene is the real product. The dedicated watch page is [/watch/v0.3/](/watch/v0.3/).
 
 <figure class="video">
   <video src="/posts/v0.3/launch.mp4" poster="/posts/v0.3/launch-poster.png" controls preload="metadata" playsinline></video>
-  <figcaption>chmonitor v0.3 — launch film. Dashboard, AI agent, query monitoring, data explorer, topology, health & self-host.</figcaption>
+  <figcaption>chmonitor v0.3 — launch film. Dashboard, AI agent, query monitoring, data explorer, topology, health & self-host. <a href="/watch/v0.3/">Open the watch page</a>.</figcaption>
 </figure>
 
 v0.3 lands 8 new features, more than 70 fixes, 13 performance wins, and 71 charts.

--- a/apps/blog/src/lib/crawler-index.test.ts
+++ b/apps/blog/src/lib/crawler-index.test.ts
@@ -44,6 +44,7 @@ describe('blog crawler index', () => {
     const xml = buildSitemapXml(posts)
     expect(xml).toContain('https://blog.chmonitor.dev/')
     expect(xml).toContain('https://blog.chmonitor.dev/v0.3/')
+    expect(xml).toContain('https://blog.chmonitor.dev/watch/v0.3/')
     expect(xml).toContain('https://blog.chmonitor.dev/too-many-parts/')
     expect(xml).toContain(
       'https://blog.chmonitor.dev/category/5-min-of-clickhouse/'

--- a/apps/blog/src/lib/crawler-index.ts
+++ b/apps/blog/src/lib/crawler-index.ts
@@ -22,6 +22,7 @@ export function buildSitemapXml(
 ): string {
   const locs = [
     `${origin}/`,
+    `${origin}/watch/v0.3/`,
     ...publishedPosts(posts).map((p) => `${origin}/${postSlug(p)}/`),
     ...categoryPaths(posts).map((path) => `${origin}${path}`),
   ]
@@ -50,6 +51,10 @@ export function buildLlmsTxt(
     `> Latest: ${published[0]?.data.title ?? 'n/a'}`,
     '',
     `HTML sitemap: ${origin}/sitemap.xml`,
+    '',
+    '## Watch',
+    '',
+    `- [chmonitor v0.3 launch film](${origin}/watch/v0.3/): 28-second launch film for the v0.3 rebuild.`,
     '',
     '## Posts',
     '',

--- a/apps/blog/src/pages/watch/v0.3.astro
+++ b/apps/blog/src/pages/watch/v0.3.astro
@@ -1,0 +1,72 @@
+---
+import Base from '../../layouts/Base.astro'
+import Nav from '../../components/Nav.astro'
+import Footer from '../../components/Footer.astro'
+
+const VIDEO = '/posts/v0.3/launch.mp4'
+const POSTER = '/posts/v0.3/launch-poster.png'
+const canonical = new URL('/watch/v0.3/', Astro.site).toString()
+const contentUrl = new URL(VIDEO, Astro.site).toString()
+const thumbnailUrl = new URL(POSTER, Astro.site).toString()
+
+const title = 'chmonitor v0.3 launch film'
+const description =
+  '28-second launch film for chmonitor v0.3: the real dashboard, AI agent, query monitoring, data explorer, topology, health, and one-command self-host.'
+
+const videoJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'VideoObject',
+  name: title,
+  description,
+  thumbnailUrl,
+  uploadDate: '2026-06-29T00:00:00Z',
+  duration: 'PT28S',
+  contentUrl,
+  embedUrl: canonical,
+  url: canonical,
+  isFamilyFriendly: true,
+  inLanguage: 'en',
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Blog', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: title, item: canonical },
+  ],
+}
+---
+<Base title={`${title} — chmonitor blog`} description={description} image={POSTER}>
+  <script type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <Nav origin="https://chmonitor.dev" />
+  <main>
+    <article class="mx-auto max-w-[960px] px-4 sm:px-6 pb-16 pt-14">
+      <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Watch</p>
+      <h1 class="mt-3 text-balance font-normal text-[clamp(1.5rem,4.4vw,2.75rem)] leading-[1.06] tracking-tight text-foreground">
+        {title}
+      </h1>
+      <p class="mt-4 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+      <div class="mt-8 overflow-hidden rounded-xl border border-border bg-card">
+        <video
+          class="block h-auto w-full bg-black"
+          controls
+          playsinline
+          preload="metadata"
+          poster={POSTER}
+          aria-label={title}
+        >
+          <source src={VIDEO} type="video/mp4" />
+        </video>
+      </div>
+      <p class="mt-4 text-sm text-muted-foreground">
+        28 seconds · uploaded 29 June 2026 ·
+        <a class="underline underline-offset-4 hover:text-foreground" href="/v0.3/">Release notes</a>
+      </p>
+    </article>
+  </main>
+  <Footer origin="https://chmonitor.dev" />
+</Base>

--- a/apps/landing/src/components/Footer.astro
+++ b/apps/landing/src/components/Footer.astro
@@ -36,6 +36,7 @@ const foot = 'text-sm text-muted-foreground transition-colors hover:text-foregro
               <a class={foot} href={to('/license/register')}>Buy a license</a>
               <a class={foot} href={to('/license/lookup')}>Look up a license</a>
               <a class={foot} href={to('/cli')}>CLI</a>
+              <a class={foot} href={to('/watch/v0.3')}>v0.3 film</a>
               <a class={foot} href="https://dash.chmonitor.dev" target="_blank" rel="noopener">Dashboard</a>
               <a class={foot} href="https://blog.chmonitor.dev">Blog</a>
             </div>

--- a/apps/landing/src/components/Hero.astro
+++ b/apps/landing/src/components/Hero.astro
@@ -142,6 +142,15 @@ const arrowSvg = `<svg class="size-3.5 shrink-0" viewBox="0 0 24 24" fill="none"
         class="hidden h-auto w-full"
       />
     </div>
+    <p class="mt-3 text-center text-sm text-muted-foreground">
+      <a
+        href="/watch/v0.3"
+        class="underline underline-offset-4 hover:text-foreground"
+        data-hero-watch-page
+      >
+        Watch the v0.3 launch film
+      </a>
+    </p>
 
     <ul
       class="mx-auto mt-12 sm:mt-16 grid max-w-3xl list-none gap-x-10 gap-y-3 sm:gap-y-3.5 sm:grid-cols-2 pt-8 sm:pt-10"

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -107,6 +107,12 @@ describe('feature sections have no 01 / 08 index labels', () => {
 })
 
 describe('hero video', () => {
+  test('links to the dedicated watch page', () => {
+    expect(hero).toContain('data-hero-watch-page')
+    expect(hero).toContain('href="/watch/v0.3"')
+    expect(existsSync(join(landing, 'src/pages/watch/v0.3.astro'))).toBe(true)
+  })
+
   test('autoplays muted and loops', () => {
     const idx = hero.indexOf('data-hero-intro')
     expect(idx).toBeGreaterThan(-1)

--- a/apps/landing/src/lib/site-urls.test.ts
+++ b/apps/landing/src/lib/site-urls.test.ts
@@ -10,6 +10,7 @@ describe('landing crawler index', () => {
     expect(paths).toContain('/pricing')
     expect(paths).toContain('/vs-datadog')
     expect(paths).toContain('/clickhouse-vs-druid-pinot')
+    expect(paths).toContain('/watch/v0.3')
     for (const feature of FEATURE_PAGES) {
       expect(paths).toContain(`/features/${feature.slug}`)
     }

--- a/apps/landing/src/lib/site-urls.ts
+++ b/apps/landing/src/lib/site-urls.ts
@@ -33,6 +33,12 @@ export const STATIC_PAGES: ListedPage[] = [
     description: 'chm / chmonitor terminal client.',
   },
   {
+    path: '/watch/v0.3',
+    title: 'chmonitor v0.3 launch film',
+    description:
+      '36-second walkthrough of the v0.3 dashboard, AI agent, and cluster health.',
+  },
+  {
     path: '/customers',
     title: 'Customers',
     description: 'Who runs ClickHouse with chmonitor.',

--- a/apps/landing/src/pages/watch/v0.3.astro
+++ b/apps/landing/src/pages/watch/v0.3.astro
@@ -1,0 +1,84 @@
+---
+import Base from '../../layouts/Base.astro'
+import Nav from '../../components/Nav.astro'
+import Footer from '../../components/Footer.astro'
+import { btnOutline, btnPrimary } from '../../lib/button-classes'
+
+const VIDEO = '/assets/videos/chmonitor-v0.3.mp4'
+const POSTER = '/assets/videos/chmonitor-v0.3-poster.jpg'
+const canonical = new URL(Astro.url.pathname.replace(/\/+$/, '') || '/', Astro.site).toString()
+const contentUrl = new URL(VIDEO, Astro.site).toString()
+const thumbnailUrl = new URL(POSTER, Astro.site).toString()
+
+const title = 'chmonitor v0.3 launch film'
+const description =
+  '36-second walkthrough of the chmonitor v0.3 dashboard: overview heatmap, AI agent, query monitoring, data explorer, cluster topology, and health.'
+
+const videoJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'VideoObject',
+  name: title,
+  description,
+  thumbnailUrl,
+  uploadDate: '2026-06-29T00:00:00Z',
+  duration: 'PT36S',
+  contentUrl,
+  embedUrl: canonical,
+  url: canonical,
+  isFamilyFriendly: true,
+  inLanguage: 'en',
+}
+
+const breadcrumbJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: new URL('/', Astro.site).toString() },
+    { '@type': 'ListItem', position: 2, name: title, item: canonical },
+  ],
+}
+---
+<Base title={`${title} — chmonitor`} description={description} image={POSTER}>
+  <script type="application/ld+json" set:html={JSON.stringify(videoJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} is:inline />
+  <Nav />
+  <main id="top">
+    <article class="mx-auto max-w-[960px] px-4 sm:px-6 pb-16 pt-14 sm:pt-16">
+      <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">Watch</p>
+      <h1 class="mt-3 text-balance font-normal text-[clamp(1.5rem,4.4vw,2.75rem)] leading-[1.06] tracking-tight text-foreground">
+        {title}
+      </h1>
+      <p class="mt-4 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
+        {description}
+      </p>
+      <div class="mt-8 overflow-hidden rounded-xl border border-border bg-card">
+        <video
+          class="block h-auto w-full bg-black"
+          controls
+          playsinline
+          preload="metadata"
+          poster={POSTER}
+          width="1920"
+          height="1126"
+          aria-label={title}
+        >
+          <source src={VIDEO} type="video/mp4" />
+        </video>
+      </div>
+      <p class="mt-4 text-sm text-muted-foreground">
+        36 seconds · uploaded 29 June 2026 ·
+        <a class="underline underline-offset-4 hover:text-foreground" href={VIDEO}>Download MP4</a>
+      </p>
+      <ul class="mt-8 list-disc space-y-2 pl-5 text-sm leading-relaxed text-muted-foreground">
+        <li>Overview with query heatmap, charts, and cluster health</li>
+        <li>AI agent answering from system tables over MCP</li>
+        <li>Running and slow queries, data explorer, topology</li>
+      </ul>
+      <div class="mt-10 flex flex-wrap gap-3">
+        <a class={btnPrimary} href="https://dash.chmonitor.dev">Open dashboard</a>
+        <a class={btnOutline} href="https://blog.chmonitor.dev/v0.3/">v0.3 release notes</a>
+      </div>
+    </article>
+  </main>
+  <Footer />
+</Base>

--- a/apps/landing/src/seo-routing.test.ts
+++ b/apps/landing/src/seo-routing.test.ts
@@ -44,6 +44,9 @@ describe('landing SEO routing', () => {
     expect(
       landingRedirectUrl(new URL('https://chmonitor.dev/install.sh'))
     ).toBeNull()
+    expect(
+      landingRedirectUrl(new URL('https://chmonitor.dev/watch/v0.3'))
+    ).toBeNull()
   })
 
   test('legacy /docs goes to the docs host', () => {


### PR DESCRIPTION
## Summary

Google Search Console reports “Video isn’t on a watch page” for the homepage hero MP4 and the v0.3 blog embed. Those pages are not dedicated to watching a video. This adds watch pages whose main content is the player, with VideoObject JSON-LD.

## Changes

- `https://chmonitor.dev/watch/v0.3` — 36s product film, VideoObject, sitemap/llms
- `https://blog.chmonitor.dev/watch/v0.3/` — 28s launch film, VideoObject, sitemap
- Homepage and v0.3 post link to the watch page (hero stays a muted loop; no VideoObject on those pages)

## Test plan

- [x] landing + blog unit tests
- [ ] After deploy: watch pages 200, JSON-LD includes VideoObject
- [ ] GSC: validate the video enhancement after recrawl (days)

Co-Authored-By: duyetbot <bot@duyet.net>