### PR TITLE
feat(dashboard): slim default sidebar to day-to-day pages

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -398,19 +398,24 @@ stays `shrink-0` on the right. Click a leaf to hide or show it — hidden
 rows stay visible but muted, like Dim unavailable pages.
 Expand/collapse does not write settings. Hide of an already-hidden-by-
 preset leaf stays on the role; Custom only when the hide list leaves
-`hideListForPreset`. Search filters the tree. Never a 40-checkbox wall
+`hideListForPreset`. Search filters the tree. When the preset is not
+Full, a **Show all** control applies Full. The sidebar **More pages**
+row opens this pane when any pages are hidden. Never a 40-checkbox wall
 or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
 demos.
 Hidden pages stay routable. Filter through
-`getVisibleMenuItems` so sidebar, ⌘K, and the Settings > Navigation
+`getVisibleMenuItems` (sidebar + ⌘K wrap it in `useVisibleMenuItems`
+so Alerts appears only with an active notification count) so sidebar,
+⌘K, and the Settings > Navigation
 tree match the **active host engine** (`useActiveHostEngine` —
 default source engine, Postgres pages when `?pg=` is active).
 Timezone uses `timezone-combobox.tsx`
 (search + browser zone on top). Palette is a card picker with mini bars, not
 a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
-Every DEFAULT reproduces the prior look byte-for-byte (`workspacePreset:
-'full'`). Applied by
+First-run workspace is Custom + the slim hide list
+(`DEFAULT_HIDDEN_MENU_HREFS`); Full still restores every page. Other
+DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
 `data-chart-palette` / `data-density` on `<html>`. For 2–3 choices use
@@ -443,6 +448,9 @@ module snapshot in `lib/format-settings.ts`; palette/density →
    `Tools`. Webhook ingest (Inbound Events) lives under Health after
    Alert Settings — not as a top-level Others item; leave `engines`
    absent so Postgres hosts inherit Health (default source-engine family).
