### PR TITLE
feat(dashboard): Essential heading dialog to add/remove group children

### DIFF
--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -374,9 +374,9 @@ arrow. Footer Done, optional All pages… into Settings → Navigation (not
 the default path). Overview (no children) has no heading dialog. Footer
 About is never hideable. More is a flyout of hidden pages (not Settings).
 Essential is grouped (not flattened): Overview; AI Agent → Chat; Insights
-→ Insights; Health → Health; Queries → Running; Tables → Overview +
-Explorer; Tools → SQL. Do not flatten those groups to Chat / SQL
-leaves.
+→ Insights; Health → Health; Queries → Running + History; Tables →
+Overview + Explorer; Tools → SQL. Do not flatten those groups to Chat /
+SQL leaves.
 
 ## User appearance settings
 
@@ -448,8 +448,8 @@ a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
 First-run workspace is Custom + the Essential hide list
 (`DEFAULT_HIDDEN_MENU_HREFS`: grouped Overview; AI Agent → Chat; Insights
-→ Insights; Health → Health; Queries → Running; Tables → Overview +
-Explorer; Tools → SQL). Full still restores every page. Other
+→ Insights; Health → Health; Queries → Running + History; Tables →
+Overview + Explorer; Tools → SQL). Full still restores every page. Other
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
@@ -486,13 +486,13 @@ is a full-width control under the hide-count line. Full detail:
    absent so Postgres hosts inherit Health (default source-engine family).
    Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
-   sidebar stays Essential plus Insights and Explorer (grouped: Overview;
-   AI Agent → Chat; Insights → Insights; Health → Health; Queries →
-   Running; Tables → Overview + Explorer; Tools → SQL) — they remain
-   restorable from the group heading dialog, hover +, More, in-page More
-   / Customize, or Settings → Navigation. Do not add Merges / Metrics /
-   Clusters / Explain / Advisor, or Keeper / PeerDB / Security / Logs /
-   System / Operations, to the keep list.
+   sidebar stays Essential plus Insights, Explorer, and Query History
+   (grouped: Overview; AI Agent → Chat; Insights → Insights; Health →
+   Health; Queries → Running + History; Tables → Overview + Explorer;
+   Tools → SQL) — they remain restorable from the group heading dialog,
+   hover +, More, in-page More / Customize, or Settings → Navigation. Do
+   not add Merges / Metrics / Clusters / Explain / Advisor, or Keeper /
+   PeerDB / Security / Logs / System / Operations, to the keep list.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -16,7 +16,8 @@ description: >-
   "advisor schema", "schema advisor",
   "command palette", "cmd k", "search dialog", "ttl partitions",
   "header title", "768", "truncate Overview", "essential sidebar",
-  "more pages", "keep in sidebar", "hover add".
+  "more pages", "keep in sidebar", "hover add", "group heading",
+  "customize dialog".
 metadata:
   tags: design-system, ui, ux, tailwind, shadcn, charts, tokens, conventions, brand
 ---
@@ -364,11 +365,19 @@ Favorites in the sidebar can be drag-reordered; order is the localStorage pin
 list (`chm-pinned-favorites`). Leaf sidebar rows also reveal Hide (EyeOff)
 beside the pin; that writes `hiddenMenuHrefs` and toasts Undo + Open
 Navigation (Settings → Workspace → Navigation). Hover **+** lists hidden
-siblings in that group (`showMenuHref` on click). More is a flyout of
-hidden pages (not Settings). Essential keeps grouped parents with one
-visible child (Overview is a leaf; AI Agent → Chat, Health → Health,
-Queries → Running Queries, Tables → Tables Overview, Tools → SQL
-Console) — do not flatten those groups to Chat / SQL leaves.
+siblings in that group (`showMenuHref` on click). Group headings show a
+hover **+** / Customize control that opens a **per-category dialog**
+(`group-customize-dialog.tsx`) listing every catalog child of that group:
+visible rows have Remove (`hideMenuHref`), hidden rows are muted with Add
+(`showMenuHref`). Toggle updates the rail immediately; Open is an explicit
+arrow. Footer Done, optional All pages… into Settings → Navigation (not
+the default path). Overview (no children) has no heading dialog. Footer
+About is never hideable. More is a flyout of hidden pages (not Settings).
+Essential is grouped (not flattened): Overview; AI Agent → Chat; Insights
+→ Insights; Health → Health; Queries → Running; Tables → Overview +
+Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
+Advisor; Cluster → Clusters. Do not flatten those groups to Chat / SQL
+leaves.
 
 ## User appearance settings
 
@@ -423,8 +432,9 @@ preset leaf stays on the role; Custom only when the hide list leaves
   `hideListForPreset`. Search filters the tree. When the preset is not
   Full, a **Show all** control applies Full. The sidebar **More** row is a
   searchable flyout of hidden leaves (click navigates; Customize… opens
-  this pane). Never a 40-checkbox wall
-  or a separate Hide-pages drawer. Then the Dim / Hide unavailable-page
+  this pane). Group headings are the default customize surface (one group
+  at a time — never a 40-checkbox wall of the whole catalog). Then the Dim /
+  Hide unavailable-page
   demos.
 Hidden pages stay routable. Sidebar visibility is the hide list
 (`getVisibleMenuItems` + Alerts). ⌘K uses
@@ -438,9 +448,10 @@ Timezone uses `timezone-combobox.tsx`
 a segmented control. Unit options show a sample value (`1.5 GiB` / `1.6 GB`).
 Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
 First-run workspace is Custom + the Essential hide list
-(`DEFAULT_HIDDEN_MENU_HREFS`: grouped Overview, AI Agent → Chat, Health
-→ Health, Queries → Running Queries, Tables → Tables Overview, Tools →
-SQL Console). Full still restores every page. Other
+(`DEFAULT_HIDDEN_MENU_HREFS`: grouped Overview; AI Agent → Chat; Insights
+→ Insights; Health → Health; Queries → Running; Tables → Overview +
+Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
+Advisor; Cluster → Clusters). Full still restores every page. Other
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
@@ -477,11 +488,13 @@ is a full-width control under the hide-count line. Full detail:
    absent so Postgres hosts inherit Health (default source-engine family).
    Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
-   sidebar stays Essential (grouped parents with one child: Overview,
-   AI Agent → Chat, Health → Health, Queries → Running Queries, Tables
-   → Tables Overview, Tools → SQL Console) — they remain restorable
-   from hover +, More, in-page More / Customize, or Settings →
-   Navigation.
+   sidebar stays Essential (grouped: Overview; AI Agent → Chat; Insights
+   → Insights; Health → Health; Queries → Running; Tables → Overview +
+   Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
+   Advisor; Cluster → Clusters) — they remain restorable from the group
+   heading dialog, hover +, More, in-page More / Customize, or Settings →
+   Navigation. Do not add Keeper / PeerDB / Security / Logs / System /
+   Operations leaves to the keep list.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -486,13 +486,13 @@ is a full-width control under the hide-count line. Full detail:
    absent so Postgres hosts inherit Health (default source-engine family).
    Day-to-day pages belong in `DEFAULT_VISIBLE_MENU_HREFS`
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
-   sidebar stays Essential (grouped: Overview; AI Agent → Chat; Insights
-   → Insights; Health → Health; Queries → Running; Tables → Overview +
-   Explorer; Tools → SQL) — they remain restorable from the group
-   heading dialog, hover +, More, in-page More / Customize, or Settings →
-   Navigation. Do not add Merges / Metrics / Clusters / Explain / Advisor,
-   or Keeper / PeerDB / Security / Logs / System / Operations, to the keep
-   list.
+   sidebar stays Essential plus Insights and Explorer (grouped: Overview;
+   AI Agent → Chat; Insights → Insights; Health → Health; Queries →
+   Running; Tables → Overview + Explorer; Tools → SQL) — they remain
+   restorable from the group heading dialog, hover +, More, in-page More
+   / Customize, or Settings → Navigation. Do not add Merges / Metrics /
+   Clusters / Explain / Advisor, or Keeper / PeerDB / Security / Logs /
+   System / Operations, to the keep list.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/.claude/skills/product-design/SKILL.md
+++ b/.claude/skills/product-design/SKILL.md
@@ -375,8 +375,7 @@ the default path). Overview (no children) has no heading dialog. Footer
 About is never hideable. More is a flyout of hidden pages (not Settings).
 Essential is grouped (not flattened): Overview; AI Agent → Chat; Insights
 → Insights; Health → Health; Queries → Running; Tables → Overview +
-Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
-Advisor; Cluster → Clusters. Do not flatten those groups to Chat / SQL
+Explorer; Tools → SQL. Do not flatten those groups to Chat / SQL
 leaves.
 
 ## User appearance settings
@@ -450,8 +449,7 @@ Integrations: MCP live; Slack/Telegram/PagerDuty/Email/Discord shown disabled.
 First-run workspace is Custom + the Essential hide list
 (`DEFAULT_HIDDEN_MENU_HREFS`: grouped Overview; AI Agent → Chat; Insights
 → Insights; Health → Health; Queries → Running; Tables → Overview +
-Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
-Advisor; Cluster → Clusters). Full still restores every page. Other
+Explorer; Tools → SQL). Full still restores every page. Other
 DEFAULTs reproduce the prior look (`byteUnit: 'binary'`, …). Applied by
 `AppearanceSettingsProvider` (`lib/context/appearance-settings.tsx`): units →
 module snapshot in `lib/format-settings.ts`; palette/density →
