### PR TITLE
fix(dashboard): command palette Enter activates the highlighted row

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -229,7 +229,9 @@ undefined `var()` renders the series black. Radius: `rounded-md` (9px) default,
   tokens highlight in the visible title/description (`HighlightText`). Titles
   stay one line (`whitespace-nowrap`) so `TTL & Partitions` does not wrap
   on `&`. All still caps explorer rows; the Databases and Tables tabs show
-  the full fetch. Reset tab + query on close.
+  the full fetch. Reset tab + query on close. Filter in userland
+  (`shouldFilter={false}` + `filterPaletteRows`): group headings and Hidden
+  badges are not navigable, so Enter opens the highlighted href.
 - **Tab strips:** define the tabs as one array and map it — an icon per tab with
   ONE size (`size-3.5`) and NO margin utility; `TabsTrigger` already supplies
   `items-center gap-1.5`. Adding `mr-*` on top of that reads as misalignment.

--- a/apps/dashboard/src/components/controls/command-palette-selection.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette-selection.test.ts
@@ -1,0 +1,115 @@
+import type { MenuItem } from '@/components/menu/types'
+
+import {
+  activatePaletteRow,
+  buildSectionedPaletteRows,
+  filterPaletteRows,
+  navigablePaletteRows,
+  paletteItemId,
+  stepPaletteIndex,
+} from './command-palette-selection'
+import { menuItemPaletteValue } from './command-palette-utils'
+import { describe, expect, test } from 'bun:test'
+
+function page(title: string, href: string, description?: string): MenuItem {
+  return { title, href, description }
+}
+
+const tablesGroup: MenuItem = {
+  title: 'Tables',
+  href: '/tables',
+  items: [
+    page('Tables Overview', '/tables-overview', 'Table storage statistics'),
+    page(
+      'Table Replicas',
+      '/replicas',
+      'Replicated table health status and lag metrics'
+    ),
+    page(
+      'Replication Queue',
+      '/replication-queue',
+      'Pending and in-progress replication tasks'
+    ),
+    page(
+      'Replicated Fetches',
+      '/replicated-fetches',
+      'Currently executing background part downloads from replica sources'
+    ),
+  ],
+}
+
+describe('filterPaletteRows + selectedIndex + Enter', () => {
+  test('Enter opens the highlighted href when a Hidden badge and group header sit above items', () => {
+    const hiddenHrefs = new Set([
+      '/replicas',
+      '/replicated-fetches',
+      '/replication-queue',
+    ])
+    const rows = buildSectionedPaletteRows([tablesGroup], hiddenHrefs)
+    const filtered = filterPaletteRows(rows, 'table replicas')
+    const navigable = navigablePaletteRows(filtered)
+
+    expect(filtered[0]).toMatchObject({ kind: 'header', title: 'Tables' })
+    expect(navigable[0]?.title).toBe('Table Replicas')
+    expect(navigable[0]?.hidden).toBe(true)
+    expect(navigable[0]?.href).toBe('/replicas')
+
+    // Naive index into the flattened list hits the header (the #3346
+    // off-by-one). Activation must skip it and use navigable[selectedIndex].
+    expect(filtered[0]?.kind).toBe('header')
+    expect(activatePaletteRow(filtered, 0)?.href).toBe('/replicas')
+    expect(activatePaletteRow(filtered, 0)?.href).not.toBe(
+      '/replicated-fetches'
+    )
+  })
+
+  test('arrow-down then Enter still matches the highlight', () => {
+    const rows = buildSectionedPaletteRows([tablesGroup])
+    const filtered = filterPaletteRows(rows, 'table replicas')
+    const navigable = navigablePaletteRows(filtered)
+    expect(navigable.length).toBeGreaterThan(1)
+
+    const selectedIndex = stepPaletteIndex(0, 1, navigable.length)
+    expect(activatePaletteRow(filtered, selectedIndex)?.href).toBe(
+      navigable[selectedIndex]?.href
+    )
+    expect(activatePaletteRow(filtered, selectedIndex)?.href).not.toBe(
+      navigable[0]?.href
+    )
+  })
+
+  test('Hidden is a badge on the item, not an extra selectedIndex slot', () => {
+    const visible = buildSectionedPaletteRows([tablesGroup])
+    const hidden = buildSectionedPaletteRows(
+      [tablesGroup],
+      new Set(['/replicas', '/replicated-fetches'])
+    )
+    const query = 'table replicas'
+    const visibleNav = navigablePaletteRows(filterPaletteRows(visible, query))
+    const hiddenNav = navigablePaletteRows(filterPaletteRows(hidden, query))
+
+    expect(hiddenNav.map((row) => row.href)).toEqual(
+      visibleNav.map((row) => row.href)
+    )
+    expect(hiddenNav[0]?.hidden).toBe(true)
+    expect(activatePaletteRow(filterPaletteRows(hidden, query), 0)?.href).toBe(
+      activatePaletteRow(filterPaletteRows(visible, query), 0)?.href
+    )
+  })
+
+  test('cmdk item identity is group+href, not the search haystack', () => {
+    const haystack = menuItemPaletteValue(
+      page(
+        'Table Replicas',
+        '/replicas',
+        'Replicated table health status and lag metrics'
+      ),
+      'Tables'
+    )
+    expect(paletteItemId('Tables', '/replicas')).toBe('page:Tables:/replicas')
+    expect(paletteItemId('Tables', '/replicas')).not.toBe(haystack)
+    expect(paletteItemId('Tables', '/replicas')).not.toBe(
+      paletteItemId('Tables', '/replicated-fetches')
+    )
+  })
+})

