### PR TITLE
fix(cli): assemble report metrics from the repo root

### DIFF
--- a/docs/knowledge/standalone-cli.md
+++ b/docs/knowledge/standalone-cli.md
@@ -129,7 +129,9 @@ cargo run --manifest-path rust/ch-monitor-cli/Cargo.toml -- doctor
 PRs (including the rolling release-please CLI PR) for the four release
 targets: linux gnu x86_64/aarch64 and macOS x86_64/aarch64. It posts one
 sticky comment (`header: cli-build-report`) and recreates it on each push
-so only the latest numbers stay. Local:
+so only the latest numbers stay. `--assemble DIR` is resolved from the
+repo root (CI downloads metrics to `$GITHUB_WORKSPACE/cli-report-metrics`,
+not `rust/`). Local:
 
 ```bash
 bash scripts/cli-build-report.sh --target x86_64-unknown-linux-gnu

--- a/scripts/cli-build-report.sh
+++ b/scripts/cli-build-report.sh
@@ -4,11 +4,21 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-cd "$ROOT/rust"
 
 usage() {
   echo "usage: $0 [--target TRIPLE] [--out DIR] [--assemble DIR] [--report PATH]" >&2
   exit 2
+}
+
+# Relative --assemble / --report / --out paths are from the repo root, not rust/.
+# The report job downloads artifacts to $GITHUB_WORKSPACE/cli-report-metrics.
+abs_from_root() {
+  local p="$1"
+  if [[ "$p" == /* ]]; then
+    printf '%s\n' "$p"
+  else
+    printf '%s\n' "$ROOT/$p"
+  fi
 }
 
 target=""
@@ -44,6 +54,8 @@ file_size() {
 }
 
 if [[ -n "$assemble_dir" ]]; then
+  assemble_dir="$(abs_from_root "$assemble_dir")"
+  report="$(abs_from_root "$report")"
   python3 - "$assemble_dir" "$report" <<'PY'
 import json, os, sys
 from pathlib import Path
@@ -51,7 +63,11 @@ from pathlib import Path
 src, dest = Path(sys.argv[1]), Path(sys.argv[2])
 files = sorted(src.rglob("*.json"))
 if not files:
-    raise SystemExit(f"no metrics json in {src}")
+    listing = []
+    if src.exists():
+        listing = [str(p) for p in sorted(src.rglob("*")) if p.is_file()]
+    extra = f" files={listing}" if listing else " (dir missing or empty)"
+    raise SystemExit(f"no metrics json in {src}{extra}")
 rows = [json.loads(p.read_text()) for p in files]
 rows.sort(key=lambda r: r.get("target") or "")
 head = rows[0]
@@ -112,6 +128,9 @@ print(f"Wrote {dest}")
 PY
   exit 0
 fi
+
+cd "$ROOT/rust"
+out_dir="$(abs_from_root "$out_dir")"
 
 host="$(host_triple)"
 if [[ -z "$target" ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `cli-report` job failed on #3356 (`no metrics json in cli-report-metrics`) even though all four matrix builds uploaded artifacts. The assemble step looked for a relative path after `cd rust/`, so CI’s workspace `cli-report-metrics` was never read.

## Changes

- Resolve `--assemble` / `--report` / `--out` from the repo root
- Only `cd rust/` for the crate build path
- Clearer empty-dir error (list files if any)

## Test plan

- [x] `bash scripts/cli-build-report.sh --assemble <dir>` from repo root with a fixture JSON writes the markdown table
- [x] Relative `--assemble cli-report-metrics` (same as the workflow) succeeds
- [x] Empty dir still exits 1 with a missing/empty hint
- [ ] `cli-report` job on this PR

## Notes for reviewer

Pre-existing; not caused by the local-connections feature. Same failure has been showing on other rust PRs.

---

Co-Authored-By: duyetbot <bot@duyet.net>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66ce0994-6c5b-4782-a658-184d6a986255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ce0994-6c5b-4782-a658-184d6a986255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

