### PR TITLE
style(rust): cargo fmt credentials purge helper

### DIFF
--- a/rust/ch-monitor-cli/src/credentials.rs
+++ b/rust/ch-monitor-cli/src/credentials.rs
@@ -145,8 +145,9 @@ fn purge_stale_plaintext_at(path: &std::path::Path, plaintext_key: &str) -> Resu
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read credentials at {}", path.display()))?;
     let had_key = content.lines().any(|line| {
-        line.split_once('=')
-            .is_some_and(|(k, v)| k.trim() == plaintext_key && !v.trim().trim_matches('"').is_empty())
+        line.split_once('=').is_some_and(|(k, v)| {
+            k.trim() == plaintext_key && !v.trim().trim_matches('"').is_empty()
+        })
     });
     if !had_key {
         return Ok(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix `cargo fmt` drift in `credentials.rs` introduced in #3337 so Rust CI passes on `main`.

Co-Authored-By: duyetbot <bot@duyet.net>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aab1b31-9a0a-49c8-828c-03e77f6a5c76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aab1b31-9a0a-49c8-828c-03e77f6a5c76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

