### PR TITLE
fix(docs): add a positive run_worker_first rule so CSS deploys

### DIFF
--- a/apps/docs/wrangler.toml
+++ b/apps/docs/wrangler.toml
@@ -28,18 +28,19 @@ enabled = true
 # "alternate with proper canonical" for slash variants).
 [assets]
 html_handling = "drop-trailing-slash"
-# HTML/API still hit the Worker first (canonical 301s, markdown Accept,
-# Cache-Control). Static files must NOT — `run_worker_first = true` sent
-# /assets/*.css through the `$` docs route, which returned HTML 404 and
-# the site rendered unstyled.
+# Worker first only for API/OG. Static files (`!/assets/*`, brand, favicons)
+# go to the assets binding — `run_worker_first = true` sent /assets/*.css
+# through the `$` docs route (HTML 404, unstyled site). Wrangler requires
+# at least one non-negative rule in this list.
 run_worker_first = [
+  "/api/*",
+  "/og/docs/*",
   "!/assets/*",
   "!/brand/*",
   "!/favicon.svg",
   "!/favicon-16.png",
   "!/favicon-32.png",
   "!/apple-touch-icon.png",
-  "!/og/og.png",
   "!/robots.txt",
 ]
 

--- a/apps/docs/wrangler.toml.test.ts
+++ b/apps/docs/wrangler.toml.test.ts
@@ -11,6 +11,7 @@ const toml = readFileSync(
 describe('docs wrangler assets', () => {
   test('does not run the Worker before hashed CSS/JS under /assets', () => {
     expect(toml).not.toMatch(/^\s*run_worker_first\s*=\s*true\s*$/m)
+    expect(toml).toContain('"/api/*"')
     expect(toml).toContain('!/assets/*')
     expect(toml).toContain('!/brand/*')
   })

--- a/docs/knowledge/workers-cache.md
+++ b/docs/knowledge/workers-cache.md
@@ -83,8 +83,8 @@ the final response, and it skips:
 Do **not** set docs `assets.run_worker_first = true`. That sent `/assets/*.css`
 (and favicons, `/brand/*`) through the TanStack `$` catch-all, which returned
 **HTML 404** — the docs site looked unstyled. HTML still hits the Worker first
-(canonical 301s). Static prefixes are excluded (`!/assets/*`, `!/brand/*`,
-favicons). See `apps/docs/wrangler.toml`.
+(canonical 301s). Static prefixes are excluded (`/api/*` plus `!/assets/*`, `!/brand/*`, favicons — Wrangler requires at
+least one non-negative rule). See `apps/docs/wrangler.toml`.
 
 `max-age=300` (5 min fresh) keeps content reasonably current; the 1-day
 `stale-while-revalidate` window means edits still serve instantly from cache and


### PR DESCRIPTION
## Summary

Follow-up to #3284. Cloudflare rejects an all-negative `run_worker_first` list, so docs production deploy failed and the site stayed unstyled.

Add `/api/*` and `/og/docs/*` as Worker-first paths; keep `!/assets/*` so CSS is not HTML 404.

## Test plan

- [x] wrangler.toml.test.ts
- [ ] After deploy, docs CSS is \`text/css\` 200

---

Co-Authored-By: duyetbot <bot@duyet.net>