+   Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
+   (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
+   sidebar stays slim — they remain restorable from Settings → Navigation.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -17,25 +17,13 @@ import {
 } from '@/components/ui/sidebar'
 import { GUEST_USER } from '@/lib/clerk/guest-user'
 import { DOCS_SITE_URL } from '@/lib/docs-site'
-import { useFeaturePermissions } from '@/lib/feature-permissions/context'
-import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
-import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { isMenuItemActive } from '@/lib/menu/breadcrumb'
-import { getVisibleMenuItems } from '@/lib/menu/visible-items'
-import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
+import { useVisibleMenuItems } from '@/lib/menu/use-visible-menu-items'
 
 export function AppSidebar() {
-  const { config } = useFeaturePermissions()
-  // Feature-permission + cloud-only (Billing/Organization) + engine gates
-  // resolved in one place — see lib/menu/visible-items.ts. The active engine
-  // swaps the menu to Postgres pages when a Postgres source is selected (#2450).
-  const engine = useActiveHostEngine()
-  const { settings } = useUserSettings()
-  const menuItems = getVisibleMenuItems(
-    config,
-    engine,
-    workspaceFromSettings(settings)
-  )
+  // Feature-permission + cloud-only + engine + workspace gates, plus Alerts
+  // when notifications are active — see useVisibleMenuItems.
+  const menuItems = useVisibleMenuItems()
   // Footer nav rows (Billing / Organization / About). Same visibility pipeline
   // as the body, so cloud-only + permission + engine gating still applies; they
   // render as compact rows in the footer instead of a labelled body group.

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -20,12 +20,8 @@ import { useTheme } from 'next-themes'
 import { CommandDialog, CommandInput } from '@/components/ui/command'
 import { useFavoriteHrefs } from '@/hooks/use-favorites'
 import { useUrlSearchParams } from '@/hooks/use-url-search-params'
-import { useFeaturePermissions } from '@/lib/feature-permissions/context'
-import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
-import { useUserSettings } from '@/lib/hooks/use-user-settings'
 import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
-import { getVisibleMenuItems } from '@/lib/menu/visible-items'
-import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
+import { useVisibleMenuItems } from '@/lib/menu/use-visible-menu-items'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl, splitHref } from '@/lib/url/url-builder'
@@ -68,14 +64,7 @@ export const CommandPalette = function CommandPalette({
     rememberSelection,
   } = useCommandPaletteState({ open: controlledOpen, onOpenChange })
 
-  const { config } = useFeaturePermissions()
-  const engine = useActiveHostEngine()
-  const { settings } = useUserSettings()
-  const menuItems = getVisibleMenuItems(
-    config,
-    engine,
-    workspaceFromSettings(settings)
-  )
+  const menuItems = useVisibleMenuItems()
   const favoriteHrefs = useFavoriteHrefs()
   const favoriteMenuItems = getFavoriteMenuItems(menuItems, favoriteHrefs)
   const { setTheme, resolvedTheme } = useTheme()

--- a/apps/dashboard/src/components/navigation/nav-main/index.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/index.tsx
@@ -3,6 +3,7 @@ import { useLocation } from '@tanstack/react-router'
 import type { NavMainProps, NavRenderSection } from './types'
 
 import { MenuGroup } from './menu-group'
+import { MorePagesButton } from './more-pages-button'
 import { NavFavorites } from './nav-favorites'
 
 /**
@@ -36,6 +37,7 @@ export function NavMain({ items }: NavMainProps) {
           pathname={pathname}
         />
       ))}
+      <MorePagesButton />
     </>
   )
 }

--- a/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * More pages: shown when the workspace hide list is non-empty, opens
+ * Settings → Navigation. happy-dom + react-dom/client.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type { ReactElement } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('MorePagesButton', () => {
+  test('renders when pages are hidden and is a 44px-high control', async () => {
+    const { MorePagesButton } = await import('./more-pages-button')
+    const { SidebarProvider } = await import('@/components/ui/sidebar')
+    const { USER_SETTINGS_QUERY_KEY } = await import(
+      '@/lib/hooks/use-user-settings'
+    )
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
+
+    const { container, cleanup } = await renderInto(
+      <QueryClientProvider client={queryClient}>
+        <SidebarProvider>
+          <MorePagesButton />
+        </SidebarProvider>
+      </QueryClientProvider>
+    )
+
+    try {
+      const button = container.querySelector(
+        '[data-testid="more-pages-button"]'
+      ) as HTMLButtonElement | null
+      expect(button).not.toBeNull()
+      expect(button?.tagName).toBe('BUTTON')
+      expect(button?.textContent).toContain('More pages')
+      expect(button?.className).toContain('min-h-11')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('is absent on Full with an empty hide list', async () => {
+    const { MorePagesButton } = await import('./more-pages-button')
+    const { SidebarProvider } = await import('@/components/ui/sidebar')
+    const { USER_SETTINGS_QUERY_KEY } = await import(
+      '@/lib/hooks/use-user-settings'
+    )
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, {
+      ...DEFAULT_USER_SETTINGS,
+      workspacePreset: 'full',
+      hiddenMenuHrefs: [],
+    })
+
+    const { container, cleanup } = await renderInto(
+      <QueryClientProvider client={queryClient}>
+        <SidebarProvider>
+          <MorePagesButton />
+        </SidebarProvider>
+      </QueryClientProvider>
+    )
+
+    try {
+      expect(container.querySelector('[data-testid="more-pages-button"]')).toBe(
+        null
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/navigation/nav-main/more-pages-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/more-pages-button.tsx
@@ -1,0 +1,59 @@
+import { Ellipsis } from 'lucide-react'
+import { menuItemsConfig } from '@/menu'
+
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import {
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar'
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
+import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import {
+  effectiveHiddenMenuHrefs,
+  workspaceFromSettings,
+} from '@/lib/menu/workspace-presets'
+
+/**
+ * Opens Settings → Navigation when the workspace hide list is non-empty
+ * (#3292). Restore is already in that tree (Show / Full); this is the
+ * sidebar entry so users do not have to remember the gear.
+ */
+export function MorePagesButton() {
+  const { settings } = useUserSettings()
+  const { isMobile, setOpenMobile } = useSidebar()
+  const openSettings = useOpenSettings()
+  const { config } = useFeaturePermissions()
+  const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
+  const hiddenCount = effectiveHiddenMenuHrefs(
+    menuItemsConfig,
+    workspaceFromSettings(settings)
+  ).length
+
+  if (!canUseSettings || hiddenCount === 0) return null
+
+  return (
+    <SidebarGroup className="p-1">
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            tooltip="Show hidden pages in Settings → Navigation"
+            className="h-11 min-h-11 lg:h-8 lg:min-h-8 text-muted-foreground"
+            data-testid="more-pages-button"
+            onClick={() => {
+              if (isMobile) setOpenMobile(false)
+              openSettings('navigation')
+            }}
+          >
+            <Ellipsis className="size-4 shrink-0" strokeWidth={1.5} />
+            <span>More pages</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -736,7 +736,7 @@ export function SettingsForm({
               <Field
                 label="Workspace"
                 icon={LayoutGrid}
-                description="Slim the sidebar and command palette to a role. Hidden pages stay reachable by URL."
+                description="Hide pages from the sidebar and command palette. Full restores every page. Hidden pages stay reachable by URL."
               >
                 <WorkspacePresetPicker
                   preset={settings.workspacePreset}

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.test.tsx
@@ -465,4 +465,43 @@ describe('WorkspacePresetPicker', () => {
       await cleanup()
     }
   })
+
+  test('Show all restores Full from a hide list', async () => {
+    const { useState } = await import('react')
+    const { WorkspacePresetPicker } = await import('./workspace-preset-picker')
+    const { act } = await import('react')
+
+    function Harness() {
+      const [state, setState] = useState<{
+        workspacePreset: WorkspacePreset
+        hiddenMenuHrefs: string[]
+      }>({ workspacePreset: 'custom', hiddenMenuHrefs: ['/advisor'] })
+      return (
+        <WorkspacePresetPicker
+          preset={state.workspacePreset}
+          hiddenMenuHrefs={state.hiddenMenuHrefs}
+          onChange={setState}
+        />
+      )
+    }
+
+    const { container, cleanup } = await renderInto(<Harness />)
+
+    try {
+      expect(selectedPreset(container)).toContain('Custom')
+      const showAll = container.querySelector(
+        '[data-testid="workspace-show-all"]'
+      )
+      expect(showAll).toBeTruthy()
+      await act(async () => {
+        showAll?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      })
+      expect(selectedPreset(container)).toContain('Full')
+      expect(
+        container.querySelector('[data-testid="workspace-show-all"]')
+      ).toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
 })

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -108,8 +108,8 @@ export function WorkspacePresetPicker({
       <p className="text-xs text-muted-foreground">{PRESET_HINT[preset]}</p>
 
       {preset !== 'full' && (
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-xs text-muted-foreground">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="min-w-0 text-xs text-muted-foreground">
             {extraHiddenCount > 0
               ? `${extraHiddenCount} extra page${extraHiddenCount === 1 ? '' : 's'} hidden. Click Show on a row, or Show all.`
               : 'Hidden pages stay in this tree. Click Show on a row, or Show all.'}
@@ -117,7 +117,7 @@ export function WorkspacePresetPicker({
           <button
             type="button"
             data-testid="workspace-show-all"
-            className="inline-flex h-8 shrink-0 items-center rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+            className="inline-flex h-8 w-fit shrink-0 items-center rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
             onClick={() => applyPreset('full')}
           >
             Show all

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -35,7 +35,7 @@ const PRESET_HINT: Record<WorkspacePreset, string> = {
     'Overview, SQL/explorer, queries, insights. Less keeper, security, and ops.',
   sre: 'Overview, health, insights, SQL tools, replication, disks, errors, running queries.',
   custom:
-    'Starts from a preset. Hide extra pages without a full checkbox wall.',
+    'Day-to-day pages by default. Hide or show more in the tree, or pick Full.',
 }
 
 interface WorkspacePresetPickerProps {
@@ -107,11 +107,22 @@ export function WorkspacePresetPicker({
       />
       <p className="text-xs text-muted-foreground">{PRESET_HINT[preset]}</p>
 
-      {extraHiddenCount > 0 && (
-        <p className="text-xs text-muted-foreground">
-          {extraHiddenCount} extra page
-          {extraHiddenCount === 1 ? '' : 's'} hidden. Click Show to restore one.
-        </p>
+      {preset !== 'full' && (
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs text-muted-foreground">
+            {extraHiddenCount > 0
+              ? `${extraHiddenCount} extra page${extraHiddenCount === 1 ? '' : 's'} hidden. Click Show on a row, or Show all.`
+              : 'Hidden pages stay in this tree. Click Show on a row, or Show all.'}
+          </p>
+          <button
+            type="button"
+            data-testid="workspace-show-all"
+            className="inline-flex h-8 shrink-0 items-center rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+            onClick={() => applyPreset('full')}
+          >
+            Show all
+          </button>
+        </div>
       )}
 
       <div className="relative">

--- a/apps/dashboard/src/lib/menu/notification-alerts.test.ts
+++ b/apps/dashboard/src/lib/menu/notification-alerts.test.ts
@@ -1,0 +1,93 @@
+import type { MenuItem } from '@/components/menu/types'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  ALERTS_HREF,
+  ALERTS_TITLE,
+  revealAlertsWhenActive,
+} from '@/lib/menu/notification-alerts'
+
+const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
+  title: overrides.title ?? 'Item',
+  href: overrides.href ?? '/item',
+  ...overrides,
+})
+
+const healthGroup = (): MenuItem => ({
+  title: 'Health',
+  href: '',
+  section: 'main',
+  items: [
+    leaf({ title: 'Health', href: '/health' }),
+    leaf({ title: 'Health Settings', href: '/health-settings' }),
+  ],
+})
+
+const catalog = (): MenuItem[] => [
+  leaf({ title: 'Overview', href: '/overview', section: 'main' }),
+  healthGroup(),
+  leaf({ title: 'About', href: '/about', section: 'footer' }),
+]
+
+describe('revealAlertsWhenActive (#3291)', () => {
+  test('does not add Alerts when the notification count is zero', () => {
+    const result = revealAlertsWhenActive(catalog(), false)
+    expect(
+      result.find((item) => item.title === 'Health')?.items?.map((i) => i.title)
+    ).toEqual(['Health', 'Health Settings'])
+    expect(JSON.stringify(result)).not.toContain(ALERTS_TITLE)
+  })
+
+  test('inserts Alerts under Health after the Health page when count > 0', () => {
+    const result = revealAlertsWhenActive(catalog(), true)
+    const health = result.find((item) => item.title === 'Health')
+    expect(health?.items?.map((item) => item.title)).toEqual([
+      'Health',
+      ALERTS_TITLE,
+      'Health Settings',
+    ])
+    expect(
+      health?.items?.find((item) => item.title === ALERTS_TITLE)?.href
+    ).toBe(ALERTS_HREF)
+  })
+
+  test('does not duplicate when Alert Settings is already visible', () => {
+    const withSettings: MenuItem[] = [
+      leaf({ title: 'Overview', href: '/overview', section: 'main' }),
+      {
+        title: 'Health',
+        href: '',
+        items: [
+          leaf({ title: 'Health', href: '/health' }),
+          leaf({ title: 'Alert Settings', href: ALERTS_HREF }),
+        ],
+      },
+    ]
+    const result = revealAlertsWhenActive(withSettings, true)
+    const hrefs =
+      result
+        .find((item) => item.title === 'Health')
+        ?.items?.map((item) => item.href) ?? []
+    expect(hrefs.filter((href) => href === ALERTS_HREF)).toEqual([ALERTS_HREF])
+    expect(
+      result
+        .find((item) => item.title === 'Health')
+        ?.items?.map((item) => item.title)
+    ).not.toContain(ALERTS_TITLE)
+  })
+
+  test('inserts a top-level Alerts row after Overview when Health is absent', () => {
+    const withoutHealth: MenuItem[] = [
+      leaf({ title: 'Overview', href: '/overview', section: 'main' }),
+      leaf({ title: 'Queries', href: '/running-queries', section: 'main' }),
+    ]
+    const result = revealAlertsWhenActive(withoutHealth, true)
+    expect(result.map((item) => item.title)).toEqual([
+      'Overview',
+      ALERTS_TITLE,
+      'Queries',
+    ])
+    expect(result[1]?.href).toBe(ALERTS_HREF)
+    expect(result[1]?.section).toBe('main')
+  })
+})

--- a/apps/dashboard/src/lib/menu/notification-alerts.ts
+++ b/apps/dashboard/src/lib/menu/notification-alerts.ts
@@ -1,0 +1,62 @@
+import { BellRingIcon } from 'lucide-react'
+
+import type { MenuItem } from '@/components/menu/types'
+
+/** Existing Alert Settings route — not a new product surface (#3291). */
+export const ALERTS_HREF = '/alert-settings'
+export const ALERTS_TITLE = 'Alerts'
+
+const ALERTS_ITEM: MenuItem = {
+  title: ALERTS_TITLE,
+  href: ALERTS_HREF,
+  description: 'Active notifications for this cluster',
+  icon: BellRingIcon,
+  permission: { feature: 'health' },
+}
+
+function menuContainsHref(items: readonly MenuItem[], href: string): boolean {
+  return items.some(
+    (item) =>
+      item.href === href ||
+      (item.items ? menuContainsHref(item.items, href) : false)
+  )
+}
+
+function insertAlertsChild(health: MenuItem): MenuItem {
+  const children = [...(health.items ?? [])]
+  const healthPageAt = children.findIndex((child) => child.href === '/health')
+  const insertAt = healthPageAt === -1 ? 0 : healthPageAt + 1
+  children.splice(insertAt, 0, { ...ALERTS_ITEM })
+  return { ...health, items: children }
+}
+
+/**
+ * Show an Alerts row only while notifications are active. Reuses
+ * `/alert-settings` (Active Alerts). No-op when that href is already visible
+ * (user restored Alert Settings) or when the count is zero.
+ */
+export function revealAlertsWhenActive(
+  items: readonly MenuItem[],
+  hasActiveNotifications: boolean
+): MenuItem[] {
+  if (!hasActiveNotifications) return items.map((item) => ({ ...item }))
+  if (menuContainsHref(items, ALERTS_HREF)) {
+    return items.map((item) => ({ ...item }))
+  }
+
+  const healthAt = items.findIndex((item) => item.title === 'Health')
+  if (healthAt >= 0) {
+    return items.map((item, index) =>
+      index === healthAt ? insertAlertsChild(item) : { ...item }
+    )
+  }
+
+  const overviewAt = items.findIndex((item) => item.href === '/overview')
+  const alertsLeaf: MenuItem = {
+    ...ALERTS_ITEM,
+    section: 'main',
+  }
+  const next = items.map((item) => ({ ...item }))
+  next.splice(overviewAt + 1, 0, alertsLeaf)
+  return next
+}

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -1,0 +1,97 @@
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_HIDDEN_MENU_HREFS,
+  DEFAULT_VISIBLE_MENU_HREFS,
+} from '@/lib/menu/slim-default'
+import {
+  applyWorkspaceVisibility,
+  collectMenuLeaves,
+} from '@/lib/menu/workspace-presets'
+import { DEFAULT_USER_SETTINGS } from '@/lib/types/user-settings'
+
+describe('slim default sidebar (#3290)', () => {
+  const leaves = collectMenuLeaves(menuItemsConfig)
+  const hidden = new Set(DEFAULT_HIDDEN_MENU_HREFS)
+  const visible = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)
+
+  test('every default-engine leaf is either day-to-day or on the hide list', () => {
+    for (const leaf of leaves) {
+      if (leaf.href.startsWith('/postgres/')) {
+        expect(hidden.has(leaf.href), leaf.href).toBe(false)
+        continue
+      }
+      expect(
+        visible.has(leaf.href) || hidden.has(leaf.href),
+        `${leaf.href} (${leaf.title}) must be in the keep list or the hide list`
+      ).toBe(true)
+      expect(
+        visible.has(leaf.href) && hidden.has(leaf.href),
+        `${leaf.href} cannot be both visible and hidden`
+      ).toBe(false)
+    }
+  })
+
+  test('day-to-day hrefs exist on the catalog', () => {
+    const leafHrefs = new Set(leaves.map((leaf) => leaf.href))
+    for (const href of DEFAULT_VISIBLE_MENU_HREFS) {
+      if (href === '/tables') {
+        expect(menuItemsConfig.some((item) => item.href === '/tables')).toBe(
+          true
+        )
+        continue
+      }
+      expect(leafHrefs.has(href), href).toBe(true)
+    }
+  })
+
+  test('footer About is never on the hide list', () => {
+    expect(DEFAULT_HIDDEN_MENU_HREFS).not.toContain('/about')
+  })
+
+  test('standing settings / specialist pages are hidden', () => {
+    for (const href of [
+      '/alert-settings',
+      '/health-settings',
+      '/inbound-events',
+      '/agents/settings',
+      '/mcp',
+      '/keeper/info',
+      '/peerdb',
+      '/logs/text-log',
+      '/settings',
+      '/backups',
+    ]) {
+      expect(DEFAULT_HIDDEN_MENU_HREFS, href).toContain(href)
+    }
+  })
+
+  test('first-run settings apply the slim hide list as Custom', () => {
+    expect(DEFAULT_USER_SETTINGS.workspacePreset).toBe('custom')
+    expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toEqual(
+      DEFAULT_HIDDEN_MENU_HREFS
+    )
+
+    const titles = applyWorkspaceVisibility(menuItemsConfig, {
+      workspacePreset: DEFAULT_USER_SETTINGS.workspacePreset,
+      hiddenMenuHrefs: DEFAULT_USER_SETTINGS.hiddenMenuHrefs,
+    }).map((item: MenuItem) => item.title)
+
+    expect(titles).toContain('Overview')
+    expect(titles).toContain('Health')
+    expect(titles).toContain('Queries')
+    expect(titles).toContain('Tables')
+    expect(titles).toContain('Tools')
+    expect(titles).toContain('Cluster')
+    expect(titles).toContain('About')
+    expect(titles).not.toContain('Keeper')
+    expect(titles).not.toContain('PeerDB')
+    expect(titles).not.toContain('Security')
+    expect(titles).not.toContain('Logs')
+    expect(titles).not.toContain('System')
+    expect(titles).not.toContain('Operations')
+  })
+})

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -1,0 +1,68 @@
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+
+/**
+ * v1 day-to-day sidebar keep list (#3290). Taken from the live menu on
+ * dash.chmonitor.dev — existing pages only, no new product areas.
+ *
+ * First-run / missing-workspace settings hide every other default-engine
+ * leaf. Postgres-only leaves are never on the hide list (engine swap already
+ * drops those groups). Footer rows are never hidden.
+ *
+ * Full in Settings → Navigation still shows every page. New pages that
+ * should stay off the default rail must not be added here.
+ */
+export const DEFAULT_VISIBLE_MENU_HREFS = [
+  '/overview',
+  '/agents',
+  '/insights',
+  '/health',
+  '/running-queries',
+  '/tables',
+  '/explorer',
+  '/tables-overview',
+  '/merges',
+  '/metrics',
+  '/sql',
+  '/explain',
+  '/advisor',
+  '/clusters',
+] as const
+
+const VISIBLE = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)
+
+function isPostgresOnly(item: MenuItem): boolean {
+  const engines = item.engines
+  if (!engines?.length) return false
+  return engines.every((engine) => engine === 'postgres')
+}
+
+function isFooterItem(item: MenuItem): boolean {
+  return item.section === 'footer'
+}
+
+function collectHideableLeaves(
+  items: readonly MenuItem[],
+  out: MenuItem[] = []
+): MenuItem[] {
+  for (const item of items) {
+    if (isFooterItem(item) || isPostgresOnly(item)) continue
+    if (item.items?.length) {
+      collectHideableLeaves(item.items, out)
+      continue
+    }
+    if (item.href) out.push(item)
+  }
+  return out
+}
+
+/**
+ * Hide list for the slim first-run default. Complementary to
+ * {@link DEFAULT_VISIBLE_MENU_HREFS} over the current menu catalog.
+ */
+export const DEFAULT_HIDDEN_MENU_HREFS: string[] = collectHideableLeaves(
+  menuItemsConfig
+)
+  .map((item) => item.href)
+  .filter((href) => !VISIBLE.has(href))

--- a/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
+++ b/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
@@ -1,0 +1,25 @@
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { revealAlertsWhenActive } from '@/lib/menu/notification-alerts'
+import { getVisibleMenuItems } from '@/lib/menu/visible-items'
+import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
+import { useHostId } from '@/lib/swr'
+import { useNotifications } from '@/lib/swr/use-notifications'
+
+/**
+ * Sidebar + ⌘K catalog after permission / engine / workspace gates, with
+ * Alerts injected only while the notifications poll reports a count.
+ */
+export function useVisibleMenuItems() {
+  const { config } = useFeaturePermissions()
+  const engine = useActiveHostEngine()
+  const { settings } = useUserSettings()
+  const hostId = useHostId()
+  const { totalCount, isLoading } = useNotifications(hostId)
+
+  return revealAlertsWhenActive(
+    getVisibleMenuItems(config, engine, workspaceFromSettings(settings)),
+    !isLoading && totalCount > 0
+  )
+}

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -19,8 +19,10 @@ describe('mergeUserSettings', () => {
     expect(merged.chartPalette).toBe('default')
     expect(merged.tableDensity).toBe('comfortable')
     expect(merged.defaultTimeRange).toBe('24h')
-    expect(merged.workspacePreset).toBe('full')
-    expect(merged.hiddenMenuHrefs).toEqual([])
+    expect(merged.workspacePreset).toBe('custom')
+    expect(merged.hiddenMenuHrefs.length).toBeGreaterThan(0)
+    expect(merged.hiddenMenuHrefs).not.toContain('/overview')
+    expect(merged.hiddenMenuHrefs).toContain('/alert-settings')
     expect(merged.lastSeenChangelogVersion).toBe('')
   })
 
@@ -44,13 +46,28 @@ describe('mergeUserSettings', () => {
     expect(mergeUserSettings(null)).not.toBe(DEFAULT_USER_SETTINGS)
   })
 
-  test('junk workspace keys fall back to Full and an empty hide list', () => {
+  test('junk workspace keys fall back to Custom and parse a hide list', () => {
     const merged = mergeUserSettings({
       workspacePreset: 'intern',
       hiddenMenuHrefs: ['/health', 12, ''],
     })
-    expect(merged.workspacePreset).toBe('full')
+    expect(merged.workspacePreset).toBe('custom')
     expect(merged.hiddenMenuHrefs).toEqual(['/health'])
+  })
+
+  test('an explicit Full empty hide list is not replaced by the slim default', () => {
+    const merged = mergeUserSettings({
+      workspacePreset: 'full',
+      hiddenMenuHrefs: [],
+    })
+    expect(merged.workspacePreset).toBe('full')
+    expect(merged.hiddenMenuHrefs).toEqual([])
+  })
+
+  test('Full without a stored hide list stays empty, not the slim default', () => {
+    const merged = mergeUserSettings({ workspacePreset: 'full' })
+    expect(merged.workspacePreset).toBe('full')
+    expect(merged.hiddenMenuHrefs).toEqual([])
   })
 
   test('lastSeenChangelogVersion is kept when it is a product version', () => {

--- a/apps/dashboard/src/lib/types/user-settings.ts
+++ b/apps/dashboard/src/lib/types/user-settings.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_HIDDEN_MENU_HREFS } from '@/lib/menu/slim-default'
 import { parseLastSeenChangelogVersion } from '@/lib/whats-new/version'
 
 export type ByteUnit = 'binary' | 'decimal'
@@ -27,9 +28,10 @@ export interface UserSettings {
    */
   dimUnavailablePages: boolean
   /**
-   * Role workspace preset. Full is the default and the only auto-expand
-   * preset (new menu pages stay visible). Named presets keep a stable group
-   * set. Custom uses `hiddenMenuHrefs` as a hide list.
+   * Role workspace preset. Full is the only auto-expand preset (new menu
+   * pages stay visible). Named presets keep a stable group set. Custom uses
+   * `hiddenMenuHrefs` as a hide list. First-run default is Custom + the slim
+   * day-to-day hide list (#3290); Full still restores every page.
    */
   workspacePreset: WorkspacePreset
   /**
@@ -55,8 +57,8 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   tableDensity: 'comfortable',
   defaultTimeRange: '24h',
   dimUnavailablePages: true,
-  workspacePreset: 'full',
-  hiddenMenuHrefs: [],
+  workspacePreset: 'custom',
+  hiddenMenuHrefs: [...DEFAULT_HIDDEN_MENU_HREFS],
   lastSeenChangelogVersion: '',
 }
 
@@ -74,8 +76,19 @@ export function mergeUserSettings(stored: unknown): UserSettings {
   }
   const partial = stored as Partial<UserSettings> & Record<string, unknown>
   const merged = { ...DEFAULT_USER_SETTINGS, ...partial }
-  merged.workspacePreset = parseWorkspacePreset(partial.workspacePreset)
-  merged.hiddenMenuHrefs = parseHiddenMenuHrefs(partial.hiddenMenuHrefs)
+  const preset = parseWorkspacePreset(partial.workspacePreset)
+  merged.workspacePreset = preset
+  // An omitted hide list picks up the slim first-run default only for Custom
+  // (and junk/missing preset, which falls back to Custom). Named presets and
+  // Full keep an empty hide list when the key was never stored. An explicit
+  // `[]` must stay empty.
+  if ('hiddenMenuHrefs' in partial) {
+    merged.hiddenMenuHrefs = parseHiddenMenuHrefs(partial.hiddenMenuHrefs)
+  } else if (preset === 'custom') {
+    merged.hiddenMenuHrefs = [...DEFAULT_USER_SETTINGS.hiddenMenuHrefs]
+  } else {
+    merged.hiddenMenuHrefs = []
+  }
   merged.lastSeenChangelogVersion = parseLastSeenChangelogVersion(
     partial.lastSeenChangelogVersion
   )

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-24
+updated: 2026-08-26
 tags:
   - design-system
   - ui
@@ -158,10 +158,17 @@ show a sample on the control (`1.5 GiB` / `1.6 GB`). Integrations lists MCP
 `segmented-control.tsx` (optional `description`). Dialog keeps
 `data-testid="settings-dialog"`.
 
-**Invariant: every default reproduces the prior behaviour byte-for-byte** —
+**Workspace default (#3290):** first-run / missing-workspace blobs use
+`workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
+(`lib/menu/slim-default.ts`) — day-to-day pages only (Overview, Chat,
+Insights, Health, Running Queries, Tables overview / explorer, Merges,
+Metrics, SQL / Explain / Advisor, Clusters). Full still means every
+page (`workspacePreset: 'full'`, `hiddenMenuHrefs: []`). An explicit
+stored Full empty hide list is never replaced by the slim list.
+Other appearance defaults stay byte-for-byte:
 `byteUnit: 'binary'`, `numberFormat: 'abbreviated'`, `chartPalette: 'default'`
 (attribute absent), `tableDensity: 'comfortable'` (attribute absent),
-`defaultTimeRange: '24h'`, `workspacePreset: 'full'`, `hiddenMenuHrefs: []`.
+`defaultTimeRange: '24h'`.
 
 How each applies (all wired by `AppearanceSettingsProvider`,
 `lib/context/appearance-settings.tsx`, mounted at `__root`):
@@ -350,6 +357,17 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   Leaf rows also reveal Hide (EyeOff) beside the pin; that writes
   `hiddenMenuHrefs` via `hideMenuHref` and toasts Undo + Open Navigation
   (Settings → Workspace → Navigation). Footer About is not hideable this way.
+  A **More pages** row (`more-pages-button.tsx`) appears at the bottom of
+  the sidebar when the hide list is non-empty and opens that same Navigation
+  pane. Settings → Navigation has **Show all** (applies Full) when the
+  preset is not Full.
+
+- **Alerts in the sidebar (#3291):** there is no standing Alerts catalog
+  item. `revealAlertsWhenActive` injects an Alerts leaf (href
+  `/alert-settings`, existing Active Alerts page) under Health — or after
+  Overview if Health is hidden — only while `useNotifications` reports a
+  count. Zero notifications → absent. Does not duplicate if Alert Settings
+  is already visible.
 
 - **Dashboard widget grid** (plan 57, `components/dashboard/`): `grid.tsx`
   lays out `DashboardWidget[]` (chart/table/stat/text, `@/types/dashboard-layout`)
@@ -759,6 +777,17 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 
 **Footer**: About (next to the Settings gear; never hidden by a workspace
 preset).
+
+**Slim first-run default (#3290):** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
+Visible groups: Overview, AI Agent (Chat), Insights, Health, Queries
+(Running Queries), Tables (Explorer + Overview), Merges, Metrics, Tools
+(SQL, Explorer, Explain, Advisor), Cluster (Clusters). Keeper, PeerDB,
+Security, Logs, System, Operations, and the extra children stay in the
+catalog — restore via Settings → Navigation (Show / Show all / Full) or
+the sidebar More pages row. Do not add a page to
+`DEFAULT_VISIBLE_MENU_HREFS` unless it is day-to-day; new specialist
+pages are hidden by default because the hide list is the complement of
+that keep list. Postgres-only leaves are never auto-hidden.
 
 **Tools** is the interactive-utility group — pages where you *do* something
 (run SQL, explore schema, explain a query, compare hosts, build charts) rather


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slim the first-run left sidebar to day-to-day pages, show Alerts only while notifications are active, and restore hidden pages through Settings → Navigation (sidebar More pages + Show all).

Closes #3290
Closes #3291
Closes #3292

## Changes

- Default workspace is Custom with a hide list of non-day-to-day catalog leaves (`lib/menu/slim-default.ts`). Catalog order is unchanged (Tools last in MAIN; Inbound Events still under Health). Full / DBA / Engineer / SRE presets stay available; they are not the first-run default.
- Alerts is not a standing nav item. When `GET /api/v1/notifications` has `totalCount > 0`, inject an Alerts row under Health that reuses `/alert-settings`. Count 0 keeps it off the rail.
- Sidebar **More pages** opens Settings → Navigation when anything is hidden. Navigation already has Show per row; **Show all** applies Full when the preset is not Full.
- Hide-in-place + toast (#3123), Navigation tree (#3130), Tools group (#3117), Inbound Events under Health (#3141) are reused, not rewritten.

## Test plan

- [x] Unit tests: slim-default, notification-alerts, user-settings merge, more-pages-button, workspace-preset-picker, menu-config-invariants
- [x] `pnpm run type-check` and `pnpm run type-check:test`
- [ ] Viewport check at 375 / 768 / 1024: no overflow-x, no slop left border; overlay below `lg`, docked at 1024
- [ ] First-run sidebar shows Overview, AI Agent, Insights, Health, Queries, Tables, Merges, Metrics, Tools, Cluster — not Keeper / PeerDB / Security / Logs / System / Operations
- [ ] No Alerts row when notification count is 0
- [ ] More pages → Settings Navigation → Show all restores Full
- [ ] Existing e2e `sidebar-navigation.cy.ts` still seeds Full and sees the full menu
- [ ] `pnpm run lint` / `pnpm run test:unit` in CI

Role presets (#3077) stay out of the v1 default (already wired; not first-run). Does not touch AnyRouter, host=0 only, does not merge release-please.

## Notes for reviewer

Hunch verified before coding: there is no catalog item titled Alerts. Closest surfaces are Health → Alert Settings and the header bell. v1 reuses `/alert-settings` rather than adding a product area.

Legacy stored settings with no `workspacePreset` key pick up Custom + the slim hide list. Stored `workspacePreset: 'full'` with omitted or `[]` hide list stays Full.

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f479c25-abde-4a58-985d-9fd10d7177fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f479c25-abde-4a58-985d-9fd10d7177fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