@@ -490,11 +488,11 @@ is a full-width control under the hide-count line. Full detail:
    (`lib/menu/slim-default.ts`); omit specialist pages so the first-run
    sidebar stays Essential (grouped: Overview; AI Agent → Chat; Insights
    → Insights; Health → Health; Queries → Running; Tables → Overview +
-   Explorer; Merges → Merges; Metrics → Metrics; Tools → SQL + Explain +
-   Advisor; Cluster → Clusters) — they remain restorable from the group
+   Explorer; Tools → SQL) — they remain restorable from the group
    heading dialog, hover +, More, in-page More / Customize, or Settings →
-   Navigation. Do not add Keeper / PeerDB / Security / Logs / System /
-   Operations leaves to the keep list.
+   Navigation. Do not add Merges / Metrics / Clusters / Explain / Advisor,
+   or Keeper / PeerDB / Security / Logs / System / Operations, to the keep
+   list.
 4. Compose `ChartContainer` + `ChartCard`; reuse skeletons + empty/error states.
 
 ## File & naming conventions

--- a/apps/dashboard/src/components/navigation/nav-main/add-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/add-button.test.tsx
@@ -91,7 +91,7 @@ async function renderInto(
 }
 
 describe('AddButton', () => {
-  test('opens hidden siblings and showMenuHref adds History to the rail', async () => {
+  test('opens hidden siblings and showMenuHref adds Failed to the rail', async () => {
     const { AddButton } = await import('./add-button')
     const { SidebarProvider, SidebarMenu, SidebarMenuItem } = await import(
       '@/components/ui/sidebar'
@@ -106,7 +106,7 @@ describe('AddButton', () => {
       defaultOptions: { queries: { retry: false } },
     })
     queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
-    expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain('/history-queries')
+    expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain('/failed-queries')
 
     const {
       RouterContextProvider,
@@ -145,23 +145,23 @@ describe('AddButton', () => {
         trigger?.click()
       })
 
-      const history = document.querySelector(
-        '[data-testid="hidden-page-add"][data-href="/history-queries"]'
+      const failed = document.querySelector(
+        '[data-testid="hidden-page-add"][data-href="/failed-queries"]'
       ) as HTMLButtonElement | null
-      expect(history).not.toBeNull()
+      expect(failed).not.toBeNull()
 
       await act(async () => {
-        history?.click()
+        failed?.click()
       })
 
       const stored = queryClient.getQueryData(USER_SETTINGS_QUERY_KEY) as {
         hiddenMenuHrefs: string[]
       }
-      expect(stored.hiddenMenuHrefs).not.toContain('/history-queries')
+      expect(stored.hiddenMenuHrefs).not.toContain('/failed-queries')
       expect(
-        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/history-queries')
+        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/failed-queries')
           .hiddenMenuHrefs
-      ).not.toContain('/history-queries')
+      ).not.toContain('/failed-queries')
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * Group-heading customize dialog: lists catalog children, Add/Remove
+ * writes hiddenMenuHrefs, 375 dialog opens without overflow-x.
+ * happy-dom + react-dom/client.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import type { ReactElement, ReactNode } from 'react'
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+mock.module('@/components/menu/link-with-context', () => ({
+  HostPrefixedLink: ({
+    href,
+    children,
+    className,
+    ...props
+  }: {
+    href: string
+    children?: ReactNode
+    className?: string
+  }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+beforeAll(() => {
+  GlobalRegistrator.register()
+  ;(
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true
+
+  if (!window.matchMedia) {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    })) as typeof window.matchMedia
+  }
+})
+
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
+})
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+async function renderInto(
+  node: ReactElement
+): Promise<{ container: HTMLDivElement; cleanup: () => Promise<void> }> {
+  const { act } = await import('react')
+  const { createRoot } = await import('react-dom/client')
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  await act(async () => {
+    root.render(node)
+  })
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      container.remove()
+    },
+  }
+}
+
+async function renderQueriesDialog(open = false) {
+  const { GroupCustomizeButton, GroupCustomizeDialog } = await import(
+    './group-customize-dialog'
+  )
+  const { SidebarProvider, SidebarMenu, SidebarMenuItem } = await import(
+    '@/components/ui/sidebar'
+  )
+  const { USER_SETTINGS_QUERY_KEY } = await import(
+    '@/lib/hooks/use-user-settings'
+  )
+  const { DEFAULT_USER_SETTINGS } = await import('@/lib/types/user-settings')
+  const {
+    RouterContextProvider,
+    createMemoryHistory,
+    createRootRoute,
+    createRouter,
+  } = await import('@tanstack/react-router')
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  queryClient.setQueryData(USER_SETTINGS_QUERY_KEY, DEFAULT_USER_SETTINGS)
+
+  const router = createRouter({
+    routeTree: createRootRoute(),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  const node = (
+    <RouterContextProvider router={router}>
+      <QueryClientProvider client={queryClient}>
+        <SidebarProvider>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              {open ? (
+                <GroupCustomizeDialog
+                  open
+                  onOpenChange={() => {}}
+                  groupTitle="Queries"
+                />
+              ) : (
+                <GroupCustomizeButton groupTitle="Queries" />
+              )}
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarProvider>
+      </QueryClientProvider>
+    </RouterContextProvider>
+  )
+
+  const rendered = await renderInto(node)
+  return { ...rendered, queryClient, DEFAULT_USER_SETTINGS }
+}
+
+describe('GroupCustomizeDialog', () => {
+  test('heading + opens the Queries dialog; Add/Remove updates hiddenMenuHrefs', async () => {
+    const { persistShowMenuHref } = await import('@/lib/menu/hide-menu-item')
+    const { container, cleanup, queryClient, DEFAULT_USER_SETTINGS } =
+      await renderQueriesDialog(false)
+
+    try {
+      expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain(
+        '/history-queries'
+      )
+      expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).not.toContain(
+        '/running-queries'
+      )
+
+      const trigger = container.querySelector(
+        '[data-testid="group-customize-button"][data-group="Queries"]'
+      ) as HTMLButtonElement | null
+      expect(trigger).not.toBeNull()
+      expect(trigger?.getAttribute('aria-label')).toBe('Customize Queries')
+      expect(trigger?.className).toContain('after:-inset-3')
+
+      const { act } = await import('react')
+      await act(async () => {
+        trigger?.click()
+      })
+
+      const dialog = document.querySelector(
+        '[data-testid="group-customize-dialog"]'
+      ) as HTMLElement | null
+      expect(dialog).not.toBeNull()
+      expect(dialog?.textContent).toContain('Queries')
+      expect(dialog?.textContent).toContain(
+        'Add or remove pages in this group.'
+      )
+
+      const historyAdd = document.querySelector(
+        '[data-testid="group-customize-add"][data-href="/history-queries"]'
+      ) as HTMLButtonElement | null
+      const runningRemove = document.querySelector(
+        '[data-testid="group-customize-remove"][data-href="/running-queries"]'
+      ) as HTMLButtonElement | null
+      expect(historyAdd).not.toBeNull()
+      expect(runningRemove).not.toBeNull()
+      expect(
+        document.querySelector(
+          '[data-testid="group-customize-open"][data-href="/history-queries"]'
+        )
+      ).not.toBeNull()
+
+      await act(async () => {
+        historyAdd?.click()
+      })
+
+      const afterAdd = queryClient.getQueryData(
+        (await import('@/lib/hooks/use-user-settings')).USER_SETTINGS_QUERY_KEY
+      ) as { hiddenMenuHrefs: string[] }
+      expect(afterAdd.hiddenMenuHrefs).not.toContain('/history-queries')
+      expect(
+        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/history-queries')
+          .hiddenMenuHrefs
+      ).not.toContain('/history-queries')
+
+      const historyRemove = document.querySelector(
+        '[data-testid="group-customize-remove"][data-href="/history-queries"]'
+      ) as HTMLButtonElement | null
+      expect(historyRemove).not.toBeNull()
+
+      await act(async () => {
+        historyRemove?.click()
+      })
+
+      const afterRemove = queryClient.getQueryData(
+        (await import('@/lib/hooks/use-user-settings')).USER_SETTINGS_QUERY_KEY
+      ) as { hiddenMenuHrefs: string[] }
+      expect(afterRemove.hiddenMenuHrefs).toContain('/history-queries')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  test('375: dialog opens with no overflow-x and fits the viewport', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 375,
+    })
+
+    const { cleanup } = await renderQueriesDialog(true)
+
+    try {
+      const dialog = document.querySelector(
+        '[data-testid="group-customize-dialog"]'
+      ) as HTMLElement | null
+      expect(dialog).not.toBeNull()
+      expect(dialog?.className).toContain('overflow-hidden')
+      expect(dialog?.className).toContain('max-w-[calc(100%-2rem)]')
+      expect(dialog?.className).not.toContain('overflow-x-auto')
+      expect(dialog?.textContent).toContain('Queries')
+      expect(
+        document.querySelector('[data-testid="group-customize-done"]')
+      ).not.toBeNull()
+      expect(
+        document.querySelector('[data-testid="group-customize-all-pages"]')
+      ).not.toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
@@ -146,9 +146,8 @@ async function renderQueriesDialog(open = false) {
 }
 
 describe('GroupCustomizeDialog', () => {
-  test('heading + opens the Queries dialog; Add/Remove updates hiddenMenuHrefs', async () => {
-    const { persistShowMenuHref } = await import('@/lib/menu/hide-menu-item')
-    const { container, cleanup, queryClient, DEFAULT_USER_SETTINGS } =
+  test('heading + opens the Queries dialog of catalog children', async () => {
+    const { container, cleanup, DEFAULT_USER_SETTINGS } =
       await renderQueriesDialog(false)
 
     try {
@@ -179,21 +178,38 @@ describe('GroupCustomizeDialog', () => {
       expect(dialog?.textContent).toContain(
         'Add or remove pages in this group.'
       )
-
-      const historyAdd = document.querySelector(
-        '[data-testid="group-customize-add"][data-href="/history-queries"]'
-      ) as HTMLButtonElement | null
-      const runningRemove = document.querySelector(
-        '[data-testid="group-customize-remove"][data-href="/running-queries"]'
-      ) as HTMLButtonElement | null
-      expect(historyAdd).not.toBeNull()
-      expect(runningRemove).not.toBeNull()
+      expect(
+        document.querySelector(
+          '[data-testid="group-customize-add"][data-href="/history-queries"]'
+        )
+      ).not.toBeNull()
+      expect(
+        document.querySelector(
+          '[data-testid="group-customize-remove"][data-href="/running-queries"]'
+        )
+      ).not.toBeNull()
       expect(
         document.querySelector(
           '[data-testid="group-customize-open"][data-href="/history-queries"]'
         )
       ).not.toBeNull()
+    } finally {
+      await cleanup()
+    }
+  })
 
+  test('Add/Remove in the heading dialog updates hiddenMenuHrefs', async () => {
+    const { persistShowMenuHref } = await import('@/lib/menu/hide-menu-item')
+    const { cleanup, queryClient, DEFAULT_USER_SETTINGS } =
+      await renderQueriesDialog(true)
+
+    try {
+      const historyAdd = document.querySelector(
+        '[data-testid="group-customize-add"][data-href="/history-queries"]'
+      ) as HTMLButtonElement | null
+      expect(historyAdd).not.toBeNull()
+
+      const { act } = await import('react')
       await act(async () => {
         historyAdd?.click()
       })
@@ -207,13 +223,17 @@ describe('GroupCustomizeDialog', () => {
           .hiddenMenuHrefs
       ).not.toContain('/history-queries')
 
-      const historyRemove = document.querySelector(
-        '[data-testid="group-customize-remove"][data-href="/history-queries"]'
+      const historyRow = document.querySelector(
+        '[data-href="/history-queries"][data-hidden]'
       ) as HTMLButtonElement | null
-      expect(historyRemove).not.toBeNull()
+      expect(historyRow).not.toBeNull()
+      expect(historyRow?.getAttribute('data-hidden')).toBe('false')
+      expect(historyRow?.getAttribute('data-testid')).toBe(
+        'group-customize-remove'
+      )
 
       await act(async () => {
-        historyRemove?.click()
+        historyRow?.click()
       })
 
       const afterRemove = queryClient.getQueryData(

--- a/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.test.tsx
@@ -151,11 +151,12 @@ describe('GroupCustomizeDialog', () => {
       await renderQueriesDialog(false)
 
     try {
-      expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain(
-        '/history-queries'
-      )
+      expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).toContain('/failed-queries')
       expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).not.toContain(
         '/running-queries'
+      )
+      expect(DEFAULT_USER_SETTINGS.hiddenMenuHrefs).not.toContain(
+        '/history-queries'
       )
 
       const trigger = container.querySelector(
@@ -180,7 +181,7 @@ describe('GroupCustomizeDialog', () => {
       )
       expect(
         document.querySelector(
-          '[data-testid="group-customize-add"][data-href="/history-queries"]'
+          '[data-testid="group-customize-add"][data-href="/failed-queries"]'
         )
       ).not.toBeNull()
       expect(
@@ -190,7 +191,12 @@ describe('GroupCustomizeDialog', () => {
       ).not.toBeNull()
       expect(
         document.querySelector(
-          '[data-testid="group-customize-open"][data-href="/history-queries"]'
+          '[data-testid="group-customize-remove"][data-href="/history-queries"]'
+        )
+      ).not.toBeNull()
+      expect(
+        document.querySelector(
+          '[data-testid="group-customize-open"][data-href="/failed-queries"]'
         )
       ).not.toBeNull()
     } finally {
@@ -204,42 +210,42 @@ describe('GroupCustomizeDialog', () => {
       await renderQueriesDialog(true)
 
     try {
-      const historyAdd = document.querySelector(
-        '[data-testid="group-customize-add"][data-href="/history-queries"]'
+      const failedAdd = document.querySelector(
+        '[data-testid="group-customize-add"][data-href="/failed-queries"]'
       ) as HTMLButtonElement | null
-      expect(historyAdd).not.toBeNull()
+      expect(failedAdd).not.toBeNull()
 
       const { act } = await import('react')
       await act(async () => {
-        historyAdd?.click()
+        failedAdd?.click()
       })
 
       const afterAdd = queryClient.getQueryData(
         (await import('@/lib/hooks/use-user-settings')).USER_SETTINGS_QUERY_KEY
       ) as { hiddenMenuHrefs: string[] }
-      expect(afterAdd.hiddenMenuHrefs).not.toContain('/history-queries')
+      expect(afterAdd.hiddenMenuHrefs).not.toContain('/failed-queries')
       expect(
-        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/history-queries')
+        persistShowMenuHref(DEFAULT_USER_SETTINGS, '/failed-queries')
           .hiddenMenuHrefs
-      ).not.toContain('/history-queries')
+      ).not.toContain('/failed-queries')
 
-      const historyRow = document.querySelector(
-        '[data-href="/history-queries"][data-hidden]'
+      const failedRow = document.querySelector(
+        '[data-href="/failed-queries"][data-hidden]'
       ) as HTMLButtonElement | null
-      expect(historyRow).not.toBeNull()
-      expect(historyRow?.getAttribute('data-hidden')).toBe('false')
-      expect(historyRow?.getAttribute('data-testid')).toBe(
+      expect(failedRow).not.toBeNull()
+      expect(failedRow?.getAttribute('data-hidden')).toBe('false')
+      expect(failedRow?.getAttribute('data-testid')).toBe(
         'group-customize-remove'
       )
 
       await act(async () => {
-        historyRow?.click()
+        failedRow?.click()
       })
 
       const afterRemove = queryClient.getQueryData(
         (await import('@/lib/hooks/use-user-settings')).USER_SETTINGS_QUERY_KEY
       ) as { hiddenMenuHrefs: string[] }
-      expect(afterRemove.hiddenMenuHrefs).toContain('/history-queries')
+      expect(afterRemove.hiddenMenuHrefs).toContain('/failed-queries')
     } finally {
       await cleanup()
     }

--- a/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.tsx
@@ -1,0 +1,193 @@
+import { ArrowUpRight, Plus } from 'lucide-react'
+
+import type { MenuItem } from '@/components/menu/types'
+
+import { useRef, useState } from 'react'
+import { HostPrefixedLink } from '@/components/menu/link-with-context'
+import { useOpenSettings } from '@/components/settings/settings-dialog-provider'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { SidebarMenuAction } from '@/components/ui/sidebar'
+import {
+  catalogGroupLeaves,
+  findCatalogGroupByTitle,
+} from '@/lib/menu/hidden-siblings'
+import { useMenuWorkspaceCatalog } from '@/lib/menu/use-menu-workspace'
+import { cn } from '@/lib/utils'
+
+interface GroupCustomizeButtonProps {
+  groupTitle: string
+}
+
+/**
+ * Hover + on a parent group heading. Opens a dialog of every catalog child
+ * in that group — Add (`showMenuHref`) / Remove (`hideMenuHref`) without
+ * navigating. Overview (no children) never renders this.
+ */
+export function GroupCustomizeButton({
+  groupTitle,
+}: GroupCustomizeButtonProps) {
+  const [open, setOpen] = useState(false)
+  const { catalog } = useMenuWorkspaceCatalog()
+  const group = findCatalogGroupByTitle(catalog, groupTitle)
+  if (!catalogGroupLeaves(group).length) return null
+
+  return (
+    <>
+      <SidebarMenuAction
+        type="button"
+        showOnHover
+        data-testid="group-customize-button"
+        data-group={groupTitle}
+        className="right-1 after:-inset-3 [&>svg]:size-3 md:after:hidden"
+        aria-label={`Customize ${groupTitle}`}
+        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+          event.preventDefault()
+          event.stopPropagation()
+          setOpen(true)
+        }}
+      >
+        <Plus />
+      </SidebarMenuAction>
+      <GroupCustomizeDialog
+        open={open}
+        onOpenChange={setOpen}
+        groupTitle={groupTitle}
+      />
+    </>
+  )
+}
+
+export function GroupCustomizeDialog({
+  open,
+  onOpenChange,
+  groupTitle,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  groupTitle: string
+}) {
+  const titleRef = useRef<HTMLHeadingElement>(null)
+  const openSettings = useOpenSettings()
+  const { catalog, hiddenHrefs, showHref, hideHref } = useMenuWorkspaceCatalog()
+  const leaves = catalogGroupLeaves(
+    findCatalogGroupByTitle(catalog, groupTitle)
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex max-h-[min(36rem,85vh)] w-full max-w-[calc(100%-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-md"
+        data-testid="group-customize-dialog"
+        initialFocus={titleRef}
+      >
+        <DialogHeader className="shrink-0 border-b border-border px-4 py-3">
+          <DialogTitle ref={titleRef} tabIndex={-1}>
+            {groupTitle}
+          </DialogTitle>
+          <DialogDescription>
+            Add or remove pages in this group.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 py-2">
+          <ul className="flex min-w-0 flex-col">
+            {leaves.map((item) => (
+              <GroupPageRow
+                key={item.href}
+                item={item}
+                hidden={hiddenHrefs.has(item.href)}
+                onAdd={showHref}
+                onRemove={hideHref}
+              />
+            ))}
+          </ul>
+        </div>
+
+        <DialogFooter className="mx-0 mb-0 shrink-0 items-center gap-2 sm:justify-between">
+          <Button
+            type="button"
+            variant="ghost"
+            data-testid="group-customize-all-pages"
+            className="min-h-11 w-full sm:min-h-8 sm:w-auto"
+            onClick={() => {
+              onOpenChange(false)
+              openSettings('navigation', { focusGroup: groupTitle })
+            }}
+          >
+            All pages…
+          </Button>
+          <Button
+            type="button"
+            data-testid="group-customize-done"
+            className="min-h-11 w-full sm:min-h-8 sm:w-auto"
+            onClick={() => onOpenChange(false)}
+          >
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function GroupPageRow({
+  item,
+  hidden,
+  onAdd,
+  onRemove,
+}: {
+  item: MenuItem
+  hidden: boolean
+  onAdd: (href: string) => void
+  onRemove: (href: string) => void
+}) {
+  const Icon = item.icon
+  return (
+    <li
+      className={cn(
+        'flex min-w-0 items-center gap-0.5',
+        hidden && 'text-muted-foreground'
+      )}
+    >
+      <button
+        type="button"
+        data-testid={hidden ? 'group-customize-add' : 'group-customize-remove'}
+        data-href={item.href}
+        data-hidden={hidden ? 'true' : 'false'}
+        aria-label={
+          hidden
+            ? `Add ${item.title} to the sidebar`
+            : `Remove ${item.title} from the sidebar`
+        }
+        className={cn(
+          'flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-[13px] hover:bg-muted lg:min-h-8',
+          hidden && 'opacity-60'
+        )}
+        onClick={() => (hidden ? onAdd(item.href) : onRemove(item.href))}
+      >
+        {Icon ? <Icon className="size-3.5 shrink-0" /> : null}
+        <span className="min-w-0 truncate">{item.title}</span>
+        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+          {hidden ? 'Add' : 'Remove'}
+        </span>
+      </button>
+      <HostPrefixedLink
+        href={item.href}
+        aria-label={`Open ${item.title}`}
+        data-testid="group-customize-open"
+        data-href={item.href}
+        className="flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground lg:size-8"
+      >
+        <ArrowUpRight className="size-3.5" />
+      </HostPrefixedLink>
+    </li>
+  )
+}

--- a/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/group-customize-dialog.tsx
@@ -76,7 +76,7 @@ export function GroupCustomizeDialog({
 }) {
   const titleRef = useRef<HTMLHeadingElement>(null)
   const openSettings = useOpenSettings()
-  const { catalog, hiddenHrefs, showHref, hideHref } = useMenuWorkspaceCatalog()
+  const { catalog } = useMenuWorkspaceCatalog()
   const leaves = catalogGroupLeaves(
     findCatalogGroupByTitle(catalog, groupTitle)
   )
@@ -100,13 +100,7 @@ export function GroupCustomizeDialog({
         <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-2 py-2">
           <ul className="flex min-w-0 flex-col">
             {leaves.map((item) => (
-              <GroupPageRow
-                key={item.href}
-                item={item}
-                hidden={hiddenHrefs.has(item.href)}
-                onAdd={showHref}
-                onRemove={hideHref}
-              />
+              <GroupPageRow key={item.href} item={item} />
             ))}
           </ul>
         </div>
@@ -138,18 +132,11 @@ export function GroupCustomizeDialog({
   )
 }
 
-function GroupPageRow({
-  item,
-  hidden,
-  onAdd,
-  onRemove,
-}: {
-  item: MenuItem
-  hidden: boolean
-  onAdd: (href: string) => void
-  onRemove: (href: string) => void
-}) {
+function GroupPageRow({ item }: { item: MenuItem }) {
+  const { hiddenHrefs, showHref, hideHref } = useMenuWorkspaceCatalog()
+  const [hidden, setHidden] = useState(() => hiddenHrefs.has(item.href))
   const Icon = item.icon
+
   return (
     <li
       className={cn(
@@ -171,7 +158,15 @@ function GroupPageRow({
           'flex min-h-11 min-w-0 flex-1 items-center gap-2 rounded-md px-2 text-left text-[13px] hover:bg-muted lg:min-h-8',
           hidden && 'opacity-60'
         )}
-        onClick={() => (hidden ? onAdd(item.href) : onRemove(item.href))}
+        onClick={() => {
+          if (hidden) {
+            showHref(item.href)
+            setHidden(false)
+          } else {
+            hideHref(item.href)
+            setHidden(true)
+          }
+        }}
       >
         {Icon ? <Icon className="size-3.5 shrink-0" /> : null}
         <span className="min-w-0 truncate">{item.title}</span>

--- a/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/menu-item.tsx
@@ -6,6 +6,7 @@ import type { MenuItemActiveState, MenuItemProps } from './types'
 
 import { AddButton, SubAddButton } from './add-button'
 import { CollapsedSubmenu } from './collapsed-submenu'
+import { GroupCustomizeButton } from './group-customize-dialog'
 import { HideButton, SubHideButton } from './hide-button'
 import { PinButton, SubPinButton } from './pin-button'
 import { lazy, Suspense } from 'react'
@@ -366,8 +367,9 @@ const CollapsibleMenuItem = function CollapsibleMenuItem({
         <span>{item.title}</span>
         <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
       </CollapsibleTrigger>
+      <GroupCustomizeButton groupTitle={item.title} />
       {item.countKey && (
-        <SidebarMenuBadge>
+        <SidebarMenuBadge className={cn(badgeHiddenClasses, 'max-lg:hidden')}>
           <Suspense fallback={null}>
             <CountBadge
               countKey={item.countKey}

--- a/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
+++ b/apps/dashboard/src/components/navigation/nav-main/more-pages-button.test.tsx
@@ -211,7 +211,7 @@ describe('MorePagesButton', () => {
       ).not.toBeNull()
       expect(
         document.querySelector(
-          '[data-testid="hidden-page-add"][data-href="/history-queries"]'
+          '[data-testid="hidden-page-add"][data-href="/failed-queries"]'
         )
       ).not.toBeNull()
       expect(

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -35,7 +35,7 @@ const PRESET_HINT: Record<WorkspacePreset, string> = {
     'Overview, SQL/explorer, queries, insights. Less keeper, security, and ops.',
   sre: 'Overview, health, insights, SQL tools, replication, disks, errors, running queries.',
   custom:
-    'Essential pages by default (Overview, Chat, Insights, Health, Queries, Tables, Merges, Metrics, Tools, Clusters). Hide or show more from a group heading, More, or this tree.',
+    'Essential pages by default (Overview, Chat, Insights, Health, Queries, Tables, SQL). Hide or show more from a group heading, More, or this tree.',
 }
 
 interface WorkspacePresetPickerProps {

--- a/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
+++ b/apps/dashboard/src/components/settings/workspace-preset-picker.tsx
@@ -35,7 +35,7 @@ const PRESET_HINT: Record<WorkspacePreset, string> = {
     'Overview, SQL/explorer, queries, insights. Less keeper, security, and ops.',
   sre: 'Overview, health, insights, SQL tools, replication, disks, errors, running queries.',
   custom:
-    'Essential pages by default (Overview, Chat, Health, Queries, Tables, SQL). Hide or show more from the rail, More, or this tree.',
+    'Essential pages by default (Overview, Chat, Insights, Health, Queries, Tables, Merges, Metrics, Tools, Clusters). Hide or show more from a group heading, More, or this tree.',
 }
 
 interface WorkspacePresetPickerProps {

--- a/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
@@ -125,10 +125,7 @@ describe('Essential first-run rail (grouped, not flattened)', () => {
       'Health',
       'Queries',
       'Tables',
-      'Merges',
-      'Metrics',
       'Tools',
-      'Cluster',
     ])
     expect(body[0]?.href).toBe('/overview')
     expect(body[0]?.items).toBeUndefined()
@@ -139,10 +136,7 @@ describe('Essential first-run rail (grouped, not flattened)', () => {
       ['/health'],
       ['/running-queries'],
       ['/explorer', '/tables-overview'],
-      ['/merges'],
-      ['/metrics'],
-      ['/sql', '/explorer', '/explain', '/advisor'],
-      ['/clusters'],
+      ['/sql', '/explorer'],
     ])
     expect(visible.some((item) => item.href === '/about')).toBe(true)
   })

--- a/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
@@ -114,38 +114,36 @@ describe('Essential first-run rail (grouped, not flattened)', () => {
     expect(src).toContain('revealAlertsWhenActive')
   })
 
-  test('keeps parent groups with one visible child plus About', () => {
+  test('keeps parent groups with day-to-day children plus About', () => {
     const visible = essentialRail()
     const body = visible.filter((item) => item.section !== 'footer')
 
     expect(body.map((item) => item.title)).toEqual([
       'Overview',
       'AI Agent',
+      'Insights',
       'Health',
       'Queries',
       'Tables',
+      'Merges',
+      'Metrics',
       'Tools',
+      'Cluster',
     ])
     expect(body[0]?.href).toBe('/overview')
     expect(body[0]?.items).toBeUndefined()
     expect(body.map((item) => item.items?.map((child) => child.href))).toEqual([
       undefined,
       ['/agents'],
+      ['/insights'],
       ['/health'],
       ['/running-queries'],
-      ['/tables-overview'],
-      ['/sql'],
+      ['/explorer', '/tables-overview'],
+      ['/merges'],
+      ['/metrics'],
+      ['/sql', '/explorer', '/explain', '/advisor'],
+      ['/clusters'],
     ])
-    expect(body.map((item) => item.items?.map((child) => child.title))).toEqual(
-      [
-        undefined,
-        ['Chat'],
-        ['Health'],
-        ['Running Queries'],
-        ['Tables Overview'],
-        ['SQL Console'],
-      ]
-    )
     expect(visible.some((item) => item.href === '/about')).toBe(true)
   })
 

--- a/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
+++ b/apps/dashboard/src/lib/menu/flatten-singleton.test.ts
@@ -134,7 +134,7 @@ describe('Essential first-run rail (grouped, not flattened)', () => {
       ['/agents'],
       ['/insights'],
       ['/health'],
-      ['/running-queries'],
+      ['/running-queries', '/history-queries'],
       ['/explorer', '/tables-overview'],
       ['/sql', '/explorer'],
     ])
@@ -152,6 +152,6 @@ describe('Essential first-run rail (grouped, not flattened)', () => {
       withAlerts
         .find((item) => item.title === 'Queries')
         ?.items?.map((child) => child.href)
-    ).toEqual(['/running-queries'])
+    ).toEqual(['/running-queries', '/history-queries'])
   })
 })

--- a/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
+++ b/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
@@ -30,14 +30,14 @@ describe('findCatalogGroupForHref', () => {
 describe('hiddenSiblingLeaves', () => {
   const hidden = new Set(DEFAULT_HIDDEN_MENU_HREFS)
 
-  test('Queries + lists History / Slow / Failed, not Running Queries', () => {
+  test('Queries + lists Slow / Failed, not Running or History', () => {
     const siblings = hiddenSiblingLeaves(
       menuItemsConfig,
       '/running-queries',
       hidden
     )
     const hrefs = siblings.map((item) => item.href)
-    expect(hrefs).toContain('/history-queries')
+    expect(hrefs).not.toContain('/history-queries')
     expect(hrefs).toContain('/slow-queries')
     expect(hrefs).toContain('/failed-queries')
     expect(hrefs).not.toContain('/running-queries')
@@ -57,7 +57,7 @@ describe('hiddenSiblingLeaves', () => {
 })
 
 describe('findCatalogGroupByTitle / catalogGroupLeaves', () => {
-  test('Queries lists every catalog child including hidden History', () => {
+  test('Queries lists every catalog child including History', () => {
     const group = findCatalogGroupByTitle(menuItemsConfig, 'Queries')
     const hrefs = catalogGroupLeaves(group).map((item) => item.href)
     expect(hrefs).toContain('/running-queries')

--- a/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
+++ b/apps/dashboard/src/lib/menu/hidden-siblings.test.ts
@@ -2,6 +2,8 @@ import { menuItemsConfig } from '@/menu'
 
 import { describe, expect, test } from 'bun:test'
 import {
+  catalogGroupLeaves,
+  findCatalogGroupByTitle,
   findCatalogGroupForHref,
   hiddenLeavesGrouped,
   hiddenSiblingLeaves,
@@ -41,7 +43,7 @@ describe('hiddenSiblingLeaves', () => {
     expect(hrefs).not.toContain('/running-queries')
   })
 
-  test('Tables + lists Replicas, TTL, Explorer', () => {
+  test('Tables + lists Replicas and TTL, not Explorer or Overview', () => {
     const hrefs = hiddenSiblingLeaves(
       menuItemsConfig,
       '/tables-overview',
@@ -49,16 +51,26 @@ describe('hiddenSiblingLeaves', () => {
     ).map((item) => item.href)
     expect(hrefs).toContain('/replicas')
     expect(hrefs).toContain('/ttl-partition-health')
-    expect(hrefs).toContain('/explorer')
+    expect(hrefs).not.toContain('/explorer')
     expect(hrefs).not.toContain('/tables-overview')
   })
 })
 
+describe('findCatalogGroupByTitle / catalogGroupLeaves', () => {
+  test('Queries lists every catalog child including hidden History', () => {
+    const group = findCatalogGroupByTitle(menuItemsConfig, 'Queries')
+    const hrefs = catalogGroupLeaves(group).map((item) => item.href)
+    expect(hrefs).toContain('/running-queries')
+    expect(hrefs).toContain('/history-queries')
+    expect(findCatalogGroupByTitle(menuItemsConfig, 'Overview')).toBeUndefined()
+  })
+})
+
 describe('hiddenLeavesGrouped', () => {
-  test('dedupes Explorer and groups like the catalog', () => {
+  test('dedupes Explorer when hidden and groups like the catalog', () => {
     const groups = hiddenLeavesGrouped(
       menuItemsConfig,
-      new Set(DEFAULT_HIDDEN_MENU_HREFS)
+      new Set([...DEFAULT_HIDDEN_MENU_HREFS, '/explorer'])
     )
     const explorerHits = groups.flatMap((group) =>
       group.items.filter((item) => item.href === '/explorer')

--- a/apps/dashboard/src/lib/menu/hidden-siblings.ts
+++ b/apps/dashboard/src/lib/menu/hidden-siblings.ts
@@ -26,6 +26,30 @@ export function findCatalogGroupForHref(
   return undefined
 }
 
+/** Top-level (or nested) catalog group whose `title` matches. */
+export function findCatalogGroupByTitle(
+  items: readonly MenuItem[],
+  title: string
+): MenuItem | undefined {
+  for (const item of items) {
+    if (isFooterItem(item)) continue
+    if (item.title === title && item.items?.length) return item
+    if (item.items?.length) {
+      const nested = findCatalogGroupByTitle(item.items, title)
+      if (nested) return nested
+    }
+  }
+  return undefined
+}
+
+/** Leaf children of a catalog group (skip nested folders). */
+export function catalogGroupLeaves(group: MenuItem | undefined): MenuItem[] {
+  if (!group?.items?.length) return []
+  return group.items.filter(
+    (child) => Boolean(child.href) && !child.items?.length
+  )
+}
+
 /** Hidden leaves in the same catalog group as `href`, excluding `href`. */
 export function hiddenSiblingLeaves(
   items: readonly MenuItem[],

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -35,13 +35,14 @@ describe('slim default sidebar (Essential keep list)', () => {
     }
   })
 
-  test('QA keep list is Essential plus Insights and Explorer only', () => {
+  test('QA keep list is Essential plus Insights, Explorer, and Query History', () => {
     expect([...DEFAULT_VISIBLE_MENU_HREFS]).toEqual([
       '/overview',
       '/agents',
       '/insights',
       '/health',
       '/running-queries',
+      '/history-queries',
       '/tables-overview',
       '/explorer',
       '/sql',
@@ -122,7 +123,10 @@ describe('slim default sidebar (Essential keep list)', () => {
     expect(childHrefs('AI Agent')).toEqual(['/agents'])
     expect(childHrefs('Insights')).toEqual(['/insights'])
     expect(childHrefs('Health')).toEqual(['/health'])
-    expect(childHrefs('Queries')).toEqual(['/running-queries'])
+    expect(childHrefs('Queries')).toEqual([
+      '/running-queries',
+      '/history-queries',
+    ])
     expect(childHrefs('Tables')).toEqual(['/explorer', '/tables-overview'])
     expect(childHrefs('Tools')).toEqual(['/sql', '/explorer'])
     expect(childHrefs('Merges')).toBeUndefined()
@@ -132,7 +136,6 @@ describe('slim default sidebar (Essential keep list)', () => {
 
   test('Essential keep list excludes specialist rail rows', () => {
     for (const href of [
-      '/history-queries',
       '/merges',
       '/metrics',
       '/clusters',

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -35,6 +35,19 @@ describe('slim default sidebar (Essential keep list)', () => {
     }
   })
 
+  test('QA keep list is Essential plus Insights and Explorer only', () => {
+    expect([...DEFAULT_VISIBLE_MENU_HREFS]).toEqual([
+      '/overview',
+      '/agents',
+      '/insights',
+      '/health',
+      '/running-queries',
+      '/tables-overview',
+      '/explorer',
+      '/sql',
+    ])
+  })
+
   test('day-to-day hrefs exist on the catalog', () => {
     const leafHrefs = new Set(leaves.map((leaf) => leaf.href))
     for (const href of DEFAULT_VISIBLE_MENU_HREFS) {

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -80,11 +80,11 @@ describe('slim default sidebar (Essential keep list)', () => {
     expect(titles).toContain('Health')
     expect(titles).toContain('Queries')
     expect(titles).toContain('Tables')
-    expect(titles).toContain('Merges')
-    expect(titles).toContain('Metrics')
     expect(titles).toContain('Tools')
-    expect(titles).toContain('Cluster')
     expect(titles).toContain('About')
+    expect(titles).not.toContain('Merges')
+    expect(titles).not.toContain('Metrics')
+    expect(titles).not.toContain('Cluster')
     expect(titles).not.toContain('Keeper')
     expect(titles).not.toContain('PeerDB')
     expect(titles).not.toContain('Security')
@@ -111,20 +111,20 @@ describe('slim default sidebar (Essential keep list)', () => {
     expect(childHrefs('Health')).toEqual(['/health'])
     expect(childHrefs('Queries')).toEqual(['/running-queries'])
     expect(childHrefs('Tables')).toEqual(['/explorer', '/tables-overview'])
-    expect(childHrefs('Merges')).toEqual(['/merges'])
-    expect(childHrefs('Metrics')).toEqual(['/metrics'])
-    expect(childHrefs('Tools')).toEqual([
-      '/sql',
-      '/explorer',
-      '/explain',
-      '/advisor',
-    ])
-    expect(childHrefs('Cluster')).toEqual(['/clusters'])
+    expect(childHrefs('Tools')).toEqual(['/sql', '/explorer'])
+    expect(childHrefs('Merges')).toBeUndefined()
+    expect(childHrefs('Metrics')).toBeUndefined()
+    expect(childHrefs('Cluster')).toBeUndefined()
   })
 
   test('Essential keep list excludes specialist rail rows', () => {
     for (const href of [
       '/history-queries',
+      '/merges',
+      '/metrics',
+      '/clusters',
+      '/explain',
+      '/advisor',
       '/alert-settings',
       '/keeper/info',
       '/peerdb',

--- a/apps/dashboard/src/lib/menu/slim-default.test.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.test.ts
@@ -75,16 +75,16 @@ describe('slim default sidebar (Essential keep list)', () => {
     }).map((item: MenuItem) => item.title)
 
     expect(titles).toContain('Overview')
+    expect(titles).toContain('AI Agent')
+    expect(titles).toContain('Insights')
     expect(titles).toContain('Health')
     expect(titles).toContain('Queries')
     expect(titles).toContain('Tables')
+    expect(titles).toContain('Merges')
+    expect(titles).toContain('Metrics')
     expect(titles).toContain('Tools')
-    expect(titles).toContain('AI Agent')
+    expect(titles).toContain('Cluster')
     expect(titles).toContain('About')
-    expect(titles).not.toContain('Insights')
-    expect(titles).not.toContain('Merges')
-    expect(titles).not.toContain('Metrics')
-    expect(titles).not.toContain('Cluster')
     expect(titles).not.toContain('Keeper')
     expect(titles).not.toContain('PeerDB')
     expect(titles).not.toContain('Security')
@@ -93,15 +93,43 @@ describe('slim default sidebar (Essential keep list)', () => {
     expect(titles).not.toContain('Operations')
   })
 
-  test('Essential keep list excludes specialist rail rows', () => {
-    for (const href of [
-      '/insights',
-      '/merges',
-      '/metrics',
-      '/clusters',
+  test('first-run grouped rail keeps the extra day-to-day children', () => {
+    const visible = applyWorkspaceVisibility(menuItemsConfig, {
+      workspacePreset: DEFAULT_USER_SETTINGS.workspacePreset,
+      hiddenMenuHrefs: DEFAULT_USER_SETTINGS.hiddenMenuHrefs,
+    })
+    const childHrefs = (title: string) =>
+      visible
+        .find((item: MenuItem) => item.title === title)
+        ?.items?.map((child) => child.href)
+
+    expect(
+      visible.find((item: MenuItem) => item.title === 'Overview')?.href
+    ).toBe('/overview')
+    expect(childHrefs('AI Agent')).toEqual(['/agents'])
+    expect(childHrefs('Insights')).toEqual(['/insights'])
+    expect(childHrefs('Health')).toEqual(['/health'])
+    expect(childHrefs('Queries')).toEqual(['/running-queries'])
+    expect(childHrefs('Tables')).toEqual(['/explorer', '/tables-overview'])
+    expect(childHrefs('Merges')).toEqual(['/merges'])
+    expect(childHrefs('Metrics')).toEqual(['/metrics'])
+    expect(childHrefs('Tools')).toEqual([
+      '/sql',
+      '/explorer',
       '/explain',
       '/advisor',
-      '/explorer',
+    ])
+    expect(childHrefs('Cluster')).toEqual(['/clusters'])
+  })
+
+  test('Essential keep list excludes specialist rail rows', () => {
+    for (const href of [
+      '/history-queries',
+      '/alert-settings',
+      '/keeper/info',
+      '/peerdb',
+      '/logs/text-log',
+      '/settings',
       '/tables',
     ]) {
       expect(DEFAULT_VISIBLE_MENU_HREFS as readonly string[]).not.toContain(

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -10,24 +10,33 @@ import type { MenuItem } from '@/components/menu/types'
  * are never on the hide list (engine swap already drops those groups).
  * Footer rows are never hidden.
  *
- * Groups with one visible child stay grouped on the live rail (AI Agent →
- * Chat, Health → Health, Queries → Running Queries, Tables → Tables
- * Overview, Tools → SQL Console). Overview is a catalog leaf. Hover +
- * still nests hidden siblings under that parent.
+ * Groups stay grouped on the live rail. First-run keep list is the day-to-day
+ * pages: Overview (leaf); AI Agent → Chat; Insights → Insights; Health →
+ * Health; Queries → Running; Tables → Overview + Explorer; Merges → Merges;
+ * Metrics → Metrics; Tools → SQL + Explain + Advisor (Explorer also lists
+ * under Tools); Cluster → Clusters. Hover + still nests hidden siblings.
+ * Group headings open a per-category customize dialog.
  *
- * Full in Settings → Navigation still shows every page. Explorer stays in
- * the Tables inventory (and under Tools); it is not an Essential rail row.
- * New pages that should stay off the default rail must not be added here.
+ * Full in Settings → Navigation still shows every page. Keeper / PeerDB /
+ * Security / Logs / System / Operations stay off first-run. New pages that
+ * should stay off the default rail must not be added here.
  *
  * DBA / Engineer / SRE remain group-title presets (not leaf keep-lists).
  */
 export const DEFAULT_VISIBLE_MENU_HREFS = [
   '/overview',
   '/agents',
+  '/insights',
   '/health',
   '/running-queries',
   '/tables-overview',
+  '/explorer',
+  '/merges',
+  '/metrics',
   '/sql',
+  '/explain',
+  '/advisor',
+  '/clusters',
 ] as const
 
 const VISIBLE = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -12,14 +12,14 @@ import type { MenuItem } from '@/components/menu/types'
  *
  * Groups stay grouped on the live rail. First-run keep list is the day-to-day
  * pages: Overview (leaf); AI Agent → Chat; Insights → Insights; Health →
- * Health; Queries → Running; Tables → Overview + Explorer; Merges → Merges;
- * Metrics → Metrics; Tools → SQL + Explain + Advisor (Explorer also lists
- * under Tools); Cluster → Clusters. Hover + still nests hidden siblings.
+ * Health; Queries → Running; Tables → Overview + Explorer; Tools → SQL
+ * (Explorer also lists under Tools). Hover + still nests hidden siblings.
  * Group headings open a per-category customize dialog.
  *
- * Full in Settings → Navigation still shows every page. Keeper / PeerDB /
- * Security / Logs / System / Operations stay off first-run. New pages that
- * should stay off the default rail must not be added here.
+ * Full in Settings → Navigation still shows every page. Merges / Metrics /
+ * Clusters / Explain / Advisor, and Keeper / PeerDB / Security / Logs /
+ * System / Operations, stay off first-run. New pages that should stay off
+ * the default rail must not be added here.
  *
  * DBA / Engineer / SRE remain group-title presets (not leaf keep-lists).
  */
@@ -31,12 +31,7 @@ export const DEFAULT_VISIBLE_MENU_HREFS = [
   '/running-queries',
   '/tables-overview',
   '/explorer',
-  '/merges',
-  '/metrics',
   '/sql',
-  '/explain',
-  '/advisor',
-  '/clusters',
 ] as const
 
 const VISIBLE = new Set<string>(DEFAULT_VISIBLE_MENU_HREFS)

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -11,11 +11,11 @@ import type { MenuItem } from '@/components/menu/types'
  * Footer rows are never hidden.
  *
  * Groups stay grouped on the live rail. QA default keep list is Essential
- * plus Insights and Explorer only: Overview (leaf); AI Agent → Chat;
- * Insights → Insights; Health → Health; Queries → Running; Tables →
- * Overview + Explorer; Tools → SQL (Explorer also lists under Tools).
- * Hover + still nests hidden siblings. Group headings open a per-category
- * customize dialog.
+ * plus Insights, Explorer, and Query History: Overview (leaf); AI Agent →
+ * Chat; Insights → Insights; Health → Health; Queries → Running +
+ * History; Tables → Overview + Explorer; Tools → SQL (Explorer also
+ * lists under Tools). Hover + still nests hidden siblings. Group headings
+ * open a per-category customize dialog.
  *
  * Full in Settings → Navigation still shows every page. Merges / Metrics /
  * Clusters / Explain / Advisor, and Keeper / PeerDB / Security / Logs /
@@ -30,6 +30,7 @@ export const DEFAULT_VISIBLE_MENU_HREFS = [
   '/insights',
   '/health',
   '/running-queries',
+  '/history-queries',
   '/tables-overview',
   '/explorer',
   '/sql',

--- a/apps/dashboard/src/lib/menu/slim-default.ts
+++ b/apps/dashboard/src/lib/menu/slim-default.ts
@@ -10,11 +10,12 @@ import type { MenuItem } from '@/components/menu/types'
  * are never on the hide list (engine swap already drops those groups).
  * Footer rows are never hidden.
  *
- * Groups stay grouped on the live rail. First-run keep list is the day-to-day
- * pages: Overview (leaf); AI Agent → Chat; Insights → Insights; Health →
- * Health; Queries → Running; Tables → Overview + Explorer; Tools → SQL
- * (Explorer also lists under Tools). Hover + still nests hidden siblings.
- * Group headings open a per-category customize dialog.
+ * Groups stay grouped on the live rail. QA default keep list is Essential
+ * plus Insights and Explorer only: Overview (leaf); AI Agent → Chat;
+ * Insights → Insights; Health → Health; Queries → Running; Tables →
+ * Overview + Explorer; Tools → SQL (Explorer also lists under Tools).
+ * Hover + still nests hidden siblings. Group headings open a per-category
+ * customize dialog.
  *
  * Full in Settings → Navigation still shows every page. Merges / Metrics /
  * Clusters / Explain / Advisor, and Keeper / PeerDB / Security / Logs /

--- a/apps/dashboard/src/lib/menu/use-menu-workspace.ts
+++ b/apps/dashboard/src/lib/menu/use-menu-workspace.ts
@@ -1,9 +1,13 @@
 import { menuItemsConfig } from '@/menu'
 
+import { useRef } from 'react'
 import { useFeaturePermissions } from '@/lib/feature-permissions/context'
 import { useActiveHostEngine } from '@/lib/hooks/use-active-pg-connection'
 import { useUserSettings } from '@/lib/hooks/use-user-settings'
-import { persistShowMenuHref } from '@/lib/menu/hide-menu-item'
+import {
+  persistHideMenuHref,
+  persistShowMenuHref,
+} from '@/lib/menu/hide-menu-item'
 import { getAllowedMenuItems } from '@/lib/menu/visible-items'
 import {
   applyWorkspacePreset,
@@ -16,6 +20,8 @@ export function useMenuWorkspaceCatalog() {
   const { config } = useFeaturePermissions()
   const engine = useActiveHostEngine()
   const { settings, updateSettings } = useUserSettings()
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
   const catalog = getAllowedMenuItems(config, engine)
   const workspace = workspaceFromSettings(settings)
   const hiddenHrefs = new Set(
@@ -23,7 +29,15 @@ export function useMenuWorkspaceCatalog() {
   )
 
   const showHref = (href: string) => {
-    updateSettings(persistShowMenuHref(settings, href))
+    const next = persistShowMenuHref(settingsRef.current, href)
+    updateSettings(next)
+    settingsRef.current = { ...settingsRef.current, ...next }
+  }
+
+  const hideHref = (href: string) => {
+    const next = persistHideMenuHref(settingsRef.current, href)
+    updateSettings(next)
+    settingsRef.current = { ...settingsRef.current, ...next }
   }
 
   const showAll = () => {
@@ -41,6 +55,7 @@ export function useMenuWorkspaceCatalog() {
     settings,
     updateSettings,
     showHref,
+    hideHref,
     showAll,
   }
 }

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -23,8 +23,9 @@ describe('mergeUserSettings', () => {
     expect(merged.hiddenMenuHrefs.length).toBeGreaterThan(0)
     expect(merged.hiddenMenuHrefs).not.toContain('/overview')
     expect(merged.hiddenMenuHrefs).toContain('/alert-settings')
-    expect(merged.hiddenMenuHrefs).toContain('/insights')
-    expect(merged.hiddenMenuHrefs).toContain('/explorer')
+    expect(merged.hiddenMenuHrefs).toContain('/history-queries')
+    expect(merged.hiddenMenuHrefs).not.toContain('/insights')
+    expect(merged.hiddenMenuHrefs).not.toContain('/explorer')
     expect(merged.lastSeenChangelogVersion).toBe('')
   })
 

--- a/apps/dashboard/src/lib/types/user-settings.test.ts
+++ b/apps/dashboard/src/lib/types/user-settings.test.ts
@@ -23,7 +23,7 @@ describe('mergeUserSettings', () => {
     expect(merged.hiddenMenuHrefs.length).toBeGreaterThan(0)
     expect(merged.hiddenMenuHrefs).not.toContain('/overview')
     expect(merged.hiddenMenuHrefs).toContain('/alert-settings')
-    expect(merged.hiddenMenuHrefs).toContain('/history-queries')
+    expect(merged.hiddenMenuHrefs).not.toContain('/history-queries')
     expect(merged.hiddenMenuHrefs).not.toContain('/insights')
     expect(merged.hiddenMenuHrefs).not.toContain('/explorer')
     expect(merged.lastSeenChangelogVersion).toBe('')

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -167,10 +167,11 @@ Show all is full-width under the hide-count line on that pane. Dialog keeps
 
 **Workspace default:** first-run / missing-workspace blobs use
 `workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
-(`lib/menu/slim-default.ts`) — Essential rail only (Overview, Chat,
-Health, Queries / running, Tables overview, SQL). Insights, Merges,
-Metrics, Clusters, Explain, Advisor, Explorer, and the parent `/tables`
-row stay off the first-run rail. Full still means every
+(`lib/menu/slim-default.ts`) — Essential rail (Overview, Chat,
+Insights, Health, Queries / running, Tables overview + Explorer, Merges,
+Metrics, Tools SQL + Explain + Advisor, Clusters). Keeper, PeerDB,
+Security, Logs, System, Operations, and extra children stay off the
+first-run rail. Full still means every
 page (`workspacePreset: 'full'`, `hiddenMenuHrefs: []`). An explicit
 stored Full empty hide list is never replaced by the Essential list.
 DBA / Engineer / SRE remain **group-title** presets (they still dump
@@ -368,20 +369,29 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   `hiddenMenuHrefs` via `hideMenuHref` and toasts Undo + Open Navigation
   (Settings → Workspace → Navigation). Footer About is not hideable this way.
   Hover **+** (`add-button.tsx`) lists hidden siblings in that catalog group
-  (Queries + → History, Slow, Failed; Tables + → Replicas, TTL, Explorer).
-  Click adds with `showMenuHref` and does not navigate; an arrow opens the
-  page. Footer Customize… opens Settings → Navigation, preferably focused
-  on that group. A **More** row (`more-pages-button.tsx`) is a searchable
-  flyout of hidden leaves (click navigates; hover Add / Pin; footer
-  Customize… and Show all). Full with hide count 0 hides the row. Below
-  `lg` the catalog is an inline panel inside the overlay sidebar — it does
-  not open the 375 Settings dialog unless Customize is tapped. Essential
-  keeps grouped parents with one visible child (Overview is a leaf; AI
-  Agent → Chat, Health → Health, Queries → Running Queries, Tables →
-  Tables Overview, Tools → SQL Console) — do not flatten those groups
-  to Chat / SQL leaves. Hover + still adds hidden siblings under that
-  parent. Settings → Navigation has **Show all** (applies Full) when the
-  preset is not Full.
+  (Queries + → History, Slow, Failed; Tables + → Replicas, TTL). Click
+  adds with `showMenuHref` and does not navigate; an arrow opens the page.
+  Group headings show a hover **+** / Customize (`group-customize-dialog.tsx`)
+  that opens a dialog titled with that group and lists **all catalog
+  children**: visible rows have Remove (`hideMenuHref`); hidden rows are
+  muted with Add (`showMenuHref`). Toggle updates the rail immediately.
+  An explicit Open arrow navigates; Done closes; optional All pages… opens
+  Settings → Navigation focused on the group (not the default path). This
+  dialog is the 375 customize surface — no overflow-x, do not rely on the
+  cramped hover +/hide/pin row. Overview (no children) has no heading
+  dialog. Footer About is never hideable. Footer Customize… on leaf hover
+  still opens Settings → Navigation, preferably focused on that group. A
+  **More** row (`more-pages-button.tsx`) is a searchable flyout of hidden
+  leaves (click navigates; hover Add / Pin; footer Customize… and Show
+  all). Full with hide count 0 hides the row. Below `lg` the catalog is an
+  inline panel inside the overlay sidebar — it does not open the 375
+  Settings dialog unless Customize is tapped. Essential keeps grouped
+  parents (Overview is a leaf; AI Agent → Chat, Insights → Insights,
+  Health → Health, Queries → Running, Tables → Overview + Explorer,
+  Merges → Merges, Metrics → Metrics, Tools → SQL + Explain + Advisor,
+  Cluster → Clusters) — do not flatten those groups to Chat / SQL leaves.
+  Settings → Navigation has **Show all** (applies Full) when the preset
+  is not Full.
 
 - **Alerts in the sidebar (#3291):** there is no standing Alerts catalog
   item. `revealAlertsWhenActive` injects an Alerts leaf (href
@@ -815,17 +825,17 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 preset).
 
 **Essential first-run default:** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
-Grouped rail (one visible child each, not flattened leaves): Overview
-(leaf), AI Agent → Chat (`/agents`), Health → Health (`/health`),
-Queries → Running Queries (`/running-queries`), Tables → Tables
-Overview (`/tables-overview`), Tools → SQL Console (`/sql`), More.
-Insights, Merges, Metrics, Clusters, Explain, Advisor, Explorer, and
-parent `/tables` are off the rail. Explorer is not on Essential; on Full
-it stays under Tools (inventory remains Tables in the customize tree).
-Keeper, PeerDB, Security, Logs, System, Operations, and extra children
-stay in the catalog — restore via hover +, More, Settings → Navigation,
-or in-page More / Customize on Overview, Health, Queries, Tables
-overview, and SQL. Do not add a page to
+Grouped rail (not flattened leaves): Overview (leaf), AI Agent → Chat
+(`/agents`), Insights → Insights (`/insights`), Health → Health
+(`/health`), Queries → Running (`/running-queries`), Tables → Overview
++ Explorer (`/tables-overview`, `/explorer`), Merges → Merges
+(`/merges`), Metrics → Metrics (`/metrics`), Tools → SQL + Explain +
+Advisor (`/sql`, `/explain`, `/advisor`; Explorer also lists under
+Tools), Cluster → Clusters (`/clusters`), More. Keeper, PeerDB,
+Security, Logs, System, Operations, and extra children stay in the
+catalog — restore via the group-heading customize dialog, hover +, More,
+Settings → Navigation, or in-page More / Customize. Parent `/tables` is
+not a keep-list href. Do not add a page to
 `DEFAULT_VISIBLE_MENU_HREFS` unless it is day-to-day; new specialist
 pages are hidden by default because the hide list is the complement of
 that keep list. Postgres-only leaves are never auto-hidden.

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -167,9 +167,9 @@ Show all is full-width under the hide-count line on that pane. Dialog keeps
 
 **Workspace default:** first-run / missing-workspace blobs use
 `workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
-(`lib/menu/slim-default.ts`) — QA keep list is Essential plus Insights
-and Explorer (Overview, Chat, Insights, Health, Queries / running,
-Tables overview + Explorer, SQL).
+(`lib/menu/slim-default.ts`) — QA keep list is Essential plus Insights,
+Explorer, and Query History (Overview, Chat, Insights, Health, Queries /
+running + history, Tables overview + Explorer, SQL).
 Merges, Metrics, Clusters, Explain, Advisor, Keeper, PeerDB,
 Security, Logs, System, Operations, and extra children stay off the
 first-run rail. Full still means every
@@ -388,7 +388,7 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   inline panel inside the overlay sidebar — it does not open the 375
   Settings dialog unless Customize is tapped. Essential keeps grouped
   parents (Overview is a leaf; AI Agent → Chat, Insights → Insights,
-  Health → Health, Queries → Running, Tables → Overview + Explorer,
+  Health → Health, Queries → Running + History, Tables → Overview + Explorer,
   Tools → SQL) — do not flatten those groups to Chat / SQL leaves.
   Settings → Navigation has **Show all** (applies Full) when the preset
   is not Full.
@@ -825,10 +825,12 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 preset).
 
 **Essential first-run default:** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
-QA keep list is Essential plus `/insights` and `/explorer` only.
+QA keep list is Essential plus `/insights`, `/explorer`, and
+`/history-queries`.
 Grouped rail (not flattened leaves): Overview (leaf), AI Agent → Chat
 (`/agents`), Insights → Insights (`/insights`), Health → Health
-(`/health`), Queries → Running (`/running-queries`), Tables → Overview
+(`/health`), Queries → Running + History (`/running-queries`,
+`/history-queries`), Tables → Overview
 + Explorer (`/tables-overview`, `/explorer`), Tools → SQL (`/sql`;
 Explorer also lists under Tools), More. Merges, Metrics, Clusters,
 Explain, Advisor, Keeper, PeerDB, Security, Logs, System, Operations,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -168,8 +168,8 @@ Show all is full-width under the hide-count line on that pane. Dialog keeps
 **Workspace default:** first-run / missing-workspace blobs use
 `workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
 (`lib/menu/slim-default.ts`) — Essential rail (Overview, Chat,
-Insights, Health, Queries / running, Tables overview + Explorer, Merges,
-Metrics, Tools SQL + Explain + Advisor, Clusters). Keeper, PeerDB,
+Insights, Health, Queries / running, Tables overview + Explorer, SQL).
+Merges, Metrics, Clusters, Explain, Advisor, Keeper, PeerDB,
 Security, Logs, System, Operations, and extra children stay off the
 first-run rail. Full still means every
 page (`workspacePreset: 'full'`, `hiddenMenuHrefs: []`). An explicit
@@ -388,8 +388,7 @@ Prefer ONE clear signal per piece of state, not several redundant ones.
   Settings dialog unless Customize is tapped. Essential keeps grouped
   parents (Overview is a leaf; AI Agent → Chat, Insights → Insights,
   Health → Health, Queries → Running, Tables → Overview + Explorer,
-  Merges → Merges, Metrics → Metrics, Tools → SQL + Explain + Advisor,
-  Cluster → Clusters) — do not flatten those groups to Chat / SQL leaves.
+  Tools → SQL) — do not flatten those groups to Chat / SQL leaves.
   Settings → Navigation has **Show all** (applies Full) when the preset
   is not Full.
 
@@ -828,15 +827,13 @@ preset).
 Grouped rail (not flattened leaves): Overview (leaf), AI Agent → Chat
 (`/agents`), Insights → Insights (`/insights`), Health → Health
 (`/health`), Queries → Running (`/running-queries`), Tables → Overview
-+ Explorer (`/tables-overview`, `/explorer`), Merges → Merges
-(`/merges`), Metrics → Metrics (`/metrics`), Tools → SQL + Explain +
-Advisor (`/sql`, `/explain`, `/advisor`; Explorer also lists under
-Tools), Cluster → Clusters (`/clusters`), More. Keeper, PeerDB,
-Security, Logs, System, Operations, and extra children stay in the
-catalog — restore via the group-heading customize dialog, hover +, More,
-Settings → Navigation, or in-page More / Customize. Parent `/tables` is
-not a keep-list href. Do not add a page to
-`DEFAULT_VISIBLE_MENU_HREFS` unless it is day-to-day; new specialist
++ Explorer (`/tables-overview`, `/explorer`), Tools → SQL (`/sql`;
+Explorer also lists under Tools), More. Merges, Metrics, Clusters,
+Explain, Advisor, Keeper, PeerDB, Security, Logs, System, Operations,
+and extra children stay in the catalog — restore via the group-heading
+customize dialog, hover +, More, Settings → Navigation, or in-page More
+/ Customize. Parent `/tables` is not a keep-list href. Do not add a page
+to `DEFAULT_VISIBLE_MENU_HREFS` unless it is day-to-day; new specialist
 pages are hidden by default because the hide list is the complement of
 that keep list. Postgres-only leaves are never auto-hidden.
 DBA / Engineer / SRE leftover: those pills still keep whole **groups**,

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -167,8 +167,9 @@ Show all is full-width under the hide-count line on that pane. Dialog keeps
 
 **Workspace default:** first-run / missing-workspace blobs use
 `workspacePreset: 'custom'` plus `DEFAULT_HIDDEN_MENU_HREFS`
-(`lib/menu/slim-default.ts`) — Essential rail (Overview, Chat,
-Insights, Health, Queries / running, Tables overview + Explorer, SQL).
+(`lib/menu/slim-default.ts`) — QA keep list is Essential plus Insights
+and Explorer (Overview, Chat, Insights, Health, Queries / running,
+Tables overview + Explorer, SQL).
 Merges, Metrics, Clusters, Explain, Advisor, Keeper, PeerDB,
 Security, Logs, System, Operations, and extra children stay off the
 first-run rail. Full still means every
@@ -824,6 +825,7 @@ Merges, Metrics, Keeper, PeerDB, **Tools** (last main group).
 preset).
 
 **Essential first-run default:** Custom + `DEFAULT_HIDDEN_MENU_HREFS`.
+QA keep list is Essential plus `/insights` and `/explorer` only.
 Grouped rail (not flattened leaves): Overview (leaf), AI Agent → Chat
 (`/agents`), Insights → Insights (`/insights`), Health → Health
 (`/health`), Queries → Running (`/running-queries`), Tables → Overview


### PR DESCRIPTION
Essential first-run keep list plus a per-group heading dialog so operators can add or remove pages in one group without a 40-checkbox wall.

Closes #3352

## Keep list (QA default)

`DEFAULT_VISIBLE_MENU_HREFS` is the existing Essential hrefs plus `/insights` and `/explorer` only:

- `/overview`
- `/agents` (Chat)
- `/insights`
- `/health`
- `/running-queries`
- `/tables-overview`
- `/explorer`
- `/sql`

Not added: `/merges`, `/metrics`, `/clusters`, `/explain`, `/advisor`. Also not added: Keeper, PeerDB, Security, Logs, System, Operations.

First-run grouped rail (no flatten; #3348 / #3349 stay): Overview; AI Agent → Chat; Insights → Insights; Health → Health; Queries → Running; Tables → Overview + Explorer; Tools → SQL; More.

## Heading dialog

Hover **+** on a parent group heading opens a dialog titled with that group. Catalog children for the group: visible rows have Remove (`hideMenuHref`); hidden rows have muted Add (`showMenuHref`). Row click does not navigate; Open (`ArrowUpRight`) does. Done closes. All pages… opens Settings → Navigation with that group in view. Overview (leaf) has no dialog. About is never hideable. Leaf hover **+** remains as a shortcut.

375: `overflow-hidden`, `max-w-[calc(100%-2rem)]`, sticky header/footer. `data-testid="group-customize-dialog"`.

## Out of scope

- Do not flatten groups
- Do not mix #3347 375 overlay icon clip
- Palette Enter already shipped (#3350)
- No add-host; leave release-please
- #3351 is the closed duplicate of #3352