### PR TITLE
fix(dashboard): keep header title readable at 768

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -14,7 +14,8 @@ description: >-
   "schema compare", "settings diff", "add host", "pick a query",
   "query picker", "select labels", "ON CLUSTER", "advisor DDL",
   "advisor schema", "schema advisor",
-  "command palette", "cmd k", "search dialog", "ttl partitions".
+  "command palette", "cmd k", "search dialog", "ttl partitions",
+  "header title", "768", "truncate Overview".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -239,7 +240,11 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   sidebar sheet is opaque — no heatmap-through-frost. Phone sidebar rows /
   toggle / header utility icons (refresh, search, theme) are `min 44×44`.
   The header day switcher (1h…30d) stays compact and `flex-1` below `sm` so
-  chips + those utilities fit one 375 row. Docs article Copy Markdown / Open
+  chips + those utilities fit one 375 row. Header page title (breadcrumb
+  current page) stays fully readable at 768 — do not ellipsize it; the title
+  cluster is `shrink-0`, parent crumbs wait until `lg`, Search is icon-only
+  below `lg` (the Search… field is desktop), and the refresh countdown label
+  plus header action gap stay compact until `lg`. Docs article Copy Markdown / Open
   are 44px below `md` (not header search/menu). Agent FAB must not cover
   heatmap "Avg / active day" (`pb-16` + last-card `pr-16`; landscape FAB at
   `top-16`).

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
@@ -8,6 +8,15 @@ const src = readFileSync(
   'utf8'
 )
 
