### PR TITLE
feat(dashboard): Essential first-run sidebar with hover-add and More flyout

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -15,7 +15,8 @@ description: >-
   "query picker", "select labels", "ON CLUSTER", "advisor DDL",
   "advisor schema", "schema advisor",
   "command palette", "cmd k", "search dialog", "ttl partitions",
-  "header title", "768", "truncate Overview".
+  "header title", "768", "truncate Overview", "essential sidebar",
+  "more pages", "keep in sidebar", "hover add".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -357,7 +358,9 @@ filter/search/sort/card wiring.
 Favorites in the sidebar can be drag-reordered; order is the localStorage pin
 list (`chm-pinned-favorites`). Leaf sidebar rows also reveal Hide (EyeOff)
 beside the pin; that writes `hiddenMenuHrefs` and toasts Undo + Open
-Navigation (Settings → Workspace → Navigation).
+Navigation (Settings → Workspace → Navigation). Hover **+** lists hidden
+siblings in that group (`showMenuHref` on click). More is a flyout of
+hidden pages (not Settings). Groups with 0–1 visible children flatten.
 
 ## User appearance settings
 
@@ -409,23 +412,26 @@ stays `shrink-0` on the right. Click a leaf to hide or show it — hidden
 rows stay visible but muted, like Dim unavailable pages.
 Expand/collapse does not write settings. Hide of an already-hidden-by-
 preset leaf stays on the role; Custom only when the hide list leaves
-`hideListForPreset`. Search filters the tree. When the preset is not
-Full, a **Show all** control applies Full. The sidebar **More pages**
-row opens this pane when any pages are hidden. Never a 40-checkbox wall
-or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
-demos.
-Hidden pages stay routable. Filter through
-`getVisibleMenuItems` (sidebar + ⌘K wrap it in `useVisibleMenuItems`
-so Alerts appears only with an active notification count) so sidebar,
-⌘K, and the Settings > Navigation
+  `hideListForPreset`. Search filters the tree. When the preset is not
+  Full, a **Show all** control applies Full. The sidebar **More** row is a
+  searchable flyout of hidden leaves (click navigates; Customize… opens
+  this pane). Never a 40-checkbox wall
+  or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
+  demos.
+Hidden pages stay routable. Sidebar visibility is the hide list
+(`getVisibleMenuItems` + flatten + Alerts). ⌘K uses
+`usePaletteMenuItems` / `getAllowedMenuItems` so hidden pages stay
+indexed with a Hidden hint and do not auto-unhide. Landing on a hidden
+page shows Keep in sidebar. Settings > Navigation
 tree match the **active host engine** (`useActiveHostEngine` —
 default source engine, Postgres pages when `?pg=` is active).
 Timezone uses `timezone-combobox.tsx`
 (search + browser zone on top). Palette is a card picker with mini bars, not
 a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
-First-run workspace is Custom + the slim hide list
-(`DEFAULT_HIDDEN_MENU_HREFS`); Full still restores every page. Other
+First-run workspace is Custom + the Essential hide list
+(`DEFAULT_HIDDEN_MENU_HREFS`: Overview, Chat, Health, Queries, Tables
+overview, SQL). Full still restores every page. Other
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
@@ -462,7 +468,9 @@ is a full-width control under the hide-count line. Full detail:
    absent so Postgres hosts inherit Health (default source-engine family).
    Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
-   sidebar stays slim — they remain restorable from Settings → Navigation.
+   sidebar stays Essential (Overview, Chat, Health, Queries, Tables
+   overview, SQL) — they remain restorable from hover +, More, in-page
+   More / Customize, or Settings → Navigation.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -21,7 +21,8 @@ import { CommandDialog, CommandInput } from '@/components/ui/command'
 import { useFavoriteHrefs } from '@/hooks/use-favorites'
 import { useUrlSearchParams } from '@/hooks/use-url-search-params'
 import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
-import { useVisibleMenuItems } from '@/lib/menu/use-visible-menu-items'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
+import { usePaletteMenuItems } from '@/lib/menu/use-visible-menu-items'
 import { apiFetch } from '@/lib/swr/api-fetch'
 import { useMergedHosts } from '@/lib/swr/use-merged-hosts'
 import { buildUrl, splitHref } from '@/lib/url/url-builder'
