### PR TITLE
fix(blog): hover-only zoom icon and full-width lone screenshots

### DIFF
--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -64,11 +64,12 @@ A lone `<img>` already breaks out past the 720px prose measure (up to the
 ```
 
 Images in a row share one height (`aspect-ratio: 16/10`, `object-fit: cover`,
-top-aligned) so mixed captures line up. A top-right zoom control on each
-screenshot opens a lightbox (Escape / backdrop / × to close). Optional
-captions via `<figure>` / `<figcaption>`. Pin 2–4 columns with
-`data-cols="3"`; below 700px a 3/4-col row drops to two, below 520px to one.
-Theme-aware `data-src-light` / `data-src-dark` still works on each `<img>`.
+top-aligned) so mixed captures line up. Hover a screenshot: a small top-right
+icon (no background) opens a lightbox (Escape / backdrop / ×). Lone shots
+break out to `--maxw` like they did before the zoom wrap. Optional captions
+via `<figure>` / `<figcaption>`. Pin 2–4 columns with `data-cols="3"`; below
+700px a 3/4-col row drops to two, below 520px to one. Theme-aware
+`data-src-light` / `data-src-dark` still works on each `<img>`.
 
 ## Content engine
 

--- a/apps/blog/src/chrome.test.ts
+++ b/apps/blog/src/chrome.test.ts
@@ -61,8 +61,11 @@ describe('blog chrome matches landing shadcn tokens', () => {
     expect(base).toContain('screenshot-zoom-dialog')
     expect(base).toContain('shot-zoom')
     expect(base).toContain('data-screenshot-zoom')
+    expect(base).toContain('width:max-content')
+    expect(base).toContain('.shot-frame:hover .shot-zoom')
+    expect(base).toContain('background:transparent')
     expect(read('README.md')).toContain('class="img-row"')
-    expect(read('README.md')).toContain('top-right zoom')
+    expect(read('README.md')).toContain('small top-right')
   })
 
   test('featured card is not the old #fff8f1 hardcode', () => {

--- a/apps/blog/src/layouts/Base.astro
+++ b/apps/blog/src/layouts/Base.astro
@@ -188,20 +188,21 @@ const ogImage = new URL(image, Astro.site).toString()
       max-width:min(var(--maxw), calc(100vw - 48px));
       margin:32px 0;margin-left:50%;transform:translateX(-50%);
       border:1px solid var(--border);border-radius:calc(var(--radius) + 4px)}
-    .prose .shot-frame{position:relative;display:block;width:fit-content;
+    /* max-content (not fit-content) so a wrapped shot still breaks out of the
+       720px prose column to --maxw, same as an unwrapped <img>. */
+    .prose .shot-frame{position:relative;display:block;width:max-content;
       max-width:min(var(--maxw), calc(100vw - 48px));
       margin:32px 0;margin-left:50%;transform:translateX(-50%);
       border:1px solid var(--border);border-radius:calc(var(--radius) + 4px);
       overflow:hidden;background:var(--card)}
-    .prose .shot-frame img{margin:0;margin-left:0;transform:none;max-width:100%;
-      border:0;border-radius:0}
-    .shot-zoom{position:absolute;top:8px;right:8px;z-index:1;display:inline-flex;
-      align-items:center;justify-content:center;width:32px;height:32px;padding:0;
-      border-radius:8px;border:1px solid var(--border);background:var(--card);
-      color:var(--foreground);cursor:zoom-in;box-shadow:0 1px 2px rgba(0,0,0,.12)}
-    .shot-zoom svg{width:16px;height:16px;display:block}
-    @media (max-width:520px){
-      .shot-zoom{width:44px;height:44px}}
+    .prose .shot-frame img{margin:0;margin-left:0;transform:none;width:auto;height:auto;
+      max-width:min(var(--maxw), calc(100vw - 48px));border:0;border-radius:0}
+    .shot-zoom{position:absolute;top:10px;right:10px;z-index:1;display:inline-flex;
+      align-items:center;justify-content:center;width:20px;height:20px;padding:0;
+      border:0;border-radius:0;background:transparent;color:#fff;cursor:zoom-in;
+      opacity:0;filter:drop-shadow(0 0 1px rgba(0,0,0,.75))}
+    .shot-frame:hover .shot-zoom,.shot-frame:focus-within .shot-zoom{opacity:1}
+    .shot-zoom svg{width:14px;height:14px;display:block;stroke-width:1.75}
     .screenshot-zoom-dialog{position:fixed;inset:0;border:none;padding:0;background:transparent;
       max-width:min(96vw,1400px);width:100%;height:100%;margin:auto;outline:none}
     .screenshot-zoom-dialog[open]{display:flex;align-items:center;justify-content:center}


### PR DESCRIPTION
## Summary

Zoom control is hover-only, small, and has no background. Lone screenshots (Schema Compare) break out to the full 1080px width again.

## Changes

- Icon: transparent, 14px, drop-shadow only, visible on hover / focus
- Shot frame uses `width: max-content` so wrap JS does not pin shots to the 720px prose column

## Test plan

- [x] `bun test apps/blog/src/chrome.test.ts`
- [ ] Hover a screenshot on /v0.3.4/ — icon appears, no chip
- [ ] Schema Compare shot is as wide as other lone screenshots

---

Co-Authored-By: duyetbot <bot@duyet.net>