### PR TITLE
feat(cli): add local named connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ Developer-facing docs live in `docs/knowledge/` as a linked knowledge graph. Eac
 | Specs | [cluster-topology.md](docs/knowledge/cluster-topology.md) | Cluster topology SVG: layout pipeline, constant contracts, OKLCH `hsl(var())` gotcha, shared component, verification harness |
 | Development | [component-ci-stability.md](docs/knowledge/component-ci-stability.md) | Cypress component test fragility and fixes |
 | Development | [conventions.md](docs/knowledge/conventions.md) | Coding conventions, file org, component patterns |
-| Tools | [standalone-cli.md](docs/knowledge/standalone-cli.md) | `chm`/`chmonitor` Rust CLI: live TUI by default, dashboard API, `chm doctor`, channels, auth/cli discovery |
+| Tools | [standalone-cli.md](docs/knowledge/standalone-cli.md) | `chm`/`chmonitor` Rust CLI: live TUI, local `add`/`ls`/`use`, dashboard API, `chm doctor`, channels |
 | Operations | [install-sh-bot-fight.md](docs/knowledge/install-sh-bot-fight.md) | curl install.sh 403 from Bot Fight Mode; GitHub raw workaround; `cf:allow-install-sh` |
 
 ### When to Write to Knowledge vs Memory

--- a/docs/content/guide/guides/diagnostics-cli.mdx
+++ b/docs/content/guide/guides/diagnostics-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: chm CLI
-description: Install and use the chm / chmonitor CLI — dashboard API client, TUI, self-update, and zero-signup `chm doctor` against a cluster.
+description: Install and use the chm / chmonitor CLI — local connections, dashboard API client, TUI, self-update, and zero-signup `chm doctor` against a cluster.
 icon: Terminal
 ---
 
@@ -14,7 +14,9 @@ open the live TUI (`chm tui` is the same UI) on the Overview dashboard charts.
 dashboard when needed.
 
 `chm doctor --ch-host` (no dashboard account or backend) is a separate mode: it connects
-**straight to a ClickHouse host** with no dashboard account or backend.
+**straight to a ClickHouse host** with no dashboard account or backend. `chm add` / {/* pragma: allowlist secret */}
+`chm ls` / `chm use` manage a **local** named connection store (ClickHouse HTTP and {/* pragma: allowlist secret */}
+Postgres) with no dashboard required.
 
 <Callout type="info" title="Binary names and platforms">
 Shipped release assets are Linux and macOS only (`x86_64` / `aarch64`). There
@@ -103,6 +105,32 @@ After some commands (including `chm doctor` cluster scan), `chm` does a fast, be
 check for a newer release and prints a one-line hint to stderr if one is
 available. Silence it with `CHM_NO_UPDATE_CHECK=1`.
 </Callout>
+
+## Local connections (`chm add` / `ls` / `use`)
+
+Save named ClickHouse HTTP and Postgres URLs on this machine — no dashboard {/* pragma: allowlist secret */}
+account, no network on add (the URL is not probed):
+
+```bash
+chm add http://localhost:8123
+chm add http://user:pass@ch.example:8123/analytics --name prod
+chm add localhost:8123 --ch-user default
+chm add postgres://user:pass@localhost:5432/app
+chm ls
+chm ls --json
+chm use prod
+chm rm prod
+```
+
+`connect` is an alias of `add`. `--name` is optional; the default is a short
+host/database slug. `chm ls` prints name, engine (`clickhouse` \| `postgres`), {/* pragma: allowlist secret */}
+host, and a `*` on the active connection. Secrets stay in the credentials
+helper (OS keyring / `~/.config/chm/credentials`) and never appear in `ls` or
+JSON. The active name is `current_connection` in `~/.config/chm/config.toml`.
+
+This store is **not** `chm hosts` (that lists hosts from a running dashboard
+API). The live TUI opens against the active local ClickHouse connection and {/* pragma: allowlist secret */}
+`h`/`l` switches among local connections without restart.
 
 ## Common dashboard commands
 

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -3,7 +3,7 @@ id: knowledge-index
 title: Knowledge Graph Index
 type: index
 status: active
-updated: 2026-08-20
+updated: 2026-08-27
 tags:
   - knowledge-graph
   - index
@@ -61,7 +61,7 @@ Agents discover knowledge in this order:
 | **Development** | [component-ci-stability.md](component-ci-stability.md) | incident | Cypress component test fragility findings and fix direction |
 | **Development** | [conventions.md](conventions.md) | workflow | Coding conventions, file organization, component patterns |
 | **Design** | [product-design.md](product-design.md) | reference | Design system + UX conventions: OKLCH tokens, dark mode, shadcn rules, ChartCard/Container, EmptyState, graceful errors, ?host routing, file org (source of truth for the `product-design` skill) |
-| **Tools** | [standalone-cli.md](standalone-cli.md) | reference | `chm`/`chmonitor` Rust CLI: live TUI by default, dashboard API, `chm doctor`, channels, auth/cli discovery |
+| **Tools** | [standalone-cli.md](standalone-cli.md) | reference | `chm`/`chmonitor` Rust CLI: live TUI, local `add`/`ls`/`use`, dashboard API, `chm doctor`, channels |
 
 ## Graph Convention
 

--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -3,7 +3,7 @@ id: standalone-cli
 title: Standalone CLI (Rust)
 type: reference
 status: active
-updated: 2026-08-23
+updated: 2026-08-27
 tags:
   - rust
   - cli
@@ -55,13 +55,39 @@ channel = "stable" # or "beta"
 ```
 
 Credentials (device-login token / API key) live in the OS keyring, with a
-`0600` plaintext fallback at `~/.config/chm/credentials`.
+`0600` plaintext fallback at `~/.config/chm/credentials`. Local connection
+passwords use the same helper (`connection.<name>` keys) and are never written
+into `config.toml`.
+
+## Local connections (`chm add` / `ls` / `use`)
+
+P0 local store — no dashboard, no network on add:
+
+```bash
+chm add http://localhost:8123
+chm add http://user:pass@ch.example:8123/analytics --name prod
+chm add localhost:8123 --ch-user default          # --ch-host style
+chm add postgres://user:pass@localhost:5432/app
+chm ls                 # name, engine, host, current marker; `--json`
+chm use prod
+chm rm prod            # optional
+```
+
+`connect` is an alias of `add`. Names default to a short host/db slug. The
+active name is `current_connection` in user `config.toml`. `chm hosts` still
+lists **dashboard** `/api/v1/hosts` only. The live TUI opens against the active
+local ClickHouse connection; `h`/`l` cycles local connections without restart. <!-- pragma: allowlist secret -->
+Postgres add/use/ls works; PG TUI panes are a later slice.
 
 ## Command tree
 
 ```text
 chm                # live TUI (default; same as `chm tui`)
 ├── tui [chart]    # explicit TUI alias (alt-screen)
+├── add <url>      # save a local named connection (alias: connect)
+├── ls             # list local connections (`--json`; TTY picker to use)
+├── use <name>     # set the active local connection
+├── rm <name>      # remove a local named connection
 ├── auth
 │   ├── login [--api-key]
 │   ├── logout
@@ -74,7 +100,7 @@ chm                # live TUI (default; same as `chm tui`)
 ├── dashboard
 │   ├── list
 │   └── open <name>
-├── hosts
+├── hosts          # dashboard API hosts (not the local store)
 ├── link [path]
 ├── chart <name>
 ├── table <name>
@@ -136,7 +162,7 @@ a visible `overview | table` switcher.
 | `r` | Refresh now |
 | `?` | Help overlay |
 | `a` | Open interactive agent chat (returns to the TUI on exit) |
-| `h` / `l` or ← / → or `[` / `]` | Previous / next host (cycles the `/api/v1/hosts` list) |
+| `h` / `l` or ← / → or `[` / `]` | Previous / next host (dashboard `/api/v1/hosts`, or local `chm add` connections) |
 | `j` / `k` or ↑ / ↓ | Scroll table |
 | `Tab` | Switch pane (small terminals) |
 | `1` | Overview pane |

--- a/rust/ch-monitor-cli/README.md
+++ b/rust/ch-monitor-cli/README.md
@@ -38,6 +38,10 @@ cargo build --release --manifest-path rust/ch-monitor-cli/Cargo.toml
 ```bash
 chm                  # live TUI (default)
 chm --help
+chm add http://localhost:8123
+chm add postgres://user@localhost:5432/app --name shop
+chm ls
+chm use local
 chm auth login
 chm auth status
 chm auth logout
@@ -45,6 +49,8 @@ chm config           # interactive dialog
 chm config show
 chm config set host_id 0
 ```
+
+`chm add` (alias `chm connect`) saves a **local** named connection (ClickHouse HTTP or Postgres) with no dashboard and no network. `chm ls` lists them; `chm use <name>` sets the active one in `~/.config/chm/config.toml`. Passwords go in the credentials helper, never in `ls` / JSON. Dashboard `chm hosts` is unchanged. <!-- pragma: allowlist secret -->
 
 `chm tui` is an explicit alias of the default TUI. `chm dashboard list` opens a
 ratatui picker for Overview or a saved dashboard. Dashboard API helpers

