### PR TITLE
fix(dashboard): wrap overview metric cards before they crush

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -234,8 +234,10 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   styles use Base UI `data-active:` (trigger `border-b-2`, not Radix
   `data-[state=active]:`). Do not use `TabsList variant="line"` on an
   `overflow-x-auto` strip — the hanging `after` underline is clipped.
-- **Responsive chrome:** overview KPIs wrap from `sm` (truncate is `max-sm:`
-  only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
+- **Responsive chrome:** overview KPI strip is 1-col → 2×2 from `sm` → 4-col
+  from `lg` (never four-across below `lg`; same split as `/traffic`). Titles
+  wrap from `sm` (truncate is `max-sm:` only). App sidebar overlays below
+  `lg` (not a docked rail at 768). Mobile
   sidebar sheet is opaque — no heatmap-through-frost. Phone sidebar rows /
   toggle / header utility icons (refresh, search, theme) are `min 44×44`.
   The header day switcher (1h…30d) stays compact and `flex-1` below `sm` so

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -235,9 +235,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   `data-[state=active]:`). Do not use `TabsList variant="line"` on an
   `overflow-x-auto` strip — the hanging `after` underline is clipped.
 - **Responsive chrome:** overview KPI strip is 1-col → 2×2 from `sm` → 4-col
-  from `lg` (never four-across below `lg`; same split as `/traffic`). Titles
-  wrap from `sm` (truncate is `max-sm:` only). App sidebar overlays below
-  `lg` (not a docked rail at 768). Mobile
+  from `xl` (never four-across at `md`/`lg`: at `lg` the sidebar docks and the
+  content pane is still ~768px). Titles wrap from `sm` (truncate is `max-sm:`
+  only). App sidebar overlays below `lg` (not a docked rail at 768). Mobile
   sidebar sheet is opaque — no heatmap-through-frost. Phone sidebar rows /
   toggle / header utility icons (refresh, search, theme) are `min 44×44`.
   The header day switcher (1h…30d) stays compact and `flex-1` below `sm` so

--- a/apps/dashboard/src/components/overview-charts/kpi-card.test.tsx
+++ b/apps/dashboard/src/components/overview-charts/kpi-card.test.tsx
@@ -81,6 +81,10 @@ describe('KpiCard overflow', () => {
     expect(value?.className).toContain('sm:whitespace-normal')
     expect(value?.className.split(/\s+/)).not.toContain('truncate')
 
+    const unit = container.querySelector('span.whitespace-nowrap')
+    expect(unit?.textContent).toBe('running')
+    expect(unit?.className).toContain('shrink-0')
+
     await cleanup()
   })
 })

--- a/apps/dashboard/src/components/overview-charts/kpi-card.tsx
+++ b/apps/dashboard/src/components/overview-charts/kpi-card.tsx
@@ -118,7 +118,7 @@ export const KpiCard = function KpiCard({
       )}
     >
       {/* Row 1 — icon + label + optional sparkline.
-          The strip is 1-col / 2×2 / 4-col from lg, so titles usually fit one
+          The strip is 1-col / 2×2 / 4-col from xl, so titles usually fit one
           line. Truncate only on genuine phone widths; at sm+ the label may
           wrap so "Active Queries" stays fully readable in the four-up strip. */}
       <div className="flex items-start gap-1.5">

--- a/apps/dashboard/src/components/overview-charts/kpi-card.tsx
+++ b/apps/dashboard/src/components/overview-charts/kpi-card.tsx
@@ -118,8 +118,9 @@ export const KpiCard = function KpiCard({
       )}
     >
       {/* Row 1 — icon + label + optional sparkline.
-          Truncate only on genuine phone widths; at sm+ the label wraps so
-          "Active Queries" stays fully readable in the four-up laptop strip. */}
+          The strip is 1-col / 2×2 / 4-col from lg, so titles usually fit one
+          line. Truncate only on genuine phone widths; at sm+ the label may
+          wrap so "Active Queries" stays fully readable in the four-up strip. */}
       <div className="flex items-start gap-1.5">
         <Icon className={cn('mt-0.5 size-3.5 shrink-0', TONE_ICON[tone])} />
         <span className="min-w-0 flex-1 text-[10.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground max-sm:truncate sm:whitespace-normal sm:leading-snug">