@@ -64,7 +65,8 @@ export const CommandPalette = function CommandPalette({
     rememberSelection,
   } = useCommandPaletteState({ open: controlledOpen, onOpenChange })
 
-  const menuItems = useVisibleMenuItems()
+  const menuItems = usePaletteMenuItems()
+  const { hiddenHrefs } = useMenuWorkspaceCatalog()
   const favoriteHrefs = useFavoriteHrefs()
   const favoriteMenuItems = getFavoriteMenuItems(menuItems, favoriteHrefs)
   const { setTheme, resolvedTheme } = useTheme()
@@ -217,6 +219,7 @@ export const CommandPalette = function CommandPalette({
           onOpenInExplorer={handleOpenInExplorer}
           leafItems={leafItems}
           sectionedItems={sectionedItems}
+          hiddenHrefs={hiddenHrefs}
           onSelectMenuItem={(item) =>
             navigate(item.href, {
               id: `page-${item.href}`,

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
@@ -26,3 +26,22 @@ describe('command palette row titles', () => {
     expect(src).toContain('min-w-0 flex-1 truncate')
   })
 })
+
+describe('command palette hidden pages', () => {
+  test('workspace-hidden rows get a Hidden hint', () => {
+    expect(src).toContain('palette-hidden-hint')
+    expect(src).toContain('hiddenHrefs')
+  })
+
+  test('indexes the allowed catalog, not the sidebar hide list', () => {
+    const paletteSrc = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        '../../command-palette.tsx'
+      ),
+      'utf8'
+    )
+    expect(paletteSrc).toContain('usePaletteMenuItems')
+    expect(paletteSrc).not.toMatch(/\buseVisibleMenuItems\b/)
+  })
+})

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -109,6 +109,18 @@ const TITLE_CLASS = 'font-medium whitespace-nowrap shrink-0'
 /** Trailing meta on the same row: ellipsis instead of wrapping the title. */
 const META_CLASS = 'ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground'
 
+function HiddenHint({ hidden }: { hidden: boolean }) {
+  if (!hidden) return null
+  return (
+    <span
+      data-testid="palette-hidden-hint"
+      className="ml-1 shrink-0 text-[10px] font-medium text-muted-foreground"
+    >
+      Hidden
+    </span>
+  )
+}
+
 export const PALETTE_TABS: {
   value: PaletteTab
   label: string
@@ -191,6 +203,7 @@ export function CommandPaletteResults({
   onOpenInExplorer,
   leafItems,
   sectionedItems,
+  hiddenHrefs,
   onSelectMenuItem,
   databases,
   tables,
@@ -215,6 +228,7 @@ export function CommandPaletteResults({
   onOpenInExplorer: () => void
   leafItems: readonly MenuItem[]
   sectionedItems: readonly MenuItem[]
+  hiddenHrefs?: ReadonlySet<string>
   onSelectMenuItem: (item: MenuItem) => void
   databases: readonly string[]
   tables: readonly ExplorerTableRow[]
@@ -355,7 +369,10 @@ export function CommandPaletteResults({
               key={group.href}
               onSelect={() => onSelectMenuItem(group)}
               value={menuItemPaletteValue(group)}
-              className="group min-w-0"
+              className={cn(
+                'group min-w-0',
+                hiddenHrefs?.has(group.href) && 'text-muted-foreground'
+              )}
             >
               {group.icon && <group.icon className="size-4 shrink-0" />}
               <HighlightText
@@ -363,6 +380,7 @@ export function CommandPaletteResults({
                 query={inputValue}
                 className={TITLE_CLASS}
               />
+              <HiddenHint hidden={Boolean(hiddenHrefs?.has(group.href))} />
               <EnterHint />
             </CommandItem>
           ))}
@@ -381,7 +399,10 @@ export function CommandPaletteResults({
                 key={item.href}
                 onSelect={() => onSelectMenuItem(item)}
                 value={menuItemPaletteValue(item, group.title)}
-                className="group flex-col items-start gap-0.5 rounded-md"
+                className={cn(
+                  'group flex-col items-start gap-0.5 rounded-md',
+                  hiddenHrefs?.has(item.href) && 'text-muted-foreground'
+                )}
               >
                 <div className="flex w-full min-w-0 items-center gap-2">
                   {item.icon && <item.icon className="size-4 shrink-0" />}
@@ -390,6 +411,7 @@ export function CommandPaletteResults({
                     query={inputValue}
                     className={TITLE_CLASS}
                   />
+                  <HiddenHint hidden={Boolean(hiddenHrefs?.has(item.href))} />
                   <EnterHint />
                 </div>
                 {item.description && (

--- a/apps/dashboard/src/components/navigation/breadcrumb.test.ts
+++ b/apps/dashboard/src/components/navigation/breadcrumb.test.ts
@@ -15,7 +15,9 @@ const src = readFileSync(
 
 describe('header breadcrumb title', () => {
   test('current page does not ellipsize', () => {
-    expect(src).toContain('className="shrink-0 font-medium text-foreground"')
+    expect(src).toContain(
+      'className="inline-flex shrink-0 items-center font-medium text-foreground"'
+    )
     expect(src).not.toContain('truncate font-medium text-foreground')
   })
 

--- a/apps/dashboard/src/components/navigation/breadcrumb.tsx
+++ b/apps/dashboard/src/components/navigation/breadcrumb.tsx
@@ -3,6 +3,7 @@ import { useLocation } from '@tanstack/react-router'
 import { menuItemsConfig } from '@/menu'
 
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { KeepInSidebarChip } from '@/components/navigation/keep-in-sidebar'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { filterMenuItemsByPermissions } from '@/lib/feature-permissions/menu'
 import { getBreadcrumbPath } from '@/lib/menu/breadcrumb'
@@ -61,10 +62,11 @@ export const Breadcrumb = function Breadcrumb({ className }: BreadcrumbProps) {
               )}
               {isLast ? (
                 <span
-                  className="shrink-0 font-medium text-foreground"
+                  className="inline-flex shrink-0 items-center font-medium text-foreground"
                   aria-current="page"
                 >
                   {crumb.title}
+                  <KeepInSidebarChip />
                 </span>
               ) : crumb.href ? (
                 <HostPrefixedLink

--- a/apps/dashboard/src/components/navigation/keep-in-sidebar.tsx
+++ b/apps/dashboard/src/components/navigation/keep-in-sidebar.tsx
@@ -1,0 +1,66 @@
+import { Pin } from 'lucide-react'
+import { useLocation } from '@tanstack/react-router'
+
+import { useIsFavorite, useToggleFavorite } from '@/hooks/use-favorites'
+import { getBreadcrumbPath } from '@/lib/menu/breadcrumb'
+import { pathnameMatchesMenuHref } from '@/lib/menu/hidden-siblings'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
+import { cn } from '@/lib/utils'
+
+/**
+ * Shown on a workspace-hidden page (including via ⌘K). Keep adds the href
+ * to the sidebar; Pin is the existing favorites toggle. Does not auto-unhide
+ * on navigation.
+ */
+export function KeepInSidebarChip() {
+  const pathname = useLocation({ select: (l) => l.pathname })
+  const { catalog, hiddenHrefs, showHref } = useMenuWorkspaceCatalog()
+  const crumbs = getBreadcrumbPath(pathname, catalog)
+  const href = crumbs.find((crumb) => crumb.href)?.href
+  if (!href || !hiddenHrefs.has(href)) {
+    if (!href) return null
+    // Fallback: pathname itself may be hidden even when breadcrumb used a parent.
+    const hiddenHref = [...hiddenHrefs].find((item) =>
+      pathnameMatchesMenuHref(pathname, item)
+    )
+    if (!hiddenHref) return null
+    return <KeepChip href={hiddenHref} onKeep={showHref} />
+  }
+  return <KeepChip href={href} onKeep={showHref} />
+}
+
+function KeepChip({
+  href,
+  onKeep,
+}: {
+  href: string
+  onKeep: (href: string) => void
+}) {
+  const isPinned = useIsFavorite(href)
+  const toggleFavorite = useToggleFavorite()
+
+  return (
+    <span className="ml-1.5 inline-flex shrink-0 items-center gap-1">
+      <button
+        type="button"
+        data-testid="keep-in-sidebar"
+        onClick={() => onKeep(href)}
+        className={cn(
+          'inline-flex h-8 min-h-8 items-center rounded-md border border-border px-2 text-[13px] font-medium hover:bg-muted'
+        )}
+      >
+        Keep in sidebar
+      </button>
+      <button
+        type="button"
+        data-testid="keep-in-sidebar-pin"
+        aria-label={isPinned ? 'Unpin page' : 'Pin page'}
+        aria-pressed={isPinned}
+        onClick={() => toggleFavorite(href)}
+        className="inline-flex size-8 items-center justify-center rounded-md border border-border hover:bg-muted"
+      >
+        <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+      </button>
+    </span>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/add-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/add-button.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Hover-Add: + opens hidden siblings; clicking a leaf calls showMenuHref.
+ * happy-dom + react-dom/client.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type { ReactElement, ReactNode } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+mock.module('@/components/menu/link-with-context', () => ({
+  HostPrefixedLink: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string
+    children?: ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+describe('AddButton', () => {
+  test('opens hidden siblings and showMenuHref adds History to the rail', async () => {
+    const { AddButton } = await import('./add-button')
+    const { SidebarProvider, SidebarMenu, SidebarMenuItem } = await import(
+      '@/components/ui/sidebar'
+    )
+    const { USER_SETTINGS_QUERY_KEY } = await import(
+      '@/lib/hooks/use-user-settings'
+    )
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+    const { persistShowMenuHref } = await import('@/lib/menu/hide-menu-item')
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
+    expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain('/history-queries')
+
+    const {
+      RouterContextProvider,
+      createMemoryHistory,
+      createRootRoute,
+      createRouter,
+    } = await import('@tanstack/react-router')
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    const { container, cleanup } = await renderInto(
+      <RouterContextProvider router={router}>
+        <QueryClientProvider client={queryClient}>
+          <SidebarProvider>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <AddButton href="/running-queries" />
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarProvider>
+        </QueryClientProvider>
+      </RouterContextProvider>
+    )
+
+    try {
+      const trigger = container.querySelector(
+        '[data-testid="add-menu-item"]'
+      ) as HTMLButtonElement | null
+      expect(trigger).not.toBeNull()
+      expect(trigger?.className).toContain('after:-inset-3')
+
+      const { act } = await import('react')
+      await act(async () => {
+        trigger?.click()
+      })
+
+      const history = document.querySelector(
+        '[data-testid="hidden-page-add"][data-href="/history-queries"]'
+      ) as HTMLButtonElement | null
+      expect(history).not.toBeNull()
+
+      await act(async () => {
+        history?.click()
+      })
+
+      const stored = queryClient.getQueryData(USER_SETTINGS_QUERY_KEY) as {
+        hiddenMenuHrefs: string[]
+      }
+      expect(stored.hiddenMenuHrefs).not.toContain('/history-queries')
+      expect(
+        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/history-queries')
+          .hiddenMenuHrefs
+      ).not.toContain('/history-queries')
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/navigation/nav-main/add-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/add-button.tsx
@@ -1,0 +1,146 @@
+import { Plus } from 'lucide-react'
+
+import { HiddenPageRows } from './hidden-page-rows'
+import { useState } from 'react'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { SidebarMenuAction } from '@/components/ui/sidebar'
+import {
+  findCatalogGroupForHref,
+  hiddenSiblingLeaves,
+} from '@/lib/menu/hidden-siblings'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
+import { cn } from '@/lib/utils'
+
+interface AddButtonProps {
+  href: string
+  hasBadge?: boolean
+}
+
+/**
+ * Hover + on a rail leaf: hidden siblings in that catalog group. Primary
+ * click adds the leaf (`showMenuHref`); the arrow opens the page without
+ * un-hiding. Footer Customize… opens Settings → Navigation, focused on
+ * the group when cheap.
+ */
+export function AddButton({ href, hasBadge }: AddButtonProps) {
+  const [open, setOpen] = useState(false)
+  const openSettings = useOpenSettings()
+  const { catalog, hiddenHrefs, showHref } = useMenuWorkspaceCatalog()
+  const siblings = hiddenSiblingLeaves(catalog, href, hiddenHrefs)
+  const groupTitle = findCatalogGroupForHref(catalog, href)?.title
+
+  if (!href || siblings.length === 0) return null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <SidebarMenuAction
+            type="button"
+            showOnHover
+            data-testid="add-menu-item"
+            className={cn(
+              'right-12 after:-inset-3 [&>svg]:size-3 md:after:hidden',
+              hasBadge && 'right-16'
+            )}
+            aria-label="Add a hidden page in this group"
+          />
+        }
+      >
+        <Plus />
+      </PopoverTrigger>
+      <AddPopoverBody
+        setOpen={setOpen}
+        siblings={siblings}
+        groupTitle={groupTitle}
+        showHref={showHref}
+        openSettings={openSettings}
+      />
+    </Popover>
+  )
+}
+
+export function SubAddButton({ href, hasBadge }: AddButtonProps) {
+  const [open, setOpen] = useState(false)
+  const openSettings = useOpenSettings()
+  const { catalog, hiddenHrefs, showHref } = useMenuWorkspaceCatalog()
+  const siblings = hiddenSiblingLeaves(catalog, href, hiddenHrefs)
+  const groupTitle = findCatalogGroupForHref(catalog, href)?.title
+
+  if (!href || siblings.length === 0) return null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            data-testid="add-menu-item"
+            aria-label="Add a hidden page in this group"
+            className={cn(
+              'absolute top-1/2 right-12 flex aspect-square size-5 -translate-y-1/2 items-center justify-center rounded-md p-0 text-sidebar-foreground opacity-0 outline-hidden transition-opacity after:absolute after:-inset-3 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:opacity-100 focus-visible:ring-2 group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:opacity-100 group-data-[collapsible=icon]:hidden md:after:hidden',
+              hasBadge && 'right-16'
+            )}
+          />
+        }
+      >
+        <Plus className="size-3" />
+      </PopoverTrigger>
+      <AddPopoverBody
+        setOpen={setOpen}
+        siblings={siblings}
+        groupTitle={groupTitle}
+        showHref={showHref}
+        openSettings={openSettings}
+      />
+    </Popover>
+  )
+}
+
+function AddPopoverBody({
+  setOpen,
+  siblings,
+  groupTitle,
+  showHref,
+  openSettings,
+}: {
+  setOpen: (open: boolean) => void
+  siblings: ReturnType<typeof hiddenSiblingLeaves>
+  groupTitle: string | undefined
+  showHref: (href: string) => void
+  openSettings: ReturnType<typeof useOpenSettings>
+}) {
+  return (
+    <PopoverContent
+      align="start"
+      side="right"
+      sideOffset={8}
+      className="w-[min(18rem,calc(100vw-2rem))] max-h-[min(24rem,70vh)] overflow-x-hidden overflow-y-auto p-1.5"
+    >
+      <HiddenPageRows
+        items={siblings}
+        mode="add"
+        onAdd={(nextHref) => {
+          showHref(nextHref)
+          setOpen(false)
+        }}
+      />
+      <button
+        type="button"
+        data-testid="add-menu-customize"
+        className="mt-1 flex min-h-11 w-full items-center rounded-md px-2 text-left text-[13px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground lg:min-h-8"
+        onClick={() => {
+          setOpen(false)
+          openSettings('navigation', { focusGroup: groupTitle })
+        }}
+      >
+        Customize…
+      </button>
+    </PopoverContent>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/hidden-page-rows.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/hidden-page-rows.tsx
@@ -1,0 +1,142 @@
+import { ArrowUpRight, Pin, Plus } from 'lucide-react'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useIsFavorite, useToggleFavorite } from '@/hooks/use-favorites'
+import { cn } from '@/lib/utils'
+
+export interface HiddenPageRow {
+  href: string
+  title: string
+  description?: string
+  icon?: MenuItem['icon']
+}
+
+/**
+ * Hidden-page rows for hover-Add (primary click adds) and More (primary
+ * click navigates; hover Add / Pin).
+ */
+export function HiddenPageRows({
+  items,
+  mode,
+  onAdd,
+  onNavigate,
+}: {
+  items: readonly HiddenPageRow[]
+  mode: 'add' | 'navigate'
+  onAdd: (href: string) => void
+  onNavigate?: () => void
+}) {
+  if (items.length === 0) {
+    return (
+      <p className="px-2 py-3 text-xs text-muted-foreground">
+        No hidden pages in this group.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="flex min-w-0 flex-col">
+      {items.map((item) =>
+        mode === 'add' ? (
+          <AddRow key={item.href} item={item} onAdd={onAdd} />
+        ) : (
+          <NavigateRow
+            key={item.href}
+            item={item}
+            onAdd={onAdd}
+            onNavigate={onNavigate}
+          />
+        )
+      )}
+    </ul>
+  )
+}
+
+function AddRow({
+  item,
+  onAdd,
+}: {
+  item: HiddenPageRow
+  onAdd: (href: string) => void
+}) {
+  const Icon = item.icon
+  return (
+    <li className="flex min-w-0 items-center gap-0.5">
+      <button
+        type="button"
+        data-testid="hidden-page-add"
+        data-href={item.href}
+        className="flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-[13px] hover:bg-muted lg:min-h-8"
+        onClick={() => onAdd(item.href)}
+      >
+        {Icon ? <Icon className="size-3.5 shrink-0" /> : null}
+        <span className="min-w-0 truncate">{item.title}</span>
+      </button>
+      <HostPrefixedLink
+        href={item.href}
+        aria-label={`Open ${item.title}`}
+        className="flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground lg:size-8"
+      >
+        <ArrowUpRight className="size-3.5" />
+      </HostPrefixedLink>
+    </li>
+  )
+}
+
+function NavigateRow({
+  item,
+  onAdd,
+  onNavigate,
+}: {
+  item: HiddenPageRow
+  onAdd: (href: string) => void
+  onNavigate?: () => void
+}) {
+  const Icon = item.icon
+  const isPinned = useIsFavorite(item.href)
+  const toggleFavorite = useToggleFavorite()
+
+  return (
+    <li className="group/hidden-row flex min-w-0 items-center gap-0.5">
+      <HostPrefixedLink
+        href={item.href}
+        className="flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-[13px] hover:bg-muted lg:min-h-8"
+        onClick={onNavigate}
+      >
+        {Icon ? <Icon className="size-3.5 shrink-0" /> : null}
+        <span className="min-w-0 truncate">{item.title}</span>
+      </HostPrefixedLink>
+      <button
+        type="button"
+        data-testid="hidden-page-add"
+        data-href={item.href}
+        aria-label={`Add ${item.title} to sidebar`}
+        className={cn(
+          'flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover/hidden-row:opacity-100 group-focus-within/hidden-row:opacity-100 lg:size-8'
+        )}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onAdd(item.href)
+        }}
+      >
+        <Plus className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label={isPinned ? `Unpin ${item.title}` : `Pin ${item.title}`}
+        aria-pressed={isPinned}
+        className="flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover/hidden-row:opacity-100 group-focus-within/hidden-row:opacity-100 lg:size-8"
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          toggleFavorite(item.href)
+        }}
+      >
+        <Pin className={cn('size-3.5', isPinned && 'fill-current')} />
+      </button>
+    </li>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -4,6 +4,7 @@ import type { HTMLAttributes, ReactNode, Ref } from 'react'
 import type { MenuItem as MenuItemType } from '@/components/menu/types'
 import type { MenuItemActiveState, MenuItemProps } from './types'
 
+import { AddButton, SubAddButton } from './add-button'
 import { CollapsedSubmenu } from './collapsed-submenu'
 import { HideButton, SubHideButton } from './hide-button'
 import { PinButton, SubPinButton } from './pin-button'
@@ -11,7 +12,9 @@ import { lazy, Suspense } from 'react'
 import { useIsTableAvailable } from '@/components/menu/hooks/use-table-availability'
 import { HostPrefixedLink } from '@/components/menu/link-with-context'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { hiddenSiblingLeaves } from '@/lib/menu/hidden-siblings'
 import { useMetadataDbSatisfied } from '@/lib/menu/metadata-db'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
 import { useHostId } from '@/lib/swr'
 import { cn } from '@/lib/utils'
 
@@ -111,6 +114,10 @@ const SingleMenuItem = function SingleMenuItem({
   const available = tableAvailable && dbSatisfied
   const { settings } = useUserSettings()
   const hasBadge = Boolean(item.isNew || item.countKey)
+  const { catalog, hiddenHrefs } = useMenuWorkspaceCatalog()
+  const hasAdd =
+    Boolean(item.href) &&
+    hiddenSiblingLeaves(catalog, item.href, hiddenHrefs).length > 0
 
   // When the page's backing table is missing, either dim it (default) or hide
   // it entirely per the user's Navigation setting. A missing metadata database
@@ -147,7 +154,11 @@ const SingleMenuItem = function SingleMenuItem({
         <span
           className={cn(
             'min-w-0 truncate group-data-[state=collapsed]/sidebar:hidden',
-            hasBadge ? 'pr-16' : 'pr-12'
+            hasBadge && hasAdd
+              ? 'pr-20'
+              : hasAdd || hasBadge
+                ? 'pr-16'
+                : 'pr-12'
           )}
         >
           {item.title}
@@ -156,6 +167,7 @@ const SingleMenuItem = function SingleMenuItem({
       {item.href ? (
         <HideButton href={item.href} title={item.title} hasBadge={hasBadge} />
       ) : null}
+      {item.href ? <AddButton href={item.href} hasBadge={hasBadge} /> : null}
       <PinButton href={item.href} title={item.title} hasBadge={hasBadge} />
       {item.isNew && (
         <SidebarMenuBadge className={badgeHiddenClasses}>
@@ -203,6 +215,10 @@ const SubMenuItem = function SubMenuItem({
   const available = tableAvailable && dbSatisfied
   const { settings } = useUserSettings()
   const hasBadge = Boolean(subItem.isNew || subItem.countKey)
+  const { catalog, hiddenHrefs } = useMenuWorkspaceCatalog()
+  const hasAdd =
+    Boolean(subItem.href) &&
+    hiddenSiblingLeaves(catalog, subItem.href, hiddenHrefs).length > 0
 
   if (!tableAvailable && !settings.dimUnavailablePages) {
     return null
@@ -218,7 +234,8 @@ const SubMenuItem = function SubMenuItem({
         )}
         className={cn(
           'h-11 min-h-11 w-full cursor-pointer pr-12 lg:h-7 lg:min-h-7',
-          hasBadge && 'pr-16',
+          hasAdd && 'pr-16',
+          hasBadge && (hasAdd ? 'pr-20' : 'pr-16'),
           available ? '' : 'opacity-50 text-muted-foreground/50'
         )}
         render={
@@ -258,6 +275,9 @@ const SubMenuItem = function SubMenuItem({
           title={subItem.title}
           hasBadge={hasBadge}
         />
+      ) : null}
+      {subItem.href ? (
+        <SubAddButton href={subItem.href} hasBadge={hasBadge} />
       ) : null}
       <SubPinButton
         href={subItem.href}

--- a/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
@@ -1,11 +1,11 @@
 /**
- * More pages: shown when the workspace hide list is non-empty, opens
- * Settings → Navigation. happy-dom + react-dom/client.
+ * More flyout: shown when the workspace hide list is non-empty. Click opens
+ * the catalog, not Settings. happy-dom + react-dom/client.
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-import type { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 
 import {
   afterAll,
@@ -13,9 +13,27 @@ import {
   beforeAll,
   describe,
   expect,
+  mock,
   test,
 } from 'bun:test'
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+mock.module('@/components/menu/link-with-context', () => ({
+  HostPrefixedLink: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string
+    children?: ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}))
 
 beforeAll(() => {
   GlobalRegistrator.register()
@@ -100,7 +118,8 @@ describe('MorePagesButton', () => {
       ) as HTMLButtonElement | null
       expect(button).not.toBeNull()
       expect(button?.tagName).toBe('BUTTON')
-      expect(button?.textContent).toContain('More pages')
+      expect(button?.textContent).toContain('More')
+      expect(button?.textContent).not.toContain('More pages')
       expect(button?.className).toContain('min-h-11')
     } finally {
       await cleanup()
@@ -134,6 +153,74 @@ describe('MorePagesButton', () => {
 
     try {
       expect(container.querySelector('[data-testid="more-pages-button"]')).toBe(
+        null
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('opens a searchable flyout of hidden pages, not Settings', async () => {
+    const { MorePagesButton } = await import('./more-pages-button')
+    const { SidebarProvider } = await import('@/components/ui/sidebar')
+    const { USER_SETTINGS_QUERY_KEY } = await import(
+      '@/lib/hooks/use-user-settings'
+    )
+    const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+    const {
+      RouterContextProvider,
+      createMemoryHistory,
+      createRootRoute,
+      createRouter,
+    } = await import('@tanstack/react-router')
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
+    const router = createRouter({
+      routeTree: createRootRoute(),
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    })
+
+    const { container, cleanup } = await renderInto(
+      <RouterContextProvider router={router}>
+        <QueryClientProvider client={queryClient}>
+          <SidebarProvider>
+            <MorePagesButton />
+          </SidebarProvider>
+        </QueryClientProvider>
+      </RouterContextProvider>
+    )
+
+    try {
+      const button = container.querySelector(
+        '[data-testid="more-pages-button"]'
+      ) as HTMLButtonElement | null
+      expect(button).not.toBeNull()
+
+      const { act } = await import('react')
+      await act(async () => {
+        button?.click()
+      })
+
+      const panel = document.querySelector('[data-testid="more-pages-panel"]')
+      expect(panel).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="more-pages-search"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector(
+          '[data-testid="hidden-page-add"][data-href="/history-queries"]'
+        )
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="more-pages-customize"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="more-pages-show-all"]')
+      ).not.toBeNull()
+      expect(document.querySelector('[data-testid="settings-dialog"]')).toBe(
         null
       )
     } finally {

--- a/apps/dashboard/src/components/navigation/nav-main/more-pages-button.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/more-pages-button.tsx
@@ -1,7 +1,15 @@
-import { Ellipsis } from 'lucide-react'
+import { Ellipsis, Search } from 'lucide-react'
 import { menuItemsConfig } from '@/menu'
 
+import { HiddenPageRows } from './hidden-page-rows'
+import { useMemo, useState } from 'react'
 import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import {
   SidebarGroup,
   SidebarMenu,
@@ -13,15 +21,19 @@ import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { hiddenLeavesGrouped } from '@/lib/menu/hidden-siblings'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
 import {
   effectiveHiddenMenuHrefs,
   workspaceFromSettings,
 } from '@/lib/menu/workspace-presets'
+import { cn } from '@/lib/utils'
 
 /**
- * Opens Settings → Navigation when the workspace hide list is non-empty
- * (#3292). Restore is already in that tree (Show / Full); this is the
- * sidebar entry so users do not have to remember the gear.
+ * More flyout: searchable hidden leaves, click navigates, hover Add / Pin.
+ * Customize… opens Settings → Navigation. Show all applies Full. Empty
+ * hide list hides the row. Below lg the catalog is an inline panel in the
+ * overlay sidebar — not the 375 Settings dialog.
  */
 export function MorePagesButton() {
   const { settings } = useUserSettings()
@@ -33,27 +45,160 @@ export function MorePagesButton() {
     menuItemsConfig,
     workspaceFromSettings(settings)
   ).length
+  const [open, setOpen] = useState(false)
 
   if (!canUseSettings || hiddenCount === 0) return null
 
+  const closeOverlay = () => {
+    setOpen(false)
+    if (isMobile) setOpenMobile(false)
+  }
+
+  const trigger = (
+    <SidebarMenuButton
+      tooltip="Hidden pages"
+      className="h-11 min-h-11 lg:h-8 lg:min-h-8 text-muted-foreground"
+      data-testid="more-pages-button"
+      onClick={isMobile ? () => setOpen((value) => !value) : undefined}
+    >
+      <Ellipsis className="size-4 shrink-0" strokeWidth={1.5} />
+      <span>More</span>
+    </SidebarMenuButton>
+  )
+
   return (
-    <SidebarGroup className="p-1">
+    <SidebarGroup className="overflow-x-hidden p-1">
       <SidebarMenu>
         <SidebarMenuItem>
-          <SidebarMenuButton
-            tooltip="Show hidden pages in Settings → Navigation"
-            className="h-11 min-h-11 lg:h-8 lg:min-h-8 text-muted-foreground"
-            data-testid="more-pages-button"
-            onClick={() => {
-              if (isMobile) setOpenMobile(false)
-              openSettings('navigation')
-            }}
-          >
-            <Ellipsis className="size-4 shrink-0" strokeWidth={1.5} />
-            <span>More pages</span>
-          </SidebarMenuButton>
+          {isMobile ? (
+            <>
+              {trigger}
+              {open ? (
+                <div
+                  className="mt-1 min-w-0 overflow-x-hidden rounded-lg border border-border bg-popover p-1.5"
+                  data-testid="more-pages-panel"
+                >
+                  <MoreCatalog
+                    onClose={closeOverlay}
+                    onCustomize={() => {
+                      closeOverlay()
+                      openSettings('navigation')
+                    }}
+                  />
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger render={trigger} />
+              <PopoverContent
+                align="start"
+                side="right"
+                sideOffset={8}
+                className="w-[min(20rem,calc(100vw-2rem))] max-h-[min(28rem,75vh)] overflow-x-hidden overflow-y-auto p-1.5"
+                data-testid="more-pages-panel"
+              >
+                <MoreCatalog
+                  onClose={closeOverlay}
+                  onCustomize={() => {
+                    closeOverlay()
+                    openSettings('navigation')
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
+          )}
         </SidebarMenuItem>
       </SidebarMenu>
     </SidebarGroup>
+  )
+}
+
+function MoreCatalog({
+  onClose,
+  onCustomize,
+}: {
+  onClose: () => void
+  onCustomize: () => void
+}) {
+  const [query, setQuery] = useState('')
+  const { catalog, hiddenHrefs, showHref, showAll } = useMenuWorkspaceCatalog()
+  const groups = useMemo(() => {
+    const all = hiddenLeavesGrouped(catalog, hiddenHrefs)
+    const q = query.trim().toLowerCase()
+    if (!q) return all
+    return all
+      .map((group) => ({
+        ...group,
+        items: group.items.filter(
+          (item) =>
+            item.title.toLowerCase().includes(q) ||
+            item.href.toLowerCase().includes(q) ||
+            group.group.toLowerCase().includes(q)
+        ),
+      }))
+      .filter((group) => group.items.length > 0)
+  }, [catalog, hiddenHrefs, query])
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute top-2.5 left-2.5 size-3.5 text-muted-foreground"
+          aria-hidden
+        />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search hidden pages"
+          className="h-9 pl-8 text-[13px] lg:h-8"
+          data-testid="more-pages-search"
+        />
+      </div>
+      <div className="max-h-[min(18rem,50vh)] overflow-x-hidden overflow-y-auto">
+        {groups.length === 0 ? (
+          <p className="px-2 py-3 text-xs text-muted-foreground">
+            No hidden pages match.
+          </p>
+        ) : (
+          groups.map((group) => (
+            <div key={group.group} className="min-w-0">
+              <p className="px-2 py-1 text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
+                {group.group}
+              </p>
+              <HiddenPageRows
+                items={group.items}
+                mode="navigate"
+                onAdd={showHref}
+                onNavigate={onClose}
+              />
+            </div>
+          ))
+        )}
+      </div>
+      <div className="flex min-w-0 flex-col gap-0.5 border-t border-border pt-1">
+        <button
+          type="button"
+          data-testid="more-pages-customize"
+          className={cn(
+            'flex min-h-11 w-full items-center rounded-md px-2 text-left text-[13px] font-medium hover:bg-muted lg:min-h-8'
+          )}
+          onClick={onCustomize}
+        >
+          Customize…
+        </button>
+        <button
+          type="button"
+          data-testid="more-pages-show-all"
+          className="flex min-h-11 w-full items-center rounded-md px-2 text-left text-[13px] font-medium hover:bg-muted lg:min-h-8"
+          onClick={() => {
+            showAll()
+            onClose()
+          }}
+        >
+          Show all
+        </button>
+      </div>
+    </div>
   )
 }

--- a/apps/dashboard/src/components/navigation/related-pages-link.tsx
+++ b/apps/dashboard/src/components/navigation/related-pages-link.tsx
@@ -1,0 +1,90 @@
+import { ChevronRight } from 'lucide-react'
+
+import { useState } from 'react'
+import { HiddenPageRows } from '@/components/navigation/nav-main/hidden-page-rows'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  findCatalogGroupForHref,
+  hiddenSiblingLeaves,
+} from '@/lib/menu/hidden-siblings'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
+import { cn } from '@/lib/utils'
+
+/**
+ * Modest More / Customize on a key page header. Lists hidden siblings in
+ * the same catalog group, or opens Settings → Navigation for that group.
+ */
+export function RelatedPagesLink({
+  href,
+  className,
+}: {
+  href: string
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const openSettings = useOpenSettings()
+  const { catalog, hiddenHrefs, showHref } = useMenuWorkspaceCatalog()
+  const siblings = hiddenSiblingLeaves(catalog, href, hiddenHrefs)
+  const groupTitle = findCatalogGroupForHref(catalog, href)?.title
+
+  const openCustomize = () => {
+    setOpen(false)
+    openSettings('navigation', { focusGroup: groupTitle })
+  }
+
+  if (siblings.length === 0) {
+    return (
+      <button
+        type="button"
+        data-testid="related-pages-customize"
+        className={cn(
+          'inline-flex h-8 items-center gap-1 rounded-md px-2 text-[13px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground',
+          className
+        )}
+        onClick={openCustomize}
+      >
+        Customize
+        <ChevronRight className="size-3.5" />
+      </button>
+    )
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            data-testid="related-pages-more"
+            className={cn(
+              'inline-flex h-8 items-center gap-1 rounded-md px-2 text-[13px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground',
+              className
+            )}
+          />
+        }
+      >
+        More
+        <ChevronRight className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-[min(18rem,calc(100vw-2rem))] max-h-[min(24rem,70vh)] overflow-x-hidden overflow-y-auto p-1.5"
+      >
+        <HiddenPageRows items={siblings} mode="navigate" onAdd={showHref} />
+        <button
+          type="button"
+          data-testid="related-pages-customize"
+          className="mt-1 flex min-h-11 w-full items-center rounded-md px-2 text-left text-[13px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground lg:min-h-8"
+          onClick={openCustomize}
+        >
+          Customize…
+        </button>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/dashboard/src/components/running-queries/running-queries-view.tsx
+++ b/apps/dashboard/src/components/running-queries/running-queries-view.tsx
@@ -7,6 +7,7 @@ import type { CardError } from '@/lib/card-error-utils'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PageHeader } from '@/components/layout'
 import { CollapsedChartsRow } from '@/components/layout/query-page/collapsed-charts-row'
+import { RelatedPagesLink } from '@/components/navigation/related-pages-link'
 import { HeaderButton } from '@/components/query-tables/header-button'
 import { QueryPageSkeleton } from '@/components/query-tables/query-page-skeleton'
 import { CompletedQueriesTable } from '@/components/running-queries/completed-queries-table'
@@ -279,6 +280,7 @@ export const RunningQueriesView = function RunningQueriesView() {
           }
           actions={
             <div className="flex flex-wrap items-center gap-1.5">
+              <RelatedPagesLink href="/running-queries" />
               <HeaderButton onClick={() => setChartsOpen((v) => !v)}>
                 {chartsOpen ? (
                   <MinimizeIcon className="size-3.5" />

--- a/apps/dashboard/src/components/settings/settings-dialog-provider.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog-provider.tsx
@@ -13,13 +13,19 @@ import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { SETTINGS_FEATURE_PERMISSION } from '@/lib/feature-permissions/permissions'
 import { isFeatureAllowed } from '@/lib/feature-permissions/shared'
 
-type OpenSettings = (tab?: SettingsTab) => void
+export interface OpenSettingsOptions {
+  /** Prefill Navigation search so that catalog group is focused. */
+  focusGroup?: string
+}
+
+type OpenSettings = (tab?: SettingsTab, options?: OpenSettingsOptions) => void
 
 const SettingsDialogContext = createContext<OpenSettings | null>(null)
 
 /**
  * One Settings dialog for the shell (gear, ⌘,, command palette, hide-page
- * toast). Passing a tab opens that pane; omitting it opens General.
+ * toast, hover-Add Customize). Passing a tab opens that pane; omitting it
+ * opens General.
  */
 export function SettingsDialogProvider({
   children,
@@ -28,13 +34,15 @@ export function SettingsDialogProvider({
 }) {
   const [open, setOpen] = useState(false)
   const [initialTab, setInitialTab] = useState<SettingsTab>('general')
+  const [focusGroup, setFocusGroup] = useState<string | undefined>()
   const { config } = useFeaturePermissions()
   const canUseSettings = isFeatureAllowed(SETTINGS_FEATURE_PERMISSION, config)
 
   const openSettings = useCallback<OpenSettings>(
-    (tab = 'general') => {
+    (tab = 'general', options) => {
       if (!canUseSettings) return
       setInitialTab(tab)
+      setFocusGroup(options?.focusGroup)
       setOpen(true)
     },
     [canUseSettings]
@@ -42,7 +50,10 @@ export function SettingsDialogProvider({
 
   const handleOpenChange = useCallback((next: boolean) => {
     setOpen(next)
-    if (!next) setInitialTab('general')
+    if (!next) {
+      setInitialTab('general')
+      setFocusGroup(undefined)
+    }
   }, [])
 
   useSettingsShortcut(openSettings, canUseSettings)
@@ -57,6 +68,7 @@ export function SettingsDialogProvider({
           open={open}
           onOpenChange={handleOpenChange}
           initialTab={initialTab}
+          focusGroup={focusGroup}
         />
       ) : null}
     </SettingsDialogContext.Provider>

--- a/apps/dashboard/src/components/settings/settings-dialog.tsx
+++ b/apps/dashboard/src/components/settings/settings-dialog.tsx
@@ -20,6 +20,7 @@ interface SettingsDialogProps {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   initialTab?: SettingsTab
+  focusGroup?: string
 }
 
 export function SettingsDialog({
@@ -27,6 +28,7 @@ export function SettingsDialog({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   initialTab = 'general',
+  focusGroup,
 }: SettingsDialogProps) {
   const [internalOpen, setInternalOpen] = useState(false)
   const { settings, updateSettings } = useUserSettings()
@@ -64,6 +66,7 @@ export function SettingsDialog({
           onUpdate={updateSettings}
           onClose={() => onOpenChange(false)}
           initialTab={initialTab}
+          focusGroup={focusGroup}
         />
       </DialogContent>
     </Dialog>

--- a/apps/dashboard/src/components/settings/settings-form.tsx
+++ b/apps/dashboard/src/components/settings/settings-form.tsx
@@ -54,6 +54,8 @@ interface SettingsFormProps {
   onClose: () => void
   /** Opens this pane. Defaults to General. */
   initialTab?: SettingsTab
+  /** Prefill Navigation search so that catalog group is focused. */
+  focusGroup?: string
 }
 
 const themeOptions = [
@@ -443,6 +445,7 @@ export function SettingsForm({
   onUpdate,
   onClose,
   initialTab = 'general',
+  focusGroup,
 }: SettingsFormProps) {
   const { setTheme } = useTheme()
   const engine = useActiveHostEngine()
@@ -736,12 +739,13 @@ export function SettingsForm({
               <Field
                 label="Workspace"
                 icon={LayoutGrid}
-                description="Hide pages from the sidebar and command palette. Full restores every page. Hidden pages stay reachable by URL."
+                description="Hide pages from the sidebar and More. ⌘K still lists them. Full restores every page. Hidden pages stay reachable by URL."
               >
                 <WorkspacePresetPicker
                   preset={settings.workspacePreset}
                   hiddenMenuHrefs={settings.hiddenMenuHrefs}
                   engine={engine}
+                  focusGroup={focusGroup}
                   onChange={(next) => onUpdate(next)}
                 />
               </Field>

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -6,7 +6,7 @@ import type { WorkspacePreset } from '@/lib/types/user-settings'
 import { SegmentedControl } from './segmented-control'
 import { WorkspaceMenuTree } from './workspace-menu-tree'
 import { DEFAULT_SOURCE_ENGINE, type SourceEngine } from '@chm/types'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { getSettingsNavMenuItems } from '@/lib/menu/visible-items'
 import {
@@ -35,7 +35,7 @@ const PRESET_HINT: Record<WorkspacePreset, string> = {
     'Overview, SQL/explorer, queries, insights. Less keeper, security, and ops.',
   sre: 'Overview, health, insights, SQL tools, replication, disks, errors, running queries.',
   custom:
-    'Day-to-day pages by default. Hide or show more in the tree, or pick Full.',
+    'Essential pages by default (Overview, Chat, Health, Queries, Tables, SQL). Hide or show more from the rail, More, or this tree.',
 }
 
 interface WorkspacePresetPickerProps {
@@ -47,6 +47,8 @@ interface WorkspacePresetPickerProps {
    * unspecified hosts keep today's tree.
    */
   engine?: SourceEngine
+  /** Prefill the tree search so Customize from a group lands on that group. */
+  focusGroup?: string
   onChange: (next: {
     workspacePreset: WorkspacePreset
     hiddenMenuHrefs: string[]
@@ -57,9 +59,14 @@ export function WorkspacePresetPicker({
   preset,
   hiddenMenuHrefs,
   engine = DEFAULT_SOURCE_ENGINE,
+  focusGroup,
   onChange,
 }: WorkspacePresetPickerProps) {
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState(focusGroup ?? '')
+
+  useEffect(() => {
+    if (focusGroup) setQuery(focusGroup)
+  }, [focusGroup])
 
   const treeItems = useMemo(() => getSettingsNavMenuItems(engine), [engine])
   const leaves = useMemo(() => collectMenuLeaves(treeItems), [treeItems])

--- a/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
+++ b/apps/dashboard/src/lib/menu/__tests__/visible-items.test.ts
@@ -7,7 +7,9 @@ import { DEFAULT_SOURCE_ENGINE } from '@chm/types'
 import {
   filterCloudOnly,
   filterMenuItemsByEngine,
+  getAllowedMenuItems,
   getSettingsNavMenuItems,
+  getVisibleMenuItems,
 } from '@/lib/menu/visible-items'
 import {
   applyWorkspaceVisibility,
@@ -410,5 +412,35 @@ describe('applyWorkspaceVisibility', () => {
     expect(PRESET_GROUP_TITLES.engineer).not.toContain('Keeper')
     expect(PRESET_GROUP_TITLES.sre).toContain('Health')
     expect(PRESET_GROUP_TITLES.sre).toContain('Tools')
+  })
+})
+
+describe('palette includes hidden pages', () => {
+  const config = {
+    authProvider: 'none' as const,
+    principal: 'anonymous' as const,
+    features: {},
+  }
+
+  test('getAllowedMenuItems keeps specialist hrefs that workspace hide drops', () => {
+    const allowed = collectMenuHrefs(getAllowedMenuItems(config))
+    const sidebar = collectMenuHrefs(
+      getVisibleMenuItems(config, DEFAULT_SOURCE_ENGINE, {
+        workspacePreset: 'custom',
+        hiddenMenuHrefs: [
+          '/history-queries',
+          '/slow-queries',
+          '/insights',
+          '/explorer',
+        ],
+      })
+    )
+
+    expect(allowed).toContain('/history-queries')
+    expect(allowed).toContain('/slow-queries')
+    expect(allowed).toContain('/insights')
+    expect(sidebar).not.toContain('/history-queries')
+    expect(sidebar).not.toContain('/slow-queries')
+    expect(sidebar).not.toContain('/insights')
   })
 })

--- a/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
@@ -1,0 +1,138 @@
+import { menuItemsConfig } from '@/menu'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_SOURCE_ENGINE } from '@chm/types'
+import {
+  flattenSingletonGroups,
+  flattenSingletonTitle,
+} from '@/lib/menu/flatten-singleton'
+import { revealAlertsWhenActive } from '@/lib/menu/notification-alerts'
+import {
+  DEFAULT_HIDDEN_MENU_HREFS,
+  DEFAULT_VISIBLE_MENU_HREFS,
+} from '@/lib/menu/slim-default'
+import { filterMenuItemsByEngine } from '@/lib/menu/visible-items'
+import { applyWorkspaceVisibility } from '@/lib/menu/workspace-presets'
+
+const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
+  title: overrides.title ?? 'Item',
+  href: overrides.href ?? '/item',
+  ...overrides,
+})
+
+describe('flattenSingletonTitle', () => {
+  test('uses the parent title for Queries / Tables / Health', () => {
+    expect(
+      flattenSingletonTitle(
+        leaf({ title: 'Queries', href: '' }),
+        leaf({ title: 'Running Queries', href: '/running-queries' })
+      )
+    ).toBe('Queries')
+    expect(
+      flattenSingletonTitle(
+        leaf({ title: 'Tables', href: '/tables' }),
+        leaf({ title: 'Tables Overview', href: '/tables-overview' })
+      )
+    ).toBe('Tables')
+    expect(
+      flattenSingletonTitle(
+        leaf({ title: 'Health', href: '' }),
+        leaf({ title: 'Health', href: '/health' })
+      )
+    ).toBe('Health')
+  })
+
+  test('uses Chat / SQL for folder groups', () => {
+    expect(
+      flattenSingletonTitle(
+        leaf({ title: 'AI Agent', href: '' }),
+        leaf({ title: 'Chat', href: '/agents' })
+      )
+    ).toBe('Chat')
+    expect(
+      flattenSingletonTitle(
+        leaf({ title: 'Tools', href: '' }),
+        leaf({ title: 'SQL Console', href: '/sql' })
+      )
+    ).toBe('SQL')
+  })
+})
+
+describe('flattenSingletonGroups', () => {
+  test('hoists a single visible child and drops the chevron', () => {
+    const items: MenuItem[] = [
+      leaf({ title: 'Overview', href: '/overview', section: 'main' }),
+      {
+        title: 'Queries',
+        href: '',
+        section: 'main',
+        items: [leaf({ title: 'Running Queries', href: '/running-queries' })],
+      },
+      {
+        title: 'Queries Many',
+        href: '',
+        section: 'main',
+        items: [
+          leaf({ title: 'Running', href: '/running-queries' }),
+          leaf({ title: 'History', href: '/history-queries' }),
+        ],
+      },
+    ]
+
+    const flat = flattenSingletonGroups(items)
+    expect(flat[0]?.items).toBeUndefined()
+    expect(flat[1]?.title).toBe('Queries')
+    expect(flat[1]?.href).toBe('/running-queries')
+    expect(flat[1]?.items).toBeUndefined()
+    expect(flat[2]?.title).toBe('Queries Many')
+    expect(flat[2]?.items).toHaveLength(2)
+  })
+
+  test('Essential first-run rail is six leaves plus About, no specialist groups', () => {
+    const visible = applyWorkspaceVisibility(
+      filterMenuItemsByEngine(menuItemsConfig, DEFAULT_SOURCE_ENGINE),
+      {
+        workspacePreset: 'custom',
+        hiddenMenuHrefs: DEFAULT_HIDDEN_MENU_HREFS,
+      }
+    )
+    const flat = flattenSingletonGroups(visible)
+    const body = flat.filter((item) => item.section !== 'footer')
+
+    expect(body.map((item) => item.title)).toEqual([
+      'Overview',
+      'Chat',
+      'Health',
+      'Queries',
+      'Tables',
+      'SQL',
+    ])
+    for (const item of body) {
+      expect(item.items, item.title).toBeUndefined()
+    }
+    expect(flat.some((item) => item.href === '/about')).toBe(true)
+    expect(body.map((item) => item.href)).toEqual([
+      ...DEFAULT_VISIBLE_MENU_HREFS,
+    ])
+  })
+
+  test('Alerts injection before flatten keeps Health as a two-child group', () => {
+    const visible = applyWorkspaceVisibility(
+      filterMenuItemsByEngine(menuItemsConfig, DEFAULT_SOURCE_ENGINE),
+      {
+        workspacePreset: 'custom',
+        hiddenMenuHrefs: DEFAULT_HIDDEN_MENU_HREFS,
+      }
+    )
+    const withAlerts = revealAlertsWhenActive(visible, true)
+    const flat = flattenSingletonGroups(withAlerts)
+    const health = flat.find((item) => item.title === 'Health')
+    expect(health?.items?.map((child) => child.href)).toEqual([
+      '/health',
+      '/alert-settings',
+    ])
+    expect(flat.find((item) => item.title === 'Queries')?.items).toBeUndefined()
+  })
+})

--- a/apps/dashboard/src/lib/menu/flatten-singleton.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.ts
@@ -1,0 +1,54 @@
+import type { MenuItem } from '@/components/menu/types'
+
+/**
+ * Group titles that are folders, not the destination name. Flattening uses
+ * the child's title (Chat, SQL Console) instead of the folder name.
+ */
+const FOLDER_TITLES = new Set(['AI Agent', 'Tools'])
+
+/**
+ * Label for a 1-child group on the Essential rail: parent title for
+ * Queries / Tables / Health, child title for folder groups, and "SQL"
+ * for the Tools → SQL Console singleton.
+ */
+export function flattenSingletonTitle(
+  parent: MenuItem,
+  child: MenuItem
+): string {
+  if (parent.title === 'Tools' && child.href === '/sql') return 'SQL'
+  if (FOLDER_TITLES.has(parent.title)) return child.title
+  return parent.title
+}
+
+/**
+ * Render a group with 0–1 visible children as a leaf (no chevron). Empty
+ * parents are already dropped by hide/engine filters; a single child is
+ * hoisted to the parent's section with a short rail label.
+ *
+ * Does not recurse — only top-level groups flatten. Footer rows are left
+ * alone. Groups with 2+ children keep their chevron.
+ */
+export function flattenSingletonGroups(items: readonly MenuItem[]): MenuItem[] {
+  return items.map((item) => {
+    if (item.section === 'footer') return { ...item }
+    const children = item.items
+    if (!children || children.length !== 1) {
+      return { ...item, items: children ? [...children] : undefined }
+    }
+
+    const child = children[0]
+    if (child.items?.length) {
+      return { ...item, items: [{ ...child }] }
+    }
+
+    return {
+      ...child,
+      title: flattenSingletonTitle(item, child),
+      icon: FOLDER_TITLES.has(item.title)
+        ? (child.icon ?? item.icon)
+        : (item.icon ?? child.icon),
+      section: item.section ?? child.section,
+      items: undefined,
+    }
+  })
+}

--- a/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
+++ b/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
@@ -1,0 +1,70 @@
+import { menuItemsConfig } from '@/menu'
+
+import { describe, expect, test } from 'bun:test'
+import {
+  findCatalogGroupForHref,
+  hiddenLeavesGrouped,
+  hiddenSiblingLeaves,
+} from '@/lib/menu/hidden-siblings'
+import { DEFAULT_HIDDEN_MENU_HREFS } from '@/lib/menu/slim-default'
+
+describe('findCatalogGroupForHref', () => {
+  test('Queries owns running-queries; Tools owns sql; Tables owns explorer first', () => {
+    expect(
+      findCatalogGroupForHref(menuItemsConfig, '/running-queries')?.title
+    ).toBe('Queries')
+    expect(findCatalogGroupForHref(menuItemsConfig, '/sql')?.title).toBe(
+      'Tools'
+    )
+    expect(findCatalogGroupForHref(menuItemsConfig, '/explorer')?.title).toBe(
+      'Tables'
+    )
+    expect(
+      findCatalogGroupForHref(menuItemsConfig, '/overview')
+    ).toBeUndefined()
+  })
+})
+
+describe('hiddenSiblingLeaves', () => {
+  const hidden = new Set(DEFAULT_HIDDEN_MENU_HREFS)
+
+  test('Queries + lists History / Slow / Failed, not Running Queries', () => {
+    const siblings = hiddenSiblingLeaves(
+      menuItemsConfig,
+      '/running-queries',
+      hidden
+    )
+    const hrefs = siblings.map((item) => item.href)
+    expect(hrefs).toContain('/history-queries')
+    expect(hrefs).toContain('/slow-queries')
+    expect(hrefs).toContain('/failed-queries')
+    expect(hrefs).not.toContain('/running-queries')
+  })
+
+  test('Tables + lists Replicas, TTL, Explorer', () => {
+    const hrefs = hiddenSiblingLeaves(
+      menuItemsConfig,
+      '/tables-overview',
+      hidden
+    ).map((item) => item.href)
+    expect(hrefs).toContain('/replicas')
+    expect(hrefs).toContain('/ttl-partition-health')
+    expect(hrefs).toContain('/explorer')
+    expect(hrefs).not.toContain('/tables-overview')
+  })
+})
+
+describe('hiddenLeavesGrouped', () => {
+  test('dedupes Explorer and groups like the catalog', () => {
+    const groups = hiddenLeavesGrouped(
+      menuItemsConfig,
+      new Set(DEFAULT_HIDDEN_MENU_HREFS)
+    )
+    const explorerHits = groups.flatMap((group) =>
+      group.items.filter((item) => item.href === '/explorer')
+    )
+    expect(explorerHits).toHaveLength(1)
+    expect(groups.some((group) => group.group === 'Queries')).toBe(true)
+    expect(groups.some((group) => group.group === 'Tables')).toBe(true)
+  })
+})

--- a/apps/dashboard/src/lib/menu/hidden-siblings.ts
+++ b/apps/dashboard/src/lib/menu/hidden-siblings.ts
@@ -1,0 +1,108 @@
+import type { MenuItem } from '@/components/menu/types'
+
+import { collectMenuLeaves } from '@/lib/menu/workspace-presets'
+
+function isFooterItem(item: MenuItem): boolean {
+  return item.section === 'footer'
+}
+
+/**
+ * The catalog group that owns `href` (Queries for `/running-queries`,
+ * Tools for `/sql`). First match wins — Data Explorer is listed under
+ * Tables then Tools; hover-Add on a Tables row uses Tables.
+ */
+export function findCatalogGroupForHref(
+  items: readonly MenuItem[],
+  href: string
+): MenuItem | undefined {
+  for (const item of items) {
+    if (isFooterItem(item)) continue
+    if (item.items?.length) {
+      if (item.items.some((child) => child.href === href)) return item
+      const nested = findCatalogGroupForHref(item.items, href)
+      if (nested) return nested
+    }
+  }
+  return undefined
+}
+
+/** Hidden leaves in the same catalog group as `href`, excluding `href`. */
+export function hiddenSiblingLeaves(
+  items: readonly MenuItem[],
+  href: string,
+  hiddenHrefs: ReadonlySet<string>
+): MenuItem[] {
+  const group = findCatalogGroupForHref(items, href)
+  if (!group?.items?.length) return []
+  return group.items.filter(
+    (child) =>
+      Boolean(child.href) &&
+      child.href !== href &&
+      !child.items?.length &&
+      hiddenHrefs.has(child.href)
+  )
+}
+
+export interface HiddenLeafGroup {
+  group: string
+  items: {
+    href: string
+    title: string
+    description?: string
+    icon?: MenuItem['icon']
+  }[]
+}
+
+/**
+ * Hidden catalog leaves grouped like the sidebar, deduped by href
+ * (Explorer is listed once — Tables inventory first).
+ */
+export function hiddenLeavesGrouped(
+  items: readonly MenuItem[],
+  hiddenHrefs: ReadonlySet<string>
+): HiddenLeafGroup[] {
+  const seen = new Set<string>()
+  const byGroup = new Map<string, HiddenLeafGroup['items']>()
+
+  for (const leaf of collectMenuLeaves(items)) {
+    if (!hiddenHrefs.has(leaf.href) || seen.has(leaf.href)) continue
+    seen.add(leaf.href)
+    const list = byGroup.get(leaf.group) ?? []
+    const source = findLeaf(items, leaf.href)
+    list.push({
+      href: leaf.href,
+      title: leaf.title,
+      description: source?.description,
+      icon: source?.icon,
+    })
+    byGroup.set(leaf.group, list)
+  }
+
+  return [...byGroup.entries()].map(([group, groupItems]) => ({
+    group,
+    items: groupItems,
+  }))
+}
+
+function findLeaf(
+  items: readonly MenuItem[],
+  href: string
+): MenuItem | undefined {
+  for (const item of items) {
+    if (item.href === href && !item.items?.length) return item
+    if (item.items?.length) {
+      const found = findLeaf(item.items, href)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+export function pathnameMatchesMenuHref(
+  pathname: string,
+  href: string
+): boolean {
+  const path = pathname.split('?')[0]
+  if (!href) return false
+  return path === href || path === `${href}/`
+}

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@/lib/menu/workspace-presets'
 import { DEFAULT_USER_SETTINGS } from '@/lib/types/user-settings'
 
-describe('slim default sidebar (#3290)', () => {
+describe('slim default sidebar (Essential keep list)', () => {
   const leaves = collectMenuLeaves(menuItemsConfig)
   const hidden = new Set(DEFAULT_HIDDEN_MENU_HREFS)
   const visible = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)
@@ -38,12 +38,6 @@ describe('slim default sidebar (#3290)', () => {
   test('day-to-day hrefs exist on the catalog', () => {
     const leafHrefs = new Set(leaves.map((leaf) => leaf.href))
     for (const href of DEFAULT_VISIBLE_MENU_HREFS) {
-      if (href === '/tables') {
-        expect(menuItemsConfig.some((item) => item.href === '/tables')).toBe(
-          true
-        )
-        continue
-      }
       expect(leafHrefs.has(href), href).toBe(true)
     }
   })
@@ -69,7 +63,7 @@ describe('slim default sidebar (#3290)', () => {
     }
   })
 
-  test('first-run settings apply the slim hide list as Custom', () => {
+  test('first-run settings apply the Essential hide list as Custom', () => {
     expect(DEFAULT_USER_SETTINGS.workspacePreset).toBe('custom')
     expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toEqual(
       DEFAULT_HIDDEN_MENU_HREFS
@@ -85,13 +79,40 @@ describe('slim default sidebar (#3290)', () => {
     expect(titles).toContain('Queries')
     expect(titles).toContain('Tables')
     expect(titles).toContain('Tools')
-    expect(titles).toContain('Cluster')
+    expect(titles).toContain('AI Agent')
     expect(titles).toContain('About')
+    expect(titles).not.toContain('Insights')
+    expect(titles).not.toContain('Merges')
+    expect(titles).not.toContain('Metrics')
+    expect(titles).not.toContain('Cluster')
     expect(titles).not.toContain('Keeper')
     expect(titles).not.toContain('PeerDB')
     expect(titles).not.toContain('Security')
     expect(titles).not.toContain('Logs')
     expect(titles).not.toContain('System')
     expect(titles).not.toContain('Operations')
+  })
+
+  test('Essential keep list excludes specialist rail rows', () => {
+    for (const href of [
+      '/insights',
+      '/merges',
+      '/metrics',
+      '/clusters',
+      '/explain',
+      '/advisor',
+      '/explorer',
+      '/tables',
+    ]) {
+      expect(DEFAULT_VISIBLE_MENU_HREFS as readonly string[]).not.toContain(
+        href
+      )
+      if (href !== '/tables') {
+        expect(DEFAULT_HIDDEN_MENU_HREFS, href).toContain(href)
+      }
+    }
+    for (const href of DEFAULT_VISIBLE_MENU_HREFS) {
+      expect(DEFAULT_HIDDEN_MENU_HREFS).not.toContain(href)
+    }
   })
 })

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -3,31 +3,30 @@ import { menuItemsConfig } from '@/menu'
 import type { MenuItem } from '@/components/menu/types'
 
 /**
- * v1 day-to-day sidebar keep list (#3290). Taken from the live menu on
- * dash.chmonitor.dev — existing pages only, no new product areas.
+ * Essential first-run sidebar keep list. Taken from the live catalog —
+ * existing pages only, no new product areas.
  *
- * First-run / missing-workspace settings hide every other default-engine
- * leaf. Postgres-only leaves are never on the hide list (engine swap already
- * drops those groups). Footer rows are never hidden.
+ * Fresh profiles hide every other default-engine leaf. Postgres-only leaves
+ * are never on the hide list (engine swap already drops those groups).
+ * Footer rows are never hidden.
  *
- * Full in Settings → Navigation still shows every page. New pages that
- * should stay off the default rail must not be added here.
+ * The rail is flattened separately (`flattenSingletonGroups`) so a group
+ * with one visible child renders as a leaf (Chat, Health, Queries, Tables,
+ * SQL) without a chevron.
+ *
+ * Full in Settings → Navigation still shows every page. Explorer stays in
+ * the Tables inventory (and under Tools); it is not an Essential rail row.
+ * New pages that should stay off the default rail must not be added here.
+ *
+ * DBA / Engineer / SRE remain group-title presets (not leaf keep-lists).
  */
 export const DEFAULT_VISIBLE_MENU_HREFS = [
   '/overview',
   '/agents',
-  '/insights',
   '/health',
   '/running-queries',
-  '/tables',
-  '/explorer',
   '/tables-overview',
-  '/merges',
-  '/metrics',
   '/sql',
-  '/explain',
-  '/advisor',
-  '/clusters',
 ] as const
 
 const VISIBLE = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)
@@ -58,8 +57,9 @@ function collectHideableLeaves(
 }
 
 /**
- * Hide list for the slim first-run default. Complementary to
+ * Hide list for the Essential first-run default. Complementary to
  * {@link DEFAULT_VISIBLE_MENU_HREFS} over the current menu catalog.
+ * Hide = sidebar / More membership only — not the command palette.
  */
 export const DEFAULT_HIDDEN_MENU_HREFS: string[] = collectHideableLeaves(
   menuItemsConfig

--- a/apps/dashboard/src/lib/menu/use-menu-workspace.ts
+++ b/apps/dashboard/src/lib/menu/use-menu-workspace.ts
@@ -1,0 +1,46 @@
+import { menuItemsConfig } from '@/menu'
+
+import { useFeaturePermissions } from '@/lib/feature-permissions/context'
+import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
+import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { persistShowMenuHref } from '@/lib/menu/hide-menu-item'
+import { getAllowedMenuItems } from '@/lib/menu/visible-items'
+import {
+  applyWorkspacePreset,
+  effectiveHiddenMenuHrefs,
+  workspaceFromSettings,
+} from '@/lib/menu/workspace-presets'
+
+/** Allowed catalog + workspace hide set for hover-Add, More, and in-page links. */
+export function useMenuWorkspaceCatalog() {
+  const { config } = useFeaturePermissions()
+  const engine = useActiveHostEngine()
+  const { settings, updateSettings } = useUserSettings()
+  const catalog = getAllowedMenuItems(config, engine)
+  const workspace = workspaceFromSettings(settings)
+  const hiddenHrefs = new Set(
+    effectiveHiddenMenuHrefs(menuItemsConfig, workspace)
+  )
+
+  const showHref = (href: string) => {
+    updateSettings(persistShowMenuHref(settings, href))
+  }
+
+  const showAll = () => {
+    const next = applyWorkspacePreset(menuItemsConfig, workspace, 'full')
+    updateSettings({
+      workspacePreset: next.workspacePreset,
+      hiddenMenuHrefs: [...next.hiddenMenuHrefs],
+    })
+  }
+
+  return {
+    catalog,
+    workspace,
+    hiddenHrefs,
+    settings,
+    updateSettings,
+    showHref,
+    showAll,
+  }
+}

--- a/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
+++ b/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
@@ -1,15 +1,20 @@
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
+import { flattenSingletonGroups } from '@/lib/menu/flatten-singleton'
 import { revealAlertsWhenActive } from '@/lib/menu/notification-alerts'
-import { getVisibleMenuItems } from '@/lib/menu/visible-items'
+import {
+  getAllowedMenuItems,
+  getVisibleMenuItems,
+} from '@/lib/menu/visible-items'
 import { workspaceFromSettings } from '@/lib/menu/workspace-presets'
 import { useHostId } from '@/lib/swr'
 import { useNotifications } from '@/lib/swr/use-notifications'
 
 /**
- * Sidebar + ⌘K catalog after permission / engine / workspace gates, with
- * Alerts injected only while the notifications poll reports a count.
+ * Sidebar catalog after permission / engine / workspace gates, with Alerts
+ * injected only while the notifications poll reports a count, then 1-child
+ * groups flattened (no chevron).
  */
 export function useVisibleMenuItems() {
   const { config } = useFeaturePermissions()
@@ -18,8 +23,20 @@ export function useVisibleMenuItems() {
   const hostId = useHostId()
   const { totalCount, isLoading } = useNotifications(hostId)
 
-  return revealAlertsWhenActive(
-    getVisibleMenuItems(config, engine, workspaceFromSettings(settings)),
-    !isLoading && totalCount > 0
+  return flattenSingletonGroups(
+    revealAlertsWhenActive(
+      getVisibleMenuItems(config, engine, workspaceFromSettings(settings)),
+      !isLoading && totalCount > 0
+    )
   )
+}
+
+/**
+ * ⌘K catalog: permission / engine / cloud only. Workspace hide does not
+ * filter this list — hidden rows stay indexed with a Hidden hint.
+ */
+export function usePaletteMenuItems() {
+  const { config } = useFeaturePermissions()
+  const engine = useActiveHostEngine()
+  return getAllowedMenuItems(config, engine)
 }

--- a/apps/dashboard/src/lib/menu/visible-items.ts
+++ b/apps/dashboard/src/lib/menu/visible-items.ts
@@ -1,14 +1,7 @@
-// Central menu-visibility resolver. A menu item is shown when it passes TWO
-// independent gates, applied in one place so every nav surface (sidebar,
-// command palette, future ones) stays consistent:
-//
-//   1. Feature permission  — `filterMenuItemsByPermissions` (auth/deployment)
-//   2. Cloud-only          — drop `cloudOnly` items when not in cloud mode
-//
-// Previously the cloud-only rule lived as inline logic in app-sidebar.tsx and
-// clerk-nav.tsx but was missing from the command palette, so ⌘K leaked
-// Billing in self-host / OSS. Encoding the rule as data on the
-// item (`cloudOnly: true`) and resolving it here removes that fragility.
+// Central menu-visibility resolver. Deployment gates (permission, cloud-only,
+// engine) apply to every nav surface. Workspace hide is sidebar / More only —
+// the command palette indexes the full allowed catalog so hidden pages stay
+// reachable via ⌘K without auto-unhiding.
 
 import { menuItemsConfig } from '@/menu'
 
@@ -83,28 +76,33 @@ export function filterMenuItemsByEngine(
 }
 
 /**
- * The single source of truth for what a CLIENT nav surface may render:
- * `menuItemsConfig` with feature-permission, cloud-only, engine, and
- * workspace-preset gates applied. `isCloudModeClient()` is resolved at build
- * time, so this is cheap and stable across renders.
- *
- * `engine` is the ACTIVE host's source engine (defaults to `'clickhouse'`), so
- * a caller that doesn't thread it — and every ClickHouse host — sees exactly
- * today's menu when the workspace is Full.
+ * Permission / cloud / engine catalog — no workspace hide list. Sidebar
+ * applies hide + flatten on top; ⌘K uses this so hidden pages stay indexed.
+ */
+export function getAllowedMenuItems(
+  config: PublicFeaturePermissionConfig,
+  engine: SourceEngine = DEFAULT_SOURCE_ENGINE
+): MenuItem[] {
+  const cloudMode = isCloudModeClient()
+  const byPermission = filterMenuItemsByPermissions(menuItemsConfig, config)
+  const byCloud = filterCloudOnly(byPermission, cloudMode)
+  return filterMenuItemsByEngine(byCloud, engine)
+}
+
+/**
+ * Sidebar catalog: allowed items plus workspace hide. Flattening of 1-child
+ * groups happens in `useVisibleMenuItems` after Alerts injection.
  *
  * Workspace filtering is last and never replaces the deployment gates.
  */
 export function getVisibleMenuItems(
   config: PublicFeaturePermissionConfig,
-  engine: SourceEngine = 'clickhouse',
+  engine: SourceEngine = DEFAULT_SOURCE_ENGINE,
   workspace?: WorkspaceVisibility
 ): MenuItem[] {
-  const cloudMode = isCloudModeClient()
-  const byPermission = filterMenuItemsByPermissions(menuItemsConfig, config)
-  const byCloud = filterCloudOnly(byPermission, cloudMode)
-  const byEngine = filterMenuItemsByEngine(byCloud, engine)
-  if (!workspace) return byEngine
-  return applyWorkspaceVisibility(byEngine, workspace)
+  const allowed = getAllowedMenuItems(config, engine)
+  if (!workspace) return allowed
+  return applyWorkspaceVisibility(allowed, workspace)
 }
 
 /**

--- a/apps/dashboard/src/lib/menu/workspace-presets.ts
+++ b/apps/dashboard/src/lib/menu/workspace-presets.ts
@@ -11,6 +11,12 @@ import {
  * top-level menu groups. Full is the only auto-expand preset: new pages and
  * groups appear there automatically. Footer rows (About) are
  * never hidden — they sit next to the Settings gear and Host switcher.
+ *
+ * First-run is Custom + the Essential leaf keep list (`slim-default.ts`),
+ * not Full / DBA / Engineer / SRE. Role pills still dump whole groups onto
+ * the rail (leftover — they are not leaf keep-lists that start from
+ * Essential). Hide = sidebar / More membership; ⌘K uses the full allowed
+ * catalog.
  */
 
 export const WORKSPACE_PRESETS = [

--- a/apps/dashboard/src/lib/query-config/declarative/pack-registry.ts
+++ b/apps/dashboard/src/lib/query-config/declarative/pack-registry.ts
@@ -36,11 +36,13 @@
  * collision (logged); a later query within the same pack wins over an
  * earlier one too (same merge step).
  *
- * SERVER-ONLY MODULE: statically imports `node:fs/promises` + `node:url` (for
- * `file://`) and the `yaml` parser — none of which belong in the browser
- * bundle. Every call site MUST gate on the build-time `import.meta.env.SSR`
- * constant so Vite/Rollup dead-code-eliminates this whole module out of the
- * client build. See `getQueryConfigByName` in `../index.ts`.
+ * SERVER-ONLY MODULE: `file://` reads use Node builtins (`node:fs/promises`,
+ * `node:url`). Those are dynamically imported inside the reader so a static
+ * import of this file from the shared query-config barrel cannot throw in the
+ * Vite DEV client — named access of the externalized `node:fs/promises.readFile`
+ * crashes the whole dashboard. Call sites still MUST gate on the build-time
+ * `import.meta.env.SSR` constant so production client builds DCE the pack
+ * lookup. See `getQueryConfigByName` in `../index.ts`.
  */
 
 import { z } from 'zod'
@@ -49,8 +51,6 @@ import type { DeclarativeQueryConfig } from './schema'
 
 import { getConfigSource } from './loader'
 import { validateDeclarativeConfig } from './validate'
-import { readFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
 import { error, warn } from '@chm/logger'
 import { parse as parseYaml } from 'yaml'
 import { createHostValidationFetch } from '@/lib/browser-connections/host-url'
@@ -111,6 +111,10 @@ async function readPackSource(
   fetchImpl: typeof fetch
 ): Promise<string> {
   if (url.startsWith('file://')) {
+    const [{ readFile }, { fileURLToPath }] = await Promise.all([
+      import('node:fs/promises'),
+      import('node:url'),
+    ])
     return readFile(fileURLToPath(url), 'utf-8')
   }
 

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -23,6 +23,8 @@ describe('mergeUserSettings', () => {
     expect(merged.hiddenMenuHrefs.length).toBeGreaterThan(0)
     expect(merged.hiddenMenuHrefs).not.toContain('/overview')
     expect(merged.hiddenMenuHrefs).toContain('/alert-settings')
+    expect(merged.hiddenMenuHrefs).toContain('/insights')
+    expect(merged.hiddenMenuHrefs).toContain('/explorer')
     expect(merged.lastSeenChangelogVersion).toBe('')
   })
 

--- a/apps/dashboard/src/lib/types/user-settings.ts
+++ b/apps/dashboard/src/lib/types/user-settings.ts
@@ -30,14 +30,17 @@ export interface UserSettings {
   /**
    * Role workspace preset. Full is the only auto-expand preset (new menu
    * pages stay visible). Named presets keep a stable group set. Custom uses
-   * `hiddenMenuHrefs` as a hide list. First-run default is Custom + the slim
-   * day-to-day hide list (#3290); Full still restores every page.
+   * `hiddenMenuHrefs` as a hide list. First-run default is Custom + the
+   * Essential keep list (`DEFAULT_HIDDEN_MENU_HREFS`); Full still restores
+   * every page. DBA / Engineer / SRE stay group-title presets (not leaf
+   * keep-lists).
    */
   workspacePreset: WorkspacePreset
   /**
-   * Menu hrefs hidden from sidebar + command palette. Hidden is not
-   * unauthorized — routes stay reachable. Footer / Settings / host switcher
-   * are never filtered here.
+   * Menu hrefs hidden from the sidebar and More. Hide is not unauthorized
+   * and does not filter ⌘K — hidden pages stay indexed with a Hidden hint
+   * and stay reachable by URL. Footer / Settings / host switcher are never
+   * filtered here.
    */
   hiddenMenuHrefs: string[]
   /**
@@ -78,7 +81,7 @@ export function mergeUserSettings(stored: unknown): UserSettings {
   const merged = { ...DEFAULT_USER_SETTINGS, ...partial }
   const preset = parseWorkspacePreset(partial.workspacePreset)
   merged.workspacePreset = preset
-  // An omitted hide list picks up the slim first-run default only for Custom
+  // An omitted hide list picks up the Essential first-run default only for Custom
   // (and junk/missing preset, which falls back to Custom). Named presets and
   // Full keep an empty hide list when the key was never stored. An explicit
   // `[]` must stay empty.

--- a/apps/dashboard/src/routes/(dashboard)/health.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/health.tsx
@@ -4,6 +4,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 import { Suspense } from 'react'
 import { HealthGrid } from '@/components/health/health-grid'
 import { PageHeader } from '@/components/layout'
+import { RelatedPagesLink } from '@/components/navigation/related-pages-link'
 import { ChartsOnlyPageSkeleton } from '@/components/skeletons'
 import { AppLink } from '@/components/ui/app-link'
 import { Button } from '@/components/ui/button'
@@ -18,16 +19,21 @@ function HealthPageContent() {
         title="Health Summary"
         description="Real-time health indicators for your ClickHouse cluster"
         actions={
-          <Button
-            variant="outline"
-            size="sm"
-            render={
-              <AppLink href={buildUrl('/health-settings', { host: hostId })} />
-            }
-          >
-            <Settings className="mr-2 size-4" />
-            Settings
-          </Button>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <RelatedPagesLink href="/health" />
+            <Button
+              variant="outline"
+              size="sm"
+              render={
+                <AppLink
+                  href={buildUrl('/health-settings', { host: hostId })}
+                />
+              }
+            >
+              <Settings className="mr-2 size-4" />
+              Settings
+            </Button>
+          </div>
         }
       />
       <HealthGrid />

--- a/apps/dashboard/src/routes/(dashboard)/overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/overview.tsx
@@ -6,6 +6,7 @@ import { OVERVIEW_TABS } from './-charts-config'
 import { lazy, memo, Suspense, useMemo, useState } from 'react'
 import { ClientOnly } from '@/components/client-only'
 import { InsightsStrip } from '@/components/insights/insights-strip'
+import { RelatedPagesLink } from '@/components/navigation/related-pages-link'
 import { cardStyles } from '@/components/overview-charts/card-styles'
 import {
   OVERVIEW_KPI_GRID_CLASS,
@@ -248,18 +249,21 @@ function OverviewPageContent() {
           onValueChange={handleTabChange}
           className="space-y-2"
         >
-          <div className="scrollbar-hide min-w-0 w-full overflow-x-auto py-0.5">
-            <TabsList className="inline-flex h-auto w-max min-w-full flex-nowrap items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
-              {OVERVIEW_TABS.map((tab) => (
-                <TabsTrigger
-                  key={tab.value}
-                  value={tab.value}
-                  className={TAB_TRIGGER_CLASS}
-                >
-                  {tab.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="scrollbar-hide min-w-0 w-full flex-1 overflow-x-auto py-0.5">
+              <TabsList className="inline-flex h-auto w-max min-w-full flex-nowrap items-center justify-start gap-1 rounded-none border-b border-border bg-transparent p-0 text-muted-foreground">
+                {OVERVIEW_TABS.map((tab) => (
+                  <TabsTrigger
+                    key={tab.value}
+                    value={tab.value}
+                    className={TAB_TRIGGER_CLASS}
+                  >
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
+            <RelatedPagesLink href="/overview" className="shrink-0" />
           </div>
 
           {OVERVIEW_TABS.map((tab) => (

--- a/apps/dashboard/src/routes/(dashboard)/sql.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/sql.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { ExplorerSidebar } from '@/components/explorer/explorer-sidebar'
 import { useExplorerState } from '@/components/explorer/hooks/use-explorer-state'
+import { RelatedPagesLink } from '@/components/navigation/related-pages-link'
 import { SqlConsole } from '@/components/sql-console'
 import { Button } from '@/components/ui/button'
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -54,7 +55,10 @@ function SqlConsolePage() {
         </Button>
       )}
       <div>
-        <h1 className="text-xl font-semibold">SQL Console</h1>
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="text-xl font-semibold">SQL Console</h1>
+          <RelatedPagesLink href="/sql" className="shrink-0" />
+        </div>
         <p className="text-muted-foreground text-sm">
           Run read-only SQL with history, EXPLAIN, query log and scan analysis.
         </p>

--- a/apps/dashboard/src/routes/(dashboard)/tables-overview.tsx
+++ b/apps/dashboard/src/routes/(dashboard)/tables-overview.tsx
@@ -1,12 +1,22 @@
 import { createFileRoute } from '@tanstack/react-router'
 
-import { createPage } from '@/lib/create-page'
+import { QueryPageLayout } from '@/components/layout/query-page'
+import { RelatedPagesLink } from '@/components/navigation/related-pages-link'
 import { tablesOverviewConfig } from '@/lib/query-config/tables/tables-overview'
 
-const TablesOverviewPage = createPage({
-  queryConfig: tablesOverviewConfig,
-  title: 'Tables Overview',
-})
+function TablesOverviewPage() {
+  return (
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex justify-end">
+        <RelatedPagesLink href="/tables-overview" />
+      </div>
+      <QueryPageLayout
+        queryConfig={tablesOverviewConfig}
+        title="Tables Overview"
+      />
+    </div>
+  )
+}
 
 export const Route = createFileRoute('/(dashboard)/tables-overview')({
   component: TablesOverviewPage,

--- a/docs/knowledge/declarative-config-catalog.md
+++ b/docs/knowledge/declarative-config-catalog.md
@@ -3,7 +3,7 @@ id: declarative-config-catalog
 title: Declarative Config Catalog
 type: spec
 status: active
-updated: 2026-07-03
+updated: 2026-08-27
 tags:
   - query-config
   - declarative
@@ -196,6 +196,11 @@ every entry in `queries` is validated against the same
   (`browser-connections`, `user-connections`) `await` it before the
   synchronous `getQueryConfigByName` lookup so a pack-only query resolves
   deterministically on first request, instead of racing a background fetch.
+- **Vite DEV client** — `file://` Node builtins are dynamically imported
+  inside the reader. A static `import { readFile } from 'node:fs/promises'`
+  throws on named access in the browser (`node:fs/promises` is externalized)
+  and blanks the dashboard whenever the shared query-config barrel loads.
+  Production client builds still DCE the pack lookup via `import.meta.env.SSR`.
 - **`minChmVersion`** is schema-validated but not yet enforced against the
   running app version — deferred, same as pack signing/verification.
 

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -3,7 +3,7 @@ id: product-design
 title: Product design system & UX conventions
 type: reference
 status: active
-updated: 2026-08-26
+updated: 2026-08-27
 tags:
   - design-system
   - ui
@@ -162,14 +162,17 @@ show a sample on the control (`1.5 GiB` / `1.6 GB`). Integrations lists MCP
 Show all is full-width under the hide-count line on that pane. Dialog keeps
 `data-testid="settings-dialog"`.
 
-**Workspace default (#3290):** first-run / missing-workspace blobs use
+**Workspace default:** first-run / missing-workspace blobs use
 `workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
-(`lib/menu/slim-default.ts`) — day-to-day pages only (Overview, Chat,
-Insights, Health, Running Queries, Tables overview / explorer, Merges,
-Metrics, SQL / Explain / Advisor, Clusters). Full still means every
+(`lib/menu/slim-default.ts`) — Essential rail only (Overview, Chat,
+Health, Queries / running, Tables overview, SQL). Insights, Merges,
+Metrics, Clusters, Explain, Advisor, Explorer, and the parent `/tables`
+row stay off the first-run rail. Full still means every
 page (`workspacePreset: 'full'`, `hiddenMenuHrefs: []`). An explicit
-stored Full empty hide list is never replaced by the slim list.
-Other appearance defaults stay byte-for-byte:
+stored Full empty hide list is never replaced by the Essential list.
+DBA / Engineer / SRE remain **group-title** presets (they still dump
+whole groups onto the rail; they are not leaf keep-lists that start from
+Essential). Other appearance defaults stay byte-for-byte:
 `byteUnit: 'binary'`, `numberFormat: 'abbreviated'`, `chartPalette: 'default'`
 (attribute absent), `tableDensity: 'comfortable'` (attribute absent),
 `defaultTimeRange: '24h'`.
@@ -361,9 +364,18 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   Leaf rows also reveal Hide (EyeOff) beside the pin; that writes
   `hiddenMenuHrefs` via `hideMenuHref` and toasts Undo + Open Navigation
   (Settings → Workspace → Navigation). Footer About is not hideable this way.
-  A **More pages** row (`more-pages-button.tsx`) appears at the bottom of
-  the sidebar when the hide list is non-empty and opens that same Navigation
-  pane. Settings → Navigation has **Show all** (applies Full) when the
+  Hover **+** (`add-button.tsx`) lists hidden siblings in that catalog group
+  (Queries + → History, Slow, Failed; Tables + → Replicas, TTL, Explorer).
+  Click adds with `showMenuHref` and does not navigate; an arrow opens the
+  page. Footer Customize… opens Settings → Navigation, preferably focused
+  on that group. A **More** row (`more-pages-button.tsx`) is a searchable
+  flyout of hidden leaves (click navigates; hover Add / Pin; footer
+  Customize… and Show all). Full with hide count 0 hides the row. Below
+  `lg` the catalog is an inline panel inside the overlay sidebar — it does
+  not open the 375 Settings dialog unless Customize is tapped. Groups with
+  0–1 visible children flatten (`flattenSingletonGroups`) so Essential
+  shows Chat / Health / Queries / Tables / SQL without a chevron. Settings
+  → Navigation has **Show all** (applies Full) when the
   preset is not Full.
 
 - **Alerts in the sidebar (#3291):** there is no standing Alerts catalog
@@ -797,16 +809,21 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 **Footer**: About (next to the Settings gear; never hidden by a workspace
 preset).
 
-**Slim first-run default (#3290):** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
-Visible groups: Overview, AI Agent (Chat), Insights, Health, Queries
-(Running Queries), Tables (Explorer + Overview), Merges, Metrics, Tools
-(SQL, Explorer, Explain, Advisor), Cluster (Clusters). Keeper, PeerDB,
-Security, Logs, System, Operations, and the extra children stay in the
-catalog — restore via Settings → Navigation (Show / Show all / Full) or
-the sidebar More pages row. Do not add a page to
+**Essential first-run default:** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
+Flattened rail: Overview, Chat (`/agents`), Health, Queries
+(`/running-queries`), Tables (`/tables-overview`), SQL (`/sql`), More.
+Insights, Merges, Metrics, Clusters, Explain, Advisor, Explorer, and
+parent `/tables` are off the rail. Explorer is not on Essential; on Full
+it stays under Tools (inventory remains Tables in the customize tree).
+Keeper, PeerDB, Security, Logs, System, Operations, and extra children
+stay in the catalog — restore via hover +, More, Settings → Navigation,
+or in-page More / Customize on Overview, Health, Queries, Tables
+overview, and SQL. Do not add a page to
 `DEFAULT_VISIBLE_MENU_HREFS` unless it is day-to-day; new specialist
 pages are hidden by default because the hide list is the complement of
 that keep list. Postgres-only leaves are never auto-hidden.
+DBA / Engineer / SRE leftover: those pills still keep whole **groups**,
+not Essential-plus-a-few-leaves.
 
 **Tools** is the interactive-utility group — pages where you *do* something
 (run SQL, explore schema, explain a query, compare hosts, build charts) rather
@@ -828,8 +845,13 @@ breakdown. Do not add a third TTL reporting surface. Never `ALTER TTL`
 or `DROP PARTITION` from this page. AI Agent stays its own flagship group. Postgres-only
 items stay engine-gated and are not moved here.
 
-⌘K (`components/controls/command-palette.tsx`) indexes every visible
-menu leaf by sidebar title, document `<title>` (`lib/page-title.ts` +
+⌘K (`components/controls/command-palette.tsx`) indexes the **full**
+permission/engine/cloud-allowed catalog (`usePaletteMenuItems` /
+`getAllowedMenuItems`). Workspace `hiddenMenuHrefs` does **not** filter
+⌘K — hidden rows stay listed with a muted Hidden hint. Selecting a
+hidden page navigates and does not auto-unhide; the header shows
+**Keep in sidebar** (and Pin) on that page. Search still matches
+sidebar title, document `<title>` (`lib/page-title.ts` +
 OG `headTitle`/`title`), href, description, and optional `keywords` on
 `MenuItem` (`menuItemPaletteValue`). DBA pages (Advisor, Schema Compare,
 Settings Diff, TTL & Partitions) declare aliases so searches like


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First-run rail stays tiny (Essential keep list). The rest of the product stays one tap away from the row, More, ⌘K, or the page — not a Settings dump.

## Changes

- Essential keep list: Overview, Chat (`/agents`), Health, Queries (`/running-queries`), Tables (`/tables-overview`), SQL. Groups with one visible child flatten (no chevron). Insights, Merges, Metrics, Clusters, Explain, Advisor, and Explorer are off the first-run rail.
- Hover **+** on a rail leaf opens hidden siblings in that group. Click adds (`showMenuHref`); the arrow opens the page. Footer Customize… opens Settings → Navigation, focused on the group.
- **More** is a searchable flyout (sheet/panel below `lg` inside the overlay sidebar). Click navigates; hover Add / Pin; footer Customize… and Show all. Empty hide list still hides the row.
- ⌘K indexes the full permission/engine/cloud catalog. Hidden rows get a muted Hidden hint and do not auto-unhide. Landing on a hidden page shows **Keep in sidebar** (and Pin).
- In-page More / Customize on Overview, Health, Queries, Tables overview, and SQL.
- Hide remains sidebar/More membership only. Hidden URLs stay valid. Alerts still injects only when `totalCount > 0`. Footer About is never hideable.
- DBA / Engineer / SRE remain group-title presets (leftover — not converted to Essential-plus-a-few-leaves).
- Vite DEV: `pack-registry` loads Node builtins only inside the `file://` reader so the shared query-config barrel no longer blanks the dashboard.

## Test plan

- [x] Targeted menu / navigation / palette tests — 181 pass
- [x] `pnpm run lint` — no errors (4 pre-existing warnings in unrelated files)
- [x] `pnpm run type-check` and `pnpm run type-check:test`
- [x] CI `unit-tests` and `dashboard` on this PR (local `pnpm run test:unit` had 2 unrelated 5s timeouts in `host-status.cloud-demo-host-guard.test.ts` against a live host)
- [x] CI green on first push: lint, build, unit-tests, dashboard, e2e-test, depcruise, axe-core, codecov/patch
- [x] Manual 375 / 768 / 1024 walkthrough: overlay hamburger + inline More below `lg`; docked rail at 1280; hover +, ⌘K Hidden, Keep in sidebar, in-page More; What's new stays in the footer next to the gear
- [x] Product-design knowledge + skill updated; `docs/content/` unchanged
- [x] `docs/content/ai-agent.mdx` N/A

## Notes for reviewer

- First-run is still **Custom** + the Essential hide list, not a new preset pill.
- Explorer stays in the Tables inventory and under Tools on Full; it is not an Essential rail row.
- Parked: stored `workspacePreset: full` + empty hide list on old profiles is not rewritten.
- No standing Alerts row. No add-host. No 40-checkbox wall.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82457262-99de-4e1e-896e-887c463cf698?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82457262-99de-4e1e-896e-887c463cf698&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

