### PR TITLE
feat(ttl): show in-range vs past-TTL bytes on inventory

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -427,10 +427,12 @@ module snapshot in `lib/format-settings.ts`; palette/density →
    Interactive utilities (SQL, explorer, explain, compare, builder, advisor)
    go in `menu/tools.ts`. Data Explorer (`/explorer`) is also listed under
    Tables. TTL & Partitions (`/ttl-partition-health`) is a system-table
-   inventory — it lives under Tables, not Tools or System. The same
-   recommend-only rules also power the **TTL & Partition Health** card
-   on `/health` (flagged-table count + detail dialog). Do not invent a
-   third TTL surface; wire new reporting through those two. Other
+   inventory — it lives under Tables, not Tools or System. The listing
+   includes a stacked in-range vs past-TTL bar (part `max_date` vs the
+   parsed TTL interval). The same recommend-only rules also power the
+   **TTL & Partition Health** card on `/health` (flagged-table count +
+   detail dialog). Do not invent a third TTL surface; never ALTER TTL or
+   DROP PARTITION from these pages. Other
    system-table views stay in their domain file. Tools is the last Main group, composed
    after Logs and before the About footer in `menu/index.ts` — do not put
    it after Overview / before AI Agent. The Tools parent must not set

--- a/apps/dashboard/src/components/data-table/cells/stacked-share-format.tsx
+++ b/apps/dashboard/src/components/data-table/cells/stacked-share-format.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import type { Row, RowData } from '@tanstack/react-table'
+
+import { cn } from '@/lib/utils'
+
+export interface StackedShareOptions {
+  keepKey?: string
+  dropKey?: string
+  keepLabel?: string
+  dropLabel?: string
+}
+
+interface StackedShareFormatProps<TData extends RowData = RowData> {
+  row: Row<TData>
+  options?: StackedShareOptions
+}
+
+function num(value: unknown): number {
+  const n = Number(value)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+export function StackedShareFormat<TData extends RowData = RowData>({
+  row,
+  options,
+}: StackedShareFormatProps<TData>): React.ReactNode {
+  const original = row.original as Record<string, unknown>
+  const keepKey = options?.keepKey ?? 'bytes_in_range'
+  const dropKey = options?.dropKey ?? 'bytes_past_ttl'
+  const keep = num(original[keepKey])
+  const drop = num(original[dropKey])
+  const total = keep + drop
+  const ttlDays = num(original.ttl_days)
+  const keepLabel =
+    String(original[`readable_${keepKey}`] ?? '') || options?.keepLabel
+  const dropLabel =
+    String(original[`readable_${dropKey}`] ?? '') || options?.dropLabel
+  const rowsDrop = String(original.readable_rows_past_ttl ?? '')
+  const keepPct = total > 0 ? (keep / total) * 100 : 0
+  const dropPct = total > 0 ? (drop / total) * 100 : 0
+
+  if (ttlDays <= 0) {
+    return <span className="text-muted-foreground text-xs">No table TTL</span>
+  }
+
+  if (total <= 0) {
+    return <span className="text-muted-foreground text-xs">No parts</span>
+  }
+
+  const title = `${keepLabel || keep} in range · ${dropLabel || drop} past TTL${
+    rowsDrop ? ` (${rowsDrop} rows)` : ''
+  }`
+
+  return (
+    <div className="flex min-w-[12rem] flex-col gap-1" title={title}>
+      <div
+        className="flex h-2 w-full overflow-hidden rounded-sm bg-muted"
+        role="img"
+        aria-label={title}
+      >
+        <div
+          className="h-full bg-[var(--chart-green)]"
+          style={{ width: `${keepPct}%` }}
+        />
+        <div
+          className="h-full bg-[var(--chart-yellow)]"
+          style={{ width: `${dropPct}%` }}
+        />
+      </div>
+      <div className="text-muted-foreground flex gap-2 text-[11px] tabular-nums">
+        <span className={cn(drop > 0 ? 'text-foreground' : undefined)}>
+          {keepLabel} in range
+        </span>
+        {drop > 0 ? (
+          <span className="text-[var(--chart-yellow)]">
+            {dropLabel} past TTL
+          </span>
+        ) : (
+          <span>all in range</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/dashboard/src/components/data-table/formatters/context-formatters.tsx
+++ b/apps/dashboard/src/components/data-table/formatters/context-formatters.tsx
@@ -15,6 +15,10 @@ import {
 } from '../cells/hover-card-format'
 import { LinkFormat, type LinkFormatOptions } from '../cells/link-format'
 import { RunningQuerySummaryFormat } from '@/components/data-table/cells/running-query-summary-format'
+import {
+  StackedShareFormat,
+  type StackedShareOptions,
+} from '@/components/data-table/cells/stacked-share-format'
 import { ColumnFormat } from '@/types/column-format'
 
 /**
@@ -179,10 +183,26 @@ export const runningQuerySummaryFormatter: RowContextFormatter = <
  * Registry of context formatters
  * These formatters need access to row, table, and context data
  */
+export const stackedShareFormatter: RowContextFormatter = <
+  TData extends RowData,
+  TValue,
+>(
+  props: FormatterProps<TData, TValue>
+): React.ReactNode => {
+  const { row, options } = props
+  return (
+    <StackedShareFormat
+      row={row}
+      options={options as StackedShareOptions | undefined}
+    />
+  )
+}
+
 export const CONTEXT_FORMATTERS: Record<
   | ColumnFormat.Action
   | ColumnFormat.InlineAction
   | ColumnFormat.BackgroundBar
+  | ColumnFormat.StackedShare
   | ColumnFormat.HoverCard
   | ColumnFormat.Link
   | ColumnFormat.RunningQuerySummary,
@@ -191,6 +211,7 @@ export const CONTEXT_FORMATTERS: Record<
   [ColumnFormat.Action]: actionFormatter,
   [ColumnFormat.InlineAction]: inlineActionFormatter,
   [ColumnFormat.BackgroundBar]: backgroundBarFormatter,
+  [ColumnFormat.StackedShare]: stackedShareFormatter,
   [ColumnFormat.HoverCard]: hoverCardFormatter,
   [ColumnFormat.Link]: linkFormatter,
   [ColumnFormat.RunningQuerySummary]: runningQuerySummaryFormatter,

--- a/apps/dashboard/src/lib/health/ttl-partition-sql.test.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-sql.test.ts
@@ -43,6 +43,11 @@ describe('buildTtlPartitionInventorySql', () => {
     expect(sql).toContain(
       `SETTINGS max_execution_time = ${TTL_PARTITION_INVENTORY_MAX_EXECUTION_TIME}`
     )
+    expect(sql).toContain('bytes_past_ttl')
+    expect(sql).toContain('bytes_in_range')
+    expect(sql).toContain('ttl_retention')
+    expect(sql).toContain('max_date')
+    expect(sql).toContain('INTERVAL')
   })
 })
 

--- a/apps/dashboard/src/lib/health/ttl-partition-sql.ts
+++ b/apps/dashboard/src/lib/health/ttl-partition-sql.ts
@@ -38,6 +38,33 @@ const TTL_FROM_ENGINE_FULL = `
         ''
       )`
 
+/**
+ * Approximate TTL window in days from a table TTL expression.
+ * Covers `INTERVAL n UNIT` and `toIntervalX(n)`. Unparseable → 0.
+ */
+export const TTL_DAYS_SQL = `
+      multiIf(
+        match(ttl_expression, '(?i)toIntervalYear\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+YEAR'),
+          toUInt32OrZero(extract(ttl_expression, '(\\\\d+)')) * 365,
+        match(ttl_expression, '(?i)toIntervalQuarter\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+QUARTER'),
+          toUInt32OrZero(extract(ttl_expression, '(\\\\d+)')) * 90,
+        match(ttl_expression, '(?i)toIntervalMonth\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+MONTH'),
+          toUInt32OrZero(extract(ttl_expression, '(\\\\d+)')) * 30,
+        match(ttl_expression, '(?i)toIntervalWeek\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+WEEK'),
+          toUInt32OrZero(extract(ttl_expression, '(\\\\d+)')) * 7,
+        match(ttl_expression, '(?i)toIntervalDay\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+DAY'),
+          toUInt32OrZero(extract(ttl_expression, '(\\\\d+)')),
+        match(ttl_expression, '(?i)toIntervalHour\\\\s*\\\\(\\\\s*\\\\d+')
+          OR match(ttl_expression, '(?i)INTERVAL\\\\s+\\\\d+\\\\s+HOUR'),
+          1,
+        0
+      )`
+
 const TIME_BASED_PARTITION_SQL = `(
         positionCaseInsensitive(t.partition_key, 'toYYYYMM') > 0
         OR positionCaseInsensitive(t.partition_key, 'toStartOf') > 0
@@ -101,7 +128,8 @@ function ttlPartitionInventoryCtes(): string {
           0,
           round(count() / uniqExact(partition), 2)
         ) AS parts_per_partition,
-        sum(bytes_on_disk) AS bytes_on_disk
+        sum(bytes_on_disk) AS bytes_on_disk,
+        sum(rows) AS rows
       FROM system.parts
       WHERE active
         AND database NOT IN (${SYSTEM_DATABASES})
@@ -121,7 +149,8 @@ function ttlPartitionInventoryCtes(): string {
         ifNull(p.partitions, 0) AS partitions,
         ifNull(p.active_parts, 0) AS active_parts,
         ifNull(p.parts_per_partition, 0) AS parts_per_partition,
-        ifNull(p.bytes_on_disk, 0) AS bytes_on_disk
+        ifNull(p.bytes_on_disk, 0) AS bytes_on_disk,
+        ifNull(p.rows, 0) AS rows
       FROM mergetree_tables AS t
       LEFT JOIN part_stats AS p
         ON p.database = t.database AND p.table = t.name
@@ -140,7 +169,39 @@ export function buildTtlPartitionInventorySql(opts?: {
     TTL_PARTITION_INVENTORY_MAX_EXECUTION_TIME
   )
   return withMaxExecutionTime(
-    `WITH ${ttlPartitionInventoryCtes()}
+    `WITH ${ttlPartitionInventoryCtes()},
+    retention_keys AS (
+      SELECT
+        database,
+        table,
+        ${TTL_DAYS_SQL} AS ttl_days,
+        ${TIME_BASED_PARTITION_SQL.replaceAll('t.partition_key', 'partition_key')} AS is_time_partition
+      FROM inventory
+    ),
+    part_retention AS (
+      SELECT
+        p.database,
+        p.table,
+        any(k.ttl_days) AS ttl_days,
+        sumIf(
+          p.bytes_on_disk,
+          k.ttl_days > 0
+            AND k.is_time_partition
+            AND p.max_date < today() - k.ttl_days
+        ) AS bytes_past_ttl,
+        sumIf(
+          p.rows,
+          k.ttl_days > 0
+            AND k.is_time_partition
+            AND p.max_date < today() - k.ttl_days
+        ) AS rows_past_ttl
+      FROM system.parts AS p
+      INNER JOIN retention_keys AS k
+        ON k.database = p.database AND k.table = p.table
+      WHERE p.active
+        AND p.database NOT IN (${SYSTEM_DATABASES})
+      GROUP BY p.database, p.table
+    )
     SELECT
       database,
       table,
@@ -167,8 +228,24 @@ export function buildTtlPartitionInventorySql(opts?: {
       round(
         active_parts * 100.0 / nullIf(max(active_parts) OVER (), 0),
         2
-      ) AS pct_active_parts
+      ) AS pct_active_parts,
+      ifNull(r.ttl_days, 0) AS ttl_days,
+      ifNull(r.bytes_past_ttl, 0) AS bytes_past_ttl,
+      ifNull(r.rows_past_ttl, 0) AS rows_past_ttl,
+      greatest(bytes_on_disk - ifNull(r.bytes_past_ttl, 0), 0) AS bytes_in_range,
+      greatest(rows - ifNull(r.rows_past_ttl, 0), 0) AS rows_in_range,
+      formatReadableSize(ifNull(r.bytes_past_ttl, 0)) AS readable_bytes_past_ttl,
+      formatReadableSize(
+        greatest(bytes_on_disk - ifNull(r.bytes_past_ttl, 0), 0)
+      ) AS readable_bytes_in_range,
+      formatReadableQuantity(ifNull(r.rows_past_ttl, 0)) AS readable_rows_past_ttl,
+      formatReadableQuantity(
+        greatest(rows - ifNull(r.rows_past_ttl, 0), 0)
+      ) AS readable_rows_in_range,
+      '' AS ttl_retention
     FROM inventory
+    LEFT JOIN part_retention AS r
+      ON r.database = inventory.database AND r.table = inventory.table
     ORDER BY partitions DESC, bytes_on_disk DESC`,
     maxExecutionTime
   )

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.test.ts
@@ -2,6 +2,7 @@ import { ttlPartitionHealthConfig } from './ttl-partition-health'
 import { describe, expect, test } from 'bun:test'
 import { getAllSqlStrings } from '@chm/sql-builder'
 import { getQueryConfigByName } from '@/lib/query-config'
+import { ColumnFormat } from '@/types/column-format'
 
 describe('ttlPartitionHealthConfig', () => {
   test('is registered by name', () => {
@@ -51,10 +52,15 @@ describe('ttlPartitionHealthConfig', () => {
       'recommendation',
       'partitions',
       'active_parts',
+      'ttl_retention',
+      'readable_bytes_past_ttl',
     ]) {
       expect(ttlPartitionHealthConfig.columns).toContain(col)
     }
     expect(ttlPartitionHealthConfig.rowClassName).toBeDefined()
+    expect(ttlPartitionHealthConfig.columnFormats?.ttl_retention).toBe(
+      ColumnFormat.StackedShare
+    )
   })
 
   test('recommendation SQL uses the same partition thresholds as the heuristics', () => {

--- a/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
+++ b/apps/dashboard/src/lib/query-config/system/ttl-partition-health.ts
@@ -23,10 +23,15 @@ export const ttlPartitionHealthConfig: QueryConfig = {
   card: {
     primary: 'full_table',
     badges: ['engine'],
-    metrics: ['partitions', 'active_parts', 'readable_bytes_on_disk'],
+    metrics: [
+      'partitions',
+      'active_parts',
+      'readable_bytes_on_disk',
+      'readable_bytes_past_ttl',
+    ],
   },
   description:
-    'TTL expression, PARTITION BY, and partition/part counts per MergeTree table. Does not apply ALTER TTL or DROP PARTITION.',
+    'TTL expression, PARTITION BY, partition/part counts, and in-range vs past-TTL bytes per MergeTree table. Does not apply ALTER TTL or DROP PARTITION.',
   docs: 'https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#table_engine-mergetree-ttl', // pragma: allowlist secret
   tableCheck: 'system.parts',
   sql: ttlPartitionInventorySql,
@@ -40,6 +45,9 @@ export const ttlPartitionHealthConfig: QueryConfig = {
     'active_parts',
     'parts_per_partition',
     'readable_bytes_on_disk',
+    'ttl_retention',
+    'readable_bytes_past_ttl',
+    'readable_rows_past_ttl',
   ],
   columnDescriptions: {
     ttl_expression:
@@ -51,6 +59,11 @@ export const ttlPartitionHealthConfig: QueryConfig = {
       'Active partition count. Highlighted rows have 500+ partitions or a time-based key with no TTL.',
     parts_per_partition:
       'Active parts divided by partitions. High values mean merge backlog.',
+    ttl_retention:
+      'Bytes still inside the parsed TTL window vs parts whose max_date is already past it. Estimate from system.parts — recommend-only, never DROP PARTITION.',
+    readable_bytes_past_ttl:
+      'On-disk bytes in parts whose newest row date is older than the TTL window.',
+    readable_rows_past_ttl: 'Rows in those past-TTL parts.',
   },
   columnFormats: {
     full_table: [
@@ -66,6 +79,7 @@ export const ttlPartitionHealthConfig: QueryConfig = {
     partitions: ColumnFormat.BackgroundBar,
     active_parts: ColumnFormat.BackgroundBar,
     readable_bytes_on_disk: ColumnFormat.BackgroundBar,
+    ttl_retention: ColumnFormat.StackedShare,
   },
   relatedCharts: [
     ['partition-part-health', { title: 'Part health' }],

--- a/apps/dashboard/src/routes/(dashboard)/ttl-partition-health.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/ttl-partition-health.tsx
@@ -11,7 +11,7 @@ function TtlPartitionHealthPageContent() {
     <PageLayout
       queryConfig={ttlPartitionHealthConfig}
       title="TTL & Partition Health"
-      description="Inventory of MergeTree TTL and PARTITION BY, with partition and part counts and a recommend-only next-step column. Tables without TTL still appear. Highlighted rows have too many partitions or a time-based partition key with no TTL. Recommend-only — this page does not run ALTER TTL or DROP PARTITION. Related: Storage Economics, Advisor Schema & Settings, and the disk-capacity forecast in the agent."
+      description="Inventory of MergeTree TTL and PARTITION BY, with partition/part counts and a bar of bytes still in range vs parts whose date is already past TTL. Tables without TTL still appear. Highlighted rows have too many partitions or a time-based partition key with no TTL. Recommend-only — this page does not run ALTER TTL or DROP PARTITION. Related: Storage Economics, Advisor Schema & Settings, and the disk-capacity forecast in the agent."
     />
   )
 }

--- a/apps/dashboard/src/types/column-format.ts
+++ b/apps/dashboard/src/types/column-format.ts
@@ -6,10 +6,12 @@ import type { ColoredBadgeOptions } from '@/components/data-table/cells/colored-
 import type { HoverCardOptions } from '@/components/data-table/cells/hover-card-format'
 import type { LinkFormatOptions } from '@/components/data-table/cells/link-format'
 import type { MarkdownFormatOptions } from '@/components/data-table/cells/markdown-format'
+import type { StackedShareOptions } from '@/components/data-table/cells/stacked-share-format'
 import type { TextFormatOptions } from '@/components/data-table/cells/text-format'
 
 export enum ColumnFormat {
   BackgroundBar = 'background-bar',
+  StackedShare = 'stacked-share',
   ColoredBadge = 'colored-badge',
   RelatedTime = 'related-time',
   NumberShort = 'number-short',
@@ -42,6 +44,7 @@ export type ColumnFormatWithArgs =
   | [ColumnFormat.CodeDialog, CodeDialogOptions]
   | [ColumnFormat.CodeToggle, CodeToggleOptions]
   | [ColumnFormat.BackgroundBar, BackgroundBarOptions]
+  | [ColumnFormat.StackedShare, StackedShareOptions]
 
 // Union of all possible format options
 export type ColumnFormatOptions = ColumnFormatWithArgs[1]

--- a/docs/content/guide/guides/dba-workflows.mdx
+++ b/docs/content/guide/guides/dba-workflows.mdx
@@ -59,10 +59,11 @@ Open **System → Storage Economics**. Three tables:
 - TTL storage moves (parts that already moved because of TTL)
 
 The inventory of every table's TTL expression and partition health lives on
-**Tables → TTL & Partitions** (`/ttl-partition-health`). The same rules
-surface as the **TTL & Partition Health** card on `/health` (count of flagged
-tables; click for the breakdown). This page stays move history and current
-economics.
+**Tables → TTL & Partitions** (`/ttl-partition-health`). That page also estimates
+bytes still in the TTL window versus parts whose `max_date` is already past it
+(recommend-only; it never `DROP PARTITION`). The same flags surface as the
+**TTL & Partition Health** card on `/health` (count of flagged tables; click
+for the breakdown). This page stays move history and current economics.
 
 ### Health: TTL & Partition Health (`/health`)
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -771,10 +771,13 @@ recommend-only), Chart Builder (`/dashboard`), Schema Compare
 **also** listed under Tables (`menu/data-explorer.ts` shared leaf).
 TTL & Partitions (`/ttl-partition-health`) is a system-table inventory
 of MergeTree TTL / `PARTITION BY` — it lives under **Tables**, not
-System or Tools. The same recommend-only heuristics back the
-**TTL & Partition Health** card on `/health` (`HEALTH_CHECKS` id
+System or Tools. The listing includes a stacked **in-range vs past TTL**
+bar (bytes still inside the parsed `INTERVAL` window versus parts whose
+`max_date` is older than that window). Same recommend-only heuristics
+back the **TTL & Partition Health** card on `/health` (`HEALTH_CHECKS` id
 `ttl-partition-health`): a flagged-table count plus a detail-dialog
-breakdown. Do not add a third TTL reporting surface. AI Agent stays its own flagship group. Postgres-only
+breakdown. Do not add a third TTL reporting surface. Never `ALTER TTL`
+or `DROP PARTITION` from this page. AI Agent stays its own flagship group. Postgres-only
 items stay engine-gated and are not moved here.
 
 ⌘K (`components/controls/command-palette.tsx`) indexes every visible


### PR DESCRIPTION
## Summary

TTL & Partition Health now estimates how much data is still inside the TTL window versus parts whose date is already past it, as a stacked bar.

## Changes

- Inventory SQL classifies `system.parts` by `max_date` vs a parsed `INTERVAL` / `toInterval*` window
- Stacked bar: green in range, yellow past TTL, plus past-TTL bytes and rows
- Recommend-only — no `ALTER TTL` or `DROP PARTITION`

## Test plan

- [x] ttl-partition-sql and ttl-partition-health unit tests
- [ ] Open `/ttl-partition-health?host=0` and confirm the bar on tables with TTL
- [ ] `pnpm run lint` / `pnpm run build` / `pnpm run test:unit`

---

Co-Authored-By: duyetbot <bot@duyet.net>