+describe('command palette header trigger', () => {
+  test('keeps the Search… field at lg so 768 does not steal title space', () => {
+    expect(src).toContain('min-h-11 min-w-11 lg:hidden')
+    expect(src).toContain('lg:inline-flex')
+    expect(src).not.toContain('md:hidden')
+    expect(src).not.toContain('md:inline-flex')
+  })
+})
+
 describe('command palette row titles', () => {
   test('stay on one line so TTL & Partitions does not wrap on &', () => {
     expect(src).toContain(

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -40,8 +40,9 @@ import { IconButton } from '@/components/ui/icon-button'
 import { cn, getHost } from '@/lib/utils'
 
 /**
- * The two ways to open the palette: an icon-only button for small screens,
- * and a "Search…" trigger with the ⌘K hint for md+ screens.
+ * The two ways to open the palette: an icon-only button below `lg`, and a
+ * "Search…" trigger with the ⌘K hint once the desktop rail is up. Showing
+ * the 160px field at `md` (768) was crowding the header title to "Over…".
  */
 export function CommandPaletteTrigger({ onOpen }: { onOpen: () => void }) {
   return (
@@ -50,13 +51,13 @@ export function CommandPaletteTrigger({ onOpen }: { onOpen: () => void }) {
         icon={<Search className="size-4" />}
         onClick={onOpen}
         tooltip="Search"
-        className="min-h-11 min-w-11 md:hidden lg:min-h-8 lg:min-w-8"
+        className="min-h-11 min-w-11 lg:hidden"
       />
 
       <button
         type="button"
         onClick={onOpen}
-        className="relative hidden h-8 min-h-11 w-30 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 md:inline-flex md:w-40 lg:h-8 lg:min-h-8"
+        className="relative hidden h-8 w-40 items-center gap-2 rounded-md border bg-muted/30 px-2.5 text-xs transition-[border-color,box-shadow,background-color] hover:bg-muted/50 hover:ring-1 hover:ring-primary/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30 lg:inline-flex"
       >
         <Search aria-hidden="true" className="size-3.5 text-muted-foreground" />
         <span className="text-muted-foreground">Search…</span>

--- a/apps/dashboard/src/components/header/header-actions.tsx
+++ b/apps/dashboard/src/components/header/header-actions.tsx
@@ -43,7 +43,7 @@ export const HeaderActions = function HeaderActions({
   }
 
   return (
-    <div className="flex w-full min-w-0 flex-nowrap items-center gap-1 sm:ml-auto sm:w-auto sm:gap-3">
+    <div className="flex w-full min-w-0 flex-nowrap items-center gap-1 sm:ml-auto sm:w-auto lg:gap-3">
       {showTimeControls ? (
         <>
           <GlobalTimeRangePicker />

--- a/apps/dashboard/src/components/header/header-utility-icons.test.tsx
+++ b/apps/dashboard/src/components/header/header-utility-icons.test.tsx
@@ -92,6 +92,9 @@ describe('header utility icons', () => {
     expect(button).not.toBeNull()
     expectPhoneTapTarget(button as Element)
     expect(button?.innerHTML).toContain('h-3.5')
+    const countdown = button?.querySelector('span.font-mono')
+    expect(countdown?.className).toContain('lg:inline')
+    expect(countdown?.className.split(/\s+/)).not.toContain('sm:inline')
 
     await cleanup()
   })
@@ -109,9 +112,33 @@ describe('header utility icons', () => {
 
     const button = container.querySelector('button[aria-label="Search"]')
     expect(button).not.toBeNull()
-    expectPhoneTapTarget(button as Element)
-    expect(button?.className).toContain('md:hidden')
+    expect(button?.className).toContain('min-h-11')
+    expect(button?.className).toContain('min-w-11')
+    expect(button?.className).toContain('lg:hidden')
+    expect(button?.className.split(/\s+/)).not.toContain('md:hidden')
     expect(button?.innerHTML).toContain('size-4')
+
+    await cleanup()
+  })
+
+  test('Search… field stays desktop-only so 768 keeps the icon', async () => {
+    const { CommandPaletteTrigger } = await import(
+      '@/components/controls/command-palette/command-palette-items'
+    )
+    const { TooltipProvider } = await import('@/components/ui/tooltip')
+    const { container, cleanup } = await renderInto(
+      <TooltipProvider>
+        <CommandPaletteTrigger onOpen={() => {}} />
+      </TooltipProvider>
+    )
+
+    const searchBox = Array.from(container.querySelectorAll('button')).find(
+      (el) => el.textContent?.includes('Search…')
+    )
+    expect(searchBox).toBeDefined()
+    expect(searchBox?.className).toContain('lg:inline-flex')
+    expect(searchBox?.className.split(/\s+/)).not.toContain('md:inline-flex')
+    expect(searchBox?.className).toContain('w-40')
 
     await cleanup()
   })

--- a/apps/dashboard/src/components/header/refresh-countdown.tsx
+++ b/apps/dashboard/src/components/header/refresh-countdown.tsx
@@ -63,7 +63,7 @@ export const RefreshCountdown = function RefreshCountdown() {
           className={cn('h-3.5 w-3.5', isRefreshing && 'animate-spin')}
           aria-hidden="true"
         />
-        <span className="hidden font-mono text-muted-foreground tabular-nums sm:inline">
+        <span className="hidden font-mono text-muted-foreground tabular-nums lg:inline">
           {reloadInterval ? formatReadableSecondDuration(remaining) : 'Off'}
         </span>
       </DropdownMenuTrigger>

--- a/apps/dashboard/src/components/layout/dashboard-shell.test.ts
+++ b/apps/dashboard/src/components/layout/dashboard-shell.test.ts
@@ -1,0 +1,30 @@
+/**
+ * At 768 the header is one nowrap row. The title cluster must not be the
+ * flex leftover (`min-w-0 flex-1` + truncate → "Over…").
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const src = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), './dashboard-shell.tsx'),
+  'utf8'
+)
+
+describe('dashboard header title cluster', () => {
+  test('does not shrink so Overview stays readable at 768', () => {
+    expect(src).toContain(
+      'className="flex shrink-0 items-center gap-2 px-3 pt-2 sm:px-4 sm:pt-0"'
+    )
+    expect(src).not.toContain(
+      'flex min-w-0 flex-1 items-center gap-2 px-3 pt-2'
+    )
+  })
+
+  test('header actions can scroll instead of compressing the title', () => {
+    expect(src).toContain('sm:flex-1')
+    expect(src).toContain('lg:flex-none lg:overflow-visible')
+  })
+})

--- a/apps/dashboard/src/components/layout/dashboard-shell.tsx
+++ b/apps/dashboard/src/components/layout/dashboard-shell.tsx
@@ -47,16 +47,22 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           <AppSidebar />
           <SidebarInset className="min-w-0 overflow-hidden">
             <header className="relative z-10 flex min-h-16 shrink-0 flex-wrap items-center gap-x-2 gap-y-2 transition-[width,height] ease-linear sm:h-16 sm:flex-nowrap sm:group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 sm:group-has-data-[collapsible=icon]/sidebar-wrapper:min-h-12">
-              <div className="flex min-w-0 flex-1 items-center gap-2 px-3 pt-2 sm:px-4 sm:pt-0">
+              {/* shrink-0: the page title must not be the flex leftover that
+                ellipsizes to "Over…" when tablet chrome (day switcher + 44px
+                utilities) shares this nowrap row. Below sm the header wraps
+                and the title already has a full row. */}
+              <div className="flex shrink-0 items-center gap-2 px-3 pt-2 sm:px-4 sm:pt-0">
                 <SidebarTrigger className="-ml-1 size-11 lg:size-7" />
                 <Separator orientation="vertical" className="h-4" />
                 <Suspense fallback={<Skeleton className="h-4 w-32" />}>
-                  <Breadcrumb className="min-w-0" />
+                  <Breadcrumb />
                 </Suspense>
               </div>
               {/* scrollbar-hide: stays swipe-scrollable on narrow viewports
-                without a visible scrollbar under the header controls. */}
-              <div className="scrollbar-hide w-full min-w-0 overflow-x-auto px-3 pb-2 sm:ml-auto sm:w-auto sm:overflow-visible sm:px-4 sm:pb-0">
+                without a visible scrollbar under the header controls.
+                min-w-0 flex-1 until lg lets extras scroll instead of
+                compressing the title; lg restores intrinsic width. */}
+              <div className="scrollbar-hide w-full min-w-0 overflow-x-auto px-3 pb-2 sm:ml-auto sm:min-w-0 sm:flex-1 sm:px-4 sm:pb-0 lg:flex-none lg:overflow-visible">
                 <HeaderActions />
               </div>
             </header>

--- a/apps/dashboard/src/components/navigation/breadcrumb.test.ts
+++ b/apps/dashboard/src/components/navigation/breadcrumb.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Header title must stay fully readable at 768. Source-level so the
+ * truncate / parent-crumb breakpoints cannot regress without this test.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const src = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), './breadcrumb.tsx'),
+  'utf8'
+)
+
+describe('header breadcrumb title', () => {
+  test('current page does not ellipsize', () => {
+    expect(src).toContain('className="shrink-0 font-medium text-foreground"')
+    expect(src).not.toContain('truncate font-medium text-foreground')
+  })
+
+  test('parent crumbs wait until lg so tablet shows only the page title', () => {
+    expect(src).toContain("isLast ? 'shrink-0' : 'hidden lg:flex'")
+    expect(src).not.toContain('hidden truncate')
+    expect(src).not.toContain('sm:inline')
+  })
+})

--- a/apps/dashboard/src/components/navigation/breadcrumb.test.ts
+++ b/apps/dashboard/src/components/navigation/breadcrumb.test.ts
@@ -21,6 +21,7 @@ describe('header breadcrumb title', () => {
 
   test('parent crumbs wait until lg so tablet shows only the page title', () => {
     expect(src).toContain("isLast ? 'shrink-0' : 'hidden lg:flex'")
+    expect(src).toContain('hidden size-3.5 shrink-0 lg:block')
     expect(src).not.toContain('hidden truncate')
     expect(src).not.toContain('sm:inline')
   })

--- a/apps/dashboard/src/components/navigation/breadcrumb.tsx
+++ b/apps/dashboard/src/components/navigation/breadcrumb.tsx
@@ -54,7 +54,7 @@ export const Breadcrumb = function Breadcrumb({ className }: BreadcrumbProps) {
             >
               {index > 0 && (
                 <ChevronRightIcon
-                  className="size-3.5 shrink-0"
+                  className="hidden size-3.5 shrink-0 lg:block"
                   strokeWidth={2.5}
                   aria-hidden="true"
                 />

--- a/apps/dashboard/src/components/navigation/breadcrumb.tsx
+++ b/apps/dashboard/src/components/navigation/breadcrumb.tsx
@@ -12,6 +12,12 @@ interface BreadcrumbProps {
   className?: string
 }
 
+/**
+ * Header breadcrumb. The current page title is the header heading — it must
+ * stay fully readable at tablet (768). Parent crumbs (and their chevrons)
+ * hide until `lg`, matching the overlay-sidebar breakpoint, so nested pages
+ * like "TTL & Partition Health" are not squeezed into "Over…".
+ */
 export const Breadcrumb = function Breadcrumb({ className }: BreadcrumbProps) {
   const pathname = useLocation({ select: (l) => l.pathname })
   const { config } = useFeaturePermissions()
@@ -32,46 +38,43 @@ export const Breadcrumb = function Breadcrumb({ className }: BreadcrumbProps) {
   return (
     <nav
       aria-label={breadcrumbLabel}
-      className={cn('flex min-w-0 items-center overflow-hidden', className)}
+      className={cn('flex items-center', className)}
     >
-      <ol className="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap text-sm text-muted-foreground">
+      <ol className="flex items-center gap-1.5 whitespace-nowrap text-sm text-muted-foreground">
         {breadcrumbs.map((crumb, index) => {
           const isLast = index === breadcrumbs.length - 1
 
           return (
             <li
               key={`${index}-${crumb.href}`}
-              className="flex min-w-0 items-center gap-1.5"
+              className={cn(
+                'flex items-center gap-1.5',
+                isLast ? 'shrink-0' : 'hidden lg:flex'
+              )}
             >
               {index > 0 && (
                 <ChevronRightIcon
-                  className="hidden size-3.5 shrink-0 sm:block"
+                  className="size-3.5 shrink-0"
                   strokeWidth={2.5}
                   aria-hidden="true"
                 />
               )}
               {isLast ? (
                 <span
-                  className="truncate font-medium text-foreground"
+                  className="shrink-0 font-medium text-foreground"
                   aria-current="page"
                 >
                   {crumb.title}
                 </span>
               ) : crumb.href ? (
-                <>
-                  <span className="sr-only sm:hidden">{crumb.title}</span>
-                  <HostPrefixedLink
-                    href={crumb.href}
-                    className="hidden truncate transition-colors hover:text-foreground hover:underline sm:inline"
-                  >
-                    {crumb.title}
-                  </HostPrefixedLink>
-                </>
+                <HostPrefixedLink
+                  href={crumb.href}
+                  className="truncate transition-colors hover:text-foreground hover:underline"
+                >
+                  {crumb.title}
+                </HostPrefixedLink>
               ) : (
-                <>
-                  <span className="sr-only sm:hidden">{crumb.title}</span>
-                  <span className="hidden sm:inline">{crumb.title}</span>
-                </>
+                <span>{crumb.title}</span>
               )}
             </li>
           )

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -642,9 +642,14 @@ would clip it.
   below `sm`) so they fill the row beside those 44×44 utilities on 375
   without clipping the theme icon or leaving an empty band. Chart
   `DateRangeSelector` dropdown chips stay `min-h-11 min-w-11` until `sm`.
-  Docs article **Copy Markdown** / **Open** (`[data-article-actions]`, below
-  `md`) are the same 44px floor; docs header search/menu is a separate control
-  (`#nd-nav` / `#nd-subnav`).
+  **Header page title** (breadcrumb current page) stays fully readable at
+  768. Do not `truncate` it — the title cluster is `shrink-0` so sibling
+  chrome cannot squeeze "Overview" into "Over…". Parent crumbs hide until
+  `lg` (overlay-sidebar breakpoint). Header Search is icon-only below `lg`;
+  the 160px Search… field is desktop-only. Refresh countdown text and the
+  header action gap stay compact until `lg`. Docs article **Copy Markdown** /
+  **Open** (`[data-article-actions]`, below `md`) are the same 44px floor;
+  docs header search/menu is a separate control (`#nd-nav` / `#nd-subnav`).
 
 ## UX conventions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #3295.

## Summary

At 768 the header is a single nowrap row, so the breadcrumb was the only item that could shrink. Combined with the 160px Search field at `md`, the current page title ellipsized to **Over…**. This keeps the title fully readable without renaming pages or touching sidebar/nav work.

## Changes

- Header title cluster is `shrink-0` instead of `min-w-0 flex-1`, so it is no longer the leftover that gets truncated.
- Current breadcrumb page has no `truncate`; parent crumbs (and their chevron) hide until `lg` (same breakpoint as the overlay sidebar).
- Search stays icon-only below `lg`; the Search… field is desktop-only.
- Refresh countdown label and header action gap stay compact until `lg`.
- Day switcher chip layout from #3289 / #3293 is unchanged.

## Test plan

- [x] Unit tests for header utilities, breadcrumb classes, dashboard-shell shrink, and command-palette trigger breakpoints
- [x] First-push CI: `lint`, `dashboard`, `unit-tests` passed (required checks). Follow-up commit retriggers CI.
- [x] Manual `/overview?host=0` at **768** — live DOM: `text: "Overview"`, `clientWidth === scrollWidth` (63px), `flex-shrink: 0`, `text-overflow: clip` (not ellipsis). Day switcher one compact row. Refresh / search icon / theme visible. `header.scrollWidth === 768`.
- [x] Manual `/overview?host=0` at **375** — title still Overview on its own row; day switcher still one compact row (no empty band).
- [x] Manual `/overview?host=0` at **1024** — title Overview; Search… field visible on desktop chrome; no clip/overflow.
- [x] Manual `/ttl-partition-health?host=0` at **768** — header reads **TTL & Partitions** (menu/breadcrumb label) in full, `clientWidth === scrollWidth`, no ellipsis, no horizontal page overflow. In-page heading remains "TTL & Partition Health".

## Notes for reviewer

Do not add a host. 525 cluster unreachable is ops, not this bug. Sidebar / nav PRs (#3290–#3292, #3294) are untouched.

![Header at 768 on Overview — full Overview title](https://cursor.com/artifacts/c/art-06a510e0-e473-4a8f-866f-cae34cb8b2e9)
![Header at 375 on Overview — full title, wrapped utilities](https://cursor.com/artifacts/c/art-c938421b-08d4-4258-b586-ff668137d127)
![Header at 1024 on Overview — full title plus Search field](https://cursor.com/artifacts/c/art-cfcb704d-48b1-41f9-a726-0b1bd4ce15b4)
![Header at 768 on TTL & Partitions — longer title fully visible](https://cursor.com/artifacts/c/art-fe1212bd-655e-46db-804e-799650c148f4)
<a href="https://cursor.com/agents/bc-20869457-3774-40ee-a40c-175cf50d048e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_title_375_768_1024.mp4"><img src="https://cursor.com/artifacts/c/art-5f82aaa4-2042-49fa-96c1-818e92a3e045" alt="header_title_375_768_1024.mp4" /></a>

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20869457-3774-40ee-a40c-175cf50d048e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20869457-3774-40ee-a40c-175cf50d048e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

