### PR TITLE
fix(landing): stop shipping an empty changelog page

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -47,6 +47,11 @@ permissions:
 #     fallback in each `if:` forces the deploy.
 #   • Jobs always run (only their steps are gated), so the required
 #     `dashboard` / `landing` / `docs` / `bug-handler` status checks still post.
+#   • Landing also rebuilds on CHANGELOG.md and docs/whats-new/**: /changelog
+#     cards and the footer version are baked at Astro build. GitHub Releases
+#     alone are not enough — CLI `chm-v*` tags crowd out product `vX.Y.Z`
+#     (see #3286). Release-please tag pushes using GITHUB_TOKEN do not trigger
+#     this workflow, so the CHANGELOG path filter is what ships the new version.
 #
 # Reconciliation with the build-only workflows (docs.yml / landing.yml /
 # blog.yml): those are separate PR *build* checks (they never deploy) and are
@@ -607,6 +612,10 @@ jobs:
               - 'apps/landing/**'
               # Hero latest-post pill is baked at Astro build from blog markdown.
               - 'apps/blog/src/content/blog/**'
+              # Footer version + /changelog cards bake CHANGELOG.md and
+              # docs/whats-new at Astro build (#3286).
+              - 'CHANGELOG.md'
+              - 'docs/whats-new/**'
               - 'scripts/**'
               - 'assets/**'
               - 'bun.lock'
@@ -642,7 +651,11 @@ jobs:
           github.event_name == 'workflow_dispatch' ||
           github.event_name == 'release' ||
           github.ref_type == 'tag'
-        run: pnpm run build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm run build
+          pnpm run verify:structure
 
       - name: Deploy preview
         if: >-

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test
-        run: pnpm test
-
       - name: Build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -8,11 +8,15 @@ on:
   pull_request:
     paths:
       - 'apps/landing/**'
+      - 'CHANGELOG.md'
+      - 'docs/whats-new/**'
       - '.github/workflows/landing.yml'
   push:
     branches: [main]
     paths:
       - 'apps/landing/**'
+      - 'CHANGELOG.md'
+      - 'docs/whats-new/**'
       - '.github/workflows/landing.yml'
 
 permissions:
@@ -39,11 +43,24 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/landing/pnpm-lock.yaml
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test
+        run: pnpm test
+
       - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build
+
+      - name: Verify structure
+        run: pnpm run verify:structure
 
       # Informational only (never blocks the PR): GitHub-hosted runners have no
       # GPU, so headless Chrome falls back to software WebGL. The hero's

--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -2,6 +2,8 @@
  * Post-build structural assertions for the redesigned homepage.
  * Run: cd apps/landing && pnpm run build && bun scripts/verify-landing-structure.ts
  */