--- a/rust/ch-monitor-cli/src/cli.rs
+++ b/rust/ch-monitor-cli/src/cli.rs
@@ -9,7 +9,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
     name = "chm",
     version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CHM_TARGET"), ")"),
     about = "chmonitor CLI (`chm` / `chmonitor`) — live TUI by default",
-    after_help = "Run `chm` with no subcommand to open the live TUI. Pipes, CI, agents, `--json`, and `--no-tui` print a snapshot instead. Direct cluster: `chm --ch-host http://localhost:8123`. `chm --help` / `chm help` / `chm -h` print this help."
+    after_help = "Run `chm` with no subcommand to open the live TUI. Pipes, CI, agents, `--json`, and `--no-tui` print a snapshot instead. Direct cluster: `chm --ch-host http://localhost:8123` or `chm add` / `chm use`. `chm --help` / `chm help` / `chm -h` print this help."
 )]
 pub struct Cli {
     /// Path to config.toml (default ~/.config/chm/config.toml)
@@ -144,6 +144,21 @@ pub enum Commands {
     Config(ConfigArgs),
     /// List or open Overview / saved dashboards
     Dashboard(DashboardArgs),
+    /// Save a local named database connection (no network)
+    #[command(visible_alias = "connect")]
+    Add(AddConnectionArgs),
+    /// List local named connections (not dashboard hosts)
+    Ls,
+    /// Set the active local connection
+    Use {
+        /// Connection name from `chm ls`
+        name: String,
+    },
+    /// Remove a local named connection
+    Rm {
+        /// Connection name from `chm ls`
+        name: String,
+    },
     /// List hosts from a running chmonitor dashboard
     Hosts,
     /// Open the dashboard (or a path) in the browser
@@ -202,6 +217,18 @@ pub enum Commands {
     /// (`scripts/install.sh` or `cargo install chmonitor`).
     /// `--beta` / `--stable` switch the saved channel and then update.
     Update(UpdateArgs),
+}
+
+/// Flags for `chm add` / `chm connect`.
+#[derive(Args, Debug, Clone)]
+pub struct AddConnectionArgs {
+    #[arg(
+        help = "Database URL. ClickHouse HTTP `http(s)://[user:pass@]host:8123[/db]` (or `--ch-host` style `host:8123`), Postgres `postgres://` / `postgresql://`." // pragma: allowlist secret
+    )]
+    pub url: String,
+    /// Connection name (default: derived from host / database)
+    #[arg(long, short = 'n')]
+    pub name: Option<String>,
 }
 
 /// Flags for `chm` / `chm tui`.

