### PR TITLE
fix(blog): give screenshot rows a shared height

### DIFF
--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -63,9 +63,11 @@ A lone `<img>` already breaks out past the 720px prose measure (up to the
 </div>
 ```
 
-Optional captions via `<figure>` / `<figcaption>`. Pin 2–4 columns with
-`data-cols="3"`; below 700px a 3/4-col row drops to two, below 520px to one.
-Theme-aware `data-src-light` / `data-src-dark` still works on each `<img>`.
+Images in a row share one height (`aspect-ratio: 16/10`, `object-fit: cover`,
+top-aligned) so mixed captures line up. Optional captions via `<figure>` /
+`<figcaption>`. Pin 2–4 columns with `data-cols="3"`; below 700px a 3/4-col
+row drops to two, below 520px to one. Theme-aware `data-src-light` /
+`data-src-dark` still works on each `<img>`.
 
 ## Content engine
 

--- a/apps/blog/src/chrome.test.ts
+++ b/apps/blog/src/chrome.test.ts
@@ -55,6 +55,8 @@ describe('blog chrome matches landing shadcn tokens', () => {
     )
     expect(base).toContain('.prose .img-row img{')
     expect(base).toContain('transform:none')
+    expect(base).toContain('aspect-ratio:16/10')
+    expect(base).toContain('object-fit:cover')
     expect(base).toContain('.img-row[data-cols="3"]')
     expect(read('README.md')).toContain('class="img-row"')
   })

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -201,7 +201,8 @@ const ogImage = new URL(image, Astro.site).toString()
     .img-row[data-cols="3"]{grid-template-columns:repeat(3,minmax(0,1fr))}
     .img-row[data-cols="4"]{grid-template-columns:repeat(4,minmax(0,1fr))}
     .prose .img-row img{
-      margin:0;margin-left:0;transform:none;width:100%;max-width:none;height:auto}
+      margin:0;margin-left:0;transform:none;width:100%;max-width:none;
+      height:auto;aspect-ratio:16/10;object-fit:cover;object-position:top}
     .img-row figure{margin:0;min-width:0}
     .img-row figcaption{font-size:13px;color:var(--muted-foreground);padding:8px 2px 0;
       text-wrap:pretty;line-height:1.45}
@@ -209,7 +210,8 @@ const ogImage = new URL(image, Astro.site).toString()
       .img-row[data-cols="3"],.img-row[data-cols="4"]{grid-template-columns:repeat(2,minmax(0,1fr))}}
     @media (max-width:520px){
       .img-row,.img-row[data-cols="2"],.img-row[data-cols="3"],.img-row[data-cols="4"]{
-        grid-template-columns:1fr}}
+        grid-template-columns:1fr}
+      .prose .img-row img{aspect-ratio:auto;object-fit:unset}}
     .prose table{width:100%;border-collapse:collapse;font-size:14.5px;display:block;overflow-x:auto}
     .prose th{text-align:left;font-size:11px;letter-spacing:.05em;text-transform:uppercase;color:var(--muted-foreground);
       font-weight:600;padding:10px 14px;background:var(--canvas-soft);border-bottom:1px solid var(--border)}


### PR DESCRIPTION
## Summary

Screenshot rows on the blog (v0.3.4 Tools and workspace) now share one height so mixed captures line up.

## Changes

- `.img-row` images use `aspect-ratio: 16/10`, `object-fit: cover`, top-aligned
- Single-column (narrow) rows keep the native aspect so nothing is cropped

## Test plan

- [x] `bun test apps/blog/src/chrome.test.ts`
- [ ] Check https://blog.chmonitor.dev/v0.3.4/ after deploy

---

Co-Authored-By: duyetbot <bot@duyet.net>