### PR TITLE
fix(dashboard): keep Essential sidebar as parent/child groups

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -363,7 +363,10 @@ list (`chm-pinned-favorites`). Leaf sidebar rows also reveal Hide (EyeOff)
 beside the pin; that writes `hiddenMenuHrefs` and toasts Undo + Open
 Navigation (Settings → Workspace → Navigation). Hover **+** lists hidden
 siblings in that group (`showMenuHref` on click). More is a flyout of
-hidden pages (not Settings). Groups with 0–1 visible children flatten.
+hidden pages (not Settings). Essential keeps grouped parents with one
+visible child (Overview is a leaf; AI Agent → Chat, Health → Health,
+Queries → Running Queries, Tables → Tables Overview, Tools → SQL
+Console) — do not flatten those groups to Chat / SQL leaves.
 
 ## User appearance settings
 
@@ -422,7 +425,7 @@ preset leaf stays on the role; Custom only when the hide list leaves
   or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
   demos.
 Hidden pages stay routable. Sidebar visibility is the hide list
-(`getVisibleMenuItems` + flatten + Alerts). ⌘K uses
+(`getVisibleMenuItems` + Alerts). ⌘K uses
 `usePaletteMenuItems` / `getAllowedMenuItems` so hidden pages stay
 indexed with a Hidden hint and do not auto-unhide. Landing on a hidden
 page shows Keep in sidebar. Settings > Navigation
@@ -433,8 +436,9 @@ Timezone uses `timezone-combobox.tsx`
 a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
 First-run workspace is Custom + the Essential hide list
-(`DEFAULT_HIDDEN_MENU_HREFS`: Overview, Chat, Health, Queries, Tables
-overview, SQL). Full still restores every page. Other
+(`DEFAULT_HIDDEN_MENU_HREFS`: grouped Overview, AI Agent → Chat, Health
+→ Health, Queries → Running Queries, Tables → Tables Overview, Tools →
+SQL Console). Full still restores every page. Other
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
@@ -471,9 +475,11 @@ is a full-width control under the hide-count line. Full detail:
    absent so Postgres hosts inherit Health (default source-engine family).
    Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
-   sidebar stays Essential (Overview, Chat, Health, Queries, Tables
-   overview, SQL) — they remain restorable from hover +, More, in-page
-   More / Customize, or Settings → Navigation.
+   sidebar stays Essential (grouped parents with one child: Overview,
+   AI Agent → Chat, Health → Health, Queries → Running Queries, Tables
+   → Tables Overview, Tools → SQL Console) — they remain restorable
+   from hover +, More, in-page More / Customize, or Settings →
+   Navigation.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
@@ -3,16 +3,16 @@ import { menuItemsConfig } from '@/menu'
 import type { MenuItem } from '@/components/menu/types'
 
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { DEFAULT_SOURCE_ENGINE } from '@chm/types'
 import {
   flattenSingletonGroups,
   flattenSingletonTitle,
 } from '@/lib/menu/flatten-singleton'
 import { revealAlertsWhenActive } from '@/lib/menu/notification-alerts'
-import {
-  DEFAULT_HIDDEN_MENU_HREFS,
-  DEFAULT_VISIBLE_MENU_HREFS,
-} from '@/lib/menu/slim-default'
+import { DEFAULT_HIDDEN_MENU_HREFS } from '@/lib/menu/slim-default'
 import { filterMenuItemsByEngine } from '@/lib/menu/visible-items'
 import { applyWorkspaceVisibility } from '@/lib/menu/workspace-presets'
 
@@ -21,6 +21,16 @@ const leaf = (overrides: Partial<MenuItem> = {}): MenuItem => ({
   href: overrides.href ?? '/item',
   ...overrides,
 })
