### PR TITLE
fix(dashboard): compact 375 day switcher and scroll overview tabs

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -228,18 +228,21 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
 - **Tab strips:** define the tabs as one array and map it — an icon per tab with
   ONE size (`size-3.5`) and NO margin utility; `TabsTrigger` already supplies
   `items-center gap-1.5`. Adding `mr-*` on top of that reads as misalignment.
-  Wrap the list in `scrollbar-hide overflow-x-auto` + `w-max min-w-full` so
-  labels like "Memory & CPU" scroll instead of clipping. Selected styles use
-  Base UI `data-active:` (trigger `border-b-2`, not Radix
+  Wrap the list in `scrollbar-hide min-w-0 w-full overflow-x-auto` +
+  `TabsList w-max min-w-full flex-nowrap` so labels like "Memory & CPU"
+  scroll inside the strip (`min-w-0` is required on the flex child). Selected
+  styles use Base UI `data-active:` (trigger `border-b-2`, not Radix
   `data-[state=active]:`). Do not use `TabsList variant="line"` on an
   `overflow-x-auto` strip — the hanging `after` underline is clipped.
 - **Responsive chrome:** overview KPIs wrap from `sm` (truncate is `max-sm:`
   only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
-  sidebar sheet is opaque — no heatmap-through-frost.   Phone time chips /
-  sidebar rows / toggle / header utility icons (refresh, search, theme) are
-  `min 44×44`. Docs article Copy Markdown / Open are 44px below `md` (not
-  header search/menu). Agent FAB must not cover heatmap
-  "Avg / active day" (`pb-16` + last-card `pr-16`; landscape FAB at `top-16`).
+  sidebar sheet is opaque — no heatmap-through-frost. Phone sidebar rows /
+  toggle / header utility icons (refresh, search, theme) are `min 44×44`.
+  The header day switcher (1h…30d) stays compact and `flex-1` below `sm` so
+  chips + those utilities fit one 375 row. Docs article Copy Markdown / Open
+  are 44px below `md` (not header search/menu). Agent FAB must not cover
+  heatmap "Avg / active day" (`pb-16` + last-card `pr-16`; landscape FAB at
+  `top-16`).
 - **Paired page sections** (e.g. AI-generated vs. plain-statistics content):
   identical-weight header on both — `icon (size-4, muted-foreground) + <h2
   className="text-sm font-medium text-foreground">`. A *genuinely* empty section

--- a/apps/dashboard/src/components/header/header-actions.tsx
+++ b/apps/dashboard/src/components/header/header-actions.tsx
@@ -43,7 +43,7 @@ export const HeaderActions = function HeaderActions({
   }
 
   return (
-    <div className="flex w-max shrink-0 items-center gap-1 sm:ml-auto sm:w-auto sm:gap-3">
+    <div className="flex w-full min-w-0 flex-nowrap items-center gap-1 sm:ml-auto sm:w-auto sm:gap-3">
       {showTimeControls ? (
         <>
           <GlobalTimeRangePicker />

--- a/apps/dashboard/src/components/header/header-utility-icons.test.tsx
+++ b/apps/dashboard/src/components/header/header-utility-icons.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Persistent header utility icons (refresh, search, theme) must be 44×44
- * below lg. Glyph stays 16–20px. Time chips and the sidebar toggle are
- * covered by time-range-picker.test.tsx.
+ * below lg. Glyph stays 16–20px. The header day switcher stays compact
+ * (time-range-picker.test.tsx) so those 44px icons still fit on 375.
  */
 
 import type { ReactElement } from 'react'

--- a/apps/dashboard/src/components/header/time-range-picker.test.tsx
+++ b/apps/dashboard/src/components/header/time-range-picker.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Header time chips must be at least 44×44 on phones.
+ * Header day-switcher chips stay compact so 1h…30d + 44px utilities fit
+ * on one 375 row (44×44 chips overflowed and clipped the theme icon).
  */
 
 import type { ReactElement } from 'react'
@@ -70,7 +71,7 @@ async function renderInto(
 }
 
 describe('GlobalTimeRangePicker', () => {
-  test('each preset chip is a 44px tap target on phones', async () => {
+  test('chips stay compact and fill remaining header width on phones', async () => {
     const { TimeRangeProvider } = await import(
       '@/lib/context/time-range-context'
     )
@@ -81,11 +82,22 @@ describe('GlobalTimeRangePicker', () => {
       </TimeRangeProvider>
     )
 
+    const group = container.querySelector(
+      '[role="group"][aria-label="Global time range"]'
+    )
+    expect(group).not.toBeNull()
+    expect(group?.className).toContain('flex-1')
+    expect(group?.className).toContain('min-w-0')
+    expect(group?.className).toContain('sm:flex-none')
+
     const chips = container.querySelectorAll('[role="group"] button')
     expect(chips.length).toBeGreaterThanOrEqual(4)
     for (const chip of chips) {
-      expect(chip.className).toContain('min-h-11')
-      expect(chip.className).toContain('min-w-11')
+      expect(chip.className).not.toContain('min-h-11')
+      expect(chip.className).not.toContain('min-w-11')
+      expect(chip.className).toContain('flex-1')
+      expect(chip.className).toContain('min-w-0')
+      expect(chip.className).toContain('sm:flex-none')
     }
 
     await cleanup()

--- a/apps/dashboard/src/components/header/time-range-picker.tsx
+++ b/apps/dashboard/src/components/header/time-range-picker.tsx
@@ -9,13 +9,19 @@ import { cn } from '@/lib/utils'
  *
  * Sets the global default lastHours used by all charts that do not have an
  * individual per-chart date range selector configured.
+ *
+ * Phone (below `sm`): chips stay compact and `flex-1` so 1h…30d fills the
+ * remaining header row beside the 44×44 utilities. 44×44 chips (#3108)
+ * overflowed 375 and clipped the theme icon / left an empty band.
+ * From `sm` the group shrinks to intrinsic width (same compact chips as
+ * before) because the header is a single nowrap row with more room.
  */
 export const GlobalTimeRangePicker = function GlobalTimeRangePicker() {
   const { timeRange, setTimeRange } = useTimeRange()
 
   return (
     <div
-      className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/50 bg-muted/40 p-0.5"
+      className="flex min-w-0 flex-1 items-center gap-0.5 rounded-md border border-border/50 bg-muted/40 p-0.5 sm:flex-none sm:shrink-0"
       role="group"
       aria-label="Global time range"
     >
@@ -29,7 +35,7 @@ export const GlobalTimeRangePicker = function GlobalTimeRangePicker() {
             aria-pressed={isActive}
             title={`Show last ${preset.label}`}
             className={cn(
-              'inline-flex min-h-11 min-w-11 items-center justify-center rounded px-2.5 text-xs font-medium transition-colors sm:min-h-0 sm:min-w-0 sm:px-2 sm:py-0.5',
+              'inline-flex min-w-0 flex-1 items-center justify-center rounded px-1.5 py-0.5 text-xs font-medium transition-colors sm:flex-none sm:px-2',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
               isActive
                 ? 'bg-background text-foreground'

--- a/apps/dashboard/src/components/skeletons/tabs.test.tsx
+++ b/apps/dashboard/src/components/skeletons/tabs.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Overview underline tab skeleton must match the scrollable strip so CLS
+ * and 375 overflow stay in sync with overview.tsx.
+ */
+
+import type { ReactElement } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('TabsSkeleton', () => {
+  test('underline variant is a bounded overflow-x strip', async () => {
+    const { TabsSkeleton } = await import('./tabs')
+    const { container, cleanup } = await renderInto(
+      <TabsSkeleton tabCount={7} variant="underline" />
+    )
+
+    const strip = container.querySelector('.overflow-x-auto')
+    expect(strip).not.toBeNull()
+    expect(strip?.className).toContain('min-w-0')
+    expect(strip?.className).toContain('w-full')
+    expect(strip?.className).toContain('scrollbar-hide')
+
+    const list = strip?.firstElementChild
+    expect(list?.className).toContain('w-max')
+    expect(list?.className).toContain('min-w-full')
+    expect(list?.className).toContain('flex-nowrap')
+
+    await cleanup()
+  })
+})

--- a/apps/dashboard/src/components/skeletons/tabs.tsx
+++ b/apps/dashboard/src/components/skeletons/tabs.tsx
@@ -26,8 +26,8 @@ export function TabsSkeleton({
     <div className={cn('space-y-2', className)}>
       {/* Tabs list skeleton */}
       {variant === 'underline' ? (
-        <div>
-          <div className="inline-flex h-auto w-full items-center justify-start gap-1 border-b border-border bg-transparent p-0">
+        <div className="scrollbar-hide min-w-0 w-full overflow-x-auto py-0.5">
+          <div className="inline-flex h-auto w-max min-w-full flex-nowrap items-center justify-start gap-1 border-b border-border bg-transparent p-0">
             {Array.from({ length: tabCount }).map((_, i) => (
               <Skeleton
                 key={i}

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -245,8 +245,8 @@ function OverviewPageContent() {
           onValueChange={handleTabChange}
           className="space-y-2"
         >
-          <div className="scrollbar-hide overflow-x-auto">
-            <TabsList className="inline-flex h-auto w-max min-w-full items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
+          <div className="scrollbar-hide min-w-0 w-full overflow-x-auto py-0.5">
+            <TabsList className="inline-flex h-auto w-max min-w-full flex-nowrap items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
               {OVERVIEW_TABS.map((tab) => (
                 <TabsTrigger
                   key={tab.value}

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-24
+updated: 2026-08-26
 tags:
   - design-system
   - ui
@@ -585,8 +585,11 @@ when the user unblocks the site. Gate "Send test" on the live permission.
 Define tabs as one array and map it. One icon size (`size-3.5`), no margin
 utility — `TabsTrigger` already provides `items-center gap-1.5`; a stacked
 `mr-*` is what makes icons look off-baseline. Keep the strip in the
-`scrollbar-hide overflow-x-auto` + `TabsList w-max min-w-full flex-nowrap`
-wrapper so many tabs (Overview's "Memory & CPU") scroll instead of clipping.
+`scrollbar-hide min-w-0 w-full overflow-x-auto` + `TabsList w-max min-w-full
+flex-nowrap` wrapper so many tabs (Overview's "Memory & CPU") scroll
+inside the strip. `min-w-0 w-full` is required: the strip is a flex child
+of `Tabs` (`flex flex-col`), and without a bounded min-width the list
+grows to its content (~650px) and "Memo" clips with no in-strip scroll.
 Selected state is Base UI `data-active:` (underline via trigger
 `border-b-2` + `data-active:border-foreground`), never Radix
 `data-[state=active]:` — those selectors never match, so light-mode overview
@@ -613,10 +616,14 @@ would clip it.
   `lg`; the heatmap's last stat card (`Avg / active day`) is `max-lg:col-span-2
   max-lg:pr-16` so the bubble does not cover the label. On phone landscape the
   FAB moves to `top-16`.
-- **Phone tap targets are 44×44.** Time chips (`min-h-11 min-w-11` until
-  `sm`), sidebar rows (`h-11` until `lg`), sidebar trigger (`size-11` until
-  `lg`), header utility icons — refresh, search, theme (`min-h-11 min-w-11`
-  until `lg`). Glyph stays 16–20px. Compact sizes return at the desktop rail.
+- **Phone tap targets are 44×44** for sidebar rows (`h-11` until `lg`), the
+  sidebar trigger (`size-11` until `lg`), and header utility icons — refresh,
+  search, theme (`min-h-11 min-w-11` until `lg`). Glyph stays 16–20px. Compact
+  sizes return at the desktop rail. The **global header day switcher**
+  (1h…30d) is the exception: chips stay compact (`px-1.5 py-0.5`, `flex-1`
+  below `sm`) so they fill the row beside those 44×44 utilities on 375
+  without clipping the theme icon or leaving an empty band. Chart
+  `DateRangeSelector` dropdown chips stay `min-h-11 min-w-11` until `sm`.
   Docs article **Copy Markdown** / **Open** (`[data-article-actions]`, below
   `md`) are the same 44px floor; docs header search/menu is a separate control
   (`#nd-nav` / `#nd-subnav`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #3289: at 375, the overview day switcher (1h…30d) was a 44×44 chip row that overflowed and clipped the theme icon; Memory and later section tabs clipped with no usable in-strip scroll.

## Changes

- Header day switcher: compact chips that `flex-1` below `sm`, filling the row beside 44×44 refresh/search/theme (`time-range-picker.tsx`, `header-actions.tsx`).
- Overview section tabs: `min-w-0 w-full overflow-x-auto` + `flex-nowrap` so Memory and later tabs scroll inside the strip (`overview.tsx`, matching `TabsSkeleton`).
- Tests for compact chips, 44px utilities, and the underline tab skeleton strip. Product-design skill/docs updated.

## Test plan

- [x] `pnpm run lint` passes with no errors (Biome on changed files)
- [x] `pnpm run type-check:test` passes
- [x] Header + `TabsSkeleton` unit tests pass
- [x] CI `unit-tests` and `dashboard` passed on `f7d2bf9`
- [x] Live 375 before: chips 44×44, theme `right` 390 (clips), Memory clipped
- [x] New classes at 375: chips 36×20, group 26px, theme 44×44 `right` 348; tab scroll reveals Memory & CPU
- [x] 768: compact chips, theme 44×44, all seven tabs fit, no page overflow-x
- [ ] `docs/content/ai-agent.mdx` — N/A

`preview.dash.chmonitor.dev` is a shared last-writer-wins worker. After this PR deployed (`dashboard-shell-BXqbY8A-.js`), a later PR overwrote it (`dashboard-shell-CHrVxKbQ.js` still has `min-h-11` chips). Use this branch's deploy, not the shared URL, to QA.

![Live 375 before: 44px chips, theme clipped](https://cursor.com/artifacts/c/art-9c00ffae-e01e-4058-9dcd-c077b2dea820)
![375 after: compact day switcher, theme fully visible](https://cursor.com/artifacts/c/art-e5101555-ba51-4c7f-bd95-029c2a7dafc5)
![375 after: tab strip scrolled to Memory and CPU](https://cursor.com/artifacts/c/art-eb553999-735d-4720-b63a-81dfbea77920)
![768 after: chips plus 44px utilities, all tabs fit](https://cursor.com/artifacts/c/art-640ba67c-a4f4-4cbc-a147-74de13e116db)

## Notes for reviewer

Measured live `dash.chmonitor.dev/overview?host=0` at 375 before coding. 44×44 day-switcher chips (#3108 leftover) overflow the row; utilities stay 44×44.

Read-only `?host=0`. No add-host, Settings, or AnyRouter changes.

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-997ac6c0-3234-46e0-909a-4348ef918f36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-997ac6c0-3234-46e0-909a-4348ef918f36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