--- a/apps/dashboard/src/components/controls/command-palette-selection.ts
+++ b/apps/dashboard/src/components/controls/command-palette-selection.ts
@@ -1,0 +1,212 @@
+/**
+ * Keyboard selection for ⌘K: group headings and Hidden badges are not
+ * navigable rows. cmdk's own filter reorders DOM nodes and can leave Enter
+ * bound to the item *below* the highlighted row (#3346). Filter/rank here,
+ * then activate `navigable[selectedIndex]` so Enter matches the highlight.
+ */
+
+import { defaultFilter } from 'cmdk'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { menuItemPaletteValue } from './command-palette-utils'
+
+export interface PaletteHeaderRow {
+  kind: 'header'
+  id: string
+  title: string
+}
+
+export interface PaletteItemRow {
+  kind: 'item'
+  id: string
+  title: string
+  href: string
+  searchValue: string
+  hidden?: boolean
+  description?: string
+}
+
+export type PaletteRow = PaletteHeaderRow | PaletteItemRow
+
+export interface PaletteItemGroup {
+  heading?: string
+  items: PaletteItemRow[]
+}
+
+/** Unique cmdk `value` so identity is not the long search haystack. */
+export function paletteItemId(groupTitle: string, href: string): string {
+  return `page:${groupTitle}:${href}`
+}
+
+export function paletteItemScore(searchValue: string, query: string): number {
+  const q = query.trim()
+  if (q.length === 0) return 1
+  return defaultFilter(searchValue, q) ?? 0
+}
+
+export function matchesPaletteQuery(
+  searchValue: string,
+  query: string
+): boolean {
+  return paletteItemScore(searchValue, query) > 0
+}
+
+export function filterRankedByQuery<T>(
+  items: readonly T[],
+  query: string,
+  searchValue: (item: T) => string
+): T[] {
+  const q = query.trim()
+  const scored = items
+    .map((item) => ({ item, score: paletteItemScore(searchValue(item), q) }))
+    .filter(({ score }) => score > 0)
+  if (q.length > 0) {
+    scored.sort((a, b) => b.score - a.score)
+  }
+  return scored.map(({ item }) => item)
+}
+
+export function buildLeafPaletteRows(
+  leafItems: readonly MenuItem[],
+  hiddenHrefs?: ReadonlySet<string>
+): PaletteRow[] {
+  if (leafItems.length === 0) return []
+  return [
+    { kind: 'header', id: 'header:Go to', title: 'Go to' },
+    ...leafItems.map((item) => menuItemToRow(item, 'Go to', hiddenHrefs)),
+  ]
+}
+
+export function buildSectionedPaletteRows(
+  sectionedItems: readonly MenuItem[],
+  hiddenHrefs?: ReadonlySet<string>
+): PaletteRow[] {
+  const rows: PaletteRow[] = []
+  for (const group of sectionedItems) {
+    const children = group.items ?? []
+    if (children.length === 0) continue
+    rows.push({
+      kind: 'header',
+      id: `header:${group.title}`,
+      title: group.title,
+    })
+    for (const item of children) {
+      rows.push(menuItemToRow(item, group.title, hiddenHrefs))
+    }
+  }
+  return rows
+}
+
+function menuItemToRow(
+  item: MenuItem,
+  groupTitle: string,
+  hiddenHrefs?: ReadonlySet<string>
+): PaletteItemRow {
+  return {
+    kind: 'item',
+    id: paletteItemId(groupTitle, item.href),
+    title: item.title,
+    href: item.href,
+    description: item.description,
+    hidden: Boolean(hiddenHrefs?.has(item.href)),
+    searchValue: menuItemPaletteValue(item, groupTitle),
+  }
+}
+
+/**
+ * Split a flattened palette list into heading + item groups. Headers are
+ * labels only — they never occupy a `selectedIndex` slot.
+ */
+export function groupedPaletteRows(
+  rows: readonly PaletteRow[]
+): PaletteItemGroup[] {
+  const groups: PaletteItemGroup[] = []
+  for (const row of rows) {
+    if (row.kind === 'header') {
+      groups.push({ heading: row.title, items: [] })
+      continue
+    }
+    const last = groups[groups.length - 1]
+    if (!last) groups.push({ items: [row] })
+    else last.items.push(row)
+  }
+  return groups.filter((group) => group.items.length > 0)
+}
+
+/**
+ * Keep matching items, drop empty groups, and rank by cmdk's score so the
+ * highlighted top row is the best match (e.g. Table Replicas for
+ * `table replicas`). Hidden is a badge on the item, not its own row.
+ */
+export function filterPaletteRows(
+  rows: readonly PaletteRow[],
+  query: string
+): PaletteRow[] {
+  const q = query.trim()
+  const ranked = groupedPaletteRows(rows)
+    .map((group) => {
+      const scored = group.items
+        .map((item) => ({
+          item,
+          score: paletteItemScore(item.searchValue, q),
+        }))
+        .filter(({ score }) => score > 0)
+      if (q.length > 0) {
+        scored.sort((a, b) => b.score - a.score)
+      }
+      const items = scored.map(({ item }) => item)
+      const maxScore = scored.reduce(
+        (max, entry) => Math.max(max, entry.score),
+        0
+      )
+      return { heading: group.heading, items, maxScore }
+    })
+    .filter((group) => group.items.length > 0)
+
+  if (q.length > 0) {
+    ranked.sort((a, b) => b.maxScore - a.maxScore)
+  }
+
+  const out: PaletteRow[] = []
+  for (const group of ranked) {
+    if (group.heading) {
+      out.push({
+        kind: 'header',
+        id: `header:${group.heading}`,
+        title: group.heading,
+      })
+    }
+    out.push(...group.items)
+  }
+  return out
+}
+
+export function navigablePaletteRows(
+  rows: readonly PaletteRow[]
+): PaletteItemRow[] {
+  return rows.filter((row): row is PaletteItemRow => row.kind === 'item')
+}
+
+export function stepPaletteIndex(
+  selectedIndex: number,
+  delta: number,
+  count: number
+): number {
+  if (count <= 0) return 0
+  return (((selectedIndex + delta) % count) + count) % count
+}
+
+/**
+ * Enter / click target for the highlighted row. `selectedIndex` counts only
+ * navigable items — never group headers or Hidden badges.
+ */
+export function activatePaletteRow(
+  rows: readonly PaletteRow[],
+  selectedIndex: number
+): PaletteItemRow | undefined {
+  const items = navigablePaletteRows(rows)
+  if (items.length === 0) return undefined
+  if (selectedIndex < 0 || selectedIndex >= items.length) return undefined
+  return items[selectedIndex]
+}

