### PR TITLE
fix(docs): serve hashed CSS instead of HTML 404s

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "preview": "vite preview",
     "cf:deploy": "wrangler deploy",
     "types:check": "fumadocs-mdx && tsc --noEmit",
-    "test": "node --test src/styles/*.test.mjs && bun test src/lib/crawler-index.test.ts src/lib/canonical-path.test.ts",
+    "test": "node --test src/styles/*.test.mjs && bun test src/lib/crawler-index.test.ts src/lib/canonical-path.test.ts wrangler.toml.test.ts",
     "smoke": "node scripts/smoke-crawl.mjs"
   },
   "dependencies": {

--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -28,9 +28,20 @@ enabled = true
 # "alternate with proper canonical" for slash variants).
 [assets]
 html_handling = "drop-trailing-slash"
-# Worker first so /deploy/k8s/ is one 301 to /operate/deploy/k8s, not
-# asset slash-drop then a second IA redirect.
-run_worker_first = true
+# HTML/API still hit the Worker first (canonical 301s, markdown Accept,
+# Cache-Control). Static files must NOT — `run_worker_first = true` sent
+# /assets/*.css through the `$` docs route, which returned HTML 404 and
+# the site rendered unstyled.
+run_worker_first = [
+  "!/assets/*",
+  "!/brand/*",
+  "!/favicon.svg",
+  "!/favicon-16.png",
+  "!/favicon-32.png",
+  "!/apple-touch-icon.png",
+  "!/og/og.png",
+  "!/robots.txt",
+]
 
 [[routes]]
 pattern = "docs.chmonitor.dev"

--- a/apps/docs/wrangler.toml.test.ts
+++ b/apps/docs/wrangler.toml.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const toml = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'wrangler.toml'),
+  'utf8'
+)
+
+describe('docs wrangler assets', () => {
+  test('does not run the Worker before hashed CSS/JS under /assets', () => {
+    expect(toml).not.toMatch(/^\s*run_worker_first\s*=\s*true\s*$/m)
+    expect(toml).toContain('!/assets/*')
+    expect(toml).toContain('!/brand/*')
+  })
+})

--- a/docs/knowledge/workers-cache.md
+++ b/docs/knowledge/workers-cache.md
@@ -3,7 +3,7 @@ id: workers-cache
 title: Cloudflare Workers Cache
 type: reference
 status: active
-updated: 2026-07-06
+updated: 2026-08-24
 tags:
   - cloudflare-workers
   - cache
@@ -79,6 +79,12 @@ the final response, and it skips:
 - any response that already declares `Cache-Control`,
 - non-`GET` / non-200 responses,
 - requests carrying `Authorization` (also auto-bypassed by Workers Cache itself).
+
+Do **not** set docs `assets.run_worker_first = true`. That sent `/assets/*.css`
+(and favicons, `/brand/*`) through the TanStack `$` catch-all, which returned
+**HTML 404** — the docs site looked unstyled. HTML still hits the Worker first
+(canonical 301s). Static prefixes are excluded (`!/assets/*`, `!/brand/*`,
+favicons). See `apps/docs/wrangler.toml`.
 
 `max-age=300` (5 min fresh) keeps content reasonably current; the 1-day
 `stale-while-revalidate` window means edits still serve instantly from cache and


### PR DESCRIPTION
## Summary

docs.chmonitor.dev rendered unstyled: `run_worker_first = true` sent `/assets/*.css` through the docs catch-all, which returned HTML 404.

Static prefixes now skip the Worker so CSS, JS, brand, and favicons come from the assets binding. HTML still hits the Worker first for canonical redirects.

## Test plan

- [x] wrangler.toml.test.ts
- [ ] After deploy, https://docs.chmonitor.dev/assets/app-*.css is CSS, not HTML
- [ ] https://docs.chmonitor.dev/guide/guides/dba-workflows is styled

---

Co-Authored-By: duyetbot <bot@duyet.net>