### PR TITLE
fix(schema-diff): pretty-print DDL with UUID, ON CLUSTER, quoted names

### DIFF
--- a/apps/dashboard/src/lib/schema-diff/pretty-sql.test.ts
+++ b/apps/dashboard/src/lib/schema-diff/pretty-sql.test.ts
@@ -40,4 +40,31 @@ describe('prettySchemaSql', () => {
       'CREATE TABLE broken (id UInt64'
     )
   })
+
+  test('still pretty-prints when UUID / ON CLUSTER / quoted names precede columns', () => {
+    const uuid =
+      "CREATE TABLE default.foo UUID '01234567-89ab-cdef-0123-456789abcdef' (`id` Int64, `name` String) ENGINE = MergeTree ORDER BY id"
+    const clustered =
+      "CREATE TABLE default.foo ON CLUSTER '{cluster}' (`id` UInt64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}') ORDER BY id"
+    const quoted =
+      'CREATE TABLE `default`.`events` (`id` UInt64, `payload` String CODEC(ZSTD(1))) ENGINE = MergeTree PARTITION BY toYYYYMM(d) ORDER BY id SETTINGS index_granularity = 8192'
+
+    const uuidPretty = prettySchemaSql(uuid)
+    expect(uuidPretty).toContain('\n(\n  `id` Int64,\n  `name` String\n)')
+    expect(uuidPretty).toContain('ENGINE = MergeTree')
+
+    const clusteredPretty = prettySchemaSql(clustered)
+    expect(clusteredPretty.split('\n')[0]).toBe(
+      "CREATE TABLE default.foo ON CLUSTER '{cluster}'"
+    )
+    expect(clusteredPretty).toContain('  `id` UInt64')
+    expect(clusteredPretty).toContain('ENGINE = ReplicatedMergeTree')
+
+    const quotedPretty = prettySchemaSql(quoted)
+    expect(quotedPretty.split('\n')[0]).toBe('CREATE TABLE `default`.`events`')
+    expect(quotedPretty).toContain('  `id` UInt64,')
+    expect(quotedPretty).toContain('  `payload` String CODEC(ZSTD(1))')
+    expect(quotedPretty).toContain('PARTITION BY toYYYYMM(d)')
+    expect(quotedPretty).toContain('SETTINGS index_granularity = 8192')
+  })
 })

--- a/apps/dashboard/src/lib/schema-diff/pretty-sql.ts
+++ b/apps/dashboard/src/lib/schema-diff/pretty-sql.ts
@@ -54,13 +54,20 @@ function findColumnList(
   }
 }
 
-/** First `(` that opens the column/index list, not a type argument. */
+/**
+ * First `(` that opens the column/index list, not a type argument.
+ *
+ * `skipQuoted` returns the closing quote index. This scan uses a while-loop
+ * (no auto-increment), so we must step past that closer. Otherwise a UUID,
+ * ON CLUSTER '...', or `` `db`.`table` `` before the column list is treated
+ * as a new opener and the real `(` is skipped — Pretty becomes a no-op.
+ */
 function findColumnListOpen(sql: string): number {
   let i = 0
   while (i < sql.length) {
     const ch = sql[i]
     if (ch === "'" || ch === '"' || ch === '`') {
-      i = skipQuoted(sql, i)
+      i = skipQuoted(sql, i) + 1
       continue
     }
     if (ch === '(') return i


### PR DESCRIPTION
## Summary

Schema Compare Pretty did nothing on real ClickHouse `create_table_query` values. Quoted UUID, `ON CLUSTER`, and `` `db`.`table` `` sit before the column list; the scanner treated the closing quote as a new opener and skipped the `(` that Pretty needs.

## Changes

- Step past the closing quote in `findColumnListOpen` so the column-list `(` is found
- Tests for UUID, ON CLUSTER, and backticked database.table names

## Test plan

- [x] `bun test src/lib/schema-diff/pretty-sql.test.ts src/lib/schema-diff/ddl-diff.test.ts`
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes (catches test-file type errors not covered by the build — see CONTRIBUTING.md §Type-check gap)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Recommend-only Schema Compare is unchanged aside from Pretty actually formatting catalog DDL. Toggle still copies the displayed (pretty or raw) SQL.

---

Co-Authored-By: duyetbot <bot@duyet.net>