### PR TITLE
docs(blog): say v0.3.4 dropped Cloud seats for self-hosted licenses

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -20,7 +20,7 @@ Every path below opens the live demo: [dash.chmonitor.dev](https://dash.chmonito
   <div class="hl"><b>Schema Compare</b><span>Table DDL across hosts or replica nodes. Copy-only plan — never applied.</span></div>
   <div class="hl"><b>Settings Diff</b><span>system.settings and merge_tree_settings, pair or matrix. All matched when nothing differs.</span></div>
   <div class="hl"><b>TTL inventory</b><span>Every MergeTree table's TTL and PARTITION BY, plus part-health charts.</span></div>
-  <div class="hl"><b>Licenses</b><span>Self-hosted host-count licenses. Invoice, not a key in the binary.</span></div>
+  <div class="hl"><b>Licenses</b><span>Switched from Cloud seats to a self-hosted host-count license.</span></div>
 </div>
 
 ## What shipped
@@ -87,8 +87,9 @@ map.
 
 ### Licenses
 
-Paid product is a **self-hosted host-count license**, not a Cloud seat. No key
-in the binary. [We're selling self-hosted licenses](/self-hosted-licenses/).
+We dropped the SaaS Cloud seat model. Paid product is now a **self-hosted
+host-count license**. No key in the binary.
+[We're selling self-hosted licenses](/self-hosted-licenses/).
 
 ## Upgrade
 

--- a/apps/dashboard/src/lib/whats-new/friendly-notes.json
+++ b/apps/dashboard/src/lib/whats-new/friendly-notes.json
@@ -11,7 +11,7 @@
         "Settings Diff compares system.settings and merge_tree_settings. All matched when nothing differs.",
         "TTL and partition health lists every MergeTree table, including those without TTL.",
         "What's new dialog next to Settings.",
-        "Self-hosted host-count licenses. No key in the binary."
+        "Switched from Cloud seats to self-hosted host-count licenses. No key in the binary."
       ],
       "screenshots": [
         {

--- a/docs/whats-new/v0.3.4.md
+++ b/docs/whats-new/v0.3.4.md
@@ -17,4 +17,4 @@ screenshots:
 - Settings Diff compares system.settings and merge_tree_settings. All matched when nothing differs.
 - TTL and partition health lists every MergeTree table, including those without TTL.
 - What's new dialog next to Settings.
-- Self-hosted host-count licenses. No key in the binary.
+- Switched from Cloud seats to self-hosted host-count licenses. No key in the binary.


### PR DESCRIPTION
## Summary

Rewrite the v0.3.4 Licenses blurb: we changed from a SaaS Cloud seat model to a self-hosted host-count license. Link stays on the licenses post.

## Test plan

- [ ] Check https://blog.chmonitor.dev/v0.3.4/ after deploy

---

Co-Authored-By: duyetbot <bot@duyet.net>