--- a/rust/ch-monitor-cli/src/commands/connections.rs
+++ b/rust/ch-monitor-cli/src/commands/connections.rs
@@ -1,0 +1,110 @@
+//! `chm add` / `ls` / `use` / `rm` — local named connections (no dashboard).
+
+use anyhow::Result;
+
+use crate::{
+    cli::AddConnectionArgs,
+    config::AppConfig,
+    connections::{self, ConnectionStore},
+    output,
+};
+
+fn store(cfg: &AppConfig) -> ConnectionStore {
+    ConnectionStore::from_config_path(cfg.user_config_path.clone())
+}
+
+pub fn add(
+    cfg: &AppConfig,
+    url: &str,
+    args: &AddConnectionArgs,
+    ch_user: &str,
+    ch_password: &str,
+    ch_database: &str,
+) -> Result<()> {
+    let mut parsed = connections::parse_connection_url(url)?;
+    connections::apply_ch_args(&mut parsed, ch_user, ch_password, ch_database); // pragma: allowlist secret
+    let engine = parsed.engine.as_str().to_string();
+    let conn_host = format!("{}:{}", parsed.host, parsed.port);
+    let store = store(cfg);
+    let outcome = store.add(parsed, args.name.as_deref())?;
+    let verb = if outcome.replacing {
+        "updated"
+    } else {
+        "saved"
+    };
+    if !cfg.quiet {
+        output::success(&format!(
+            "{verb} connection '{}' ({} {conn_host})",
+            outcome.name, engine
+        ));
+        if outcome.current.as_deref() == Some(outcome.name.as_str()) {
+            output::info("active — `chm use` to switch, `chm ls` to list");
+        } else {
+            output::info(&format!(
+                "run `chm use {}` to make this the active connection",
+                outcome.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn ls(cfg: &AppConfig) -> Result<()> {
+    let store = store(cfg);
+    let (conns, current) = store.load()?;
+    if cfg.json {
+        output::print_json(&connections::list_json(&conns, current.as_deref()))?;
+        return Ok(());
+    }
+    if conns.is_empty() {
+        print!(
+            "{}",
+            connections::format_list_text(&conns, current.as_deref())
+        );
+        return Ok(());
+    }
+    if crate::output::wants_tui(false, false) {
+        if let Some(idx) = crate::tui::picker::run(
+            "local connections",
+            connections::picker_labels(&conns, current.as_deref()),
+            " j/k select  Enter use  q quit",
+            Some("local store — not dashboard `chm hosts`".into()),
+        )? {
+            let name = &conns[idx].name;
+            let conn = store.use_name(name)?;
+            output::success(&format!(
+                "using '{}' ({} {})",
+                conn.name,
+                conn.engine.as_str(),
+                conn.display_host()
+            ));
+        }
+        return Ok(());
+    }
+    print!(
+        "{}",
+        connections::format_list_text(&conns, current.as_deref())
+    );
+    Ok(())
+}
+
+pub fn use_name(cfg: &AppConfig, name: &str) -> Result<()> {
+    let conn = store(cfg).use_name(name)?;
+    if !cfg.quiet {
+        output::success(&format!(
+            "using '{}' ({} {})",
+            conn.name,
+            conn.engine.as_str(),
+            conn.display_host()
+        ));
+    }
+    Ok(())
+}
+
+pub fn rm(cfg: &AppConfig, name: &str) -> Result<()> {
+    let conn = store(cfg).remove(name)?;
+    if !cfg.quiet {
+        output::success(&format!("removed '{}'", conn.name));
+    }
+    Ok(())
+}

--- a/rust/ch-monitor-cli/src/commands/dashboard.rs
+++ b/rust/ch-monitor-cli/src/commands/dashboard.rs
@@ -101,6 +101,9 @@ async fn open_entry(client: &Client, cfg: &AppConfig, entry: &DashboardEntry) ->
             start_overview: true,
             host_id: cfg.host_id,
             ch: None,
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         },
     )
     .await?;

--- a/rust/ch-monitor-cli/src/commands/mod.rs
+++ b/rust/ch-monitor-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod audit;
 pub mod auth;
 pub mod chart;
 pub mod config_cmd;
+pub mod connections;
 pub mod dashboard;
 pub mod diagnose_cmd;
 pub mod doctor;
@@ -18,6 +19,7 @@ use reqwest::Client;
 use crate::{
     cli::{Cli, Commands, DoctorArgs, PromptCommand},
     config::AppConfig,
+    connections::ConnectionStore,
     prompts,
     tui::TuiOptions,
 };
@@ -37,6 +39,28 @@ async fn run_cluster_scan(
         args.json || cfg.json,
     )
     .await
+}
+
+fn resolve_tui_backend(
+    cfg: &AppConfig,
+    cli: &Cli,
+) -> (
+    Option<crate::diagnose::ChConfig>,
+    Vec<crate::connections::StoredConnection>,
+    Option<String>,
+) {
+    let explicit = cli.clickhouse.to_ch_config(); // pragma: allowlist secret
+    if let Some(ch) = explicit {
+        return (Some(ch), Vec::new(), None);
+    }
+    let store = ConnectionStore::from_config_path(cfg.user_config_path.clone());
+    let Ok((conns, current)) = store.load() else {
+        return (None, Vec::new(), None);
+    };
+    let ch = current
+        .as_deref()
+        .and_then(|name| store.ch_config_for(name).ok().flatten());
+    (ch, conns, current)
 }
 
 pub(crate) async fn run_tui_session(
@@ -79,6 +103,29 @@ pub async fn dispatch(
             Ok(0)
         }
         Commands::Dashboard(args) => dashboard::run(client, cfg, args.command).await,
+        Commands::Add(args) => {
+            connections::add(
+                cfg,
+                &args.url,
+                &args,
+                &cli.clickhouse.ch_user,     // pragma: allowlist secret
+                &cli.clickhouse.ch_password, // pragma: allowlist secret
+                &cli.clickhouse.ch_database, // pragma: allowlist secret
+            )?;
+            Ok(0)
+        }
+        Commands::Ls => {
+            connections::ls(cfg)?;
+            Ok(0)
+        }
+        Commands::Use { name } => {
+            connections::use_name(cfg, &name)?;
+            Ok(0)
+        }
+        Commands::Rm { name } => {
+            connections::rm(cfg, &name)?;
+            Ok(0)
+        }
         Commands::Hosts => {
             hosts::run(client, cfg).await?;
             Ok(0)
@@ -116,6 +163,7 @@ pub async fn dispatch(
             Ok(0)
         }
         Commands::Tui(args) => {
+            let (ch, local_connections, current_connection) = resolve_tui_backend(cfg, cli);
             run_tui_session(
                 client,
                 cfg,
@@ -127,7 +175,10 @@ pub async fn dispatch(
                     page_size: args.page_size,
                     start_overview: args.overview,
                     host_id: cfg.host_id,
-                    ch: cli.clickhouse.to_ch_config(),
+                    ch,
+                    local_connections,
+                    current_connection,
+                    config_path: Some(cfg.user_config_path.clone()),
                 },
             )
             .await?;

--- a/rust/ch-monitor-cli/src/config.rs
+++ b/rust/ch-monitor-cli/src/config.rs
@@ -25,6 +25,12 @@ pub struct FileConfig {
     pub token: Option<String>,
     pub default_chart: Option<String>,
     pub channel: Option<String>,
+    /// Active local connection name (`chm use`). Not a dashboard host id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_connection: Option<String>,
+    /// Local named connections (`chm add`). Passwords are not stored here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub connections: Vec<crate::connections::StoredConnection>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,8 +101,11 @@ pub fn load_layered_files(
     }
 
     // Layer: project over user (project wins when both set the same key).
+    // Local connections stay on the user file only.
     let mut merged = FileConfig::default();
     if let Some(user) = load_toml_file(&user_path)? {
+        merged.current_connection = user.current_connection.clone();
+        merged.connections = user.connections.clone();
         merge_file(&mut merged, user);
     }
     for candidate in project_paths {
@@ -126,6 +135,8 @@ fn merge_file(dst: &mut FileConfig, src: FileConfig) {
     if src.channel.is_some() {
         dst.channel = src.channel;
     }
+    // Local connections stay on the user (or --config) file. Project
+    // chm.toml is dashboard settings and must not drop or replace them.
 }
 
 fn parse_channel(raw: &str) -> Result<Channel> {
@@ -195,23 +206,41 @@ pub fn load_user_file_config(path: &PathBuf) -> Result<FileConfig> {
     Ok(load_toml_file(path)?.unwrap_or_default())
 }
 
-const SECRET_KEYS: &[&str] = &["api_key", "token"];
+const SECRET_KEYS: &[&str] = &["api_key", "token", "password"];
 
-/// Redact `api_key` / `token` values as `(set)` so `config show` is safe to print.
+/// Redact `api_key` / `token` / `password` values as `(set)` so `config show` is safe to print.
 pub fn redact_toml(content: &str) -> String {
     let Ok(mut value) = toml::from_str::<toml::Value>(content) else {
         return content.to_string();
     };
-    if let Some(table) = value.as_table_mut() {
-        for key in SECRET_KEYS {
-            if let Some(toml::Value::String(s)) = table.get(*key) {
-                if !s.is_empty() && s != "(set)" {
-                    table.insert((*key).to_string(), toml::Value::String("(set)".into()));
+    redact_value(&mut value);
+    toml::to_string_pretty(&value).unwrap_or_else(|_| content.to_string())
+}
+
+fn redact_value(value: &mut toml::Value) {
+    match value {
+        toml::Value::Table(table) => {
+            let keys: Vec<String> = table.keys().cloned().collect();
+            for key in keys {
+                if SECRET_KEYS.iter().any(|s| *s == key) {
+                    if let Some(toml::Value::String(s)) = table.get(&key) {
+                        if !s.is_empty() && s != "(set)" {
+                            table.insert(key.clone(), toml::Value::String("(set)".into()));
+                        }
+                    }
+                }
+                if let Some(v) = table.get_mut(&key) {
+                    redact_value(v);
                 }
             }
         }
+        toml::Value::Array(arr) => {
+            for v in arr {
+                redact_value(v);
+            }
+        }
+        _ => {}
     }
-    toml::to_string_pretty(&value).unwrap_or_else(|_| content.to_string())
 }
 
 #[derive(Debug, Clone)]
@@ -597,5 +626,52 @@ host_id = 1
         assert_eq!(json["resolved"]["host_id"], 3);
         assert_eq!(json["resolved"]["api_key_set"], true);
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn project_merge_keeps_user_connections() {
+        let root = std::env::temp_dir().join(format!(
+            "chm-cfg-conns-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let user = root.join("user.toml");
+        let project = root.join("chm.toml");
+        fs::write(
+            &user,
+            r#"
+current_connection = "local"
+
+[[connections]]
+name = "local"
+engine = "clickhouse" # pragma: allowlist secret
+host = "localhost"
+port = 8123
+"#,
+        )
+        .unwrap();
+        fs::write(&project, "host_id = 2\n").unwrap();
+        let (merged, _) = load_layered_files(user, vec![project], None).unwrap();
+        assert_eq!(merged.host_id, Some(2));
+        assert_eq!(merged.current_connection.as_deref(), Some("local"));
+        assert_eq!(merged.connections.len(), 1);
+        assert_eq!(merged.connections[0].name, "local");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn redact_toml_hides_nested_password() {
+        let raw = r#"
+[[connections]]
+name = "local"
+password = "should-not-print"
+"#;
+        let redacted = redact_toml(raw);
+        assert!(!redacted.contains("should-not-print"), "{redacted}");
+        assert!(redacted.contains("(set)"), "{redacted}");
     }
 }

--- a/rust/ch-monitor-cli/src/connections.rs
+++ b/rust/ch-monitor-cli/src/connections.rs
@@ -1,0 +1,869 @@
+//! Local named database connections (`chm add` / `ls` / `use` / `rm`).
+//!
+//! Metadata lives in user config (`~/.config/chm/config.toml`). Passwords go
+//! through the credentials helper (OS keyring with 0600 plaintext fallback)
+//! and are never printed by `ls` or JSON. Distinct from dashboard `chm hosts`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{self, FileConfig},
+    credentials, diagnose,
+};
+
+const DEFAULT_CH_HTTP_PORT: u16 = 8123;
+const DEFAULT_CH_HTTPS_PORT: u16 = 8443;
+const DEFAULT_PG_PORT: u16 = 5432;
+const CH_URL_SCHEME: &str = "clickhouse://"; // pragma: allowlist secret
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Engine {
+    ClickHouse, // pragma: allowlist secret
+    Postgres,
+}
+
+impl Engine {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Engine::ClickHouse => "clickhouse", // pragma: allowlist secret
+            Engine::Postgres => "postgres",
+        }
+    }
+}
+
+impl std::fmt::Display for Engine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Saved connection metadata. Never contains a password.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StoredConnection {
+    pub name: String,
+    pub engine: Engine,
+    pub host: String,
+    pub port: u16,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub user: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub database: String,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub tls: bool,
+}
+
+impl StoredConnection {
+    pub fn display_host(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+
+    pub fn to_ch_config(&self, password: &str) -> Option<diagnose::ChConfig> {
+        match self.engine {
+            Engine::ClickHouse /* pragma: allowlist secret */ => {
+                let scheme = if self.tls { "https" } else { "http" };
+                Some(diagnose::ChConfig {
+                    url: format!("{scheme}://{}:{}", self.host, self.port),
+                    user: if self.user.is_empty() {
+                        "default".into()
+                    } else {
+                        self.user.clone()
+                    },
+                    password: password.to_string(),
+                    database: if self.database.is_empty() {
+                        "default".into()
+                    } else {
+                        self.database.clone()
+                    },
+                })
+            }
+            Engine::Postgres => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedUrl {
+    pub engine: Engine,
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+    pub tls: bool,
+    pub user_in_url: bool,
+    pub password_in_url: bool,
+    pub database_in_url: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AddOutcome {
+    pub name: String,
+    pub replacing: bool,
+    pub current: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConnectionStore {
+    pub config_path: PathBuf,
+    pub credentials_path: PathBuf,
+    pub use_keyring: bool,
+}
+
+impl ConnectionStore {
+    pub fn from_config_path(config_path: PathBuf) -> Self {
+        let parent = config_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let credentials_path = parent.join("credentials");
+        let use_keyring = config::user_config_dir().is_some_and(|d| d == parent);
+        Self {
+            config_path,
+            credentials_path,
+            use_keyring,
+        }
+    }
+
+    pub fn load(&self) -> Result<(Vec<StoredConnection>, Option<String>)> {
+        let file = config::load_user_file_config(&self.config_path)?;
+        Ok((file.connections, file.current_connection))
+    }
+
+    fn save_file(&self, file: &FileConfig) -> Result<()> {
+        config::save_user_config(&self.config_path, file)
+    }
+
+    pub fn add(&self, parsed: ParsedUrl, name: Option<&str>) -> Result<AddOutcome> {
+        let mut file = config::load_user_file_config(&self.config_path)?;
+        let derived = derive_name(&parsed);
+        let name = match name {
+            Some(raw) => parse_explicit_name(raw)?,
+            None => uniquify_derived(&derived, &parsed, &file.connections),
+        };
+        let replacing = file.connections.iter().any(|c| c.name == name);
+        let conn = StoredConnection {
+            name: name.clone(),
+            engine: parsed.engine,
+            host: parsed.host.clone(),
+            port: parsed.port,
+            user: parsed.user.clone(),
+            database: parsed.database.clone(),
+            tls: parsed.tls,
+        };
+        file.connections.retain(|c| c.name != name);
+        file.connections.push(conn);
+        file.connections.sort_by(|a, b| a.name.cmp(&b.name));
+        if file
+            .current_connection
+            .as_ref()
+            .is_none_or(|c| c.trim().is_empty())
+        {
+            file.current_connection = Some(name.clone());
+        }
+        self.save_file(&file)?;
+        if !parsed.password.is_empty() {
+            credentials::store_connection_password_at(
+                &self.credentials_path,
+                &name,
+                &parsed.password,
+                self.use_keyring,
+            )?;
+        }
+        Ok(AddOutcome {
+            name,
+            replacing,
+            current: file.current_connection,
+        })
+    }
+
+    pub fn use_name(&self, name: &str) -> Result<StoredConnection> {
+        let mut file = config::load_user_file_config(&self.config_path)?;
+        let conn = find_connection(&file.connections, name)?.clone();
+        file.current_connection = Some(conn.name.clone());
+        self.save_file(&file)?;
+        Ok(conn)
+    }
+
+    pub fn remove(&self, name: &str) -> Result<StoredConnection> {
+        let mut file = config::load_user_file_config(&self.config_path)?;
+        let conn = find_connection(&file.connections, name)?.clone();
+        file.connections.retain(|c| !eq_name(&c.name, &conn.name));
+        if file
+            .current_connection
+            .as_ref()
+            .is_some_and(|c| eq_name(c, &conn.name))
+        {
+            file.current_connection = file.connections.first().map(|c| c.name.clone());
+        }
+        self.save_file(&file)?;
+        let _ = credentials::clear_connection_password_at(
+            &self.credentials_path,
+            &conn.name,
+            self.use_keyring,
+        );
+        Ok(conn)
+    }
+
+    pub fn load_password(&self, name: &str) -> Result<Option<String>> {
+        credentials::load_connection_password_at(&self.credentials_path, name, self.use_keyring)
+    }
+
+    pub fn ch_config_for(&self, name: &str) -> Result<Option<diagnose::ChConfig>> {
+        let (conns, _) = self.load()?;
+        let conn = find_connection(&conns, name)?;
+        let password = self.load_password(&conn.name)?.unwrap_or_default();
+        Ok(conn.to_ch_config(&password))
+    }
+}
+
+fn eq_name(a: &str, b: &str) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+fn find_connection<'a>(conns: &'a [StoredConnection], name: &str) -> Result<&'a StoredConnection> {
+    if let Some(c) = conns.iter().find(|c| eq_name(&c.name, name)) {
+        return Ok(c);
+    }
+    let names: Vec<_> = conns.iter().map(|c| c.name.as_str()).collect();
+    if names.is_empty() {
+        bail!("unknown connection '{name}'. No local connections — run `chm add <url>`.");
+    }
+    bail!(
+        "unknown connection '{name}'. Available: {}",
+        names.join(", ")
+    )
+}
+
+pub fn parse_connection_url(raw: &str) -> Result<ParsedUrl> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        bail!("connection URL must not be empty");
+    }
+    let lower = raw.to_ascii_lowercase();
+    if lower.starts_with("postgres://") || lower.starts_with("postgresql://") {
+        parse_postgres_url(raw)
+    } else if lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with(CH_URL_SCHEME)
+    // pragma: allowlist secret
+    {
+        parse_ch_url(raw) // pragma: allowlist secret
+    } else if lower.contains("://") {
+        let scheme = raw.split("://").next().unwrap_or(raw);
+        bail!("unsupported URL scheme '{scheme}' (use http(s):// or postgres://)");
+    } else {
+        parse_ch_host(raw) // pragma: allowlist secret
+    }
+}
+
+fn parse_postgres_url(raw: &str) -> Result<ParsedUrl> {
+    let parsed = parse_scheme_url(raw)?;
+    let tls = postgres_tls_from_query(&parsed.query);
+    Ok(ParsedUrl {
+        engine: Engine::Postgres,
+        host: parsed.host,
+        port: parsed.port.unwrap_or(DEFAULT_PG_PORT),
+        user: parsed.user.clone(),
+        password: parsed.password,
+        database: parsed.database.clone(),
+        tls,
+        user_in_url: !parsed.user.is_empty(),
+        password_in_url: parsed.password_in_url,
+        database_in_url: !parsed.database.is_empty(),
+    })
+}
+
+fn postgres_tls_from_query(query: &str) -> bool {
+    for pair in query.split('&').filter(|p| !p.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        let key = percent_decode(key);
+        let value = percent_decode(value);
+        if key.eq_ignore_ascii_case("sslmode") {
+            let v = value.to_ascii_lowercase();
+            return matches!(v.as_str(), "require" | "verify-ca" | "verify-full");
+        }
+        if key.eq_ignore_ascii_case("ssl") {
+            return value.eq_ignore_ascii_case("true") || value == "1";
+        }
+    }
+    false
+}
+
+fn parse_ch_url(raw: &str) -> Result<ParsedUrl> {
+    // pragma: allowlist secret
+    let normalized = if raw.to_ascii_lowercase().starts_with(CH_URL_SCHEME) {
+        // pragma: allowlist secret
+        format!(
+            "http://{}",
+            raw.split_once("://").map(|s| s.1).unwrap_or(raw)
+        )
+    } else {
+        raw.to_string()
+    };
+    let parsed =
+        parse_scheme_url(&normalized).with_context(|| format!("invalid ClickHouse URL '{raw}'"))?; // pragma: allowlist secret
+    let tls = parsed.scheme == "https";
+    let port = parsed.port.unwrap_or(if tls {
+        DEFAULT_CH_HTTPS_PORT
+    } else {
+        DEFAULT_CH_HTTP_PORT
+    });
+    Ok(ParsedUrl {
+        engine: Engine::ClickHouse, // pragma: allowlist secret
+        host: parsed.host,
+        port,
+        user: parsed.user.clone(),
+        password: parsed.password,
+        database: parsed.database.clone(),
+        tls,
+        user_in_url: !parsed.user.is_empty(),
+        password_in_url: parsed.password_in_url,
+        database_in_url: !parsed.database.is_empty(),
+    })
+}
+
+struct SchemeUrl {
+    scheme: String,
+    host: String,
+    port: Option<u16>,
+    user: String,
+    password: String,
+    password_in_url: bool,
+    database: String,
+    query: String,
+}
+
+fn parse_scheme_url(raw: &str) -> Result<SchemeUrl> {
+    let Some((scheme, rest)) = raw.split_once("://") else {
+        bail!("invalid URL '{raw}'");
+    };
+    let scheme = scheme.to_ascii_lowercase();
+    let (rest, query) = match rest.split_once('?') {
+        Some((r, q)) => (r, q.split('#').next().unwrap_or(q).to_string()),
+        None => (rest.split('#').next().unwrap_or(rest), String::new()),
+    };
+    let (auth_host, path) = match rest.split_once('/') {
+        Some((h, p)) => (h, p),
+        None => (rest, ""),
+    };
+    if auth_host.is_empty() {
+        bail!("URL is missing a host");
+    }
+    let (userinfo, hostport) = match auth_host.rsplit_once('@') {
+        Some((u, h)) => (Some(u), h),
+        None => (None, auth_host),
+    };
+    let (host, port) = split_host_port_opt(hostport)?;
+    if host.is_empty() {
+        bail!("URL is missing a host");
+    }
+    let mut user = String::new();
+    let mut password = String::new();
+    let mut password_in_url = false;
+    if let Some(userinfo) = userinfo {
+        match userinfo.split_once(':') {
+            Some((u, p)) => {
+                user = percent_decode(u);
+                password = percent_decode(p);
+                password_in_url = true;
+            }
+            None => {
+                user = percent_decode(userinfo);
+            }
+        }
+    }
+    let database = path.split('/').next().unwrap_or("").to_string();
+    let database = percent_decode(&database);
+    Ok(SchemeUrl {
+        scheme,
+        host,
+        port,
+        user,
+        password,
+        password_in_url,
+        database,
+        query,
+    })
+}
+
+fn split_host_port_opt(hostport: &str) -> Result<(String, Option<u16>)> {
+    if let Some(rest) = hostport.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
+            bail!("invalid IPv6 host '{hostport}'");
+        };
+        if after.is_empty() {
+            return Ok((host.to_string(), None));
+        }
+        let Some(port_str) = after.strip_prefix(':') else {
+            bail!("invalid IPv6 host '{hostport}'");
+        };
+        let port: u16 = port_str
+            .parse()
+            .with_context(|| format!("invalid port '{port_str}'"))?;
+        return Ok((host.to_string(), Some(port)));
+    }
+    if let Some((host, port_str)) = hostport.rsplit_once(':') {
+        if !host.is_empty() && port_str.chars().all(|c| c.is_ascii_digit()) && !port_str.is_empty()
+        {
+            let port: u16 = port_str
+                .parse()
+                .with_context(|| format!("invalid port '{port_str}'"))?;
+            return Ok((host.to_string(), Some(port)));
+        }
+    }
+    Ok((hostport.to_string(), None))
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = bytes[i + 1];
+            let lo = bytes[i + 2];
+            if let (Some(h), Some(l)) = (from_hex(hi), from_hex(lo)) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn from_hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// `--ch-host` style: `host`, `host:port`, `host:port/db`, `host/db`.
+fn parse_ch_host(raw: &str) -> Result<ParsedUrl> {
+    // pragma: allowlist secret
+    let raw = raw.trim().trim_end_matches('/');
+    let (hostport, db) = match raw.split_once('/') {
+        Some((h, d)) => (h, Some(d)),
+        None => (raw, None),
+    };
+    if hostport.is_empty() {
+        bail!("ClickHouse host must not be empty"); // pragma: allowlist secret
+    }
+    let (host, port) = split_host_port(hostport, DEFAULT_CH_HTTP_PORT)?;
+    let database_in_url = db.is_some_and(|d| !d.is_empty());
+    let database = db.unwrap_or("").to_string();
+    Ok(ParsedUrl {
+        engine: Engine::ClickHouse, // pragma: allowlist secret
+        host,
+        port,
+        user: String::new(),
+        password: String::new(),
+        database,
+        tls: false,
+        user_in_url: false,
+        password_in_url: false,
+        database_in_url,
+    })
+}
+
+fn split_host_port(hostport: &str, default_port: u16) -> Result<(String, u16)> {
+    if let Some(rest) = hostport.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
+            bail!("invalid IPv6 host '{hostport}'");
+        };
+        if after.is_empty() {
+            return Ok((host.to_string(), default_port));
+        }
+        let Some(port_str) = after.strip_prefix(':') else {
+            bail!("invalid IPv6 host '{hostport}'");
+        };
+        let port: u16 = port_str
+            .parse()
+            .with_context(|| format!("invalid port '{port_str}'"))?;
+        return Ok((host.to_string(), port));
+    }
+    if let Some((host, port_str)) = hostport.rsplit_once(':') {
+        if !host.is_empty() && port_str.chars().all(|c| c.is_ascii_digit()) && !port_str.is_empty()
+        {
+            let port: u16 = port_str
+                .parse()
+                .with_context(|| format!("invalid port '{port_str}'"))?;
+            return Ok((host.to_string(), port));
+        }
+    }
+    Ok((hostport.to_string(), default_port))
+}
+
+pub fn apply_ch_args(
+    // pragma: allowlist secret
+    parsed: &mut ParsedUrl,
+    user: &str,
+    password: &str,
+    database: &str,
+) {
+    if !matches!(
+        parsed.engine,
+        Engine::ClickHouse /* pragma: allowlist secret */
+    ) {
+        return;
+    }
+    if !parsed.user_in_url && !user.is_empty() {
+        parsed.user = user.to_string();
+    }
+    if !parsed.password_in_url && !password.is_empty() {
+        parsed.password = password.to_string();
+    }
+    if !parsed.database_in_url && !database.is_empty() {
+        parsed.database = database.to_string();
+    }
+}
+
+pub fn sanitize_name(raw: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for c in raw.trim().chars() {
+        let c = c.to_ascii_lowercase();
+        let ok = c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-';
+        if ok {
+            out.push(c);
+            last_dash = c == '-';
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    while out.starts_with('-') {
+        out.remove(0);
+    }
+    if out.len() > 48 {
+        out.truncate(48);
+        while out.ends_with('-') {
+            out.pop();
+        }
+    }
+    out
+}
+
+pub fn parse_explicit_name(raw: &str) -> Result<String> {
+    let name = sanitize_name(raw);
+    if name.is_empty() {
+        bail!("connection name must contain a letter or digit");
+    }
+    Ok(name)
+}
+
+pub fn derive_name(parsed: &ParsedUrl) -> String {
+    let host = host_label(&parsed.host);
+    let db = parsed.database.trim();
+    let skip_db =
+        db.is_empty() || db.eq_ignore_ascii_case("default") || db.eq_ignore_ascii_case("postgres");
+    let base = if skip_db {
+        host
+    } else {
+        format!("{host}-{}", sanitize_name(db))
+    };
+    let name = sanitize_name(&base);
+    if name.is_empty() {
+        "db".into()
+    } else {
+        name
+    }
+}
+
+fn host_label(host: &str) -> String {
+    if host == "127.0.0.1" || host == "::1" || host.eq_ignore_ascii_case("localhost") {
+        return "localhost".into();
+    }
+    host.split('.').next().unwrap_or(host).to_string()
+}
+
+fn uniquify_derived(derived: &str, parsed: &ParsedUrl, existing: &[StoredConnection]) -> String {
+    if let Some(c) = existing.iter().find(|c| c.name == derived) {
+        if c.engine == parsed.engine && c.host == parsed.host && c.port == parsed.port {
+            return derived.to_string();
+        }
+    } else {
+        return derived.to_string();
+    }
+    for i in 2..1000 {
+        let candidate = format!("{derived}-{i}");
+        if !existing.iter().any(|c| c.name == candidate) {
+            return candidate;
+        }
+    }
+    format!("{derived}-new")
+}
+
+pub fn list_json(connections: &[StoredConnection], current: Option<&str>) -> serde_json::Value {
+    let current_name = current.map(str::trim).filter(|s| !s.is_empty());
+    serde_json::json!({
+        "current": current_name,
+        "connections": connections.iter().map(|c| {
+            let is_current = current_name.is_some_and(|n| eq_name(n, &c.name));
+            serde_json::json!({
+                "name": c.name,
+                "engine": c.engine.as_str(),
+                "host": c.display_host(),
+                "user": c.user,
+                "database": c.database,
+                "tls": c.tls,
+                "current": is_current,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+pub fn format_list_text(connections: &[StoredConnection], current: Option<&str>) -> String {
+    if connections.is_empty() {
+        return "no local connections\nhint: chm add http://localhost:8123\n".into();
+    }
+    let current_name = current.map(str::trim).filter(|s| !s.is_empty());
+    let mut out = String::new();
+    for c in connections {
+        let marker = if current_name.is_some_and(|n| eq_name(n, &c.name)) {
+            "*"
+        } else {
+            " "
+        };
+        out.push_str(&format!(
+            "{marker} {:<16} {:<11} {}\n",
+            c.name,
+            c.engine.as_str(),
+            c.display_host()
+        ));
+    }
+    out
+}
+
+pub fn picker_labels(connections: &[StoredConnection], current: Option<&str>) -> Vec<String> {
+    let current_name = current.map(str::trim).filter(|s| !s.is_empty());
+    connections
+        .iter()
+        .map(|c| {
+            let marker = if current_name.is_some_and(|n| eq_name(n, &c.name)) {
+                "*"
+            } else {
+                " "
+            };
+            format!(
+                "{marker} {}  {}  {}",
+                c.name,
+                c.engine.as_str(),
+                c.display_host()
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_store() -> (PathBuf, ConnectionStore) {
+        let dir = std::env::temp_dir().join(format!(
+            "chm-conn-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let store = ConnectionStore::from_config_path(dir.join("config.toml"));
+        assert!(
+            !store.use_keyring,
+            "temp config dir must not use the OS keyring"
+        );
+        (dir, store)
+    }
+
+    #[test]
+    fn parse_ch_http_with_userinfo_and_db() {
+        // pragma: allowlist secret
+        let p = parse_connection_url("http://alice:s3cret@ch.example.com:8123/analytics").unwrap();
+        assert_eq!(p.engine, Engine::ClickHouse); // pragma: allowlist secret
+        assert_eq!(p.host, "ch.example.com");
+        assert_eq!(p.port, 8123);
+        assert_eq!(p.user, "alice");
+        assert_eq!(p.password, "s3cret");
+        assert_eq!(p.database, "analytics");
+        assert!(!p.tls);
+        assert!(p.user_in_url && p.password_in_url && p.database_in_url);
+        assert_eq!(derive_name(&p), "ch-analytics");
+    }
+
+    #[test]
+    fn parse_ch_https_default_port() {
+        // pragma: allowlist secret
+        let p = parse_connection_url("https://secure.example").unwrap();
+        assert_eq!(p.port, 8443);
+        assert!(p.tls);
+        assert_eq!(p.host, "secure.example");
+        assert!(!p.user_in_url);
+    }
+
+    #[test]
+    fn parse_ch_host_style() {
+        // pragma: allowlist secret
+        let p = parse_connection_url("localhost:8123").unwrap();
+        assert_eq!(p.engine, Engine::ClickHouse); // pragma: allowlist secret
+        assert_eq!(p.host, "localhost");
+        assert_eq!(p.port, 8123);
+        assert!(!p.tls);
+        assert_eq!(derive_name(&p), "localhost");
+
+        let with_db = parse_connection_url("127.0.0.1:8443/metrics").unwrap();
+        assert_eq!(with_db.host, "127.0.0.1");
+        assert_eq!(with_db.port, 8443);
+        assert_eq!(with_db.database, "metrics");
+        assert_eq!(derive_name(&with_db), "localhost-metrics");
+    }
+
+    #[test]
+    fn parse_ch_percent_encoded_password() {
+        // pragma: allowlist secret
+        let p = parse_connection_url("http://u:p%40ss@localhost:8123").unwrap();
+        assert_eq!(p.password, "p@ss");
+    }
+
+    #[test]
+    fn parse_postgres_url() {
+        let p = parse_connection_url("postgres://bob:p%40ss@db.example:5432/app").unwrap();
+        assert_eq!(p.engine, Engine::Postgres);
+        assert_eq!(p.host, "db.example");
+        assert_eq!(p.port, 5432);
+        assert_eq!(p.user, "bob");
+        assert_eq!(p.password, "p@ss");
+        assert_eq!(p.database, "app");
+        assert!(!p.tls);
+        assert_eq!(derive_name(&p), "db-app");
+    }
+
+    #[test]
+    fn parse_postgresql_sslmode_require() {
+        let p = parse_connection_url("postgresql://localhost/app?sslmode=require").unwrap();
+        assert_eq!(p.engine, Engine::Postgres);
+        assert_eq!(p.host, "localhost");
+        assert_eq!(p.port, 5432);
+        assert_eq!(p.database, "app");
+        assert!(p.tls);
+        assert_eq!(derive_name(&p), "localhost-app");
+    }
+
+    #[test]
+    fn reject_unknown_scheme() {
+        let err = parse_connection_url("ftp://localhost/db").unwrap_err();
+        assert!(err.to_string().contains("unsupported URL scheme"), "{err}");
+    }
+
+    #[test]
+    fn add_use_ls_rm_on_temp_config_hides_secrets() {
+        let (dir, store) = temp_store();
+        let mut parsed =
+            parse_connection_url("http://alice:super-secret@localhost:8123/default").unwrap();
+        apply_ch_args(&mut parsed, "ignored", "", "ignored"); // pragma: allowlist secret
+        assert_eq!(parsed.user, "alice");
+        assert_eq!(parsed.password, "super-secret");
+
+        let added = store.add(parsed, None).unwrap();
+        assert_eq!(added.name, "localhost");
+        assert!(!added.replacing);
+        assert_eq!(added.current.as_deref(), Some("localhost"));
+
+        let pg = parse_connection_url("postgres://app:pg-secret@localhost:5432/orders").unwrap();
+        let pg_added = store.add(pg, Some("shop")).unwrap();
+        assert_eq!(pg_added.name, "shop");
+        assert_eq!(pg_added.current.as_deref(), Some("localhost"));
+
+        let (conns, current) = store.load().unwrap();
+        let text = format_list_text(&conns, current.as_deref());
+        assert!(text.contains("* localhost"), "{text}");
+        assert!(text.contains("clickhouse"), "{text}"); // pragma: allowlist secret
+        assert!(text.contains("shop"), "{text}");
+        assert!(text.contains("postgres"), "{text}");
+        assert!(!text.contains("super-secret"), "{text}");
+        assert!(!text.contains("pg-secret"), "{text}");
+
+        let json = list_json(&conns, current.as_deref());
+        let dumped = json.to_string();
+        assert!(!dumped.contains("super-secret"), "{dumped}");
+        assert!(!dumped.contains("pg-secret"), "{dumped}");
+        assert!(!dumped.contains("password"), "{dumped}");
+        assert_eq!(json["current"], "localhost");
+        assert_eq!(json["connections"][0]["engine"], "clickhouse"); // pragma: allowlist secret
+        assert_eq!(json["connections"][1]["name"], "shop");
+
+        let toml = fs::read_to_string(&store.config_path).unwrap();
+        assert!(!toml.contains("super-secret"), "{toml}");
+        assert!(!toml.contains("pg-secret"), "{toml}");
+        assert!(toml.contains("current_connection"), "{toml}");
+
+        let creds = fs::read_to_string(&store.credentials_path).unwrap();
+        assert!(creds.contains("super-secret"), "{creds}");
+        assert!(creds.contains("pg-secret"), "{creds}");
+
+        store.use_name("shop").unwrap();
+        let (_, current) = store.load().unwrap();
+        assert_eq!(current.as_deref(), Some("shop"));
+
+        store.remove("shop").unwrap();
+        let (conns, current) = store.load().unwrap();
+        assert_eq!(conns.len(), 1);
+        assert_eq!(current.as_deref(), Some("localhost"));
+        let creds = fs::read_to_string(&store.credentials_path).unwrap();
+        assert!(!creds.contains("pg-secret"), "{creds}");
+        assert!(creds.contains("super-secret"), "{creds}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_uniquifies_conflicting_auto_names() {
+        let (dir, store) = temp_store();
+        store
+            .add(parse_connection_url("http://localhost:8123").unwrap(), None)
+            .unwrap();
+        let second = store
+            .add(parse_connection_url("http://localhost:8443").unwrap(), None)
+            .unwrap();
+        assert_eq!(second.name, "localhost-2");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ch_args_fill_host_style_url() {
+        // pragma: allowlist secret
+        let mut parsed = parse_connection_url("localhost:8123").unwrap();
+        apply_ch_args(&mut parsed, "default", "from-flag", "analytics"); // pragma: allowlist secret
+        assert_eq!(parsed.user, "default");
+        assert_eq!(parsed.password, "from-flag");
+        assert_eq!(parsed.database, "analytics");
+    }
+
+    #[test]
+    fn to_ch_config_skips_postgres() {
+        let conn = StoredConnection {
+            name: "pg".into(),
+            engine: Engine::Postgres,
+            host: "localhost".into(),
+            port: 5432,
+            user: "app".into(),
+            database: "app".into(),
+            tls: false,
+        };
+        assert!(conn.to_ch_config("x").is_none());
+    }
+}

--- a/rust/ch-monitor-cli/src/credentials.rs
+++ b/rust/ch-monitor-cli/src/credentials.rs
@@ -2,7 +2,11 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
-use std::{fs, io::Write, path::PathBuf};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result};
 use keyring::Entry;
@@ -33,14 +37,11 @@ fn keyring_entry(user: &str) -> Result<Entry> {
     Entry::new(SERVICE, user).context("failed to open OS keyring entry")
 }
 
-fn read_plaintext(key: &str) -> Result<Option<String>> {
-    let Some(path) = credentials_path() else {
-        return Ok(None);
-    };
+fn read_plaintext_at(path: &Path, key: &str) -> Result<Option<String>> {
     if !path.exists() {
         return Ok(None);
     }
-    let content = fs::read_to_string(&path)
+    let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read credentials at {}", path.display()))?;
     for line in content.lines() {
         let line = line.trim();
@@ -59,15 +60,21 @@ fn read_plaintext(key: &str) -> Result<Option<String>> {
     Ok(None)
 }
 
-fn write_plaintext(key: &str, value: &str) -> Result<()> {
-    let path = credentials_path().context("could not resolve credentials path")?;
+fn read_plaintext(key: &str) -> Result<Option<String>> {
+    let Some(path) = credentials_path() else {
+        return Ok(None);
+    };
+    read_plaintext_at(&path, key)
+}
+
+fn write_plaintext_at(path: &Path, key: &str, value: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         ensure_private_dir(parent)?;
     }
 
     let mut map = std::collections::BTreeMap::<String, String>::new();
     if path.exists() {
-        let existing = fs::read_to_string(&path).unwrap_or_default();
+        let existing = fs::read_to_string(path).unwrap_or_default();
         for line in existing.lines() {
             if let Some((k, v)) = line.split_once('=') {
                 map.insert(k.trim().to_string(), v.trim().trim_matches('"').to_string());
@@ -88,12 +95,17 @@ fn write_plaintext(key: &str, value: &str) -> Result<()> {
         opts.mode(0o600);
     }
     let mut file = opts
-        .open(&path)
+        .open(path)
         .with_context(|| format!("failed to open {}", path.display()))?;
 
     file.write_all(out.as_bytes())
         .with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
+}
+
+fn write_plaintext(key: &str, value: &str) -> Result<()> {
+    let path = credentials_path().context("could not resolve credentials path")?;
+    write_plaintext_at(&path, key, value)
 }
 
 fn clear_plaintext_at(path: &std::path::Path, key: &str) -> Result<()> {
@@ -248,6 +260,64 @@ pub fn resolve_api_key(cli_or_config: Option<&str>) -> Result<Option<String>> {
         }
     }
     load_api_key()
+}
+
+fn connection_plaintext_key(name: &str) -> String {
+    format!("connection.{name}")
+}
+
+fn connection_keyring_user(name: &str) -> String {
+    format!("connection:{name}")
+}
+
+/// Store a local-connection password. Keyring when `use_keyring` is true and
+/// available; otherwise 0600 plaintext at `path` (same file format as token/api_key).
+pub fn store_connection_password_at(
+    path: &Path,
+    name: &str,
+    password: &str,
+    use_keyring: bool,
+) -> Result<()> {
+    let plaintext_key = connection_plaintext_key(name);
+    if use_keyring
+        && keyring_entry(&connection_keyring_user(name))
+            .and_then(|e| {
+                e.set_password(password)
+                    .context("failed to store secret in OS keyring")
+            })
+            .is_ok()
+    {
+        let _ = purge_stale_plaintext_at(path, &plaintext_key);
+        return Ok(());
+    }
+    write_plaintext_at(path, &plaintext_key, password)
+}
+
+pub fn load_connection_password_at(
+    path: &Path,
+    name: &str,
+    use_keyring: bool,
+) -> Result<Option<String>> {
+    if use_keyring {
+        if let Ok(entry) = keyring_entry(&connection_keyring_user(name)) {
+            match entry.get_password() {
+                Ok(v) if !v.is_empty() => return Ok(Some(v)),
+                Ok(_) => {}
+                Err(keyring::Error::NoEntry) => {}
+                Err(_) => {}
+            }
+        }
+    }
+    read_plaintext_at(path, &connection_plaintext_key(name))
+}
+
+pub fn clear_connection_password_at(path: &Path, name: &str, use_keyring: bool) -> Result<()> {
+    if use_keyring {
+        if let Ok(entry) = keyring_entry(&connection_keyring_user(name)) {
+            let _ = entry.delete_credential();
+        }
+    }
+    clear_plaintext_at(path, &connection_plaintext_key(name))
 }
 
 #[cfg(test)]

--- a/rust/ch-monitor-cli/src/main.rs
+++ b/rust/ch-monitor-cli/src/main.rs
@@ -4,6 +4,7 @@ mod cli;
 mod client;
 mod commands;
 mod config;
+mod connections;
 mod credentials;
 mod dashboards;
 mod diagnose;
@@ -45,6 +46,10 @@ async fn main() -> Result<()> {
     let (tel_event, tel_command): (&'static str, &'static str) = match &command {
         Commands::Doctor(_) if cli.clickhouse.has_cluster_host() => ("cli_diagnose", "doctor"),
         Commands::Doctor(_) => ("cli_run", "doctor"),
+        Commands::Add(_) => ("cli_run", "add"),
+        Commands::Ls => ("cli_run", "ls"),
+        Commands::Use { .. } => ("cli_run", "use"),
+        Commands::Rm { .. } => ("cli_run", "rm"),
         Commands::Hosts => ("cli_run", "hosts"),
         Commands::Chart { .. } => ("cli_run", "chart"),
         Commands::Table { .. } => ("cli_run", "table"),
@@ -169,6 +174,7 @@ mod tests {
         assert!(help.contains("doctor"), "{help}");
         assert!(help.contains("auth"), "{help}");
         assert!(help.contains("config"), "{help}");
+        assert!(help.contains("add"), "{help}");
         assert!(help.contains("--base-url"), "{help}");
         assert!(!help.contains("diagnose"), "{help}");
     }
@@ -477,5 +483,65 @@ mod tests {
         let help = cmd.render_long_help().to_string();
         assert!(help.contains("dashboard"), "{help}");
         assert!(help.contains("config"), "{help}");
+    }
+
+    #[test]
+    fn add_connect_ls_use_rm_parse() {
+        let add = Cli::try_parse_from(["chm", "add", "http://localhost:8123", "--name", "local"])
+            .expect("parse add");
+        match add.command {
+            Some(Commands::Add(args)) => {
+                assert_eq!(args.url, "http://localhost:8123");
+                assert_eq!(args.name.as_deref(), Some("local"));
+            }
+            other => panic!("expected Add, got {other:?}"),
+        }
+
+        let connect = Cli::try_parse_from(["chm", "connect", "postgres://localhost/app"])
+            .expect("parse connect alias");
+        match connect.command {
+            Some(Commands::Add(args)) => {
+                assert_eq!(args.url, "postgres://localhost/app");
+                assert!(args.name.is_none());
+            }
+            other => panic!("expected Add via connect, got {other:?}"),
+        }
+
+        let ls = Cli::try_parse_from(["chm", "ls"]).expect("parse ls");
+        assert!(matches!(ls.command, Some(Commands::Ls)));
+
+        let use_cmd = Cli::try_parse_from(["chm", "use", "local"]).expect("parse use");
+        match use_cmd.command {
+            Some(Commands::Use { name }) => assert_eq!(name, "local"),
+            other => panic!("expected Use, got {other:?}"),
+        }
+
+        let rm = Cli::try_parse_from(["chm", "rm", "local"]).expect("parse rm");
+        match rm.command {
+            Some(Commands::Rm { name }) => assert_eq!(name, "local"),
+            other => panic!("expected Rm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_lists_local_connection_commands() {
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(help.contains("add"), "{help}");
+        assert!(help.contains("connect"), "{help}");
+        assert!(help.contains("ls"), "{help}");
+        assert!(help.contains("use"), "{help}");
+        assert!(help.contains("local named"), "{help}");
+        let add_help = cmd
+            .find_subcommand_mut("add")
+            .expect("add subcommand")
+            .render_long_help()
+            .to_string();
+        assert!(add_help.contains("postgres://"), "{add_help}");
+        assert!(add_help.contains("--name"), "{add_help}");
+        assert!(
+            add_help.contains("no network") || add_help.contains("Save a local"),
+            "{add_help}"
+        );
     }
 }

--- a/rust/ch-monitor-cli/src/tui/config_form.rs
+++ b/rust/ch-monitor-cli/src/tui/config_form.rs
@@ -209,6 +209,7 @@ impl ConfigForm {
             token: None,
             default_chart: Some(default_chart.to_string()),
             channel: Some(self.channel.as_str().to_string()),
+            ..Default::default()
         })
     }
 }

--- a/rust/ch-monitor-cli/src/tui/mod.rs
+++ b/rust/ch-monitor-cli/src/tui/mod.rs
@@ -10,6 +10,7 @@ pub mod picker;
 
 use std::{
     io,
+    path::PathBuf,
     time::{Duration, Instant},
 };
 
@@ -35,6 +36,7 @@ use serde_json::Value;
 use crate::{
     client,
     config::{AppConfig, DEFAULT_TABLE},
+    connections::{ConnectionStore, Engine, StoredConnection},
     dashboards,
     diagnose::{self, ChConfig, Finding, Report},
     metrics, output,
@@ -55,6 +57,8 @@ const EMERALD: Color = Color::Rgb(16, 185, 129);
 const AUTH_HINT: &str = "Dashboard needs login — run `chm auth login`, then press r";
 const CH_AGENT_HINT: &str =
     "Agent chat needs a chmonitor dashboard — drop --ch-host or set CHM_BASE_URL";
+const PG_TUI_HINT: &str =
+    "Postgres TUI is not in this slice — connection is active (`chm ls` / `chm use`). Press h/l to switch.";
 const HELP_TEXT: &str = "\
 chmonitor keys (ops cockpit)
 
@@ -62,8 +66,8 @@ chmonitor keys (ops cockpit)
   r           refresh now
   ?           toggle this help
   a           open agent chat (dashboard API)
-  h / ←       previous host
-  l / →       next host
+  h / ←       previous host / local connection
+  l / →       next host / local connection
   j / ↓       scroll table down
   k / ↑       scroll table up
   Tab         switch pane (small terminals)
@@ -71,9 +75,8 @@ chmonitor keys (ops cockpit)
   2           queries table
   3           doctor findings
   /           filter table
-  c           (connection is --ch-host vs --base-url)
 
-Connect with dashboard API (default) or `chm --ch-host http://host:8123`.
+Connect with dashboard API (default), `chm --ch-host`, or `chm add` / `chm use`.
 Non-TTY / CI / --json / --no-tui prints a snapshot instead of alt-screen.";
 
 const PREFERRED_TABLE_COLUMNS: &[&str] = &[
@@ -133,6 +136,9 @@ pub struct TuiOptions {
     pub start_overview: bool,
     pub host_id: u32,
     pub ch: Option<ChConfig>,
+    pub local_connections: Vec<StoredConnection>,
+    pub current_connection: Option<String>,
+    pub config_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -176,6 +182,8 @@ struct App {
     ch: Option<ChConfig>,
     report: Option<Report>,
     agent_hint: Option<String>,
+    local_connections: Vec<StoredConnection>,
+    config_path: Option<PathBuf>,
 }
 
 impl App {
@@ -186,6 +194,13 @@ impl App {
             opts.charts.clone()
         };
         let _ = opts.start_overview;
+        let hosts = local_hosts(&opts.local_connections);
+        let host_id = if hosts.is_empty() {
+            opts.host_id
+        } else {
+            current_local_id(&opts.local_connections, opts.current_connection.as_deref())
+                .unwrap_or(0)
+        };
         Self {
             dashboard: if opts.dashboard.trim().is_empty() {
                 dashboards::OVERVIEW_NAME.to_string()
@@ -198,8 +213,8 @@ impl App {
                 opts.table.clone()
             },
             page_size: opts.page_size,
-            host_id: opts.host_id,
-            hosts: Vec::new(),
+            host_id,
+            hosts,
             charts: charts
                 .into_iter()
                 .map(|name| ChartPane {
@@ -221,6 +236,8 @@ impl App {
             ch: opts.ch.clone(),
             report: None,
             agent_hint: None,
+            local_connections: opts.local_connections.clone(),
+            config_path: opts.config_path.clone(),
         }
     }
 
@@ -408,10 +425,16 @@ fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
             }
             KeyCode::Char('h') | KeyCode::Char('[') | KeyCode::Left => {
                 app.host_id = step_host(&app.hosts, app.host_id, -1);
+                if !app.local_connections.is_empty() {
+                    apply_local_selection(app);
+                }
                 KeyAction::Refresh
             }
             KeyCode::Char('l') | KeyCode::Char(']') | KeyCode::Right => {
                 app.host_id = step_host(&app.hosts, app.host_id, 1);
+                if !app.local_connections.is_empty() {
+                    apply_local_selection(app);
+                }
                 KeyAction::Refresh
             }
             KeyCode::Down | KeyCode::Char('j') => {
@@ -505,6 +528,19 @@ fn bound_table_rows(mut rows: Vec<Value>, page_size: usize) -> Vec<Value> {
 
 async fn refresh(client: &Client, cfg: &AppConfig, app: &mut App, force: bool) {
     app.agent_hint = None;
+    if !app.local_connections.is_empty() {
+        app.hosts = local_hosts(&app.local_connections);
+        if app.ch.is_some() {
+            refresh_clickhouse(client, app, force).await; // pragma: allowlist secret
+            app.hosts = local_hosts(&app.local_connections);
+            return;
+        }
+        app.auth_required = false;
+        if app.error.as_deref() != Some(PG_TUI_HINT) {
+            app.error = Some(PG_TUI_HINT.to_string());
+        }
+        return;
+    }
     if app.ch.is_some() {
         refresh_clickhouse(client, app, force).await;
         return;
@@ -726,12 +762,14 @@ async fn refresh_clickhouse(client: &Client, app: &mut App, force: bool) {
         Err(err) => errors.push(short_error("processes", &err)),
     }
 
-    app.hosts = vec![HostEntry {
-        id: 0,
-        name: ch.url.clone(),
-        host: ch.url,
-    }];
-    app.host_id = 0;
+    if app.local_connections.is_empty() {
+        app.hosts = vec![HostEntry {
+            id: 0,
+            name: ch.url.clone(),
+            host: ch.url,
+        }];
+        app.host_id = 0;
+    }
 
     if let Some(message) = errors.into_iter().next() {
         app.error = Some(message);
@@ -1177,6 +1215,60 @@ fn refresh_age_label(last_ok: Option<Instant>, now: Instant) -> String {
     }
 }
 
+fn local_hosts(conns: &[StoredConnection]) -> Vec<HostEntry> {
+    conns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| HostEntry {
+            id: i as u32,
+            name: c.name.clone(),
+            host: c.display_host(),
+        })
+        .collect()
+}
+
+fn current_local_id(conns: &[StoredConnection], current: Option<&str>) -> Option<u32> {
+    let current = current.map(str::trim).filter(|s| !s.is_empty())?;
+    conns
+        .iter()
+        .position(|c| c.name.eq_ignore_ascii_case(current))
+        .map(|i| i as u32)
+}
+
+fn apply_local_selection(app: &mut App) {
+    let Some(idx) = app.hosts.iter().position(|h| h.id == app.host_id) else {
+        return;
+    };
+    let Some(conn) = app.local_connections.get(idx).cloned() else {
+        return;
+    };
+    let password = app
+        .config_path
+        .as_ref()
+        .and_then(|path| {
+            ConnectionStore::from_config_path(path.clone())
+                .load_password(&conn.name)
+                .ok()
+                .flatten()
+        })
+        .unwrap_or_default();
+    match conn.engine {
+        Engine::ClickHouse /* pragma: allowlist secret */ => {
+            app.ch = conn.to_ch_config(&password);
+            if app.error.as_deref() == Some(PG_TUI_HINT) {
+                app.error = None;
+            }
+        }
+        Engine::Postgres => {
+            app.ch = None;
+            app.error = Some(PG_TUI_HINT.to_string());
+        }
+    }
+    if let Some(path) = &app.config_path {
+        let _ = ConnectionStore::from_config_path(path.clone()).use_name(&conn.name);
+    }
+}
+
 fn host_label(hosts: &[HostEntry], host_id: u32) -> String {
     hosts
         .iter()
@@ -1373,7 +1465,13 @@ pub async fn snapshot(client: &Client, cfg: &AppConfig, opts: &TuiOptions) -> Re
             })
         });
         output::print_json(&serde_json::json!({
-            "backend": if app.ch.is_some() { "clickhouse" } else { "dashboard" },
+            "backend": if app.ch.is_some() {
+                "clickhouse" // pragma: allowlist secret
+            } else if !app.local_connections.is_empty() {
+                "local"
+            } else {
+                "dashboard"
+            },
             "host": app.host_label(),
             "dashboard": app.dashboard,
             "error": app.error,
@@ -1563,6 +1661,9 @@ mod tests {
             start_overview: false,
             host_id: 0,
             ch: None,
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         };
         let mut app = App::new(&opts);
         assert_eq!(app.focused, Pane::Overview);
@@ -1616,6 +1717,9 @@ mod tests {
             start_overview: true,
             host_id: 0,
             ch: None,
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         };
         let mut app = App::new(&opts);
         app.hosts = parse_hosts(&json!([{"id":0,"name":"a"},{"id":1,"name":"b"}]));
@@ -1649,6 +1753,9 @@ mod tests {
                 password: String::new(),
                 database: "default".into(),
             }),
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         };
         let mut app = App::new(&opts);
         assert_eq!(
@@ -1674,6 +1781,9 @@ mod tests {
             start_overview: false,
             host_id: 0,
             ch: None,
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         };
         let app = App::new(&opts);
         assert_eq!(app.dashboard, "Overview");
@@ -1699,6 +1809,9 @@ mod tests {
             start_overview: true,
             host_id: 0,
             ch: None,
+            local_connections: Vec::new(),
+            current_connection: None,
+            config_path: None,
         };
         let mut app = App::new(&opts);
         app.charts[0].rows = vec![json!({"query_count": 1})];
@@ -1765,5 +1878,59 @@ mod tests {
             15,
         );
         assert_eq!(table.len(), 15);
+    }
+
+    #[test]
+    fn local_connections_cycle_without_restart() {
+        let conns = vec![
+            StoredConnection {
+                name: "ch".into(),
+                engine: Engine::ClickHouse, // pragma: allowlist secret
+                host: "localhost".into(),
+                port: 8123,
+                user: "default".into(),
+                database: "default".into(),
+                tls: false,
+            },
+            StoredConnection {
+                name: "pg".into(),
+                engine: Engine::Postgres,
+                host: "localhost".into(),
+                port: 5432,
+                user: "app".into(),
+                database: "app".into(),
+                tls: false,
+            },
+        ];
+        let opts = TuiOptions {
+            dashboard: "Overview".into(),
+            charts: vec!["query-count".into()],
+            table: "running-queries".into(),
+            page_size: 15,
+            start_overview: true,
+            host_id: 0,
+            ch: conns[0].to_ch_config(""),
+            local_connections: conns,
+            current_connection: Some("ch".into()),
+            config_path: None,
+        };
+        let mut app = App::new(&opts);
+        assert_eq!(app.hosts.len(), 2);
+        assert_eq!(app.host_id, 0);
+        assert!(app.ch.is_some());
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('l'))),
+            KeyAction::Refresh
+        );
+        assert_eq!(app.host_id, 1);
+        assert!(app.ch.is_none());
+        assert_eq!(app.error.as_deref(), Some(PG_TUI_HINT));
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('h'))),
+            KeyAction::Refresh
+        );
+        assert_eq!(app.host_id, 0);
+        assert!(app.ch.is_some());
+        assert_eq!(app.host_label(), "ch");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P0 of local named connections in `chm`: add, list, switch, and remove saved cluster HTTP + Postgres URLs without a dashboard or a network probe.

## Changes

- `chm add <url>` (alias `connect`) saves a local named connection; optional `--name`, otherwise a short host/db slug
- URLs: HTTP `http(s)://[user:pass@]host:8123[/db]`, existing `--ch-host` style, and `postgres://` / `postgresql://`
- `chm ls` prints name, engine (`clickhouse` | `postgres`), host, and a current marker; `--json` supported
- `chm use <name>` sets `current_connection` in user `config.toml`
- `chm rm <name>` removes a saved connection
- Secrets go through the existing credentials helper (keyring / `0600` plaintext); never printed in `ls` or JSON
- Live TUI opens against the active local HTTP connection; `h`/`l` cycles local connections without restart (Postgres shows a P0 stub)
- Dashboard `chm hosts` is unchanged
- Docs: clap help, `rust/ch-monitor-cli/README.md`, `docs/content/guide/guides/diagnostics-cli.mdx`, `docs/knowledge/standalone-cli.md`

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` (workspace)
- [x] `cargo test --workspace`
- [x] URL parse tests for HTTP + Postgres
- [x] `add` / `use` / `ls` / `rm` against a temp `--config` dir; secrets absent from text, JSON, and `config.toml`
- [x] Docs updated in `docs/content/`
- [ ] `pnpm run lint` / `pnpm run build` / `pnpm run test:unit` — not applicable (Rust CLI only)

## Notes for reviewer

P1/P2 left out: Postgres doctor/health/queries, agent on the local connection, add-host, release-please, #3347.

Closes #3354

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66ce0994-6c5b-4782-a658-184d6a986255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ce0994-6c5b-4782-a658-184d6a986255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

