### PR TITLE
fix(landing): hero latest post is Release or Update only

### DIFF
--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -71,7 +71,7 @@ describe('header nav advertises Pricing', () => {
   })
 })
 
-describe('hero pill links to the latest published blog post', () => {
+describe('hero pill links to the latest Release or Update post', () => {
   const latest = getLatestBlogPost()
 
   test('helper resolves a published post on blog.chmonitor.dev', () => {

--- a/apps/landing/src/lib/latest-blog-post.test.ts
+++ b/apps/landing/src/lib/latest-blog-post.test.ts
@@ -29,6 +29,7 @@ describe('getLatestBlogPost', () => {
     expect(latest!.href.endsWith('/')).toBe(true)
     expect(latest!.slug.length).toBeGreaterThan(0)
     expect(latest!.date.valueOf()).toBeLessThanOrEqual(Date.now())
+    expect(['release', 'update']).toContain(latest!.tag.toLowerCase())
   })
 
   test('sorts by date and picks the newest published post', () => {
@@ -118,6 +119,28 @@ describe('getLatestBlogPost', () => {
     expect(yml.slice(landingPaths, landingPaths + 500)).toContain(
       'apps/blog/src/content/blog/**'
     )
+  })
+
+  test('skips how-tos and guides even when they are newer', () => {
+    tmpDir()
+    writePost(
+      'guide.md',
+      'title: "Fresh guide"\ndescription: "d"\ndate: 2026-08-19\ntag: How-to'
+    )
+    writePost(
+      'release.md',
+      'title: "Release"\ndescription: "d"\ndate: 2026-08-01\ntag: Release'
+    )
+    writePost(
+      'update.md',
+      'title: "Update"\ndescription: "d"\ndate: 2026-08-10\ntag: Update'
+    )
+    const latest = getLatestBlogPost({
+      dir,
+      now: new Date('2026-08-20T12:00:00Z'),
+    })
+    expect(latest?.title).toBe('Update')
+    expect(latest?.tag).toBe('Update')
   })
 
   test('returns null when the directory has no published posts', () => {

--- a/apps/landing/src/lib/latest-blog-post.ts
+++ b/apps/landing/src/lib/latest-blog-post.ts
@@ -7,12 +7,16 @@ export const BLOG_ORIGIN = 'https://blog.chmonitor.dev'
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/
 
+/** Hero pill only links to product news, not how-tos or guides. */
+export const LATEST_POST_TAGS = ['release', 'update'] as const
+
 export type LatestBlogPost = {
   title: string
   description: string
   date: Date
   slug: string
   href: string
+  tag: string
 }
 
 export type LatestBlogPostOptions = {
@@ -50,6 +54,7 @@ export function getPublishedBlogPosts(
       date: parsed.date,
       slug: parsed.slug,
       href: parsed.href,
+      tag: parsed.tag,
     })
   }
   return posts.sort((a, b) => b.date.valueOf() - a.date.valueOf())
@@ -58,7 +63,14 @@ export function getPublishedBlogPosts(
 export function getLatestBlogPost(
   options: LatestBlogPostOptions = {}
 ): LatestBlogPost | null {
-  return getPublishedBlogPosts(options)[0] ?? null
+  return (
+    getPublishedBlogPosts(options).find((post) => isLatestPostTag(post.tag)) ??
+    null
+  )
+}
+
+function isLatestPostTag(tag: string): boolean {
+  return (LATEST_POST_TAGS as readonly string[]).includes(tag.toLowerCase())
 }
 
 export function resolveBlogContentDir(): string | null {
@@ -101,6 +113,7 @@ function parseBlogPostFile(
     date,
     slug,
     href: `${BLOG_ORIGIN}/${slug}/`,
+    tag: fields.tag || 'Release',
     draft: fields.draft === 'true',
   }
 }


### PR DESCRIPTION
## Summary
The landing hero pill was linking to the newest published blog post of any category (how-tos, 5-min guides, etc.). It now only picks **Release** or **Update** posts so the homepage advertises product news.

Sitemap / published-post listing is unchanged.

## Test plan
- [x] `bun test src/lib/latest-blog-post.test.ts src/homepage.test.ts` in `apps/landing`
- [ ] After deploy, confirm chmonitor.dev hero pill links to the latest Release or Update post