--- a/apps/dashboard/src/components/controls/command-palette.tsx
+++ b/apps/dashboard/src/components/controls/command-palette.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useLocation, useNavigate } from '@tanstack/react-router'
 
 import {
+  CommandPaletteDialog,
   CommandPaletteFooter,
   CommandPaletteResults,
   CommandPaletteTabs,
@@ -17,7 +18,7 @@ import {
 } from './command-palette/use-palette-groups'
 import { parseTableName } from './command-palette-utils'
 import { useTheme } from 'next-themes'
-import { CommandDialog, CommandInput } from '@/components/ui/command'
+import { CommandInput } from '@/components/ui/command'
 import { useFavoriteHrefs } from '@/hooks/use-favorites'
 import { useUrlSearchParams } from '@/hooks/use-url-search-params'
 import { getFavoriteMenuItems } from '@/lib/menu/derive-favorites'
@@ -171,7 +172,7 @@ export const CommandPalette = function CommandPalette({
     <>
       <CommandPaletteTrigger onOpen={() => setOpen(true)} />
 
-      <CommandDialog
+      <CommandPaletteDialog
         open={open}
         onOpenChange={(value) => {
           setOpen(value)
@@ -180,8 +181,6 @@ export const CommandPalette = function CommandPalette({
             setTab('all')
           }
         }}
-        aria-label="Command palette"
-        showCloseButton={false}
         className="sm:max-w-2xl"
       >
         <CommandInput
@@ -246,7 +245,7 @@ export const CommandPalette = function CommandPalette({
         />
 
         <CommandPaletteFooter />
-      </CommandDialog>
+      </CommandPaletteDialog>
     </>
   )
 }

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/command-palette-items.test.ts
@@ -44,4 +44,10 @@ describe('command palette hidden pages', () => {
     expect(paletteSrc).toContain('usePaletteMenuItems')
     expect(paletteSrc).not.toMatch(/\buseVisibleMenuItems\b/)
   })
+
+  test('cmdk does not filter or reorder rows (Enter follows the highlight)', () => {
+    expect(src).toContain('shouldFilter={false}')
+    expect(src).toContain('filterPaletteRows')
+    expect(src).toContain('paletteItemId')
+  })
 })

--- a/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
+++ b/apps/dashboard/src/components/controls/command-palette/__tests__/use-palette-groups.test.ts
@@ -49,8 +49,8 @@ describe('derivePaletteGroups', () => {
       currentHostId: 0,
       query: 'overview',
     })
-    // Group derivation is query-independent — cmdk's own fuzzy filter narrows
-    // the rendered rows, so the un-filtered menu item is still present here.
+    // Group derivation is query-independent — filterPaletteRows ranks the
+    // rendered rows, so the un-filtered menu item is still present here.
     expect(result.leafItems.map((i) => i.href)).toEqual(['/overview'])
   })
 

