### PR TITLE
fix(settings-diff): embed listing in the shared table chrome

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -130,17 +130,20 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   table matches** (`MatchOk`), never EmptyState "no data" or
   "Select a table". Keep "No tables match" only for a name-filter
   miss.
-  Settings Diff (`/settings-diff`) uses the same host toolbar. The
-  listing is the shared `DataTable` (search, Filters, sort, resize,
-  drag-to-reorder, density, column visibility, CSV) — name search
-  lives there, not next to Source/Target. Diffs-only with zero
-  deltas still lists matching settings. The Match column uses the
-  shared boolean check (green) / cross (rose); column headers carry
-  lucide icons (`CheckCircle2`, `SlidersHorizontal`, `Table2`,
-  `Pencil`, `Undo2`, `Server`). "Changed from default" is a
-  pressable chip, not a second switch. Empty catalog copy is
-  DataTable's "No settings found" / "No settings match your
-  filters" — only a name or changed-from-default miss.
+  Settings Diff (`/settings-diff`) uses the same host toolbar
+  (Connections / Replica nodes + Source/Target only). The listing is
+  the shared `DataTable` in **embedded** mode — one `rounded-xl
+  border bg-card` like Running Queries, no second page title. Search,
+  Differences / All, Changed from default, Filters, Display options,
+  density, column visibility, and CSV live on that table toolbar.
+  Diffs-only with zero deltas still lists matching settings. The
+  Match column uses the shared boolean check (green) / cross (rose);
+  column headers carry lucide icons (`CheckCircle2`,
+  `SlidersHorizontal`, `Table2`, `Pencil`, `Undo2`, `Server`).
+  "Changed from default" is a pressable chip, not a second switch.
+  Empty catalog copy is DataTable's "No settings found" / "No
+  settings match your filters" — only a name or changed-from-default
+  miss.
 - **Sidebar favorites:** the row is a link (`cursor-pointer`). Pin is
   hover-only. Favorites also reveal a grip handle on hover — drag it to
   reorder (`nav-favorites.tsx`).

--- a/apps/dashboard/src/components/data-table/components/data-table-content.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-content.tsx
@@ -77,6 +77,8 @@ export interface DataTableContentProps<
   onResetColumnOrder?: () => void
   /** Compact mode: removes borders, background, and margin */
   compact?: boolean
+  /** Parent already draws the card; skip the inner listing border. */
+  embedded?: boolean
   /** When set, rows render an expand chevron and clicking a row toggles a detail panel below it. */
   expandable?: true | ExpandableConfig
   /**
@@ -138,6 +140,7 @@ export const DataTableContent = memo(function DataTableContent<
   onColumnOrderChange,
   onResetColumnOrder: _onResetColumnOrder,
   compact = false,
+  embedded = false,
   expandable,
   onRowClick,
   view = 'auto',
@@ -246,7 +249,8 @@ export const DataTableContent = memo(function DataTableContent<
             isVirtualized ? 'flex-1 overflow-auto' : 'w-full overflow-x-auto',
             {
               'max-h-[50vh]': compact && !isVirtualized,
-              'mb-5 border border-border/50 bg-card/30': !compact && !cardsOnly,
+              'mb-5 border border-border/50 bg-card/30':
+                !compact && !embedded && !cardsOnly,
             }
           )}
           role="region"

--- a/apps/dashboard/src/components/data-table/components/data-table-header.tsx
+++ b/apps/dashboard/src/components/data-table/components/data-table-header.tsx
@@ -39,6 +39,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 import { getSqlForDisplay } from '@/types/query-config'
 
 export interface DataTableHeaderProps<TData extends RowData> {
@@ -66,6 +67,8 @@ export interface DataTableHeaderProps<TData extends RowData> {
   enableColumnReordering?: boolean
   /** Callback to reset column order to default */
   onResetColumnOrder?: () => void
+  /** Skip the title row and sit extras on the search toolbar. */
+  embedded?: boolean
   /** Current row density mode */
   density?: TableDensity
   /** Callback to change row density mode */
