### PR TITLE
docs(blog): drop license checkout, ping, and CLI bullets

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -85,14 +85,10 @@ map.
 - Chat messages, tool cards, and markdown rendering are tighter. The tool loop
   stops at 16 steps.
 
-### Licenses and CLI
+### Licenses
 
-- Paid product is a **self-hosted commercial license** sized by host count, not
-  a Cloud seat. No key in the binary. Details:
-  [We're selling self-hosted licenses](/self-hosted-licenses/).
-- Checkout asks for company details before Polar charges.
-- Instance ping can send `CHM_LICENSE_KEY`.
-- CLI: `chm upgrade` (ranks `chm-v*` tags by semver).
+Paid product is a **self-hosted host-count license**, not a Cloud seat. No key
+in the binary. [We're selling self-hosted licenses](/self-hosted-licenses/).
 
 ## Upgrade
 


### PR DESCRIPTION
## Summary

Remove the Polar checkout, instance ping, and `chm upgrade` bullets from the v0.3.4 post. Licenses stay a short line with a link to the licenses post.

## Test plan

- [ ] Check https://blog.chmonitor.dev/v0.3.4/ after deploy

---

Co-Authored-By: duyetbot <bot@duyet.net>