### PR TITLE
docs(blog): add per-platform deploy docs to v0.3.4 upgrade

### DIFF
--- a/apps/blog/src/content/blog/chmonitor-v0-3-4.md
+++ b/apps/blog/src/content/blog/chmonitor-v0-3-4.md
@@ -93,14 +93,26 @@ host-count license**. No key in the binary.
 
 ## Upgrade
 
-Self-hosters: pull the image you already run.
+Self-hosters: pin this tag.
 
 ```bash
 docker pull ghcr.io/chmonitor/chmonitor:v0.3.4
 ```
 
+Then follow the deploy guide for your platform:
+
+- [Docker](https://docs.chmonitor.dev/operate/deploy/docker)
+- [Kubernetes](https://docs.chmonitor.dev/operate/deploy/k8s)
+- [Cloudflare Workers](https://docs.chmonitor.dev/operate/deploy/cloudflare)
+- [Vercel](https://docs.chmonitor.dev/operate/deploy/vercel)
+- [Node / standalone](https://docs.chmonitor.dev/operate/deploy/self-host)
+- [Traefik](https://docs.chmonitor.dev/operate/deploy/traefik)
+- [One-click](https://docs.chmonitor.dev/operate/deploy/one-click)
+- [Production checklist](https://docs.chmonitor.dev/operate/deploy/production-checklist)
+
+All platforms: [Deploy](https://docs.chmonitor.dev/operate/deploy).
+
 Cloud ([dash.chmonitor.dev](https://dash.chmonitor.dev)) already has this.
-Nothing to migrate.
 
 The full changelog is in the
 [GitHub release](https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4).


### PR DESCRIPTION
## Summary

Upgrade on the v0.3.4 post now links the deploy guide for each platform (Docker, Kubernetes, Cloudflare, Vercel, Node, Traefik, one-click, production checklist).

## Test plan

- [ ] Check https://blog.chmonitor.dev/v0.3.4/ after deploy

---

Co-Authored-By: duyetbot <bot@duyet.net>