### PR TITLE
fix(dashboard): keep Navigation presets and Show all inside a 375 dialog

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -421,8 +421,9 @@ First-run workspace is Custom + the slim hide list
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
-`data-chart-palette` / `data-density` on `<html>`. For 2–3 choices use
-`components/settings/segmented-control.tsx`. Full detail:
+`data-chart-palette` / `data-density` on `<html>`. For 2–3 choices use `components/settings/segmented-control.tsx`; 4+
+options wrap so the Navigation presets fit a 375 Settings pane. Show all
+is a full-width control under the hide-count line. Full detail:
 `docs/knowledge/product-design.md`.
 
 ## Adding a page

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -389,7 +389,8 @@ icon + title + one-line "Local to this browser"; surface is
 `rounded-xl border bg-card p-0` with a **stable height** (`h-[min(42rem,90vh)]`, `sm:max-w-4xl`)
 and `select-text` so labels copy. Left rail is a flat column (no boxed
 tab well): section labels + icon rows, selected = muted pill, `border-r`
-divider. Content pane shows the active tab title. Theme (Light / Dark /
+divider. Below `sm` the rail stacks above the pane so Navigation fits
+375. Content pane shows the active tab title. Theme (Light / Dark /
 System) is a settings row (label left, three window thumbnails right)
 on Appearance only. Navigation leads with a `SegmentedControl` workspace
 preset (Full / DBA / Engineer / SRE / Custom) plus an in-page sidebar-like

--- a/apps/dashboard/src/components/settings/segmented-control.tsx
+++ b/apps/dashboard/src/components/settings/segmented-control.tsx
@@ -18,9 +18,10 @@ interface SegmentedControlProps<T extends string> {
 }
 
 /**
- * A compact segmented button group for 2–3 mutually exclusive choices, styled
- * to match the theme picker's card look. Used across the Settings dialog for
- * unit / palette / density toggles.
+ * A compact segmented button group for mutually exclusive choices, styled
+ * to match the theme picker's card look. Two or three options stay on one
+ * row; four or more wrap (2 / 3 / 5 columns) so Navigation's five workspace
+ * presets fit a narrow Settings pane.
  */
 export function SegmentedControl<T extends string>({
   value,
@@ -28,14 +29,18 @@ export function SegmentedControl<T extends string>({
   options,
   ariaLabel,
 }: SegmentedControlProps<T>) {
+  const columnsClass =
+    options.length <= 2
+      ? 'grid-cols-2'
+      : options.length === 3
+        ? 'grid-cols-3'
+        : 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5'
+
   return (
     <div
       role="radiogroup"
       aria-label={ariaLabel}
-      className="grid gap-2"
-      style={{
-        gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))`,
-      }}
+      className={cn('grid gap-2', columnsClass)}
     >
       {options.map((option) => {
         const Icon = option.icon

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -608,7 +608,7 @@ export function SettingsForm({
           <div className="flex items-center px-5 pt-4 pr-12">
             <h2 className="text-sm font-semibold">{activeLabel}</h2>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-5 py-4">
             {/* General */}
             <TabsContent value="general" className="space-y-4 px-1 pb-2">
               <Field

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -547,14 +547,14 @@ export function SettingsForm({
       .find((item) => item.value === activeTab)?.label ?? 'Settings'
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
       <Tabs
         value={activeTab}
         onValueChange={(value) => value && setActiveTab(value)}
         orientation="vertical"
-        className="flex min-h-0 flex-1 gap-0"
+        className="flex min-h-0 min-w-0 flex-1 gap-0 max-sm:flex-col"
       >
-        <aside className="flex w-44 shrink-0 flex-col border-r border-border px-3 py-4 sm:w-48">
+        <aside className="flex w-44 shrink-0 flex-col border-r border-border px-3 py-4 max-sm:max-h-40 max-sm:w-full max-sm:overflow-auto max-sm:border-r-0 max-sm:border-b max-sm:py-2 sm:w-48">
           <div className="mb-4 px-2.5">
             <p className="flex items-center gap-2 text-sm font-semibold">
               <Settings

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -98,7 +98,7 @@ export function WorkspacePresetPicker({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="min-w-0 space-y-3">
       <SegmentedControl
         ariaLabel="Workspace preset"
         value={preset}
@@ -108,16 +108,16 @@ export function WorkspacePresetPicker({
       <p className="text-xs text-muted-foreground">{PRESET_HINT[preset]}</p>
 
       {preset !== 'full' && (
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-2">
           <p className="min-w-0 text-xs text-muted-foreground">
             {extraHiddenCount > 0
-              ? `${extraHiddenCount} extra page${extraHiddenCount === 1 ? '' : 's'} hidden. Click Show on a row, or Show all.`
-              : 'Hidden pages stay in this tree. Click Show on a row, or Show all.'}
+              ? `${extraHiddenCount} extra page${extraHiddenCount === 1 ? '' : 's'} hidden. Show a row, or Show all.`
+              : 'Hidden pages stay in this tree. Show a row, or Show all.'}
           </p>
           <button
             type="button"
             data-testid="workspace-show-all"
-            className="inline-flex h-8 w-fit shrink-0 items-center rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted"
+            className="inline-flex h-8 w-full shrink-0 items-center justify-center rounded-md border border-border px-3 text-[13px] font-medium hover:bg-muted sm:w-fit"
             onClick={() => applyPreset('full')}
           >
             Show all

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -155,7 +155,9 @@ Timezone is a searchable combobox
 Chart palette is a three-card picker with a mini bar preview. Unit options
 show a sample on the control (`1.5 GiB` / `1.6 GB`). Integrations lists MCP
 (available) plus disabled coming-soon channels. 2–3 choice toggles use
-`segmented-control.tsx` (optional `description`). Dialog keeps
+`segmented-control.tsx` (optional `description`; 4+ options wrap to
+2 / 3 / 5 columns so the Navigation presets fit a 375 Settings pane).
+Show all is full-width under the hide-count line on that pane. Dialog keeps
 `data-testid="settings-dialog"`.
 
 **Workspace default (#3290):** first-run / missing-workspace blobs use

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -124,6 +124,8 @@ Settings dialog (`components/settings/settings-dialog.tsx` +
 so labels copy. Layout is `p-0`: a flat left rail (section labels
 Preferences / Display / Workspace, icon + label rows, selected as a muted
 pill, `border-r`) and a content pane whose heading is the active tab.
+Below `sm` the rail stacks above the pane so Navigation presets and
+Show all fit a 375 dialog.
 Theme (Light / Dark / System, next-themes) is a
 label-left / thumbnails-right row on Appearance only. Navigation
 leads with a workspace **preset** (`Full` / `DBA` / `Engineer` / `SRE` /


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #3294: keep Settings → Navigation (presets + Show all) inside a 375-wide dialog so restore is usable on a phone.

Related: #3290 #3291 #3292 (v1 sidebar already merged in #3294).

## Changes

- Workspace preset `SegmentedControl` wraps at 4+ options (2 / 3 / 5 columns) instead of one overflowing row.
- Show all is full-width under the hide-count line.
- Settings dialog flex row is `min-w-0 overflow-hidden`; below `sm` the left rail stacks above the pane.

## Test plan

- [x] Playwright at 375: all five presets visible, Show all text is `Show all`, buttonRight inside the dialog, no document overflow-x
- [x] 768 / 1024 slim sidebar: no overflow-x; More pages 44px below `lg`, 32px at 1024
- [ ] `pnpm run lint` / unit-tests / dashboard on this PR CI
- [ ] Docs: `docs/knowledge/product-design.md` and the product-design skill

![375 Settings Navigation with wrapped presets and Show all](https://cursor.com/artifacts/c/art-315ecfe4-2ff2-4ffb-834e-13ec43f0121c)
![375 slim sidebar with More pages](https://cursor.com/artifacts/c/art-ae8c5855-7bfc-4cb6-957d-6947d8afe553)

## Notes for reviewer

#3294 auto-merged the slim default + Alerts-when-active + More pages. This is only the 375 dialog clip that landed after that squash.

---

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f479c25-abde-4a58-985d-9fd10d7177fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f479c25-abde-4a58-985d-9fd10d7177fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