@@ -148,7 +149,7 @@ export const KpiCard = function KpiCard({
           <span className={cn(VALUE_CLASS, 'font-mono')}>{value}</span>
         )}
         {unit && (
-          <span className="text-[13px] font-medium text-muted-foreground">
+          <span className="shrink-0 whitespace-nowrap text-[13px] font-medium text-muted-foreground">
             {unit}
           </span>
         )}
@@ -175,7 +176,7 @@ export const KpiCard = function KpiCard({
 
   if (href) {
     return (
-      <Link href={href} className="group block h-full">
+      <Link href={href} className="group block h-full min-h-11">
         {content}
       </Link>
     )

--- a/apps/dashboard/src/components/overview-charts/overview-charts-client.test.ts
+++ b/apps/dashboard/src/components/overview-charts/overview-charts-client.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Overview metric cards must wrap before they crush: 1-col on phones, 2×2 from
+ * sm, four-across only from lg. `md:grid-cols-4` is 768px and was the live
+ * four-across crush on /overview (#3296).
+ */
+
+import { OVERVIEW_KPI_GRID_CLASS } from './overview-charts-client'
+import { describe, expect, test } from 'bun:test'
+
+describe('OVERVIEW_KPI_GRID_CLASS', () => {
+  test('is 1-col, 2-col from sm, 4-col from lg — never 4-across at md', () => {
+    const tokens = OVERVIEW_KPI_GRID_CLASS.split(/\s+/)
+
+    expect(tokens).toContain('grid-cols-1')
+    expect(tokens).toContain('sm:grid-cols-2')
+    expect(tokens).toContain('lg:grid-cols-4')
+    expect(tokens).not.toContain('grid-cols-2')
+    expect(tokens).not.toContain('grid-cols-4')
+    expect(OVERVIEW_KPI_GRID_CLASS).not.toContain('md:grid-cols-4')
+  })
+})

--- a/apps/dashboard/src/components/overview-charts/overview-charts-client.test.ts
+++ b/apps/dashboard/src/components/overview-charts/overview-charts-client.test.ts
@@ -1,21 +1,22 @@
 /**
  * Overview metric cards must wrap before they crush: 1-col on phones, 2×2 from
- * sm, four-across only from lg. `md:grid-cols-4` is 768px and was the live
- * four-across crush on /overview (#3296).
+ * sm, four-across only from xl. `md:grid-cols-4` is 768px; `lg:grid-cols-4` is
+ * 1024px with a docked sidebar (~768px content) — both crush /overview (#3296).
  */
 
 import { OVERVIEW_KPI_GRID_CLASS } from './overview-charts-client'
 import { describe, expect, test } from 'bun:test'
 
 describe('OVERVIEW_KPI_GRID_CLASS', () => {
-  test('is 1-col, 2-col from sm, 4-col from lg — never 4-across at md', () => {
+  test('is 1-col, 2-col from sm, 4-col from xl — never 4-across at md or lg', () => {
     const tokens = OVERVIEW_KPI_GRID_CLASS.split(/\s+/)
 
     expect(tokens).toContain('grid-cols-1')
     expect(tokens).toContain('sm:grid-cols-2')
-    expect(tokens).toContain('lg:grid-cols-4')
+    expect(tokens).toContain('xl:grid-cols-4')
     expect(tokens).not.toContain('grid-cols-2')
     expect(tokens).not.toContain('grid-cols-4')
     expect(OVERVIEW_KPI_GRID_CLASS).not.toContain('md:grid-cols-4')
+    expect(OVERVIEW_KPI_GRID_CLASS).not.toContain('lg:grid-cols-4')
   })
 })

--- a/apps/dashboard/src/components/overview-charts/overview-charts-client.tsx
+++ b/apps/dashboard/src/components/overview-charts/overview-charts-client.tsx
@@ -9,6 +9,14 @@ import { cn } from '@/lib/utils'
 // ============================================================================
 
 /**
+ * Overview KPI strip: 1 column on phones, 2×2 from `sm`, four-across from `lg`.
+ * `md:grid-cols-4` (768) crushes titles like "Active Queries" and collides
+ * value + unit; `/traffic` uses the same 1 / 2 / 4 split.
+ */
+export const OVERVIEW_KPI_GRID_CLASS =
+  'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4'
+
+/**
  * OverviewCharts - Main grid component for overview metrics
  * Displays 4 cards: Running/Today Queries, Databases/Tables, Disk Usage, Version
  */
@@ -22,10 +30,7 @@ export const OverviewCharts = function OverviewCharts({
 }: OverviewChartsProps) {
   return (
     <div
-      className={cn(
-        'grid auto-rows-fr grid-cols-2 gap-2 sm:gap-4 md:grid-cols-4',
-        className
-      )}
+      className={cn(OVERVIEW_KPI_GRID_CLASS, className)}
       role="region"
       aria-label="Overview metrics"
     >

--- a/apps/dashboard/src/components/overview-charts/overview-charts-client.tsx
+++ b/apps/dashboard/src/components/overview-charts/overview-charts-client.tsx
@@ -9,12 +9,13 @@ import { cn } from '@/lib/utils'
 // ============================================================================
 
 /**
- * Overview KPI strip: 1 column on phones, 2×2 from `sm`, four-across from `lg`.
- * `md:grid-cols-4` (768) crushes titles like "Active Queries" and collides
- * value + unit; `/traffic` uses the same 1 / 2 / 4 split.
+ * Overview KPI strip: 1 column on phones, 2×2 from `sm`, four-across from `xl`.
+ * `md:grid-cols-4` (768) and `lg:grid-cols-4` (1024) both crush: at `lg` the
+ * 16rem sidebar docks, so the content pane is still ~768px. Four-across waits
+ * until `xl` (1280) so "Active Queries" stays one line.
  */
 export const OVERVIEW_KPI_GRID_CLASS =
-  'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-2 lg:grid-cols-4'
+  'grid auto-rows-fr grid-cols-1 gap-2 sm:gap-4 sm:grid-cols-2 xl:grid-cols-4'
 
 /**
  * OverviewCharts - Main grid component for overview metrics

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -7,7 +7,10 @@ import { lazy, memo, Suspense, useMemo, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { InsightsStrip } from '@/components/insights/insights-strip'
 import { cardStyles } from '@/components/overview-charts/card-styles'
-import { OverviewCharts } from '@/components/overview-charts/overview-charts-client'
+import {
+  OVERVIEW_KPI_GRID_CLASS,
+  OverviewCharts,
+} from '@/components/overview-charts/overview-charts-client'
 import { OverviewStatusStrip } from '@/components/overview-charts/overview-status-strip'
 import { ChartSkeleton, Skeleton, TabsSkeleton } from '@/components/skeletons'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -320,7 +323,7 @@ function OverviewPageFallback() {
   return (
     <div>
       <Skeleton className="mb-3 h-5 w-full rounded-lg" />
-      <div className="mb-4 grid auto-rows-fr grid-cols-1 gap-3 sm:mb-6 sm:gap-4 sm:grid-cols-2 md:grid-cols-4">
+      <div className={cn(OVERVIEW_KPI_GRID_CLASS, 'mb-4 sm:mb-6')}>
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className={cn(cardStyles.base, 'gap-2.5 p-3 sm:p-4')}>
             <Skeleton className="h-3 w-24" />

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -619,11 +619,11 @@ would clip it.
 ### Responsive chrome (phones + tablets)
 
 - **Overview KPI cards** (`OverviewCharts`) use 1 column, 2×2 from `sm`,
-  four-across from `lg` — the same split as `/traffic`. `md:grid-cols-4`
-  (768) keeps four crushed columns and wraps "Active Queries". Titles/values
-  wrap from `sm` up; `truncate` is `max-sm:` only so a four-up strip at 1280
-  still shows "Active Queries" and typical values in full. Clickable cards
-  keep a 44px tap (`min-h-11`).
+  four-across from `xl`. `md:grid-cols-4` (768) and `lg:grid-cols-4` (1024)
+  both crush: at `lg` the 16rem sidebar docks, leaving ~768px for four cards,
+  so "Active Queries" wraps. Titles/values wrap from `sm` up; `truncate` is
+  `max-sm:` only so a four-up strip at 1280 still shows the full label.
+  Clickable cards keep a 44px tap (`min-h-11`).
 - **App sidebar overlays below `lg` (1024)**, not `md`. A docked 16rem rail at
   768 / landscape crushes the card grid. `SidebarProvider` uses `useIsLgDown()`;
   the desktop rail + resize handle are `lg:flex` / `lg:block`. The mobile

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -618,9 +618,12 @@ would clip it.
 
 ### Responsive chrome (phones + tablets)
 
-- **Overview KPI cards** wrap titles/values from `sm` up. `truncate` is
-  `max-sm:` only — a four-up strip at 1280 must show "Active Queries" and
-  typical values in full.
+- **Overview KPI cards** (`OverviewCharts`) use 1 column, 2×2 from `sm`,
+  four-across from `lg` — the same split as `/traffic`. `md:grid-cols-4`
+  (768) keeps four crushed columns and wraps "Active Queries". Titles/values
+  wrap from `sm` up; `truncate` is `max-sm:` only so a four-up strip at 1280
+  still shows "Active Queries" and typical values in full. Clickable cards
+  keep a 44px tap (`min-h-11`).
 - **App sidebar overlays below `lg` (1024)**, not `md`. A docked 16rem rail at
   768 / landscape crushes the card grid. `SidebarProvider` uses `useIsLgDown()`;
   the desktop rail + resize handle are `lg:flex` / `lg:block`. The mobile


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On `/overview`, the top metric cards (Active Queries / Schema / Storage / Version) stayed two- or four-across on small screens, so titles wrapped and value + unit collided. They now wrap before they crush: one column on phones, 2×2 from `sm`, four-across from `xl`.

At `lg` (1024) the 16rem sidebar docks, so the content pane is still ~768px — the same crush as `md:grid-cols-4`. Four-across waits until `xl` (1280).

Closes #3296.

## Changes

- `OverviewCharts` uses `grid-cols-1 sm:grid-cols-2 xl:grid-cols-4` (`OVERVIEW_KPI_GRID_CLASS`).
- Overview page loading fallback uses the same grid so the skeleton does not flash four crushed columns.
- KPI unit text is `shrink-0 whitespace-nowrap`; clickable cards keep a 44px tap (`min-h-11`).
- Unit test locks the grid contract; product-design skill + knowledge doc updated.

## Test plan

- [x] `bun test` on overview KPI card + grid contract tests
- [x] `biome check` on touched files
- [x] Fixture + Chrome at 320 / 375: 1-col, titles one line, value+unit not colliding
- [x] 768: 2×2, titles one line
- [x] 1024 with docked sidebar: 2×2 (not four-across crush)
- [x] 1280 with docked sidebar: four-across, titles one line
- [x] Did not add a host. Did not mix with sidebar/nav (#3290–#3292 / #3294) or header title (#3295)

## Notes for reviewer

`md:grid-cols-4` is 768px; `lg:grid-cols-4` is 1024px with a docked rail (~768px content). Both keep four crushed columns. Four-across now starts at `xl`.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-803cd490-a4c6-4670-9dab-14e7233cc9e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-803cd490-a4c6-4670-9dab-14e7233cc9e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

