### PR TITLE
fix(seo): collapse GSC redirect chains to one hop

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 [![License](https://img.shields.io/github/license/chmonitor/chmonitor)](LICENSE)
 
 <p align="center">
-  <a href="https://dash.chmonitor.dev/?ref=github"><strong>Live demo</strong></a>
-  · <a href="https://chmonitor.dev/?ref=github">Website</a>
+  <a href="https://dash.chmonitor.dev/overview?host=0"><strong>Live demo</strong></a>
+  · <a href="https://chmonitor.dev/">Website</a>
   · <a href="https://docs.chmonitor.dev">Docs</a>
   · <a href="https://docs.chmonitor.dev/guide/getting-started">Getting started</a>
   · <a href="#quick-start">Quick start</a>
@@ -34,7 +34,7 @@ storage, health — then recommends what to change next.
 It does **not** apply DDL for you. Recommendations stay recommendations.
 
 Runs the same way on Docker, Kubernetes, bare metal, or ClickHouse Cloud.
-Self-host it free (GPL-3.0), or use the [hosted demo](https://dash.chmonitor.dev/?ref=github).
+Self-host it free (GPL-3.0), or use the [hosted demo](https://dash.chmonitor.dev/overview?host=0).
 
 Current release: **[v0.3.0](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.0)**.
 Upgrading from v0.2? See [Migrate to v0.3](https://docs.chmonitor.dev/reference/migrating/v0-3).
@@ -73,7 +73,7 @@ docker run -d --name chmonitor -p 3000:3000 \
 
 Open **http://localhost:3000**. Pin a version tag in production; use `:latest` only if you want the rolling tip.
 
-Want a look first? **[dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=github)** — no setup.
+Want a look first? **[dash.chmonitor.dev](https://dash.chmonitor.dev/overview?host=0)** — no setup.
 
 Install the CLI:
 

--- a/apps/blog/src/content/blog/clickhouse-memory-limit-exceeded.md
+++ b/apps/blog/src/content/blog/clickhouse-memory-limit-exceeded.md
@@ -139,7 +139,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 That's all 8 launch posts in the **5 min of ClickHouse** series — back next
 week with more.
 

--- a/apps/blog/src/content/blog/clickhouse-mutation-alter-delete-cost.md
+++ b/apps/blog/src/content/blog/clickhouse-mutation-alter-delete-cost.md
@@ -116,7 +116,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-partition-key-mistakes.md
+++ b/apps/blog/src/content/blog/clickhouse-partition-key-mistakes.md
@@ -129,7 +129,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-prewhere-vs-where.md
+++ b/apps/blog/src/content/blog/clickhouse-prewhere-vs-where.md
@@ -123,7 +123,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-projections-vs-materialized-views.md
+++ b/apps/blog/src/content/blog/clickhouse-projections-vs-materialized-views.md
@@ -132,7 +132,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-slowest-queries-system-query-log.md
+++ b/apps/blog/src/content/blog/clickhouse-slowest-queries-system-query-log.md
@@ -119,7 +119,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-system-merges-merge-storm.md
+++ b/apps/blog/src/content/blog/clickhouse-system-merges-merge-storm.md
@@ -113,7 +113,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/blog/src/content/blog/clickhouse-too-many-parts.md
+++ b/apps/blog/src/content/blog/clickhouse-too-many-parts.md
@@ -137,7 +137,7 @@ docker run -d --name chmonitor -p 3000:3000 \
   ghcr.io/chmonitor/chmonitor:latest
 ```
 
-Or skip setup and try the [live demo](https://dash.chmonitor.dev/?ref=blog).
+Or skip setup and try the [live demo](https://dash.chmonitor.dev/overview?host=0).
 
 ## Related
 

--- a/apps/docs/src/lib/canonical-path.test.ts
+++ b/apps/docs/src/lib/canonical-path.test.ts
@@ -1,4 +1,8 @@
-import { isPreviewHost, stripTrailingSlash } from './canonical-path'
+import {
+  docsCanonicalRedirect,
+  isPreviewHost,
+  stripTrailingSlash,
+} from './canonical-path'
 import { describe, expect, test } from 'bun:test'
 
 describe('docs canonical path', () => {
@@ -8,6 +12,22 @@ describe('docs canonical path', () => {
     expect(stripTrailingSlash('/operate/authentication/')).toBe(
       '/operate/authentication'
     )
+  })
+
+  test('legacy IA + slash is a single hop to the new path', () => {
+    expect(docsCanonicalRedirect('/deploy/k8s')).toBe('/operate/deploy/k8s')
+    expect(docsCanonicalRedirect('/deploy/k8s/')).toBe('/operate/deploy/k8s')
+    expect(docsCanonicalRedirect('/features/operations')).toBe(
+      '/guide/features/operations'
+    )
+    expect(docsCanonicalRedirect('/features/operations/')).toBe(
+      '/guide/features/operations'
+    )
+    expect(docsCanonicalRedirect('/advanced/peerdb-monitoring')).toBe(
+      '/operate/advanced/peerdb-monitoring'
+    )
+    expect(docsCanonicalRedirect('/guide/')).toBe('/guide')
+    expect(docsCanonicalRedirect('/guide/features/operations')).toBeNull()
   })
 
   test('preview hosts are noindexed', () => {

--- a/apps/docs/src/lib/canonical-path.ts
+++ b/apps/docs/src/lib/canonical-path.ts
@@ -6,6 +6,41 @@ export function stripTrailingSlash(pathname: string): string {
   return pathname
 }
 
+/** Old flat docs IA → current /guide|/operate|/reference prefixes. */
+export const LEGACY_REDIRECT_PREFIX: Record<string, string> = {
+  'getting-started': 'guide/getting-started',
+  features: 'guide/features',
+  'ai-agent': 'guide/ai-agent',
+  guides: 'guide/guides',
+  introduction: 'guide',
+  deploy: 'operate/deploy',
+  authentication: 'operate/authentication',
+  advanced: 'operate/advanced',
+  releases: 'reference/releases',
+  migrating: 'reference/migrating',
+  faq: 'reference/faq',
+  settings: 'reference/settings',
+}
+
+export function legacyDocsPath(pathname: string): string | null {
+  const slugs = stripTrailingSlash(pathname).split('/').filter(Boolean)
+  const [first, ...rest] = slugs
+  if (!first) return null
+  const prefix = LEGACY_REDIRECT_PREFIX[first]
+  if (!prefix) return null
+  return `/${[prefix, ...rest].join('/')}`.replace(/\/$/, '') || '/'
+}
+
+/** One-hop 301 target: IA move and/or trailing slash, never a chain. */
+export function docsCanonicalRedirect(pathname: string): string | null {
+  if (pathname.includes('.') && !pathname.endsWith('/')) return null
+  const legacy = legacyDocsPath(pathname)
+  if (legacy) return legacy
+  const stripped = stripTrailingSlash(pathname)
+  if (stripped !== pathname) return stripped
+  return null
+}
+
 export function isPreviewHost(hostname: string): boolean {
   return hostname.startsWith('preview.') || hostname.endsWith('.workers.dev')
 }

--- a/apps/docs/src/routes/$.tsx
+++ b/apps/docs/src/routes/$.tsx
@@ -15,6 +15,7 @@ import {
 import { Suspense } from 'react'
 import { getMDXComponents } from '@/components/mdx'
 import { SidebarFooter } from '@/components/sidebar-footer'
+import { legacyDocsPath } from '@/lib/canonical-path'
 import { baseOptions } from '@/lib/layout.shared'
 import { gitConfig, siteUrl } from '@/lib/shared'
 import { getPageImage, slugsToMarkdownPath, source } from '@/lib/source'
@@ -62,41 +63,13 @@ export const Route = createFileRoute('/$')({
   },
 })
 
-// Legacy → new path map after the 3-tab IA move (guide / operate / reference).
-// Keyed by the first URL segment; the value is the new prefix. Old links and
-// bookmarks (e.g. /features/overview) redirect to /guide/features/overview.
-// Keep in sync with FOLDER_META in scripts/sync-docs.mjs.
-const REDIRECT_PREFIX: Record<string, string> = {
-  'getting-started': 'guide/getting-started',
-  features: 'guide/features',
-  'ai-agent': 'guide/ai-agent',
-  guides: 'guide/guides',
-  introduction: 'guide',
-  deploy: 'operate/deploy',
-  authentication: 'operate/authentication',
-  advanced: 'operate/advanced',
-  releases: 'reference/releases',
-  migrating: 'reference/migrating',
-  faq: 'reference/faq',
-  settings: 'reference/settings',
-}
-
-// Returns the new path for a legacy slug array, or null if no mapping applies.
-function legacyRedirect(slugs: string[]): string | null {
-  const [first, ...rest] = slugs
-  const prefix = REDIRECT_PREFIX[first]
-  if (!prefix) return null
-  // `introduction` has no children, so rest is empty → /guide.
-  return `/${[prefix, ...rest].join('/')}`.replace(/\/$/, '')
-}
-
 const serverLoader = createServerFn({ method: 'GET' })
   .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
     const page = source.getPage(slugs)
     if (!page) {
       // Old flat URL? Permanently redirect to its new home under a tab.
-      const target = legacyRedirect(slugs)
+      const target = legacyDocsPath(`/${slugs.join('/')}`)
       if (target && source.getPage(target.split('/').filter(Boolean))) {
         throw redirect({ href: target, statusCode: 301 })
       }

--- a/apps/docs/src/start.ts
+++ b/apps/docs/src/start.ts
@@ -6,9 +6,9 @@ import {
 } from '@tanstack/react-start'
 
 import {
+  docsCanonicalRedirect,
   isPreviewHost,
   previewRobotsTxt,
-  stripTrailingSlash,
 } from './lib/canonical-path'
 import { slugsToMarkdownPath } from './lib/source'
 import { isMarkdownPreferred } from 'fumadocs-core/negotiation'
@@ -69,14 +69,10 @@ const canonicalUrlMiddleware = createMiddleware().server(
       }
     }
 
-    // Never strip a file extension path (`/llms.txt`).
-    const stripped =
-      url.pathname.includes('.') && !url.pathname.endsWith('/')
-        ? url.pathname
-        : stripTrailingSlash(url.pathname)
-    if (stripped !== url.pathname) {
+    const dest = docsCanonicalRedirect(url.pathname)
+    if (dest) {
       throw redirect({
-        href: `${stripped}${url.search}`,
+        href: `${dest}${url.search}`,
         statusCode: 301,
       })
     }

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -28,6 +28,9 @@ enabled = true
 # "alternate with proper canonical" for slash variants).
 [assets]
 html_handling = "drop-trailing-slash"
+# Worker first so /deploy/k8s/ is one 301 to /operate/deploy/k8s, not
+# asset slash-drop then a second IA redirect.
+run_worker_first = true
 
 [[routes]]
 pattern = "docs.chmonitor.dev"

--- a/apps/landing/src/seo-routing.test.ts
+++ b/apps/landing/src/seo-routing.test.ts
@@ -1,5 +1,6 @@
 import {
   DASHBOARD_PREFIXES,
+  isSamePathSlashRedirect,
   landingRedirectUrl,
   shouldNoindexHost,
   stripTrailingSlash,
@@ -64,6 +65,21 @@ describe('landing SEO routing', () => {
     expect(DASHBOARD_PREFIXES.has('explorer')).toBe(true)
     expect(DASHBOARD_PREFIXES.has('table')).toBe(true)
     expect(DASHBOARD_PREFIXES.has('pricing')).toBe(false)
+  })
+
+  test('slash-only asset redirects are the same path', () => {
+    expect(
+      isSamePathSlashRedirect(
+        new URL('https://chmonitor.dev/features/storage'),
+        '/features/storage/'
+      )
+    ).toBe(true)
+    expect(
+      isSamePathSlashRedirect(
+        new URL('https://chmonitor.dev/features/storage'),
+        '/features/postgres/'
+      )
+    ).toBe(false)
   })
 
   test('preview hosts are noindexed', () => {

--- a/apps/landing/src/seo-routing.ts
+++ b/apps/landing/src/seo-routing.ts
@@ -127,6 +127,21 @@ Disallow: /
 `
 }
 
+/** Assets often 307 `/foo` → `/foo/`. Treat that as the same URL, not a hop. */
+export function isSamePathSlashRedirect(from: URL, location: string): boolean {
+  let to: URL
+  try {
+    to = new URL(location, from)
+  } catch {
+    return false
+  }
+  if (to.origin !== from.origin || to.search !== from.search) return false
+  return (
+    stripTrailingSlash(to.pathname) === stripTrailingSlash(from.pathname) &&
+    to.pathname !== from.pathname
+  )
+}
+
 /** Absolute 301 target, or null to serve the landing asset. */
 export function landingRedirectUrl(url: URL): string | null {
   const path = stripTrailingSlash(url.pathname)

--- a/apps/landing/src/seo-worker.ts
+++ b/apps/landing/src/seo-worker.ts
@@ -1,4 +1,5 @@
 import {
+  isSamePathSlashRedirect,
   landingRedirectUrl,
   previewRobotsTxt,
   shouldNoindexHost,
@@ -26,7 +27,17 @@ export default {
       return Response.redirect(dest, 301)
     }
 
-    const asset = await env.ASSETS.fetch(request)
+    let asset = await env.ASSETS.fetch(request)
+    const loc = asset.headers.get('Location')
+    if (
+      loc &&
+      [301, 302, 307, 308].includes(asset.status) &&
+      isSamePathSlashRedirect(url, loc)
+    ) {
+      asset = await env.ASSETS.fetch(
+        new Request(new URL(loc, url).toString(), request)
+      )
+    }
     if (!shouldNoindexHost(url.hostname)) return asset
 
     const headers = new Headers(asset.headers)

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -223,7 +223,7 @@ Deep dive, live charts, and the AI advisor: https://dash.chmonitor.dev (hosted) 
 - **Exit code** is `1` if any finding is critical, `0` otherwise — safe to wire into a CI step or cron job.
 - Each finding's detail line names the exact next step (e.g. `OPTIMIZE`, review a partition key, check `system.mutations.latest_fail_reason`).
 
-For live charts, alerting, the AI advisor, and multi-host clusters, point the same [REDACTED] credentials at the full dashboard — [self-host it](/operate/deploy) or use the hosted [dash.chmonitor.dev](https://dash.chmonitor.dev/?ref=docs).
+For live charts, alerting, the AI advisor, and multi-host clusters, point the same [REDACTED] credentials at the full dashboard — [self-host it](/operate/deploy) or use the hosted [dash.chmonitor.dev](https://dash.chmonitor.dev/overview?host=0).
 
 ## Anonymous telemetry
 


### PR DESCRIPTION
## Summary

The GSC \"Page with redirect\" report (111 URLs) is mostly *working* 301s of old docs paths. Real bugs: slash+IA **chains** (\`/deploy/k8s/\` → \`/deploy/k8s\` → \`/operate/deploy/k8s\`), landing \`/features/storage\` 307 to a trailing slash, and demo links to \`dash.chmonitor.dev/?ref=\` which 302 off \`/\`.

## Changes

- Docs: one 301 from legacy path (with or without slash) to the current IA path; Worker-first so assets do not slash-drop first
- Landing: if Assets only adds/removes a trailing slash, follow internally and return 200 on the URL in the sitemap
- Demo links → \`https://dash.chmonitor.dev/overview?host=0\` (README, blog, docs)

## What will remain in GSC

Old URLs that 301 to the canonical stay in this report until Google drops them. That is the desired outcome — they should not be indexed. After recrawl, chains and slash 307s should leave the list or become a single redirect that then ages out.

## Test plan

- [x] docs canonical-path tests for GSC example URLs
- [x] landing slash-twin helper tests
- [ ] After deploy: \`curl -sI https://docs.chmonitor.dev/deploy/k8s/\` → **one** 301 to \`/operate/deploy/k8s\`
- [ ] \`curl -sI https://chmonitor.dev/features/storage\` → 200 (not 307)

Co-Authored-By: duyetbot <bot@duyet.net>