### PR TITLE
fix(dashboard): center the What's new dialog in the viewport

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -99,6 +99,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   markdown link deep in an older note and `scrollIntoView` the list to the
   middle. Screenshot thumbs (`WhatsNewScreenshotGallery`) open a full-size
   overlay in the same dialog; Escape closes the overlay before the dialog.
+  Do not add `relative` on `DialogContent` — `cn()`/`twMerge` drops the
+  primitive's `fixed`, so `top-1/2 left-1/2 -translate-*` no longer centers
+  in the viewport. `fixed` already contains an inner `absolute` overlay.
 - **Base UI Select labels:** pass `items={{ value: 'Human label' }}` on
   `Select` (the Root) so `SelectValue` shows the label, not the raw value.
   `placeholder` only appears when nothing is selected — a selected `24` /

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.test.tsx
@@ -151,6 +151,15 @@ describe("What's new dialog layout", () => {
       expect(body?.scrollTop).toBe(0)
       expect(body?.contains(title as Node)).toBe(false)
 
+      // Keep the primitive's `fixed` + `top/left-1/2` translate centering.
+      // `relative` here is merged away via twMerge and un-centers the popup.
+      const dialogClasses = dialog?.className.split(/\s+/) ?? []
+      expect(dialogClasses).toContain('fixed')
+      expect(dialogClasses).toContain('top-1/2')
+      expect(dialogClasses).toContain('left-1/2')
+      expect(dialogClasses).toContain('-translate-x-1/2')
+      expect(dialogClasses).toContain('-translate-y-1/2')
+      expect(dialogClasses).not.toContain('relative')
       expect(dialog?.className).toContain('flex-col')
       expect(dialog?.className).toContain('overflow-hidden')
       expect(body?.className).toContain('min-h-0')

--- a/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
+++ b/apps/dashboard/src/components/whats-new/whats-new-dialog.tsx
@@ -103,7 +103,9 @@ export function WhatsNewDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="relative flex max-h-[min(40rem,90vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-xl"
+        // Do not add `relative`: twMerge would drop DialogContent's `fixed`
+        // and un-center the popup. `fixed` already contains the lightbox.
+        className="flex max-h-[min(40rem,90vh)] flex-col gap-0 overflow-hidden rounded-xl border bg-card p-0 sm:max-w-xl"
         data-testid="whats-new-dialog"
         initialFocus={titleRef}
       >

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-26
+updated: 2026-08-27
 tags:
   - design-system
   - ui
@@ -100,6 +100,9 @@ body `scrollTop` resets on open, so markdown links in older notes cannot
 `scrollIntoView` the list to the middle. Each version can show a row of
 screenshot **thumbnails** (`WhatsNewScreenshotGallery`); click one to
 open a full-size overlay inside the same dialog (`WhatsNewScreenshotLightbox`).
+Do not put `relative` on `DialogContent`: `cn()`/`twMerge` drops the
+primitive's `fixed`, so `top-1/2 left-1/2 -translate-*` no longer centers in
+the viewport. `fixed` already contains that inner `absolute` overlay.
 Escape / close dismisses the overlay first, then the dialog. Notes come from `GET /api/v1/releases` (server-side GitHub Releases with
 `docs/whats-new` friendly copy first). Airgap fallback is a **build-time
 snapshot** of latest `v*` notes, not the full CHANGELOG.md. Settings icon is lucide `Settings` (`size-4`, `strokeWidth={1.5}`),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Center the What's new dialog in the middle of the viewport. `relative` on `DialogContent` was winning over the primitive's `fixed` via `twMerge`, so `top-1/2 left-1/2 -translate-*` no longer applied to the viewport.

## Changes

- Remove `relative` from `WhatsNewDialog` `DialogContent` so the shared dialog primitive keeps `fixed` centering
- Keep the in-dialog screenshot lightbox: `fixed` already contains `absolute inset-0`
- Guard the merged classes in the layout unit test (`fixed`, `top-1/2`, `left-1/2`, no `relative`)
- Document the `twMerge` gotcha in the product-design skill and knowledge note

## Test plan

- [x] `pnpm run lint` — Biome check on the dialog files (pre-existing import-order warning only; no new lint)
- [x] `pnpm exec tsc --noEmit` in `apps/dashboard` (type-check)
- [x] `pnpm run type-check:test` in `apps/dashboard`
- [x] Dialog unit tests: `bun test src/components/whats-new/whats-new-dialog.test.tsx` — 3 pass
- [x] Tested in local Vite: open What's new from the sidebar footer
- [x] Geometry at 375 / 768 / 1024 / 1280 (`getBoundingClientRect` vs `innerWidth`/`innerHeight`): `|dx|` and `|dy|` under 0.5px; `position: fixed`; overlay covers the full viewport including the sidebar
- [x] Screenshot lightbox still covers the dialog; Escape / close dismisses it first
- [x] Docs: product-design skill + knowledge note only (no `docs/content/` behaviour change)
- [x] `docs/content/ai-agent.mdx` N/A

Manual: open What's new from the sidebar footer at 375 / 768 / 1024 / 1280. The dialog sits in the middle of the **viewport** (not the content column / a corner). Screenshot lightbox still covers the dialog. Settings dialog centering is unchanged.

## Notes for reviewer

Hypothesis from the report was overlay/content aligned to a corner, a sidebar offset, or missing flex/grid center. The actual cause is `relative` on this one dialog: #3133 was sticky header/footer/scroll, and the later screenshot overlay added `relative` so `absolute inset-0` had a containing block. `fixed` already provides that.

No GitHub issue found for this report, so this PR does not use `Closes #N`.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a0b89cd-3b8b-4885-9413-15120fea3815?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a0b89cd-3b8b-4885-9413-15120fea3815&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