+
+function essentialRail(): MenuItem[] {
+  return applyWorkspaceVisibility(
+    filterMenuItemsByEngine(menuItemsConfig, DEFAULT_SOURCE_ENGINE),
+    {
+      workspacePreset: 'custom',
+      hiddenMenuHrefs: DEFAULT_HIDDEN_MENU_HREFS,
+    }
+  )
+}
 
 describe('flattenSingletonTitle', () => {
   test('uses the parent title for Queries / Tables / Health', () => {
@@ -89,50 +99,67 @@ describe('flattenSingletonGroups', () => {
     expect(flat[2]?.title).toBe('Queries Many')
     expect(flat[2]?.items).toHaveLength(2)
   })
+})
 
-  test('Essential first-run rail is six leaves plus About, no specialist groups', () => {
-    const visible = applyWorkspaceVisibility(
-      filterMenuItemsByEngine(menuItemsConfig, DEFAULT_SOURCE_ENGINE),
-      {
-        workspacePreset: 'custom',
-        hiddenMenuHrefs: DEFAULT_HIDDEN_MENU_HREFS,
-      }
+describe('Essential first-run rail (grouped, not flattened)', () => {
+  test('live sidebar source does not flatten singleton groups', () => {
+    const src = readFileSync(
+      join(
+        dirname(fileURLToPath(import.meta.url)),
+        'use-visible-menu-items.ts'
+      ),
+      'utf8'
     )
-    const flat = flattenSingletonGroups(visible)
-    const body = flat.filter((item) => item.section !== 'footer')
+    expect(src).not.toMatch(/\bflattenSingletonGroups\b/)
+    expect(src).toContain('revealAlertsWhenActive')
+  })
+
+  test('keeps parent groups with one visible child plus About', () => {
+    const visible = essentialRail()
+    const body = visible.filter((item) => item.section !== 'footer')
 
     expect(body.map((item) => item.title)).toEqual([
       'Overview',
-      'Chat',
+      'AI Agent',
       'Health',
       'Queries',
       'Tables',
-      'SQL',
+      'Tools',
     ])
-    for (const item of body) {
-      expect(item.items, item.title).toBeUndefined()
-    }
-    expect(flat.some((item) => item.href === '/about')).toBe(true)
-    expect(body.map((item) => item.href)).toEqual([
-      ...DEFAULT_VISIBLE_MENU_HREFS,
+    expect(body[0]?.href).toBe('/overview')
+    expect(body[0]?.items).toBeUndefined()
+    expect(body.map((item) => item.items?.map((child) => child.href))).toEqual([
+      undefined,
+      ['/agents'],
+      ['/health'],
+      ['/running-queries'],
+      ['/tables-overview'],
+      ['/sql'],
     ])
+    expect(body.map((item) => item.items?.map((child) => child.title))).toEqual(
+      [
+        undefined,
+        ['Chat'],
+        ['Health'],
+        ['Running Queries'],
+        ['Tables Overview'],
+        ['SQL Console'],
+      ]
+    )
+    expect(visible.some((item) => item.href === '/about')).toBe(true)
   })
 
-  test('Alerts injection before flatten keeps Health as a two-child group', () => {
-    const visible = applyWorkspaceVisibility(
-      filterMenuItemsByEngine(menuItemsConfig, DEFAULT_SOURCE_ENGINE),
-      {
-        workspacePreset: 'custom',
-        hiddenMenuHrefs: DEFAULT_HIDDEN_MENU_HREFS,
-      }
-    )
-    const withAlerts = revealAlertsWhenActive(visible, true)
-    const flat = flattenSingletonGroups(withAlerts)
-    const health = flat.find((item) => item.title === 'Health')
+  test('Alerts injection keeps Health as a two-child group', () => {
+    const withAlerts = revealAlertsWhenActive(essentialRail(), true)
+    const health = withAlerts.find((item) => item.title === 'Health')
     expect(health?.items?.map((child) => child.href)).toEqual([
       '/health',
       '/alert-settings',
     ])
-    expect(flat.find((item) => item.title === 'Queries')?.items).toBeUndefined()
+    expect(
+      withAlerts
+        .find((item) => item.title === 'Queries')
+        ?.items?.map((child) => child.href)
+    ).toEqual(['/running-queries'])
   })
 })

--- a/apps/dashboard/src/lib/menu/flatten-singleton.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.ts
@@ -1,15 +1,18 @@
 import type { MenuItem } from '@/components/menu/types'
 
 /**
- * Group titles that are folders, not the destination name. Flattening uses
- * the child's title (Chat, SQL Console) instead of the folder name.
+ * Unused on the live sidebar (#3348). Essential keeps parent/child groups
+ * even when a group has one visible child, so hover + can nest hidden
+ * siblings under that parent. Helper stays unit-tested in case another
+ * surface wants a flat label.
  */
+
+/** Group titles that are folders; flattening uses the child's title. */
 const FOLDER_TITLES = new Set(['AI Agent', 'Tools'])
 
 /**
- * Label for a 1-child group on the Essential rail: parent title for
- * Queries / Tables / Health, child title for folder groups, and "SQL"
- * for the Tools → SQL Console singleton.
+ * Short label for a 1-child group: parent title for Queries / Tables /
+ * Health, child title for folder groups, and "SQL" for Tools → SQL Console.
  */
 export function flattenSingletonTitle(
   parent: MenuItem,

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -10,9 +10,10 @@ import type { MenuItem } from '@/components/menu/types'
  * are never on the hide list (engine swap already drops those groups).
  * Footer rows are never hidden.
  *
- * The rail is flattened separately (`flattenSingletonGroups`) so a group
- * with one visible child renders as a leaf (Chat, Health, Queries, Tables,
- * SQL) without a chevron.
+ * Groups with one visible child stay grouped on the live rail (AI Agent →
+ * Chat, Health → Health, Queries → Running Queries, Tables → Tables
+ * Overview, Tools → SQL Console). Overview is a catalog leaf. Hover +
+ * still nests hidden siblings under that parent.
  *
  * Full in Settings → Navigation still shows every page. Explorer stays in
  * the Tables inventory (and under Tools); it is not an Essential rail row.

--- a/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
+++ b/apps/dashboard/src/lib/menu/use-visible-menu-items.ts
@@ -1,7 +1,6 @@
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
-import { flattenSingletonGroups } from '@/lib/menu/flatten-singleton'
 import { revealAlertsWhenActive } from '@/lib/menu/notification-alerts'
 import {
   getAllowedMenuItems,
@@ -13,8 +12,9 @@ import { useNotifications } from '@/lib/swr/use-notifications'
 
 /**
  * Sidebar catalog after permission / engine / workspace gates, with Alerts
- * injected only while the notifications poll reports a count, then 1-child
- * groups flattened (no chevron).
+ * injected only while the notifications poll reports a count. Groups with
+ * one visible child keep their parent (chevron + nested leaf) so hover +
+ * can add hidden siblings under that parent.
  */
 export function useVisibleMenuItems() {
   const { config } = useFeaturePermissions()
@@ -23,11 +23,9 @@ export function useVisibleMenuItems() {
   const hostId = useHostId()
   const { totalCount, isLoading } = useNotifications(hostId)
 
-  return flattenSingletonGroups(
-    revealAlertsWhenActive(
-      getVisibleMenuItems(config, engine, workspaceFromSettings(settings)),
-      !isLoading && totalCount > 0
-    )
+  return revealAlertsWhenActive(
+    getVisibleMenuItems(config, engine, workspaceFromSettings(settings)),
+    !isLoading && totalCount > 0
   )
 }
 

--- a/apps/dashboard/src/lib/menu/visible-items.ts
+++ b/apps/dashboard/src/lib/menu/visible-items.ts
@@ -77,7 +77,7 @@ export function filterMenuItemsByEngine(
 
 /**
  * Permission / cloud / engine catalog — no workspace hide list. Sidebar
- * applies hide + flatten on top; ⌘K uses this so hidden pages stay indexed.
+ * applies hide on top; ⌘K uses this so hidden pages stay indexed.
  */
 export function getAllowedMenuItems(
   config: PublicFeaturePermissionConfig,
@@ -90,8 +90,9 @@ export function getAllowedMenuItems(
 }
 
 /**
- * Sidebar catalog: allowed items plus workspace hide. Flattening of 1-child
- * groups happens in `useVisibleMenuItems` after Alerts injection.
+ * Sidebar catalog: allowed items plus workspace hide. Alerts injection
+ * happens in `useVisibleMenuItems`. Groups with one visible child stay
+ * grouped (parent + nested leaf), not flattened to a leaf.
  *
  * Workspace filtering is last and never replaces the deployment gates.
  */

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -375,10 +375,12 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   flyout of hidden leaves (click navigates; hover Add / Pin; footer
   Customize… and Show all). Full with hide count 0 hides the row. Below
   `lg` the catalog is an inline panel inside the overlay sidebar — it does
-  not open the 375 Settings dialog unless Customize is tapped. Groups with
-  0–1 visible children flatten (`flattenSingletonGroups`) so Essential
-  shows Chat / Health / Queries / Tables / SQL without a chevron. Settings
-  → Navigation has **Show all** (applies Full) when the
+  not open the 375 Settings dialog unless Customize is tapped. Essential
+  keeps grouped parents with one visible child (Overview is a leaf; AI
+  Agent → Chat, Health → Health, Queries → Running Queries, Tables →
+  Tables Overview, Tools → SQL Console) — do not flatten those groups
+  to Chat / SQL leaves. Hover + still adds hidden siblings under that
+  parent. Settings → Navigation has **Show all** (applies Full) when the
   preset is not Full.
 
 - **Alerts in the sidebar (#3291):** there is no standing Alerts catalog
@@ -813,8 +815,10 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 preset).
 
 **Essential first-run default:** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
-Flattened rail: Overview, Chat (`/agents`), Health, Queries
-(`/running-queries`), Tables (`/tables-overview`), SQL (`/sql`), More.
+Grouped rail (one visible child each, not flattened leaves): Overview
+(leaf), AI Agent → Chat (`/agents`), Health → Health (`/health`),
+Queries → Running Queries (`/running-queries`), Tables → Tables
+Overview (`/tables-overview`), Tools → SQL Console (`/sql`), More.
 Insights, Merges, Metrics, Clusters, Explain, Advisor, Explorer, and
 parent `/tables` are off the rail. Explorer is not on Essential; on Full
 it stays under Tools (inventory remains Tables in the customize tree).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stop flattening 1-child groups on the live Essential sidebar. First-run rail keeps parent/child groups (one visible child each) instead of a flat list of Chat / Health / Queries / Tables / SQL leaves.

Closes #3348

## Changes

- Remove `flattenSingletonGroups` from `useVisibleMenuItems` so the live rail stays grouped
- Keep `DEFAULT_VISIBLE_MENU_HREFS` as-is (do not restore Insights / Merges / Metrics / Clusters / Explain / Advisor / Explorer)
- Keep the flatten helper unused and unit-tested; first-run tests now assert grouped parents with one child
- Update product-design skill and knowledge doc: Essential is grouped parents, not flattened leaves

## Test plan

- [x] Flatten helper unused on the live rail (`useVisibleMenuItems` does not call it)
- [x] Fresh-profile rail: Overview leaf; AI Agent → Chat; Health → Health; Queries → Running Queries; Tables → Tables Overview; Tools → SQL Console; More
- [x] Alerts still injects only when count > 0 (Health becomes a two-child group)
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` / type-check passes
- [ ] `pnpm run test:unit` (menu flatten / slim-default tests)
- [ ] Hover + still nests hidden siblings under that parent
- [ ] More flyout, ⌘K Hidden, Keep in sidebar unchanged
- [x] Docs updated in product-design skill + knowledge doc
- [x] `docs/content/ai-agent.mdx` unchanged (no agent tools/skills/env vars)

## Notes for reviewer

Out of scope: #3346 palette Enter, #3347 375 icon clip, add-host, release-please.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da41fe38-69d6-47fd-bd53-7de86dfc0cd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da41fe38-69d6-47fd-bd53-7de86dfc0cd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