@@ -110,6 +113,7 @@ export const DataTableHeader = memo(function DataTableHeader<
   metadata,
   enableColumnReordering = false,
   onResetColumnOrder,
+  embedded = false,
   density = 'comfortable',
   onDensityChange,
   globalSearch,
@@ -219,48 +223,64 @@ export const DataTableHeader = memo(function DataTableHeader<
     onAdvancedFiltersChange([])
   }
 
+  const toolbarClassName = embedded
+    ? 'flex flex-col gap-2 sm:flex-row sm:items-center border-b border-border px-2.5 py-2 sm:px-3'
+    : 'flex flex-col sm:flex-row items-stretch sm:items-center gap-2 bg-card/65 dark:bg-card/40 border border-border/60 p-2 rounded-xl shadow-xs'
+
   return (
-    <div className="flex flex-col gap-2.5 pb-2.5">
+    <div
+      className={cn(
+        embedded ? 'flex flex-col' : 'flex flex-col gap-2.5 pb-2.5'
+      )}
+    >
       {/* Row 1: Title and Description */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-            <h1 className="text-xl font-bold tracking-tight text-foreground flex-none">
-              {title}
-            </h1>
-            {isRefreshing && (
-              <Loader2Icon
-                className="text-muted-foreground size-4 animate-spin shrink-0"
-                aria-label="Loading data"
-              />
-            )}
-            {toolbarExtras && (
-              <div className="flex items-center gap-1">{toolbarExtras}</div>
-            )}
-            {queryConfig.bulkActions && queryConfig.bulkActions.length > 0 && (
-              <BulkActions
-                table={table}
-                bulkActions={queryConfig.bulkActions}
-                bulkActionKey={queryConfig.bulkActionKey || 'query_id'}
-              />
+      {!embedded ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
+              <h1 className="text-xl font-bold tracking-tight text-foreground flex-none">
+                {title}
+              </h1>
+              {isRefreshing && (
+                <Loader2Icon
+                  className="text-muted-foreground size-4 animate-spin shrink-0"
+                  aria-label="Loading data"
+                />
+              )}
+              {toolbarExtras && (
+                <div className="flex items-center gap-1">{toolbarExtras}</div>
+              )}
+              {queryConfig.bulkActions &&
+                queryConfig.bulkActions.length > 0 && (
+                  <BulkActions
+                    table={table}
+                    bulkActions={queryConfig.bulkActions}
+                    bulkActionKey={queryConfig.bulkActionKey || 'query_id'}
+                  />
+                )}
+            </div>
+            <p className="text-xs sm:text-sm text-muted-foreground truncate mt-0.5">
+              {description || queryConfig.description}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            {topRightToolbarExtras}
+            {showSQL && (
+              <CardToolbar sql={displaySql} metadata={metadata} alwaysVisible />
             )}
           </div>
-          <p className="text-xs sm:text-sm text-muted-foreground truncate mt-0.5">
-            {description || queryConfig.description}
-          </p>
         </div>
-        <div className="flex items-center gap-2">
-          {topRightToolbarExtras}
-          {showSQL && (
-            <CardToolbar sql={displaySql} metadata={metadata} alwaysVisible />
-          )}
-        </div>
-      </div>
+      ) : null}
 
       {/* Row 2: Unified toolbar — single row for all modes */}
       {filterBarSlot ? (
         /* Schema-driven mode: FilterBar slot (left) + action buttons (right) */
-        <div className="flex flex-wrap items-center gap-2 bg-card/65 dark:bg-card/40 border border-border/60 p-2 rounded-xl shadow-xs">
+        <div className={toolbarClassName}>
+          {embedded && toolbarExtras ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              {toolbarExtras}
+            </div>
+          ) : null}
           {filterBarSlot}
           <div className="flex flex-wrap items-center gap-2 ml-auto">
             {/* Sort control for card view — moved from separate row into unified toolbar */}
@@ -285,7 +305,12 @@ export const DataTableHeader = memo(function DataTableHeader<
           </div>
         </div>
       ) : (
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 bg-card/65 dark:bg-card/40 border border-border/60 p-2 rounded-xl shadow-xs">
+        <div className={toolbarClassName}>
+          {embedded && toolbarExtras ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              {toolbarExtras}
+            </div>
+          ) : null}
           {/* Search TextBox on left */}
           <div className="relative flex-1 min-w-[200px]">
             <SearchIcon

--- a/apps/dashboard/src/components/data-table/data-table.tsx
+++ b/apps/dashboard/src/components/data-table/data-table.tsx
@@ -75,6 +75,7 @@ export function DataTable<
   enableColumnReordering: enableColumnReorderingProp,
   columnOrderStorageKey,
   compact = false,
+  embedded = false,
   expandable: expandableProp,
   onRowClick,
   showFilterBar = true,
@@ -219,6 +220,7 @@ export function DataTable<
             metadata={metadata}
             enableColumnReordering={resolvedEnableColumnReordering}
             onResetColumnOrder={handleResetColumnOrder}
+            embedded={embedded}
             density={density}
             onDensityChange={setDensity}
             globalSearch={globalSearch}
@@ -254,6 +256,7 @@ export function DataTable<
           onColumnOrderChange={handleDragEndColumnReorder}
           onResetColumnOrder={handleResetColumnOrder}
           compact={compact}
+          embedded={embedded}
           expandable={expandable}
           onRowClick={onRowClick}
           view={view}

--- a/apps/dashboard/src/components/data-table/data-table.types.ts
+++ b/apps/dashboard/src/components/data-table/data-table.types.ts
@@ -80,6 +80,12 @@ export interface DataTableProps<TData extends RowData> {
   /** Compact mode: hides header/toolbar, removes borders, forces dense density (default: false) */
   compact?: boolean
   /**
+   * Nested listing (page already has a title). Skips the table h1, puts
+   * `toolbarExtras` on the search/filter row, and leaves card chrome to the
+   * parent — same strip as Running Queries.
+   */
+  embedded?: boolean
+  /**
    * Inline row expansion. When set, each row renders a chevron and a click on
    * the row (outside interactive children) toggles a full-width detail panel.
    * Overrides `queryConfig.expandable`.

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.test.tsx
@@ -148,6 +148,7 @@ describe('Settings Diff one-host vs default', () => {
             showChangedOnly: false,
             nameFilter: '',
           })}
+          toolbarExtras={<button type="button">Changed from default</button>}
         />
       </div>
     )
@@ -165,10 +166,13 @@ describe('Settings Diff one-host vs default', () => {
       expect(
         document.querySelector('[data-testid="add-host"]')?.className
       ).toContain('min-h-11')
-      const { search, filters, display } = tableToolbar()
+      const { table, search, filters, display } = tableToolbar()
       expect(search).not.toBeNull()
       expect(filters).toBeDefined()
       expect(display).toBeDefined()
+      expect(table?.querySelector('h1')).toBeNull()
+      expect(table?.className).toContain('rounded-xl')
+      expect(table?.textContent).toContain('Changed from default')
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-page.tsx
@@ -276,7 +276,6 @@ export function SettingsDiffPage() {
             hosts={peers}
             sourceHostId={pair.sourceId}
             targetHostId={pair.targetId}
-            showDiffsOnly={showDiffsOnly}
             onPairChange={(source, target) =>
               setSearch({
                 source,
@@ -285,34 +284,8 @@ export function SettingsDiffPage() {
                 view: scope === 'hosts' ? 'pair' : undefined,
               })
             }
-            onShowDiffsOnlyChange={setShowDiffsOnly}
-            extraFilters={
-              <ChangedFromDefaultChip
-                pressed={showChangedOnly}
-                onPressedChange={setShowChangedOnly}
-              />
-            }
           />
-        ) : (
-          <div className="flex flex-wrap items-center gap-2">
-            {hostCount > 1 ? (
-              <SegmentedControl
-                size="sm"
-                ariaLabel="Show differences or all rows"
-                value={showDiffsOnly ? 'diffs' : 'all'}
-                onChange={(next) => setShowDiffsOnly(next === 'diffs')}
-                options={[
-                  { label: 'Differences', value: 'diffs' },
-                  { label: 'All', value: 'all' },
-                ]}
-              />
-            ) : null}
-            <ChangedFromDefaultChip
-              pressed={showChangedOnly}
-              onPressedChange={setShowChangedOnly}
-            />
-          </div>
-        )}
+        ) : null}
       </CompareToolbar>
 
       {listingLoading ? (
@@ -331,7 +304,30 @@ export function SettingsDiffPage() {
           />
         </div>
       ) : (
-        <SettingsDiffTable columns={columns} rows={filteredRows} />
+        <SettingsDiffTable
+          columns={columns}
+          rows={filteredRows}
+          toolbarExtras={
+            <>
+              {hostCount > 1 ? (
+                <SegmentedControl
+                  size="sm"
+                  ariaLabel="Show differences or all rows"
+                  value={showDiffsOnly ? 'diffs' : 'all'}
+                  onChange={(next) => setShowDiffsOnly(next === 'diffs')}
+                  options={[
+                    { label: 'Differences', value: 'diffs' },
+                    { label: 'All', value: 'all' },
+                  ]}
+                />
+              ) : null}
+              <ChangedFromDefaultChip
+                pressed={showChangedOnly}
+                onPressedChange={setShowChangedOnly}
+              />
+            </>
+          }
+        />
       )}
     </div>
   )
@@ -351,6 +347,7 @@ function ChangedFromDefaultChip({
       variant={pressed ? 'secondary' : 'outline'}
       aria-pressed={pressed}
       className="h-8 rounded-md text-[13px]"
+      data-testid="settings-diff-changed-from-default"
       onClick={() => onPressedChange(!pressed)}
     >
       Changed from default

--- a/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
+++ b/apps/dashboard/src/components/settings-diff/settings-diff-table.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type {
   SettingsDiffHostInfo,
   SettingsDiffRow,
@@ -16,9 +17,14 @@ const EMPTY_TABLE_CONTEXT: Record<string, string> = {}
 interface SettingsDiffTableProps {
   columns: SettingsDiffHostInfo[]
   rows: SettingsDiffRow[]
+  toolbarExtras?: ReactNode
 }
 
-export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
+export function SettingsDiffTable({
+  columns,
+  rows,
+  toolbarExtras,
+}: SettingsDiffTableProps) {
   const showMatchColumn = columns.length > 1
   const hostColumns = useMemo(() => uniqueHostColumnKeys(columns), [columns])
   const data = useMemo(
@@ -31,7 +37,10 @@ export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
   )
 
   return (
-    <div data-testid="settings-diff-table">
+    <div
+      className="overflow-hidden rounded-xl border border-border bg-card"
+      data-testid="settings-diff-table"
+    >
       <DataTable
         title="Settings"
         data={data}
@@ -39,6 +48,8 @@ export function SettingsDiffTable({ columns, rows }: SettingsDiffTableProps) {
         context={EMPTY_TABLE_CONTEXT}
         defaultPageSize={100}
         showSQL={false}
+        embedded
+        toolbarExtras={toolbarExtras}
         enableColumnReordering
         columnOrderStorageKey="settings-diff"
         enableColumnFilters

--- a/apps/dashboard/src/lib/settings-diff/table-rows.ts
+++ b/apps/dashboard/src/lib/settings-diff/table-rows.ts
@@ -173,6 +173,6 @@ export function buildSettingsDiffQueryConfig(
       enableColumnReordering: true,
     },
     rowClassName: (row) =>
-      row._hasDiff ? 'bg-amber-50 dark:bg-amber-950/20' : undefined,
+      row._hasDiff ? 'bg-[var(--chart-yellow)]/10' : undefined,
   }
 }

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -711,14 +711,16 @@ would clip it.
   with one host keeps the live vs-default matrix and a banner to add
   another host; two or more merged hosts (env + database + browser,
   including negative ids) keep an All-hosts matrix with an optional pair
-  mode (`HostPairFilter` + URL `source`/`target`). The listing is the
-  shared `DataTable` (search, Filters, sort, resize, drag-to-reorder,
-  density, column visibility, CSV). Name search lives on that table,
-  not the host toolbar. Diffs-only with zero deltas still lists
-  matching settings; the Match column uses the shared boolean check
-  (green) / cross (rose). Empty catalog copy is DataTable's "No
-  settings found" / "No settings match your filters" (a name or
-  changed-from-default miss). Compare APIs resolve
+  mode (`HostPairFilter` + URL `source`/`target`). Host toolbar is
+  Connections / Replica nodes + Source/Target only. The listing is the
+  shared `DataTable` in embedded mode (one `rounded-xl border bg-card`
+  like Running Queries, no second page title). Search, Differences /
+  All, Changed from default, Filters, Display options, density, column
+  visibility, and CSV live on that table toolbar. Diffs-only with zero
+  deltas still lists matching settings; the Match column uses the
+  shared boolean check (green) / cross (rose). Empty catalog copy is
+  DataTable's "No settings found" / "No settings match your filters"
+  (a name or changed-from-default miss). Compare APIs resolve
   merged hosts the same way charts do (`resolve-host-fetch.ts` /
   `use-merged-hosts.ts`).
 - Overflow strip: for a single-row scroller that must not wrap, use


### PR DESCRIPTION
## Summary

Settings Diff listing now uses the same table chrome as Running Queries and other DataTable pages: one card, search and filters on the table toolbar, no second page title.

## Changes

- DataTable `embedded` mode skips the inner h1 and sits extras on the search/filter strip
- Settings Diff wraps the listing in `rounded-xl border bg-card`
- Differences / All and Changed from default stay as table toolbar tools, not on the host pair row
- Diff row tint uses the chart-yellow token

## Test plan

- [x] `bun test src/components/settings-diff/settings-diff-page.test.tsx src/lib/settings-diff/table-rows.test.ts`
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run type-check:test` passes
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [ ] Docs updated in `docs/content/` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

Host toolbar is still Connections / Replica nodes + Source/Target. Recommend-only, no apply.

---

Co-Authored-By: duyetbot <bot@duyet.net>