+
+import { loadLatestChangelogVersion } from '../src/data/changelog-features'
 import { getLatestBlogPost } from '../src/lib/latest-blog-post'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -314,11 +316,49 @@ try {
 const distChangelog = join(process.cwd(), 'dist/changelog/index.html')
 try {
   const changelogHtml = readFileSync(distChangelog, 'utf8')
-  if (!changelogHtml.toLowerCase().includes('changelog')) {
-    console.error('MISSING changelog content in dist/changelog/index.html')
+  const latestVersion = loadLatestChangelogVersion()
+  if (changelogHtml.includes('could not be loaded at build time')) {
+    console.error(
+      'EMPTY changelog SSG fallback shipped in dist/changelog/index.html'
+    )
     failed = true
-  } else {
-    console.log('OK: dist/changelog/index.html built')
+  }
+  if (!changelogHtml.includes('data-changelog-releases')) {
+    console.error(
+      'MISSING data-changelog-releases in dist/changelog/index.html'
+    )
+    failed = true
+  }
+  if (!changelogHtml.includes('cl-entry')) {
+    console.error(
+      'MISSING release cards (cl-entry) in dist/changelog/index.html'
+    )
+    failed = true
+  }
+  if (
+    latestVersion &&
+    !changelogHtml.includes(`/changelog#v${latestVersion}`)
+  ) {
+    console.error(
+      `MISSING latest changelog version v${latestVersion} in dist/changelog/index.html`
+    )
+    failed = true
+  }
+  if (latestVersion && !html.includes(`/changelog#v${latestVersion}`)) {
+    console.error(
+      `MISSING footer changelog version v${latestVersion} in dist/index.html`
+    )
+    failed = true
+  }
+  if (
+    changelogHtml.includes('data-changelog-releases') &&
+    changelogHtml.includes('cl-entry') &&
+    !changelogHtml.includes('could not be loaded at build time') &&
+    (!latestVersion || changelogHtml.includes(`/changelog#v${latestVersion}`))
+  ) {
+    console.log(
+      `OK: dist/changelog/index.html has release cards${latestVersion ? ` (v${latestVersion})` : ''}`
+    )
   }
 } catch {
   console.error('MISSING dist/changelog/index.html — run build first')

--- a/apps/landing/scripts/verify-landing-structure.ts
+++ b/apps/landing/scripts/verify-landing-structure.ts
@@ -218,11 +218,11 @@ const header =
   headerStart === -1 || headerEnd === -1
     ? ''
     : html.slice(headerStart, headerEnd)
-if (/href="\/pricing"/.test(header)) {
-  console.error('FORBIDDEN Pricing link in homepage header nav')
+if (!/href="\/pricing"/.test(header)) {
+  console.error('MISSING Pricing link in homepage header nav')
   failed = true
 } else {
-  console.log('OK: homepage header nav has no Pricing link')
+  console.log('OK: homepage header nav links to /pricing')
 }
 
 const drawerStart = html.indexOf('id="mobile-menu"')
@@ -231,11 +231,11 @@ const drawer =
   drawerStart === -1 || drawerFoot === -1
     ? ''
     : html.slice(drawerStart, drawerFoot)
-if (/href="\/pricing"/.test(drawer)) {
-  console.error('FORBIDDEN Pricing link in homepage mobile nav')
+if (!/href="\/pricing"/.test(drawer)) {
+  console.error('MISSING Pricing link in homepage mobile nav')
   failed = true
 } else {
-  console.log('OK: homepage mobile nav has no Pricing link')
+  console.log('OK: homepage mobile nav links to /pricing')
 }
 
 const distPricing = join(process.cwd(), 'dist/pricing/index.html')

--- a/apps/landing/src/data/changelog-features.ts
+++ b/apps/landing/src/data/changelog-features.ts
@@ -1,23 +1,10 @@
+import { readChangelogMarkdown } from '../lib/changelog-file'
 import {
   type ChangelogFeature,
   type ChangelogFeatureGroup,
   groupChangelogFeatures,
   parseChangelogFeatures,
 } from '../lib/parse-changelog-features'
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-function resolveChangelogPath(): string {
-  const candidates = [
-    join(process.cwd(), '../../CHANGELOG.md'),
-    fileURLToPath(new URL('../../../../CHANGELOG.md', import.meta.url)),
-  ]
-  for (const path of candidates) {
-    if (existsSync(path)) return path
-  }
-  throw new Error('CHANGELOG.md not found')
-}
 
 let cached: {
   features: ChangelogFeature[]
@@ -28,7 +15,7 @@ let cached: {
 export function loadChangelogFeatures() {
   if (cached) return cached
 
-  const markdown = readFileSync(resolveChangelogPath(), 'utf8')
+  const markdown = readChangelogMarkdown()
   const features = parseChangelogFeatures(markdown)
   const groups = groupChangelogFeatures(features)
 
@@ -50,7 +37,7 @@ let cachedLatestVersion: string | null | undefined
 export function loadLatestChangelogVersion(): string | null {
   if (cachedLatestVersion !== undefined) return cachedLatestVersion
 
-  const markdown = readFileSync(resolveChangelogPath(), 'utf8')
+  const markdown = readChangelogMarkdown()
   const match = markdown.match(/^## \[(\d+\.\d+\.\d+)\]/m)
   cachedLatestVersion = match ? match[1] : null
   return cachedLatestVersion

--- a/apps/landing/src/homepage.test.ts
+++ b/apps/landing/src/homepage.test.ts
@@ -43,6 +43,13 @@ describe('header nav advertises Pricing', () => {
     expect(nav).toContain("to('/changelog')")
   })
 
+  test('changelog page loads releases at build time instead of shipping the empty fallback', () => {
+    const page = read('src/pages/changelog.astro')
+    expect(page).toContain('loadLandingReleases')
+    expect(page).toContain('data-changelog-releases')
+    expect(page).not.toContain('could not be loaded at build time')
+  })
+
   test('CLI is listed under Features, not as a top-level item', () => {
     expect(nav).toContain("to('/cli')")
     expect(nav).toContain('featureIcons.cli')

--- a/apps/landing/src/lib/changelog-file.ts
+++ b/apps/landing/src/lib/changelog-file.ts
@@ -1,0 +1,18 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export function resolveChangelogPath(): string {
+  const candidates = [
+    join(process.cwd(), '../../CHANGELOG.md'),
+    fileURLToPath(new URL('../../../../CHANGELOG.md', import.meta.url)),
+  ]
+  for (const path of candidates) {
+    if (existsSync(path)) return path
+  }
+  throw new Error('CHANGELOG.md not found')
+}
+
+export function readChangelogMarkdown(): string {
+  return readFileSync(resolveChangelogPath(), 'utf8')
+}

--- a/apps/landing/src/lib/load-landing-releases.test.ts
+++ b/apps/landing/src/lib/load-landing-releases.test.ts
@@ -1,0 +1,165 @@
+import {
+  EMPTY_CHANGELOG_BUILD_ERROR,
+  fetchGithubProductReleases,
+  loadLandingReleases,
+  mergeLandingReleases,
+} from './load-landing-releases'
+import { parseChangelogReleases } from './parse-changelog-releases'
+import { describe, expect, test } from 'bun:test'
+
+const CHANGELOG = `# Changelog
+## [0.3.4](https://github.com/chmonitor/chmonitor/compare/v0.3.3...v0.3.4) (2026-08-24)
+* **landing:** restore changelog cards
+## [0.3.3](https://github.com/chmonitor/chmonitor/compare/v0.3.2...v0.3.3) (2026-08-15)
+* **dashboard:** what's new
+`
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function cliFloodPage() {
+  return Array.from({ length: 100 }, (_, i) => ({
+    tag_name: i === 0 ? 'chm-v0.1.0' : `chm-v0.1.2-beta.${i}`,
+    draft: i === 0,
+    prerelease: i !== 0,
+    html_url: `https://github.com/chmonitor/chmonitor/releases/tag/${i === 0 ? 'chm-v0.1.0' : `chm-v0.1.2-beta.${i}`}`,
+    body: '',
+  }))
+}
+
+describe('fetchGithubProductReleases', () => {
+  test('walks past CLI tags on page 1 to product vX.Y.Z tags', async () => {
+    const fetchImpl: typeof fetch = async (input) => {
+      const page = new URL(String(input)).searchParams.get('page')
+      if (page === '1') return jsonResponse(cliFloodPage())
+      if (page === '2') {
+        return jsonResponse([
+          {
+            tag_name: 'v0.3.4',
+            name: 'v0.3.4',
+            published_at: '2026-08-24T12:56:30Z',
+            html_url:
+              'https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4',
+            body: 'GitHub body',
+            draft: false,
+            prerelease: false,
+          },
+          {
+            tag_name: 'helm-chmonitor-0.2.15',
+            draft: false,
+            prerelease: false,
+            html_url:
+              'https://github.com/chmonitor/chmonitor/releases/tag/helm-chmonitor-0.2.15',
+            body: '',
+          },
+        ])
+      }
+      return jsonResponse([])
+    }
+
+    const releases = await fetchGithubProductReleases({
+      fetch: fetchImpl,
+      retries: 0,
+      sleep: async () => {},
+    })
+    expect(releases.map((r) => r.tag_name)).toEqual(['v0.3.4'])
+    expect(releases[0]?.body).toBe('GitHub body')
+  })
+
+  test('sends User-Agent and optional token', async () => {
+    let headers: HeadersInit | undefined
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      headers = init?.headers
+      return jsonResponse([])
+    }
+    await fetchGithubProductReleases({
+      fetch: fetchImpl,
+      token: 'ghp_test',
+      retries: 0,
+      sleep: async () => {},
+    })
+    const record = new Headers(headers)
+    expect(record.get('User-Agent')).toBe('chmonitor-landing')
+    expect(record.get('Authorization')).toBe('Bearer ghp_test')
+  })
+
+  test('retries a 403 then succeeds', async () => {
+    let calls = 0
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1
+      if (calls === 1) return jsonResponse({ message: 'rate limit' }, 403)
+      return jsonResponse([
+        {
+          tag_name: 'v0.3.4',
+          name: 'v0.3.4',
+          published_at: '2026-08-24T12:56:30Z',
+          html_url:
+            'https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4',
+          body: 'ok',
+          draft: false,
+          prerelease: false,
+        },
+      ])
+    }
+
+    const releases = await fetchGithubProductReleases({
+      fetch: fetchImpl,
+      retries: 2,
+      sleep: async () => {},
+    })
+    expect(calls).toBe(2)
+    expect(releases).toHaveLength(1)
+  })
+
+  test('returns an empty list after GitHub stays down', async () => {
+    const releases = await fetchGithubProductReleases({
+      fetch: async () => jsonResponse('nope', 503),
+      retries: 1,
+      sleep: async () => {},
+    })
+    expect(releases).toEqual([])
+  })
+})
+
+describe('mergeLandingReleases', () => {
+  test('keeps CHANGELOG order and overlays GitHub bodies', () => {
+    const changelog = parseChangelogReleases(CHANGELOG)
+    const merged = mergeLandingReleases(changelog, [
+      {
+        tag_name: 'v0.3.4',
+        name: 'chmonitor v0.3.4',
+        published_at: '2026-08-24T12:56:30Z',
+        html_url: 'https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4',
+        body: 'GitHub highlights',
+      },
+    ])
+    expect(merged.map((r) => r.tag_name)).toEqual(['v0.3.4', 'v0.3.3'])
+    expect(merged[0]?.body).toBe('GitHub highlights')
+    expect(merged[0]?.name).toBe('chmonitor v0.3.4')
+    expect(merged[1]?.body).toContain("what's new")
+  })
+})
+
+describe('loadLandingReleases', () => {
+  test('renders CHANGELOG cards when GitHub page 1 is only CLI tags', async () => {
+    const releases = await loadLandingReleases({
+      changelogMarkdown: CHANGELOG,
+      githubReleases: [],
+      limit: 12,
+    })
+    expect(releases.map((r) => r.tag_name)).toEqual(['v0.3.4', 'v0.3.3'])
+  })
+
+  test('fails the build when both sources are empty', async () => {
+    await expect(
+      loadLandingReleases({
+        changelogMarkdown: '# Changelog\n\n## [Unreleased]\n',
+        githubReleases: [],
+      })
+    ).rejects.toThrow(EMPTY_CHANGELOG_BUILD_ERROR)
+  })
+})

--- a/apps/landing/src/lib/load-landing-releases.ts
+++ b/apps/landing/src/lib/load-landing-releases.ts
@@ -1,0 +1,180 @@
+import { readChangelogMarkdown } from './changelog-file'
+import { GITHUB_REPO } from './github-stars'
+import {
+  type LandingRelease,
+  parseChangelogReleases,
+} from './parse-changelog-releases'
+import { isProductReleaseTag } from './parse-github-release-notes'
+
+export type { LandingRelease } from './parse-changelog-releases'
+
+export const LANDING_RELEASE_LIMIT = 12
+export const GITHUB_RELEASES_PER_PAGE = 100
+export const GITHUB_RELEASES_MAX_PAGES = 5
+export const GITHUB_RELEASES_TIMEOUT_MS = 10_000
+export const EMPTY_CHANGELOG_BUILD_ERROR =
+  'Landing changelog is empty after CHANGELOG.md and GitHub Releases. Refusing to ship the empty SSG fallback.'
+
+const GITHUB_RELEASES_API = `https://api.github.com/repos/${GITHUB_REPO}/releases`
+
+type FetchLike = typeof fetch
+
+interface GithubReleaseJson {
+  tag_name?: unknown
+  name?: unknown
+  published_at?: unknown
+  html_url?: unknown
+  body?: unknown
+  draft?: unknown
+  prerelease?: unknown
+}
+
+export interface LoadLandingReleasesOptions {
+  changelogMarkdown?: string
+  /** Injected GitHub list. `null` skips the network fetch. */
+  githubReleases?: LandingRelease[] | null
+  fetch?: FetchLike
+  token?: string
+  retries?: number
+  sleep?: (ms: number) => Promise<void>
+  limit?: number
+}
+
+function githubHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'chmonitor-landing',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
+function resolveGithubToken(explicit?: string): string | undefined {
+  const token =
+    explicit ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? ''
+  return token.trim() || undefined
+}
+
+function asRelease(item: GithubReleaseJson): LandingRelease | null {
+  if (item.draft === true || item.prerelease === true) return null
+  if (typeof item.tag_name !== 'string') return null
+  if (!isProductReleaseTag(item.tag_name)) return null
+  return {
+    tag_name: item.tag_name,
+    name:
+      typeof item.name === 'string' && item.name ? item.name : item.tag_name,
+    published_at:
+      typeof item.published_at === 'string' ? item.published_at : '',
+    html_url:
+      typeof item.html_url === 'string' && item.html_url
+        ? item.html_url
+        : `https://github.com/${GITHUB_REPO}/releases/tag/${item.tag_name}`,
+    body: typeof item.body === 'string' ? item.body : '',
+  }
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  if (ms <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchGithubPage(
+  url: string,
+  fetchImpl: FetchLike,
+  token: string | undefined,
+  retries: number,
+  sleep: (ms: number) => Promise<void>
+): Promise<unknown> {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await sleep(400 * 2 ** (attempt - 1))
+    try {
+      const res = await fetchImpl(url, {
+        headers: githubHeaders(token),
+        signal: AbortSignal.timeout(GITHUB_RELEASES_TIMEOUT_MS),
+      })
+      if (res.status === 403 || res.status === 429 || res.status >= 500) {
+        lastError = new Error(`GitHub Releases HTTP ${res.status}`)
+        continue
+      }
+      if (!res.ok) {
+        throw new Error(`GitHub Releases HTTP ${res.status}`)
+      }
+      return await res.json()
+    } catch (error) {
+      lastError = error
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('GitHub Releases fetch failed')
+}
+
+/**
+ * Product `vX.Y.Z` GitHub Releases, walking past CLI `chm-v*` / Helm tags.
+ * Returns [] when GitHub is down so CHANGELOG.md can still fill the page.
+ */
+export async function fetchGithubProductReleases(
+  options: LoadLandingReleasesOptions = {}
+): Promise<LandingRelease[]> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const token = resolveGithubToken(options.token)
+  const retries = options.retries ?? 3
+  const sleep = options.sleep ?? defaultSleep
+  const limit = options.limit ?? LANDING_RELEASE_LIMIT
+  const collected: LandingRelease[] = []
+
+  try {
+    for (let page = 1; page <= GITHUB_RELEASES_MAX_PAGES; page++) {
+      const url = `${GITHUB_RELEASES_API}?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}`
+      const raw = await fetchGithubPage(url, fetchImpl, token, retries, sleep)
+      if (!Array.isArray(raw) || raw.length === 0) break
+      for (const item of raw as GithubReleaseJson[]) {
+        const release = asRelease(item)
+        if (!release) continue
+        collected.push(release)
+        if (collected.length >= limit) return collected
+      }
+      if (raw.length < GITHUB_RELEASES_PER_PAGE) break
+    }
+  } catch {
+    return []
+  }
+
+  return collected
+}
+
+export function mergeLandingReleases(
+  changelog: readonly LandingRelease[],
+  github: readonly LandingRelease[]
+): LandingRelease[] {
+  const byTag = new Map(github.map((release) => [release.tag_name, release]))
+  if (changelog.length === 0) return [...github]
+  return changelog.map((local) => {
+    const remote = byTag.get(local.tag_name)
+    return remote ? { ...local, ...remote } : local
+  })
+}
+
+/**
+ * Build-time changelog cards: CHANGELOG.md is the list, GitHub enriches
+ * bodies/dates, docs/whats-new overlays in the page. Empty list fails the build.
+ */
+export async function loadLandingReleases(
+  options: LoadLandingReleasesOptions = {}
+): Promise<LandingRelease[]> {
+  const limit = options.limit ?? LANDING_RELEASE_LIMIT
+  const changelog = parseChangelogReleases(
+    options.changelogMarkdown ?? readChangelogMarkdown()
+  )
+  const github =
+    options.githubReleases === undefined
+      ? await fetchGithubProductReleases(options)
+      : (options.githubReleases ?? [])
+  const merged = mergeLandingReleases(changelog, github).slice(0, limit)
+  if (merged.length === 0) {
+    throw new Error(EMPTY_CHANGELOG_BUILD_ERROR)
+  }
+  return merged
+}

--- a/apps/landing/src/lib/parse-changelog-features.test.ts
+++ b/apps/landing/src/lib/parse-changelog-features.test.ts
@@ -1,3 +1,4 @@
+import { loadLatestChangelogVersion } from '../data/changelog-features'
 import {
   countFeatureBulletsInMarkdown,
   groupChangelogFeatures,
@@ -11,10 +12,9 @@ import { fileURLToPath } from 'node:url'
 const CHANGELOG_PATH = fileURLToPath(
   new URL('../../../../CHANGELOG.md', import.meta.url)
 )
+const markdown = readFileSync(CHANGELOG_PATH, 'utf8')
 
 describe('parseChangelogFeatures', () => {
-  const markdown = readFileSync(CHANGELOG_PATH, 'utf8')
-
   test('parsed count matches regex count over root CHANGELOG.md', () => {
     const parsed = parseChangelogFeatures(markdown)
     const regexCount = countFeatureBulletsInMarkdown(markdown)
@@ -40,5 +40,13 @@ describe('parseChangelogFeatures', () => {
       expect(group.scope.length).toBeGreaterThan(0)
       expect(group.features.length).toBeGreaterThan(0)
     }
+  })
+})
+
+describe('loadLatestChangelogVersion', () => {
+  test('matches the first versioned CHANGELOG heading', () => {
+    const first = markdown.match(/^## \[(\d+\.\d+\.\d+)\]/m)?.[1] ?? null
+    expect(loadLatestChangelogVersion()).toBe(first)
+    expect(first).toMatch(/^\d+\.\d+\.\d+$/)
   })
 })

--- a/apps/landing/src/lib/parse-changelog-releases.test.ts
+++ b/apps/landing/src/lib/parse-changelog-releases.test.ts
@@ -1,0 +1,53 @@
+import {
+  parseChangelogReleases,
+  toProductReleaseTag,
+} from './parse-changelog-releases'
+import { describe, expect, test } from 'bun:test'
+
+const SAMPLE = `# Changelog
+
+## [Unreleased]
+
+* **landing:** not shipped yet
+
+## [0.3.4](https://github.com/chmonitor/chmonitor/compare/v0.3.3...v0.3.4) (2026-08-24)
+
+### ✨ Features
+
+* **advisor:** schema tab
+
+## [0.3.3](https://github.com/chmonitor/chmonitor/compare/v0.3.2...v0.3.3) (2026-08-15)
+
+### ✨ Features
+
+* **dashboard:** what's new dialog
+
+## [chm-v0.1.3](https://github.com/chmonitor/chmonitor/compare/chm-v0.1.2...chm-v0.1.3) (2026-08-21)
+
+### ✨ Features
+
+* **cli:** TUI default
+`
+
+describe('toProductReleaseTag', () => {
+  test('accepts product versions and rejects CLI / unreleased', () => {
+    expect(toProductReleaseTag('0.3.4')).toBe('v0.3.4')
+    expect(toProductReleaseTag('v0.3.4')).toBe('v0.3.4')
+    expect(toProductReleaseTag('Unreleased')).toBeNull()
+    expect(toProductReleaseTag('chm-v0.1.3')).toBeNull()
+    expect(toProductReleaseTag('helm-chmonitor-0.2.15')).toBeNull()
+  })
+})
+
+describe('parseChangelogReleases', () => {
+  test('returns newest product versions and skips Unreleased plus CLI tags', () => {
+    const releases = parseChangelogReleases(SAMPLE)
+    expect(releases.map((r) => r.tag_name)).toEqual(['v0.3.4', 'v0.3.3'])
+    expect(releases[0]?.published_at).toBe('2026-08-24T00:00:00.000Z')
+    expect(releases[0]?.html_url).toBe(
+      'https://github.com/chmonitor/chmonitor/releases/tag/v0.3.4'
+    )
+    expect(releases[0]?.body).toContain('schema tab')
+    expect(releases.some((r) => r.tag_name.startsWith('chm-'))).toBe(false)
+  })
+})

--- a/apps/landing/src/lib/parse-changelog-releases.ts
+++ b/apps/landing/src/lib/parse-changelog-releases.ts
@@ -1,0 +1,58 @@
+import { isProductReleaseTag } from './parse-github-release-notes'
+
+const SECTION_RE = /^## \[([^\]]+)\](?:\([^)]+\))?(?:\s+\(([^)]+)\))?[ \t]*$/gm
+
+export type LandingRelease = {
+  tag_name: string
+  name: string
+  published_at: string
+  html_url: string
+  body: string
+}
+
+export function githubReleaseUrl(tag: string): string {
+  return `https://github.com/chmonitor/chmonitor/releases/tag/${tag}`
+}
+
+export function toProductReleaseTag(heading: string): string | null {
+  const trimmed = heading.trim()
+  if (/^unreleased$/i.test(trimmed)) return null
+  const tag = trimmed.startsWith('v') ? trimmed : `v${trimmed}`
+  return isProductReleaseTag(tag) ? tag : null
+}
+
+function parseChangelogDate(raw: string | undefined): string {
+  if (!raw) return ''
+  const isoDay = raw.trim().match(/^(\d{4}-\d{2}-\d{2})/)
+  return isoDay ? `${isoDay[1]}T00:00:00.000Z` : ''
+}
+
+/**
+ * Product `vX.Y.Z` sections from CHANGELOG.md, newest first.
+ * Skips Unreleased, CLI `chm-v*`, and Helm chart tags.
+ */
+export function parseChangelogReleases(markdown: string): LandingRelease[] {
+  const text = markdown.replace(/\r\n/g, '\n')
+  const matches = [...text.matchAll(SECTION_RE)]
+  const releases: LandingRelease[] = []
+
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i]!
+    const tag = toProductReleaseTag(match[1] ?? '')
+    if (!tag) continue
+    const start = (match.index ?? 0) + match[0].length
+    const end =
+      i + 1 < matches.length
+        ? (matches[i + 1]!.index ?? text.length)
+        : text.length
+    releases.push({
+      tag_name: tag,
+      name: tag,
+      published_at: parseChangelogDate(match[2]),
+      html_url: githubReleaseUrl(tag),
+      body: text.slice(start, end).trim(),
+    })
+  }
+
+  return releases
+}

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -2,11 +2,11 @@
 import Base from '../layouts/Base.astro'
 import Nav from '../components/Nav.astro'
 import Footer from '../components/Footer.astro'
+import { extractImages, mdToHtml } from '../lib/parse-github-release-notes'
 import {
-  extractImages,
-  isProductReleaseTag,
-  mdToHtml,
-} from '../lib/parse-github-release-notes'
+  type LandingRelease,
+  loadLandingReleases,
+} from '../lib/load-landing-releases'
 import {
   friendlyNoteImages,
   friendlyNoteToHtml,
@@ -14,36 +14,22 @@ import {
   stripVersionPrefix,
 } from '../lib/load-friendly-notes'
 
-interface Release {
-  tag_name: string
-  name: string
-  published_at: string
-  html_url: string
-  body: string
-  prerelease: boolean
-}
-
-let releases: Release[] = []
-try {
-  const res = await fetch(
-    'https://api.github.com/repos/chmonitor/chmonitor/releases?per_page=20',
-    { headers: { 'Accept': 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' } }
-  )
-  if (res.ok) {
-    const data = await res.json()
-    releases = (data as Release[])
-      .filter((r) => !r.prerelease && isProductReleaseTag(r.tag_name))
-      .slice(0, 12)
-  }
-} catch (_) { /* build-time fetch unavailable */ }
+const releases = await loadLandingReleases()
 
 function fmtDate(iso: string) {
-  return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+  if (!iso) return ''
+  const date = new Date(iso)
+  if (Number.isNaN(date.valueOf())) return ''
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
 }
 
 const friendlyNotes = loadLandingFriendlyNotes()
 
-function notesForRelease(release: Release) {
+function notesForRelease(release: LandingRelease) {
   const friendly =
     friendlyNotes.get(release.tag_name) ??
     friendlyNotes.get(stripVersionPrefix(release.tag_name))
@@ -85,48 +71,39 @@ const breadcrumbJsonLd = {
           <p>Release notes for chmonitor. Full history on <a href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener" style="color:var(--orange)">GitHub Releases</a>.</p>
         </div>
 
-        {releases.length > 0 ? (
-          <div class="cl-list">
-            {releases.map((r) => {
-              const notes = notesForRelease(r)
-              return (
-              <div class="cl-entry" id={r.tag_name}>
-                <div class="cl-meta">
-                  <a class="cl-tag" href={r.html_url} target="_blank" rel="noopener">{r.tag_name}</a>
-                  <span class="cl-date">{fmtDate(r.published_at)}</span>
-                </div>
-                <div class="cl-body">
-                  <h4>{r.name || r.tag_name}</h4>
-                  {notes.html && (
-                    <div class="cl-notes" set:html={notes.html} />
-                  )}
-                  {notes.images.length > 0 && (
-                    <div class="cl-shots">
-                      {notes.images.map((img) => (
-                        <a href={img.src} target="_blank" rel="noopener" title={img.alt}>
-                          <img src={img.src} alt={img.alt} loading="lazy" decoding="async" />
-                        </a>
-                      ))}
-                    </div>
-                  )}
-                  <a href={r.html_url} target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:5px;margin-top:10px;font-size:13px;color:var(--orange);text-decoration:underline;text-underline-offset:3px">
-                    Full release notes
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:13px;height:13px"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-                  </a>
-                </div>
+        <div class="cl-list" data-changelog-releases>
+          {releases.map((r) => {
+            const notes = notesForRelease(r)
+            const published = fmtDate(r.published_at)
+            return (
+            <article class="cl-entry" id={r.tag_name}>
+              <div class="cl-meta">
+                <a class="cl-tag" href={r.html_url} target="_blank" rel="noopener">{r.tag_name}</a>
+                {published && <span class="cl-date">{published}</span>}
               </div>
-              )
-            })}
-          </div>
-        ) : (
-          <div style="margin-top:52px;text-align:center;padding:48px 24px;border:1px solid var(--border);border-radius:var(--radius)">
-            <p style="color:var(--muted-fg)">Release list could not be loaded at build time.</p>
-            <a class="btn btn-ghost" style="margin-top:16px;display:inline-flex" href="https://github.com/chmonitor/chmonitor/releases" target="_blank" rel="noopener">
-              View all releases on GitHub
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:15px;height:13px"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </a>
-          </div>
-        )}
+              <div class="cl-body">
+                <h4>{r.name || r.tag_name}</h4>
+                {notes.html && (
+                  <div class="cl-notes" set:html={notes.html} />
+                )}
+                {notes.images.length > 0 && (
+                  <div class="cl-shots">
+                    {notes.images.map((img) => (
+                      <a href={img.src} target="_blank" rel="noopener" title={img.alt}>
+                        <img src={img.src} alt={img.alt} loading="lazy" decoding="async" />
+                      </a>
+                    ))}
+                  </div>
+                )}
+                <a href={r.html_url} target="_blank" rel="noopener" style="display:inline-flex;align-items:center;gap:5px;margin-top:10px;font-size:13px;color:var(--orange);text-decoration:underline;text-underline-offset:3px">
+                  Full release notes
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:13px;height:13px"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+                </a>
+              </div>
+            </article>
+            )
+          })}
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3286.

https://chmonitor.dev/changelog was 200 with only the build-time empty fallback (“Release list could not be loaded at build time”). Footer still said Changelog · v0.3.3 while the homepage banner was v0.3.4.

Verified before coding:
- `changelog.astro` fetched GitHub Releases `per_page=20` with no User-Agent, swallowed errors, and shipped the empty SSG box.
- Product `v0.3.3` sits at GitHub Releases position ~31 because CLI `chm-v*` tags flood the first page. Last landing deploy that actually rebuilt (blog markdown is in the path filter; CHANGELOG.md was not) baked that empty list. Release-please’s GITHUB_TOKEN tag does not retrigger this workflow.
- Footer version is `loadLatestChangelogVersion()` from CHANGELOG.md at Astro build. Current CHANGELOG heading is 0.3.4; production never rebuilt after that heading landed.

## Changes
- Bake `/changelog` cards from CHANGELOG.md (newest `vX.Y.Z`), overlay `docs/whats-new` when present, and optionally enrich from GitHub (User-Agent, token, pagination, retries).
- Throw if the merged list is empty so production cannot ship the fallback copy.
- Rebuild landing when `CHANGELOG.md` or `docs/whats-new/**` change; pass `GITHUB_TOKEN` into the Astro build; fail CI if dist still contains the fallback or is missing `v{latest}`.

## Test plan
- [x] `bun test` in `apps/landing` for changelog parse/merge/pagination/empty-throw (29 pass)
- [x] `cd apps/landing && pnpm run build && pnpm run verify:structure` — 12 cards, v0.3.4 first, footer `/changelog#v0.3.4`
- [x] Built `/changelog` lists recent v0.3.x cards with `docs/whats-new` notes, not the fallback box
- [x] Footer on homepage and `/changelog` shows `Changelog · v0.3.4`
- [x] `curl -A 'Mozilla/5.0'` against local preview `/changelog` is 200 and includes v0.3.4 cards

![Changelog release cards starting at v0.3.4](https://cursor.com/artifacts/c/art-5c2752d9-4515-4642-9539-099dc3bfd27a)
![Homepage footer Changelog v0.3.4](https://cursor.com/artifacts/c/art-01294499-0f17-4c6b-9a55-dd6b675b3165)
<a href="https://cursor.com/agents/bc-7bca04bf-92b3-4928-aa7a-e2c2bf15433e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchangelog_cards_and_footer_v034.mp4"><img src="https://cursor.com/artifacts/c/art-fa48a415-2bfb-4224-b934-81ffdcc81c9b" alt="changelog_cards_and_footer_v034.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bca04bf-92b3-4928-aa7a-e2c2bf15433e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bca04bf-92b3-4928-aa7a-e2c2bf15433e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