--- a/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
+++ b/apps/dashboard/src/components/controls/command-palette/command-palette-items.tsx
@@ -26,18 +26,77 @@ import type { RecentPaletteItemKind } from '@/lib/command-palette/recent-items'
 import type { PaletteTab } from '../command-palette-utils'
 import type { ExplorerTableRow } from './use-palette-groups'
 
+import {
+  buildLeafPaletteRows,
+  buildSectionedPaletteRows,
+  filterPaletteRows,
+  filterRankedByQuery,
+  groupedPaletteRows,
+  matchesPaletteQuery,
+  paletteItemId,
+} from '../command-palette-selection'
 import { menuItemPaletteValue } from '../command-palette-utils'
 import { HighlightText } from './highlight-text'
 import { EXPLORER_GROUP_MAX } from './use-palette-groups'
 import {
+  Command,
   CommandEmpty,
   CommandGroup,
   CommandItem,
   CommandList,
   CommandSeparator,
 } from '@/components/ui/command'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { IconButton } from '@/components/ui/icon-button'
 import { cn, getHost } from '@/lib/utils'
+
+/** Same chrome as `CommandDialog`, with cmdk filtering off (#3346). */
+const PALETTE_COMMAND_CLASS =
+  '**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'
+
+const SECTIONED_GROUP_CLASS =
+  '[&_[cmdk-group-items]]:ml-3 [&_[cmdk-group-items]]:border-l [&_[cmdk-group-items]]:border-border [&_[cmdk-group-items]]:pl-2.5'
+
+export function CommandPaletteDialog({
+  open,
+  onOpenChange,
+  children,
+  className,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      aria-label="Command palette"
+    >
+      <DialogHeader className="sr-only">
+        <DialogTitle>Command palette</DialogTitle>
+        <DialogDescription>
+          Search pages, query id, or database.table
+        </DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn('overflow-hidden p-0', className)}
+        showCloseButton={false}
+      >
+        <Command shouldFilter={false} className={PALETTE_COMMAND_CLASS}>
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 /**
  * The two ways to open the palette: an icon-only button below `lg`, and a
@@ -248,10 +307,61 @@ export function CommandPaletteResults({
   const showTables = showAll || tab === 'tables'
   const showActions = showAll || tab === 'actions'
   const showChrome = showAll
-  const listedDatabases = showAll
-    ? databases.slice(0, EXPLORER_GROUP_MAX)
-    : databases
-  const listedTables = showAll ? tables.slice(0, EXPLORER_GROUP_MAX) : tables
+  const listedDatabases = filterRankedByQuery(
+    showAll ? databases.slice(0, EXPLORER_GROUP_MAX) : databases,
+    inputValue,
+    (database) => `database ${database}`
+  )
+  const listedTables = filterRankedByQuery(
+    showAll ? tables.slice(0, EXPLORER_GROUP_MAX) : tables,
+    inputValue,
+    (row) => `table ${row.database}.${row.name} ${row.engine}`
+  )
+  const listedFavorites = showChrome
+    ? filterRankedByQuery(
+        favoriteMenuItems,
+        inputValue,
+        (item) => `favorite ${menuItemPaletteValue(item)}`
+      )
+    : []
+  const pageGroups = showPages
+    ? groupedPaletteRows(
+        filterPaletteRows(
+          [
+            ...buildLeafPaletteRows(leafItems, hiddenHrefs),
+            ...buildSectionedPaletteRows(sectionedItems, hiddenHrefs),
+          ],
+          inputValue
+        )
+      )
+    : []
+  const menuById = new Map<string, MenuItem>()
+  for (const item of leafItems) {
+    menuById.set(paletteItemId('Go to', item.href), item)
+  }
+  for (const group of sectionedItems) {
+    for (const item of group.items ?? []) {
+      menuById.set(paletteItemId(group.title, item.href), item)
+    }
+  }
+  const showAiChat = matchesPaletteQuery(
+    'Open AI Agent chat assistant',
+    inputValue
+  )
+  const showTheme =
+    mounted &&
+    matchesPaletteQuery('Toggle dark light theme appearance', inputValue)
+  const listedHosts = filterRankedByQuery(
+    otherHosts,
+    inputValue,
+    (host) => `switch host ${host.name || getHost(host.host)}`
+  )
+  const showSettings = Boolean(
+    onOpenSettings && matchesPaletteQuery('Settings preferences', inputValue)
+  )
+  const hasActions =
+    showActions &&
+    (showAiChat || showTheme || listedHosts.length > 0 || showSettings)
 
   return (
     <CommandList className="max-h-[60vh] scroll-py-2">
@@ -266,17 +376,16 @@ export function CommandPaletteResults({
         </div>
       </CommandEmpty>
 
-      {/* Pinned favorites (issue #2769) surface first, above Recent —
-          cmdk's own value-based filter still narrows this group when the
-          user types, so it isn't gated to the empty-query state. */}
-      {showChrome && favoriteMenuItems.length > 0 && (
+      {/* Pinned favorites (issue #2769) surface first, above Recent.
+          Filtering is userland so cmdk cannot reorder DOM nodes (#3346). */}
+      {showChrome && listedFavorites.length > 0 && (
         <>
           <CommandGroup heading="Favorites">
-            {favoriteMenuItems.map((item) => (
+            {listedFavorites.map((item) => (
               <CommandItem
                 key={`favorite-${item.href}`}
                 onSelect={() => onSelectFavorite(item)}
-                value={`favorite ${menuItemPaletteValue(item)}`}
+                value={`favorite:${item.href}`}
                 className="group min-w-0"
               >
                 <Pin className="size-4 shrink-0 fill-current text-muted-foreground" />
@@ -362,69 +471,72 @@ export function CommandPaletteResults({
         </>
       )}
 
-      {showPages && leafItems.length > 0 && (
-        <CommandGroup heading="Go to">
-          {leafItems.map((group) => (
-            <CommandItem
-              key={group.href}
-              onSelect={() => onSelectMenuItem(group)}
-              value={menuItemPaletteValue(group)}
-              className={cn(
-                'group min-w-0',
-                hiddenHrefs?.has(group.href) && 'text-muted-foreground'
-              )}
-            >
-              {group.icon && <group.icon className="size-4 shrink-0" />}
-              <HighlightText
-                text={group.title}
-                query={inputValue}
-                className={TITLE_CLASS}
-              />
-              <HiddenHint hidden={Boolean(hiddenHrefs?.has(group.href))} />
-              <EnterHint />
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      )}
-
-      {showPages &&
-        sectionedItems.map((group) => (
+      {pageGroups.map((group) => {
+        const isGoTo = group.heading === 'Go to'
+        return (
           <CommandGroup
-            key={group.title}
-            heading={group.title}
-            className="[&_[cmdk-group-items]]:ml-3 [&_[cmdk-group-items]]:border-l [&_[cmdk-group-items]]:border-border [&_[cmdk-group-items]]:pl-2.5"
+            key={group.heading ?? 'pages'}
+            heading={group.heading}
+            className={isGoTo ? undefined : SECTIONED_GROUP_CLASS}
           >
-            {group.items?.map((item) => (
-              <CommandItem
-                key={item.href}
-                onSelect={() => onSelectMenuItem(item)}
-                value={menuItemPaletteValue(item, group.title)}
-                className={cn(
-                  'group flex-col items-start gap-0.5 rounded-md',
-                  hiddenHrefs?.has(item.href) && 'text-muted-foreground'
-                )}
-              >
-                <div className="flex w-full min-w-0 items-center gap-2">
-                  {item.icon && <item.icon className="size-4 shrink-0" />}
-                  <HighlightText
-                    text={item.title}
-                    query={inputValue}
-                    className={TITLE_CLASS}
-                  />
-                  <HiddenHint hidden={Boolean(hiddenHrefs?.has(item.href))} />
-                  <EnterHint />
-                </div>
-                {item.description && (
-                  <HighlightText
-                    text={item.description}
-                    query={inputValue}
-                    className="w-full truncate pl-6 text-xs text-muted-foreground"
-                  />
-                )}
-              </CommandItem>
-            ))}
+            {group.items.map((row) => {
+              const item = menuById.get(row.id)
+              if (!item) return null
+              if (isGoTo) {
+                return (
+                  <CommandItem
+                    key={row.id}
+                    onSelect={() => onSelectMenuItem(item)}
+                    value={row.id}
+                    className={cn(
+                      'group min-w-0',
+                      row.hidden && 'text-muted-foreground'
+                    )}
+                  >
+                    {item.icon && <item.icon className="size-4 shrink-0" />}
+                    <HighlightText
+                      text={item.title}
+                      query={inputValue}
+                      className={TITLE_CLASS}
+                    />
+                    <HiddenHint hidden={Boolean(row.hidden)} />
+                    <EnterHint />
+                  </CommandItem>
+                )
+              }
+              return (
+                <CommandItem
+                  key={row.id}
+                  onSelect={() => onSelectMenuItem(item)}
+                  value={row.id}
+                  className={cn(
+                    'group flex-col items-start gap-0.5 rounded-md',
+                    row.hidden && 'text-muted-foreground'
+                  )}
+                >
+                  <div className="flex w-full min-w-0 items-center gap-2">
+                    {item.icon && <item.icon className="size-4 shrink-0" />}
+                    <HighlightText
+                      text={item.title}
+                      query={inputValue}
+                      className={TITLE_CLASS}
+                    />
+                    <HiddenHint hidden={Boolean(row.hidden)} />
+                    <EnterHint />
+                  </div>
+                  {item.description && (
+                    <HighlightText
+                      text={item.description}
+                      query={inputValue}
+                      className="w-full truncate pl-6 text-xs text-muted-foreground"
+                    />
+                  )}
+                </CommandItem>
+              )
+            })}
           </CommandGroup>
-        ))}
+        )
+      })}
 
       {showDatabases && listedDatabases.length > 0 && (
         <CommandGroup heading="Databases">
@@ -432,7 +544,7 @@ export function CommandPaletteResults({
             <CommandItem
               key={`db-${database}`}
               onSelect={() => onSelectDatabase(database)}
-              value={`database ${database}`}
+              value={`database:${database}`}
               className="group min-w-0"
             >
               <Database className="size-4 shrink-0" />
@@ -453,7 +565,7 @@ export function CommandPaletteResults({
             <CommandItem
               key={`table-${row.database}-${row.name}`}
               onSelect={() => onSelectTable(row)}
-              value={`table ${row.database}.${row.name} ${row.engine}`}
+              value={`table:${row.database}:${row.name}`}
               className="group min-w-0"
             >
               <Table className="size-4 shrink-0" />
@@ -469,23 +581,25 @@ export function CommandPaletteResults({
         </CommandGroup>
       )}
 
-      {showActions && <CommandSeparator />}
-      {showActions && (
+      {hasActions && <CommandSeparator />}
+      {hasActions && (
         <CommandGroup heading="Actions">
-          <CommandItem
-            onSelect={onOpenAiChat}
-            value="Open AI Agent chat assistant"
-            className="group"
-          >
-            <Sparkles className="size-4 shrink-0" />
-            <span>Open AI Agent chat</span>
-            <EnterHint />
-          </CommandItem>
+          {showAiChat && (
+            <CommandItem
+              onSelect={onOpenAiChat}
+              value="action:open-ai-chat"
+              className="group"
+            >
+              <Sparkles className="size-4 shrink-0" />
+              <span>Open AI Agent chat</span>
+              <EnterHint />
+            </CommandItem>
+          )}
 
-          {mounted && (
+          {showTheme && (
             <CommandItem
               onSelect={onToggleTheme}
-              value="Toggle dark light theme appearance"
+              value="action:toggle-theme"
               className="group"
             >
               {resolvedTheme === 'dark' ? (
@@ -500,11 +614,11 @@ export function CommandPaletteResults({
             </CommandItem>
           )}
 
-          {otherHosts.map((host) => (
+          {listedHosts.map((host) => (
             <CommandItem
               key={`switch-host-${host.id}`}
               onSelect={() => onSwitchHost(host.id)}
-              value={`switch host ${host.name || getHost(host.host)}`}
+              value={`action:switch-host:${host.id}`}
               className="group"
             >
               <GlobeIcon className="size-4 shrink-0" />
@@ -513,10 +627,10 @@ export function CommandPaletteResults({
             </CommandItem>
           ))}
 
-          {onOpenSettings && (
+          {showSettings && (
             <CommandItem
-              onSelect={onOpenSettings}
-              value="Settings preferences"
+              onSelect={() => onOpenSettings?.()}
+              value="action:settings"
               className="group"
             >
               <Settings className="size-4 shrink-0" />

--- a/apps/dashboard/src/components/controls/command-palette/use-palette-groups.ts
+++ b/apps/dashboard/src/components/controls/command-palette/use-palette-groups.ts
@@ -32,11 +32,11 @@ export interface PaletteGroups {
 
 /**
  * Pure derivation of the command palette's groups from menu items,
- * favorites, the explorer table listing, and the merged host list. cmdk still
- * does its own fuzzy filtering per `CommandItem` `value`, so this does NOT
- * filter by `query`; it only computes the quick-navigation affordance
- * (`isQueryId` / `isTableName`), which genuinely depends on the current
- * input.
+ * favorites, the explorer table listing, and the merged host list. The
+ * palette UI filters and ranks rows in `filterPaletteRows` (cmdk
+ * `shouldFilter` is off), so this does NOT filter by `query`; it only
+ * computes the quick-navigation affordance (`isQueryId` / `isTableName`),
+ * which genuinely depends on the current input.
  */
 export function derivePaletteGroups({
   menuItems,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -856,7 +856,11 @@ hidden page navigates and does not auto-unhide; the header shows
 **Keep in sidebar** (and Pin) on that page. Search still matches
 sidebar title, document `<title>` (`lib/page-title.ts` +
 OG `headTitle`/`title`), href, description, and optional `keywords` on
-`MenuItem` (`menuItemPaletteValue`). DBA pages (Advisor, Schema Compare,
+`MenuItem` (`menuItemPaletteValue`). Filtering is userland
+(`Command shouldFilter={false}` + `filterPaletteRows`): group headings
+and Hidden badges are not selectable rows, so Enter/click activate
+`navigable[selectedIndex]` (the highlighted href), not the row below.
+DBA pages (Advisor, Schema Compare,
 Settings Diff, TTL & Partitions) declare aliases so searches like
 `ddl`, `schema diff`, `config diff`, `ttl inventory`, or the tab title
 `TTL & Partition Health` hit them. The dialog has category tabs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

⌘K Enter opened the row below the highlight. Typing `table replicas` highlighted Table Replicas (Hidden) but Enter opened Replicated Fetches. cmdk’s own filter reorders DOM nodes, so visual `data-selected` and the activated item could disagree when a group heading sits above items.

Filter and rank rows in userland (`shouldFilter={false}`). `selectedIndex` counts navigable items only — group headings and Hidden badges are not extra slots. Enter/click activate that highlighted href.

Closes #3346

## Changes

- Add `filterPaletteRows` / `activatePaletteRow` so Enter uses `navigable[selectedIndex]`
- Palette items use unique ids (`page:Tables:/replicas`) instead of the search haystack as cmdk `value`
- Hidden pages stay listed with a Hidden hint; no sidebar icon-clip or add-host changes

## Test plan

- [x] Unit test: filtered results + selectedIndex + Enter activate the highlighted href, including Hidden badge and a group header above items
- [x] Arrow-down then Enter still matches the highlight
- [x] `pnpm run type-check` passes
- [x] `pnpm run type-check:test` passes
- [ ] `pnpm run lint` passes with no errors
- [ ] `pnpm run build` passes (includes `tsc --noEmit`)
- [ ] `pnpm run test:unit` passes
- [ ] Tested manually in local dev (`pnpm run dev`)
- [x] Docs updated in `docs/knowledge/product-design.md` if behaviour or config changed
- [ ] `docs/content/ai-agent.mdx` updated if agent tools/skills/env vars changed

## Notes for reviewer

The recert case is encoded in `command-palette-selection.test.ts`: query `table replicas`, header `Tables`, Hidden on Table Replicas, Enter must open `/replicas` not `/replicated-fetches`.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0ef53e8-2e6f-446d-8433-b8a13e52560c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0ef53e8-2e6f-446d-8433-b8a13e52560c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

